### PR TITLE
Set GOOS=linux to build binaries for Linux by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 NAMESPACE=openshift-monitoring
 KUBECONFIG?=$(HOME)/.kube/config
 PKGS   = $(shell go list ./... | grep -v -E '/vendor/|/test|/examples')
+GOOS   = linux
 VERSION=$(shell cat VERSION | tr -d " \t\n\r")
 
 build:
-	go build --ldflags="-s -X github.com/openshift/cluster-monitoring-operator/pkg/operator.Version=$(VERSION)" -o operator $(MAIN_PKG)
+	GOOS=$(GOOS) go build --ldflags="-s -X github.com/openshift/cluster-monitoring-operator/pkg/operator.Version=$(VERSION)" -o operator $(MAIN_PKG)
 
 run:
 	./operator


### PR DESCRIPTION
Since the default intent for building is to put this into a Docker
image, it should build with GOOS=linux by default.

If needed to build natively for the local OS, it can be done using
`make build GOOS=$(go env GOOS)`.