### PR TITLE
Fix creation of default rules

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -190,6 +190,21 @@ func (c *Client) CreateOrUpdatePrometheus(p *monv1.Prometheus) error {
 	return errors.Wrap(err, "updating Prometheus object failed")
 }
 
+func (c *Client) CreateOrUpdatePrometheusRule(p *monv1.PrometheusRule) error {
+	pclient := c.mclient.MonitoringV1().PrometheusRules(p.GetNamespace())
+	_, err := pclient.Get(p.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := pclient.Create(p)
+		return errors.Wrap(err, "creating PrometheusRule object failed")
+	}
+	if err != nil {
+		return errors.Wrap(err, "retrieving PrometheusRule object failed")
+	}
+
+	_, err = pclient.Update(p)
+	return errors.Wrap(err, "updating PrometheusRule object failed")
+}
+
 func (c *Client) CreateOrUpdateAlertmanager(a *monv1.Alertmanager) error {
 	aclient := c.mclient.MonitoringV1().Alertmanagers(a.GetNamespace())
 	_, err := aclient.Get(a.GetName(), metav1.GetOptions{})

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -533,8 +533,8 @@ func (f *Factory) PrometheusK8sRole() (*rbacv1beta1.Role, error) {
 	return r, nil
 }
 
-func (f *Factory) PrometheusK8sRules() (*v1.ConfigMap, error) {
-	r, err := f.NewConfigMap(MustAssetReader(PrometheusK8sRules))
+func (f *Factory) PrometheusK8sRules() (*monv1.PrometheusRule, error) {
+	r, err := f.NewPrometheusRule(MustAssetReader(PrometheusK8sRules))
 	if err != nil {
 		return nil, err
 	}
@@ -924,6 +924,19 @@ func (f *Factory) NewPrometheus(manifest io.Reader) (*monv1.Prometheus, error) {
 	return p, nil
 }
 
+func (f *Factory) NewPrometheusRule(manifest io.Reader) (*monv1.PrometheusRule, error) {
+	p, err := NewPrometheusRule(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.GetNamespace() == "" {
+		p.SetNamespace(f.namespace)
+	}
+
+	return p, nil
+}
+
 func (f *Factory) NewAlertmanager(manifest io.Reader) (*monv1.Alertmanager, error) {
 	a, err := NewAlertmanager(manifest)
 	if err != nil {
@@ -1089,6 +1102,16 @@ func NewServiceAccount(manifest io.Reader) (*v1.ServiceAccount, error) {
 
 func NewPrometheus(manifest io.Reader) (*monv1.Prometheus, error) {
 	p := monv1.Prometheus{}
+	err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&p)
+	if err != nil {
+		return nil, err
+	}
+
+	return &p, nil
+}
+
+func NewPrometheusRule(manifest io.Reader) (*monv1.PrometheusRule, error) {
+	p := monv1.PrometheusRule{}
 	err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&p)
 	if err != nil {
 		return nil, err

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -169,14 +169,14 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "reconciling Prometheus config RoleBinding failed")
 	}
 
-	cm, err := t.factory.PrometheusK8sRules()
+	pm, err := t.factory.PrometheusK8sRules()
 	if err != nil {
-		return errors.Wrap(err, "initializing Prometheus rules ConfigMap failed")
+		return errors.Wrap(err, "initializing Prometheus rules PrometheusRule failed")
 	}
 
-	err = t.client.CreateOrUpdateConfigMap(cm)
+	err = t.client.CreateOrUpdatePrometheusRule(pm)
 	if err != nil {
-		return errors.Wrap(err, "reconciling Prometheus rules ConfigMap failed")
+		return errors.Wrap(err, "reconciling Prometheus rules PrometheusRule failed")
 	}
 
 	smk, err := t.factory.PrometheusK8sKubeletServiceMonitor()


### PR DESCRIPTION
Fix the creation of the default rules. Default rules are now expressed as a
PrometheusRule object, but the manifest was still being unmarshalled into a
ConfigMap causing the creation of an empty ConfigMap rather than a
PrometheusRule.