### PR TITLE
manifests: Make node-selectors configurable

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -58,8 +58,9 @@ type AlertmanagerMainConfig struct {
 }
 
 type GrafanaConfig struct {
-	BaseImage string `json:"baseImage"`
-	Hostport  string `json:"hostport"`
+	BaseImage    string            `json:"baseImage"`
+	NodeSelector map[string]string `json:"nodeSelector"`
+	Hostport     string            `json:"hostport"`
 }
 
 type AuthConfig struct {
@@ -71,7 +72,8 @@ type NodeExporterConfig struct {
 }
 
 type KubeStateMetricsConfig struct {
-	BaseImage string `json:"baseImage"`
+	BaseImage    string            `json:"baseImage"`
+	NodeSelector map[string]string `json:"nodeSelector"`
 }
 
 type KubeRbacProxyConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -345,6 +345,10 @@ func (f *Factory) KubeStateMetricsDeployment() (*appsv1.Deployment, error) {
 		d.Spec.Template.Spec.Containers[2].Image = image.String()
 	}
 
+	if f.config.KubeStateMetricsConfig.NodeSelector != nil {
+		d.Spec.Template.Spec.NodeSelector = f.config.KubeStateMetricsConfig.NodeSelector
+	}
+
 	d.Namespace = f.namespace
 
 	return d, nil
@@ -936,6 +940,10 @@ func (f *Factory) GrafanaDeployment() (*appsv1.Deployment, error) {
 		}
 		image.repo = f.config.AuthConfig.BaseImage
 		d.Spec.Template.Spec.Containers[1].Image = image.String()
+	}
+
+	if f.config.GrafanaConfig.NodeSelector != nil {
+		d.Spec.Template.Spec.NodeSelector = f.config.GrafanaConfig.NodeSelector
 	}
 
 	d.Namespace = f.namespace


### PR DESCRIPTION
This pull request make the Grafana and kube-state-metrics node selectors configurable, making all necessary components configurable now.

@mxinden 

cc @mrsiano 

Related https://github.com/openshift/openshift-ansible/issues/9102