### PR TITLE
*: add basic instrumentation

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -18,12 +18,15 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/errgroup"
 
 	cmo "github.com/openshift/cluster-monitoring-operator/pkg/operator"
@@ -88,11 +91,22 @@ func Main() int {
 		fmt.Fprint(os.Stderr, "`--configmap` flag is required, but not specified.")
 	}
 
+	r := prometheus.NewRegistry()
+	r.MustRegister(
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(os.Getpid(), ""),
+	)
+
 	o, err := cmo.New(*namespace, *configMapName, tags.asMap())
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
 		return 1
 	}
+
+	o.RegisterMetrics(r)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
+	go http.ListenAndServe(":8080", mux)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	wg, ctx := errgroup.WithContext(ctx)

--- a/hack/ocp-images.sh
+++ b/hack/ocp-images.sh
@@ -111,6 +111,9 @@ spec:
         #- "-tags=node-exporter=${TAG}"
         - "-tags=kube-state-metrics=${TAG}"
         - "-tags=kube-rbac-proxy=${TAG}"
+        ports:
+        - containerPort: 8080
+          name: http
         resources:
           limits:
             cpu: 20m

--- a/manifests/cluster-monitoring-operator.yaml
+++ b/manifests/cluster-monitoring-operator.yaml
@@ -34,6 +34,9 @@ spec:
         #- "-tags=node-exporter=master"
         #- "-tags=kube-state-metrics=master"
         #- "-tags=kube-rbac-proxy=master"
+        ports:
+        - containerPort: 8080
+          name: http
         resources:
           limits:
             cpu: 20m

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -50,6 +51,9 @@ type Operator struct {
 	cmapInf cache.SharedIndexInformer
 
 	queue workqueue.RateLimitingInterface
+
+	reconcileAttempts prometheus.Counter
+	reconcileErrors   prometheus.Counter
 }
 
 func New(namespace string, configMapName string, tagOverrides map[string]string) (*Operator, error) {
@@ -76,6 +80,24 @@ func New(namespace string, configMapName string, tagOverrides map[string]string)
 	})
 
 	return o, nil
+}
+
+// RegisterMetrics registers the operator's metrics with the given registerer.
+func (o *Operator) RegisterMetrics(r prometheus.Registerer) {
+	o.reconcileAttempts = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cluster_monitoring_operator_reconcile_attempts_total",
+		Help: "Number of attempts to reconcile the operator configuration",
+	})
+
+	o.reconcileErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cluster_monitoring_operator_reconcile_errors_total",
+		Help: "Number of errors that occurred while reconciling the operator configuration",
+	})
+
+	r.MustRegister(
+		o.reconcileAttempts,
+		o.reconcileErrors,
+	)
 }
 
 // Run the controller.
@@ -111,7 +133,7 @@ func (o *Operator) Run(stopc <-chan struct{}) error {
 	return nil
 }
 
-func (c *Operator) keyFunc(obj interface{}) (string, bool) {
+func (o *Operator) keyFunc(obj interface{}) (string, bool) {
 	k, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		glog.V(4).Infof("creating key failed, err: %s", err)
@@ -120,11 +142,7 @@ func (c *Operator) keyFunc(obj interface{}) (string, bool) {
 	return k, true
 }
 
-func (o *Operator) handleConfigMapAdd(obj interface{}) {
-	o.handleEvent(obj)
-}
-
-func (o *Operator) handleConfigMapUpdate(old, cur interface{}) {
+func (o *Operator) handleConfigMapUpdate(_, cur interface{}) {
 	o.handleEvent(cur)
 }
 
@@ -177,14 +195,16 @@ func (o *Operator) processNextWorkItem() bool {
 	}
 	defer o.queue.Done(key)
 
+	o.reconcileAttempts.Inc()
 	err := o.sync(key.(string))
 	if err == nil {
 		o.queue.Forget(key)
 		return true
 	}
 
+	o.reconcileErrors.Inc()
 	glog.Errorf("Syncing %q failed", key)
-	utilruntime.HandleError(errors.Wrap(err, fmt.Sprintf("Sync %q failed", key)))
+	utilruntime.HandleError(errors.Wrap(err, fmt.Sprintf("sync %q failed", key)))
 	o.queue.AddRateLimited(key)
 
 	return true


### PR DESCRIPTION
This commit implements basic instrumentation for the Cluster Monitoring
Operator. The CMO will report how many errors it has gotten while
attempting to reconcile. The metrics endpoint is exposed on port 8080,
for consistency with the Prometheus Operator.

cc @mxinden @brancz 