### PR TITLE
Dockerfile: install jq from Github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN mkdir $GOPATH
 
 COPY . $GOPATH/src/github.com/openshift/cluster-monitoring-operator
 
-RUN yum install -y epel-release && \
-    yum install -y golang make git jq && \
+RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq && \
+    yum install -y golang make git && \
     cd $GOPATH/src/github.com/openshift/cluster-monitoring-operator && \
     make build && cp $GOPATH/src/github.com/openshift/cluster-monitoring-operator/operator /usr/bin/ && \
-    yum erase -y golang make git jq && yum remove -y epel-release && yum clean all
+    yum erase -y golang make git && yum clean all && rm /usr/local/bin/jq
 
 LABEL io.k8s.display-name="OpenShift cluster-monitoring-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of the Prometheus based cluster monitoring stack." \


### PR DESCRIPTION
This commit modifies the Dockerfile to download the jq binary directly
from the Github release page rather than relying on the `epel-release`
repository, which is not available when building OCP images.

cc @brancz 

Tested `make container` locally and everything builds correctly.