### PR TITLE
Makefile: don't install binaries as direct deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ jobs:
   include:
   - script: yamllint .
   - stage: Build
-    script: make build
+    script: make dependencies build
   - script: make generate && git diff --exit-code

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ RUN mkdir $GOPATH
 
 COPY . $GOPATH/src/github.com/openshift/cluster-monitoring-operator
 
-RUN yum install -y epel-release && \
-    yum install -y golang make git jq && \
+RUN yum install -y golang make git && \
     cd $GOPATH/src/github.com/openshift/cluster-monitoring-operator && \
     make build && cp $GOPATH/src/github.com/openshift/cluster-monitoring-operator/operator /usr/bin/ && \
-    yum erase -y golang make git jq && yum remove -y epel-release && yum clean all
+    yum erase -y golang make git && yum clean all
 
 LABEL io.k8s.display-name="OpenShift cluster-monitoring-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of the Prometheus based cluster monitoring stack." \


### PR DESCRIPTION
This commit modifies the Makefile dependency tree so that all utility
binaries are no longer automatically installed as direct dependencies of
the targets. This ensures that in a Docker container with no jsonnet,
for example, the entire static asset tree will not be regenerated. This
in turn allows us to avoid having to install extra tools like jq during
the container build process.

cc @brancz 