### PR TITLE
pkg/manifests: add nodeSelector to prometheus operator config

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -41,12 +41,13 @@ type HTTPConfig struct {
 }
 
 type PrometheusOperatorConfig struct {
-	BaseImage                   string `json:"baseImage"`
-	Tag                         string `json:"-"`
-	PrometheusConfigReloader    string `json:"prometheusConfigReloaderBaseImage"`
-	PrometheusConfigReloaderTag string `json:"-"`
-	ConfigReloaderImage         string `json:"configReloaderBaseImage"`
-	ConfigReloaderTag           string `json:"-"`
+	BaseImage                   string            `json:"baseImage"`
+	Tag                         string            `json:"-"`
+	PrometheusConfigReloader    string            `json:"prometheusConfigReloaderBaseImage"`
+	PrometheusConfigReloaderTag string            `json:"-"`
+	ConfigReloaderImage         string            `json:"configReloaderBaseImage"`
+	ConfigReloaderTag           string            `json:"-"`
+	NodeSelector                map[string]string `json:"nodeSelector"`
 }
 
 type PrometheusK8sConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -831,6 +831,10 @@ func (f *Factory) PrometheusOperatorDeployment() (*appsv1.Deployment, error) {
 		return nil, err
 	}
 
+	if len(f.config.PrometheusOperatorConfig.NodeSelector) > 0 {
+		d.Spec.Template.Spec.NodeSelector = f.config.PrometheusOperatorConfig.NodeSelector
+	}
+
 	if f.config.PrometheusOperatorConfig.BaseImage != "" {
 		image, err := imageFromString(d.Spec.Template.Spec.Containers[0].Image)
 		if err != nil {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -393,6 +393,8 @@ func TestHTTPConfig(t *testing.T) {
 
 func TestPrometheusOperatorConfiguration(t *testing.T) {
 	c, err := NewConfigFromString(`prometheusOperator:
+  nodeSelector:
+    type: master
   baseImage: quay.io/test/prometheus-operator
   prometheusConfigReloaderBaseImage: quay.io/test/prometheus-config-reloader
   configReloaderBaseImage: quay.io/test/configmap-reload
@@ -405,6 +407,14 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 	d, err := f.PrometheusOperatorDeployment()
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if len(d.Spec.Template.Spec.NodeSelector) == 0 {
+		t.Fatal("expected node selector to be present, got none")
+	}
+
+	if got := d.Spec.Template.Spec.NodeSelector["type"]; got != "master" {
+		t.Fatalf("expected node selector to be master, got %q", got)
 	}
 
 	if !strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Image, "quay.io/test/prometheus-operator") {


### PR DESCRIPTION
Currently, the node selector in the prometheus operator config is
ignored.

This fixes it
Fixes MON-270