### PR TITLE
Makefile: container build operator with deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ jobs:
   - stage: Build
     script: make dependencies build
   - script: make generate && git diff --exit-code
+  - script: make container

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . $GOPATH/src/github.com/openshift/cluster-monitoring-operator
 
 RUN yum install -y golang make git && \
     cd $GOPATH/src/github.com/openshift/cluster-monitoring-operator && \
-    make build && cp $GOPATH/src/github.com/openshift/cluster-monitoring-operator/operator /usr/bin/ && \
+    make operator-no-deps && cp $GOPATH/src/github.com/openshift/cluster-monitoring-operator/operator /usr/bin/ && \
     yum erase -y golang make git && yum clean all
 
 LABEL io.k8s.display-name="OpenShift cluster-monitoring-operator" \

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,15 @@ JB_BIN=$(GOPATH)/bin/jb
 ASSETS=$(shell grep -oh 'assets/.*\.yaml' pkg/manifests/manifests.go)
 JSONNET_SRC=$(shell find ./jsonnet -type f)
 JSONNET_VENDOR=$(addprefix jsonnet/vendor/, $(sort $(shell grep -oh "'.*libsonnet'" ./jsonnet/* --exclude-dir=./jsonnet/vendor | tr -d "'")))
+GO_BUILD_RECIPE=GOOS=$(GOOS) go build --ldflags="-s -X github.com/openshift/cluster-monitoring-operator/pkg/operator.Version=$(VERSION)" -o $(BIN) $(MAIN_PKG)
 
 build: $(BIN)
 
 $(BIN): $(SRC)
-	GOOS=$(GOOS) go build --ldflags="-s -X github.com/openshift/cluster-monitoring-operator/pkg/operator.Version=$(VERSION)" -o $@ $(MAIN_PKG)
+	$(GO_BUILD_RECIPE)
+
+operator-no-deps:
+	$(GO_BUILD_RECIPE)
 
 run: build
 	./$(BIN)
@@ -105,4 +109,4 @@ merge-cluster-roles: manifests/cluster-monitoring-operator-role.yaml
 manifests/cluster-monitoring-operator-role.yaml: $(ASSETS) hack/merge_cluster_roles.py manifests/cluster-monitoring-operator-role.yaml.in
 	python2 hack/merge_cluster_roles.py manifests/cluster-monitoring-operator-role.yaml.in `find assets | grep role | grep -v "role-binding" | sort` > manifests/cluster-monitoring-operator-role.yaml
 
-.PHONY: all build run crossbuild container push clean deps generate dependencies test e2e-test e2e-clean merge-cluster-roles
+.PHONY: all build operator-no-deps run crossbuild container push clean deps generate dependencies test e2e-test e2e-clean merge-cluster-roles


### PR DESCRIPTION
This commit allows the Docker build flow to compile the operator binary without any Make dependencies. This means the compilation during container build time depends exactly on the static assets that are checked into the repository and will not regenerate any assets if they are actually out of date.

cc @brancz 