### PR TITLE
assets: bump kube-prometheus assets

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -51,4 +51,4 @@ spec:
   - alertmanager-main-proxy
   securityContext: {}
   serviceAccountName: alertmanager-main
-  version: v0.15.0
+  version: v0.15.2

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -19,6 +19,8 @@ spec:
         - --web.listen-address=127.0.0.1:9101
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
         - --no-collector.wifi
         image: openshift/prometheus-node-exporter:v0.15.2
         name: node-exporter
@@ -30,6 +32,10 @@ spec:
         - mountPath: /host/sys
           name: sys
           readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
       - args:
         - --secure-listen-address=:9100
         - --upstream=http://127.0.0.1:9101/
@@ -68,6 +74,9 @@ spec:
       - hostPath:
           path: /sys
         name: sys
+      - hostPath:
+          path: /root
+        name: root
       - name: node-exporter-tls
         secret:
           secretName: node-exporter-tls

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -72,4 +72,4 @@ spec:
     matchExpressions:
     - key: k8s-app
       operator: Exists
-  version: v2.3.1
+  version: v2.3.2

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "2595c90b97334937abe2093c14ce162c502ae1f5"
+            "version": "3ddb75acc881aaa2f06bc512c3b40c7c12b9d74e"
         }
     ]
 }

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "2595c90b97334937abe2093c14ce162c502ae1f5"
+            "version": "3ddb75acc881aaa2f06bc512c3b40c7c12b9d74e"
         },
         {
             "name": "ksonnet",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "e72730ab20045683a7da6ede30439554c7a02418"
+            "version": "6890a9e633b0cdccdeaf65ccda3d84fb0838801f"
         }
     ]
 }


### PR DESCRIPTION
This mechanically bumps kube-prometheus assets to include
https://github.com/coreos/prometheus-operator/pull/1806

Fixes MON-285