### PR TITLE
Add cluster-monitoring-view ClusterRole

### DIFF
--- a/assets/cluster-monitoring-operator/cluster-role.yaml
+++ b/assets/cluster-monitoring-operator/cluster-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-monitoring-view
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get

--- a/jsonnet/cluster-monitoring-operator.jsonnet
+++ b/jsonnet/cluster-monitoring-operator.jsonnet
@@ -44,5 +44,20 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         ],
       },
     },
+
+    clusterRole:
+      local clusterRole = k.rbac.v1.clusterRole;
+      local policyRule = clusterRole.rulesType;
+
+      local namespacesRule = policyRule.new() +
+                             policyRule.withApiGroups(['']) +
+                             policyRule.withResources(['namespaces']) +
+                             policyRule.withVerbs(['get']);
+
+      local rules = [namespacesRule];
+
+      clusterRole.new() +
+      clusterRole.mixin.metadata.withName('cluster-monitoring-view') +
+      clusterRole.withRules(rules),
   },
 }

--- a/manifests/cluster-monitoring-operator-role.yaml
+++ b/manifests/cluster-monitoring-operator-role.yaml
@@ -4,6 +4,7 @@
 # Sources: 
 # 	manifests/cluster-monitoring-operator-role.yaml.in
 # 	assets/alertmanager/cluster-role.yaml
+# 	assets/cluster-monitoring-operator/cluster-role.yaml
 # 	assets/grafana/cluster-role.yaml
 # 	assets/kube-state-metrics/cluster-role.yaml
 # 	assets/kube-state-metrics/role.yaml
@@ -37,6 +38,9 @@ rules:
 - apiGroups: [authorization.k8s.io]
   resources: [subjectaccessreviews]
   verbs: [create]
+- apiGroups: ['']
+  resources: [namespaces]
+  verbs: [get]
 - apiGroups: [apps]
   resources: [daemonsets, deployments, replicasets, statefulsets]
   verbs: [list, watch]
@@ -64,9 +68,6 @@ rules:
   resourceNames: [kube-state-metrics]
   resources: [deployments]
   verbs: [get, update]
-- apiGroups: ['']
-  resources: [namespaces]
-  verbs: [get]
 - apiGroups: ['']
   resources: [nodes/metrics]
   verbs: [get]

--- a/pkg/manifests/bindata.go
+++ b/pkg/manifests/bindata.go
@@ -9,6 +9,7 @@
 // assets/alertmanager/service-account.yaml
 // assets/alertmanager/service-monitor.yaml
 // assets/alertmanager/service.yaml
+// assets/cluster-monitoring-operator/cluster-role.yaml
 // assets/cluster-monitoring-operator/service-monitor.yaml
 // assets/cluster-monitoring-operator/service.yaml
 // assets/grafana/cluster-role-binding.yaml
@@ -308,6 +309,26 @@ func assetsAlertmanagerServiceYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "assets/alertmanager/service.yaml", size: 365, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _assetsClusterMonitoringOperatorClusterRoleYaml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x2c\xcc\xb1\x8e\x83\x30\x0c\xc6\xf1\xdd\x4f\x61\xb1\x87\xd3\x6d\xa7\xac\x37\x74\xef\xd0\xdd\x04\x8b\x5a\x40\x1c\xd9\x0e\x95\xfa\xf4\x15\x2a\xeb\xef\xd3\xf7\xa7\x26\x0f\x36\x17\xad\x19\x6d\xa2\x32\x52\x8f\xa7\x9a\xbc\x29\x44\xeb\xb8\xfe\xf9\x28\xfa\x73\xfc\xc2\x2a\x75\xce\xf8\xbf\x75\x0f\xb6\xbb\x6e\x0c\x3b\x07\xcd\x14\x94\x01\xb1\xd2\xce\x19\xcb\x77\x4d\xbb\x56\x09\x35\xa9\x4b\x3a\x84\x5f\x60\x7d\x63\xcf\x90\x90\x9a\xdc\x4c\x7b\xf3\xf3\x93\x70\x18\x00\xd1\xd8\xb5\x5b\xe1\xcb\xce\x92\x37\x2a\xec\x80\x78\xb0\x4d\x97\x2f\x1c\xf0\x09\x00\x00\xff\xff\xd3\x7b\x70\x66\xad\x00\x00\x00")
+
+func assetsClusterMonitoringOperatorClusterRoleYamlBytes() ([]byte, error) {
+	return bindataRead(
+		_assetsClusterMonitoringOperatorClusterRoleYaml,
+		"assets/cluster-monitoring-operator/cluster-role.yaml",
+	)
+}
+
+func assetsClusterMonitoringOperatorClusterRoleYaml() (*asset, error) {
+	bytes, err := assetsClusterMonitoringOperatorClusterRoleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "assets/cluster-monitoring-operator/cluster-role.yaml", size: 173, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1493,6 +1514,7 @@ var _bindata = map[string]func() (*asset, error){
 	"assets/alertmanager/service-account.yaml": assetsAlertmanagerServiceAccountYaml,
 	"assets/alertmanager/service-monitor.yaml": assetsAlertmanagerServiceMonitorYaml,
 	"assets/alertmanager/service.yaml": assetsAlertmanagerServiceYaml,
+	"assets/cluster-monitoring-operator/cluster-role.yaml": assetsClusterMonitoringOperatorClusterRoleYaml,
 	"assets/cluster-monitoring-operator/service-monitor.yaml": assetsClusterMonitoringOperatorServiceMonitorYaml,
 	"assets/cluster-monitoring-operator/service.yaml": assetsClusterMonitoringOperatorServiceYaml,
 	"assets/grafana/cluster-role-binding.yaml": assetsGrafanaClusterRoleBindingYaml,
@@ -1604,6 +1626,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"service.yaml": &bintree{assetsAlertmanagerServiceYaml, map[string]*bintree{}},
 		}},
 		"cluster-monitoring-operator": &bintree{nil, map[string]*bintree{
+			"cluster-role.yaml": &bintree{assetsClusterMonitoringOperatorClusterRoleYaml, map[string]*bintree{}},
 			"service-monitor.yaml": &bintree{assetsClusterMonitoringOperatorServiceMonitorYaml, map[string]*bintree{}},
 			"service.yaml": &bintree{assetsClusterMonitoringOperatorServiceYaml, map[string]*bintree{}},
 		}},

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -106,6 +106,7 @@ var (
 
 	ClusterMonitoringOperatorService        = "assets/cluster-monitoring-operator/service.yaml"
 	ClusterMonitoringOperatorServiceMonitor = "assets/cluster-monitoring-operator/service-monitor.yaml"
+	ClusterMonitoringClusterRole            = "assets/cluster-monitoring-operator/cluster-role.yaml"
 )
 
 var (
@@ -1117,6 +1118,15 @@ func (f *Factory) GrafanaService() (*v1.Service, error) {
 	s.Namespace = f.namespace
 
 	return s, nil
+}
+
+func (f *Factory) ClusterMonitoringClusterRole() (*rbacv1beta1.ClusterRole, error) {
+	cr, err := f.NewClusterRole(MustAssetReader(ClusterMonitoringClusterRole))
+	if err != nil {
+		return nil, err
+	}
+
+	return cr, nil
 }
 
 func (f *Factory) ClusterMonitoringOperatorService() (*v1.Service, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -257,6 +257,21 @@ func TestUnconfiguredManifests(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	_, err = f.ClusterMonitoringClusterRole()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.ClusterMonitoringOperatorService()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.ClusterMonitoringOperatorServiceMonitor()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestHTTPConfig(t *testing.T) {

--- a/pkg/tasks/clustermonitoringoperator.go
+++ b/pkg/tasks/clustermonitoringoperator.go
@@ -49,5 +49,15 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 	}
 
 	err = t.client.CreateOrUpdateServiceMonitor(smcmo)
-	return errors.Wrap(err, "reconciling Cluster Monitoring Operator ServiceMonitor failed")
+	if err != nil {
+		return errors.Wrap(err, "reconciling Cluster Monitoring Operator ServiceMonitor failed")
+	}
+
+	cr, err := t.factory.ClusterMonitoringClusterRole()
+	if err != nil {
+		return errors.Wrap(err, "initializing cluster-monitoring ClusterRole failed")
+	}
+
+	err = t.client.CreateOrUpdateClusterRole(cr)
+	return errors.Wrap(err, "reconciling cluster-monitoring ClusterRole failed")
 }


### PR DESCRIPTION
This ClusterRole can be used by users to bind against, to allow viewing
the cluster monitoring stack. This is useful for usability but also to
allow us to modify the specific roles at a later point in time, because
existing users that bind to it will continue to have the correct roles.

@mxinden @s-urbaniak @squat @metalmatze 