### PR TITLE
manifests: Set operator version to v0.1.0

### DIFF
--- a/manifests/cluster-monitoring-operator.yaml
+++ b/manifests/cluster-monitoring-operator.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       serviceAccountName: cluster-monitoring-operator
       containers:
-      - image: quay.io/coreos/cluster-monitoring-operator:v0.0.6
+      - image: quay.io/coreos/cluster-monitoring-operator:v0.1.0
         name: cluster-monitoring-operator
         args:
         - "-namespace=openshift-monitoring"


### PR DESCRIPTION
The version in the manifests does not start anymore and is outdated.