### PR TITLE
jsonnet: Pin versions for OpenShift images

### DIFF
--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -10,7 +10,12 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
                  nodeExporter: 'openshift/prometheus-node-exporter',
                },
                versions+:: {
+                // Because we build OpenShift images separately to upstream,
+                // we have to ensure these versions exist before upgrading.
                  openshiftOauthProxy: 'v1.1.0',
+                 prometheus: 'v2.4.2',
+                 alertmanager: 'v0.15.2',
+                 nodeExporter: 'v0.16.0',
                },
                etcd+:: {
                  ips: [],


### PR DESCRIPTION
For the images that OpenShift builds itself, we should make sure that the images actually exist before upgrading. Hence relying on the upstream dependencies is unsafe, as we might not yet have a Prometheus v2.4.2 available.

In the future this should be catched by the CI nonetheless. 

/cc @mxinden @squat @s-urbaniak @simonpasquier 