### PR TITLE
Create config for Kubernetes' client-go from kubeconfig or in-cluster credentials

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -60,11 +60,7 @@ type Client struct {
 	eclient        apiextensionsclient.Interface
 }
 
-func New(namespace string, appVersionName string) (*Client, error) {
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
+func New(cfg *rest.Config, namespace string, appVersionName string) (*Client, error) {
 	mclient, err := monitoring.NewForConfig(
 		&monv1.DefaultCrdKinds,
 		monv1.Group,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -59,8 +60,8 @@ type Operator struct {
 	reconcileErrors   prometheus.Counter
 }
 
-func New(namespace, configMapName string, tagOverrides map[string]string) (*Operator, error) {
-	c, err := client.New(namespace, configMapName)
+func New(config *rest.Config, namespace, configMapName string, tagOverrides map[string]string) (*Operator, error) {
+	c, err := client.New(config, namespace, configMapName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After running `./scripts/deploy-on-openshift.sh` and everything being setup inside the cluster, we can scale down the cluster-monitoring-operator deployment to 0 replicas. Now it's possible to run the operator locally (after compiling the binary) and give it the kubeconfig for the cluster running against.

This allows for quicker development cycles by running the operator locally.

/cc @squat @brancz 

PS: I also feel like the whole instantiation for the kubernetes client should be done inside the main.go and not somewhere deep down, but that's just a nit :innocent: 