### PR TITLE
Add config sharing scheme to share URLs with console

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -177,6 +177,15 @@ func (c *Client) CreateRouteIfNotExists(r *routev1.Route) error {
 	return nil
 }
 
+func (c *Client) GetRouteHost(r *routev1.Route) (string, error) {
+	rclient := c.osrclient.RouteV1().Routes(r.GetNamespace())
+	newRoute, err := rclient.Get(r.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Wrap(err, "getting Route object failed")
+	}
+	return newRoute.Spec.Host, nil
+}
+
 func (c *Client) NamespacesToMonitor() ([]string, error) {
 	namespaces, err := c.kclient.CoreV1().Namespaces().List(metav1.ListOptions{
 		LabelSelector: c.namespaceSelector,

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -671,6 +672,19 @@ func (f *Factory) PrometheusK8sRoute() (*routev1.Route, error) {
 	r.Namespace = f.namespace
 
 	return r, nil
+}
+
+func (f *Factory) SharingConfig(promHost, amHost string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sharing-config",
+			Namespace: f.namespace,
+		},
+		Data: map[string]string{
+			"prometheusHost":   promHost,
+			"alertmanagerHost": amHost,
+		},
+	}
 }
 
 func (f *Factory) PrometheusK8s(host string) (*monv1.Prometheus, error) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -248,6 +248,7 @@ func (o *Operator) sync(key string) error {
 			tasks.NewTaskSpec("Updating node-exporter", tasks.NewNodeExporterTask(o.client, factory)),
 			tasks.NewTaskSpec("Updating kube-state-metrics", tasks.NewKubeStateMetricsTask(o.client, factory)),
 			tasks.NewTaskSpec("Updating Telemeter client", tasks.NewTelemeterClientTask(o.client, factory, config.TelemeterClientConfig)),
+			tasks.NewTaskSpec("Updating configuration sharing", tasks.NewConfigSharingTask(o.client, factory)),
 		},
 	)
 

--- a/pkg/tasks/configsharing.go
+++ b/pkg/tasks/configsharing.go
@@ -1,0 +1,63 @@
+// Copyright 2018 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"github.com/pkg/errors"
+)
+
+type ConfigSharingTask struct {
+	client  *client.Client
+	factory *manifests.Factory
+}
+
+func NewConfigSharingTask(client *client.Client, factory *manifests.Factory) *ConfigSharingTask {
+	return &ConfigSharingTask{
+		client:  client,
+		factory: factory,
+	}
+}
+
+func (t *ConfigSharingTask) Run() error {
+	promRoute, err := t.factory.PrometheusK8sRoute()
+	if err != nil {
+		return errors.Wrap(err, "initializing Prometheus Route failed")
+	}
+
+	promHost, err := t.client.GetRouteHost(promRoute)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve Prometheus host")
+	}
+
+	amRoute, err := t.factory.AlertmanagerRoute()
+	if err != nil {
+		return errors.Wrap(err, "initializing Alertmanager Route failed")
+	}
+
+	amHost, err := t.client.GetRouteHost(amRoute)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve Alertmanager host")
+	}
+
+	cm := t.factory.SharingConfig(promHost, amHost)
+	err = t.client.CreateOrUpdateConfigMap(cm)
+	if err != nil {
+		return errors.Wrap(err, "reconciling Sharing Config ConfigMap failed")
+	}
+
+	return nil
+}


### PR DESCRIPTION
The idea is that console or users of console should not have permission to list all routes to discover the URLs of Prometheus and Alertmanager, therefore we publish the URLs in a configmap that is safe to be read by anyone in the cluster. More generally this is the "config sharing scheme" used in OpenShift going forward for different components to share non-secret information with other components.

https://jira.coreos.com/browse/MON-433

@mxinden @squat @s-urbaniak @metalmatze 