### PR TITLE
pkg/tasks/telemeter: enable only cluster ID and token is given

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -123,6 +123,20 @@ type TelemeterClientConfig struct {
 	Token              string `json:"token"`
 }
 
+func (cfg *TelemeterClientConfig) IsEnabled() bool {
+	if cfg == nil {
+		return false
+	}
+
+	if (cfg.Enabled != nil && *cfg.Enabled == false) ||
+		cfg.ClusterID == "" ||
+		cfg.Token == "" {
+		return false
+	}
+
+	return true
+}
+
 func NewConfig(content io.Reader) (*Config, error) {
 	c := Config{}
 

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -37,3 +37,102 @@ func TestEmptyConfigIsValid(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTelemeterClientConfig(t *testing.T) {
+	truev, falsev := true, false
+
+	tcs := []struct {
+		enabled bool
+		cfg     *TelemeterClientConfig
+	}{
+		{
+			cfg:     nil,
+			enabled: false,
+		},
+		{
+			cfg:     &TelemeterClientConfig{},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				Enabled: &truev,
+			},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				Enabled: &falsev,
+			},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				ClusterID: "test",
+			},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				ClusterID: "test",
+				Enabled:   &falsev,
+			},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				ClusterID: "test",
+				Enabled:   &truev,
+			},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				Token: "test",
+			},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				Token:   "test",
+				Enabled: &falsev,
+			},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				Token:   "test",
+				Enabled: &truev,
+			},
+			enabled: false,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				ClusterID: "test",
+				Token:     "test",
+			},
+			enabled: true, // opt-in by default
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				ClusterID: "test",
+				Token:     "test",
+				Enabled:   &truev,
+			},
+			enabled: true,
+		},
+		{
+			cfg: &TelemeterClientConfig{
+				ClusterID: "test",
+				Token:     "test",
+				Enabled:   &falsev, // explicitely opt-out
+			},
+			enabled: false,
+		},
+	}
+
+	for i, tc := range tcs {
+		if got := tc.cfg.IsEnabled(); got != tc.enabled {
+			t.Errorf("testcase %d: expected enabled %t, got %t", i, tc.enabled, got)
+		}
+	}
+}

--- a/pkg/tasks/telemeter.go
+++ b/pkg/tasks/telemeter.go
@@ -35,11 +35,11 @@ func NewTelemeterClientTask(client *client.Client, factory *manifests.Factory, c
 }
 
 func (t *TelemeterClientTask) Run() error {
-	// Default to enabled.
-	if t.config.Enabled != nil && !*t.config.Enabled {
-		return t.destroy()
+	if t.config.IsEnabled() {
+		return t.create()
 	}
-	return t.create()
+
+	return t.destroy()
 }
 
 func (t *TelemeterClientTask) create() error {


### PR DESCRIPTION
This prevents from starting telemeter if no config, cluster ID or
token is given.

cc @squat @brancz