### PR TITLE
assets,jsonnet: fix grafana port

### DIFF
--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         image: grafana/grafana:5.2.4
         name: grafana
         ports:
-        - containerPort: 3000
+        - containerPort: 3001
           name: http
         readinessProbe:
           httpGet:

--- a/jsonnet/grafana.jsonnet
+++ b/jsonnet/grafana.jsonnet
@@ -160,7 +160,8 @@ local authorizationRole = policyRule.new() +
         spec+: {
           template+: {
             spec+: {
-              containers+: [
+              containers: [
+                super.containers[0] + container.withPorts(containerPort.newNamed('http', 3001)),
                 container.new('grafana-proxy', $._config.imageRepos.openshiftOauthProxy + ':' + $._config.versions.openshiftOauthProxy) +
                 container.withArgs([
                   '-provider=openshift',


### PR DESCRIPTION
This commit fixes an old issue that only began to manifest itself today.
In this project we add a proxy in front of Grafana, which occupies
Grarana's normal port of 3000, and move Grarana to 3001. However, we
did not redefine the named container port `http` from 3000 -> 3001.
The result was that once upstream jsonnet for Grafana added an HTTP
health check for port 3000, on our deployments this was actuall hitting
the proxy, which uses TLS, so the health check would fail.

cc @brancz @s-urbaniak 