### PR TITLE
manifests: Make URL uppercase in config sharing scheme

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -681,9 +681,9 @@ func (f *Factory) SharingConfig(promHost, amHost, grafanaHost *url.URL) *v1.Conf
 			Namespace: f.namespace,
 		},
 		Data: map[string]string{
-			"grafanaUrl":      grafanaHost.String(),
-			"prometheusUrl":   promHost.String(),
-			"alertmanagerUrl": amHost.String(),
+			"grafanaURL":      grafanaHost.String(),
+			"prometheusURL":   promHost.String(),
+			"alertmanagerURL": amHost.String(),
 		},
 	}
 }


### PR DESCRIPTION
Changing this, as that's the convention in the console, and generally makes sense. (RE: https://github.com/openshift/cluster-monitoring-operator/pull/169#issuecomment-442399151)

@s-urbaniak @squat @metalmatze @mxinden @kyoto 