### PR TITLE
pkg/tasks/telemeter: wait for serving cert secret

### DIFF
--- a/pkg/tasks/telemeter.go
+++ b/pkg/tasks/telemeter.go
@@ -113,6 +113,11 @@ func (t *TelemeterClientTask) create() error {
 		return errors.Wrap(err, "reconciling Telemeter client Service failed")
 	}
 
+	err = t.client.WaitForServingCertSecret(svc)
+	if err != nil {
+		return errors.Wrap(err, "reconciling Telemeter client Service serving certificate failed")
+	}
+
 	s, err := t.factory.TelemeterClientSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing Telemeter client Secret failed")


### PR DESCRIPTION
Currently, when deploying telemeter client the following error event
is being logged:

```
Warning  FailedMount  4m55s  kubelet, test1-worker-0-t8rrv  MountVolume.SetUp failed for volume "telemeter-client-tls" : secrets "telemeter-client-tls" not found
```

This fixes it by waiting for the secret to be available before
proceeding with the telemeter deployment.

cc @brancz @squat