### PR TITLE
pkg/client: fix namespaceSelector being ignored when creating client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -100,14 +100,15 @@ func New(cfg *rest.Config, namespace string, namespaceSelector string, appVersio
 	}
 
 	return &Client{
-		namespace:      namespace,
-		appVersionName: appVersionName,
-		kclient:        kclient,
-		ossclient:      ossclient,
-		osrclient:      osrclient,
-		mclient:        mclient,
-		eclient:        eclient,
-		aggclient:      aggclient,
+		namespace:         namespace,
+		namespaceSelector: namespaceSelector,
+		appVersionName:    appVersionName,
+		kclient:           kclient,
+		ossclient:         ossclient,
+		osrclient:         osrclient,
+		mclient:           mclient,
+		eclient:           eclient,
+		aggclient:         aggclient,
 	}, nil
 }
 


### PR DESCRIPTION
The namespace selector is being ignored when creating a client. It is getting defaulted to ""
which is equivalent to select all. During e2e test this is causing churn on prom operator as the pod is getting
redeployed continuosly with more new namespaces like this:
```console
piVersion: extensions/v1beta1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "13"
  creationTimestamp: 2018-12-10T08:47:45Z
  generation: 20
  labels:
    k8s-app: prometheus-operator
  name: prometheus-operator
  namespace: openshift-monitoring
  resourceVersion: "53430"
  selfLink: /apis/extensions/v1beta1/namespaces/openshift-monitoring/deployments/prometheus-operator
  uid: 4356b33f-fc58-11e8-852c-121e8f0b6b56
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      k8s-app: prometheus-operator
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        k8s-app: prometheus-operator
    spec:
      containers:
      - args:
        - --kubelet-service=kube-system/kubelet
        - --logtostderr=true
        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.26.0
        - --namespaces=default,e2e-tests-namespaces-hbpvn,e2e-tests-nsdeletetest-6xf7n,kube-public,kube-system,openshift,openshift-apiserver,openshift-cluster-api,openshift-cluster-dns,openshift-cluster-dns-operator,openshift-cluster-kube-apiserver-operator,openshift-cluster-kube-controller-manager-operator,openshift-cluster-kube-scheduler-operator,openshift-cluster-machine-approver,openshift-cluster-network-operator,openshift-cluster-node-tuning-operator,openshift-cluster-openshift-apiserver-operator,openshift-cluster-openshift-controller-manager-operator,openshift-cluster-samples-operator,openshift-cluster-version,openshift-config,openshift-config-managed,openshift-console,openshift-controller-manager,openshift-core-operators,openshift-csi-operator,openshift-image-registry,openshift-infra,openshift-ingress,openshift-ingress-operator,openshift-kube-apiserver,openshift-kube-controller-manager,openshift-kube-scheduler,openshift-machine-config-operator,openshift-monitoring,openshift-node,openshift-operator-lifecycle-manager,openshift-operators,openshift-sdn,openshift-service-cert-signer
        image: quay.io/coreos/prometheus-operator:v0.26.0
        imagePullPolicy: IfNotPresent
        name: prometheus-operator
        ports:
        - containerPort: 8080
          name: http
          protocol: TCP
        resources: {}
        securityContext: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      nodeSelector:
        beta.kubernetes.io/os: linux
      priorityClassName: system-cluster-critical
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: prometheus-operator
      serviceAccountName: prometheus-operator
      terminationGracePeriodSeconds: 30
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: 2018-12-10T08:48:00Z
    lastUpdateTime: 2018-12-10T08:48:00Z
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: 2018-12-10T08:47:45Z
    lastUpdateTime: 2018-12-10T09:11:04Z
    message: ReplicaSet "prometheus-operator-7b7997c968" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  observedGeneration: 20
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1
```

The generation is `20` because of new namespaces are being added and removed during e2e.

/cc @wking