### PR TITLE
Create statefulset pods in parallel

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -59,6 +59,7 @@ spec:
   listenLocal: true
   nodeSelector:
     beta.kubernetes.io/os: linux
+  podManagementPolicy: Parallel
   replicas: 3
   secrets:
   - alertmanager-main-tls

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -87,6 +87,7 @@ spec:
   listenLocal: true
   nodeSelector:
     beta.kubernetes.io/os: linux
+  podManagementPolicy: Parallel
   replicas: 2
   resources: {}
   ruleSelector:


### PR DESCRIPTION
Ref https://github.com/openshift/openshift-azure/issues/850#issuecomment-446935512

@openshift/sig-monitoring 

Needs to be cherrypicked in 3.11 in order to actually fix our issue.

```console
$ oc explain sts.spec.podManagementPolicy
KIND:     StatefulSet
VERSION:  apps/v1

FIELD:    podManagementPolicy <string>

DESCRIPTION:
     podManagementPolicy controls how pods are created during initial scale up,
     when replacing pods on nodes, or when scaling down. The default policy is
     `OrderedReady`, where pods are created in increasing order (pod-0, then
     pod-1, etc) and the controller will wait until each pod is ready before
     continuing. When scaling down, the pods are removed in the opposite order.
     The alternative policy is `Parallel` which will create pods in parallel to
     match the desired scale without waiting, and on scale down will delete all
     pods at once.
```