### PR TITLE
test/e2e: Replace e2e tests with basic stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,10 @@ $(JSONNET_BIN):
 test-unit:
 	go test $(PKGS)
 
-test: e2e-test
-
 vendor:
 	govendor add +external
 
-e2e-test:
+test-e2e:
 	go test -v -timeout=20m ./test/e2e/ --operator-image=$(REPO):$(TAG) --kubeconfig $(KUBECONFIG)
 
 e2e-clean:


### PR DESCRIPTION
In order to reintroduce the end-to-end tests and their continuous
execution, this patch disables the tests for now and replaces them with
a simple test connecting to the Kubernetes cluster.

Relates to https://github.com/openshift/release/pull/2383.

Let me know if this approach sounds reasonable to you. Happy for alternative suggestions.