### PR TITLE
test/e2e: fix panic in parsing kubeconfig cli flag

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"flag"
 	"log"
-	"os/user"
 	"strings"
 	"testing"
 	"time"
@@ -26,13 +25,13 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var f *framework.Framework
 
 func TestMain(m *testing.M) {
-	usr, _ := user.Current()
-	kubeConfigPath := flag.String("kubeconfig", usr.HomeDir+"/.kube/config", "kube config path, default: $HOME/.kube/config")
+	kubeConfigPath := flag.String("kubeconfig", clientcmd.RecommendedHomeFile, "kube config path, default: $HOME/.kube/config")
 	opImageName := flag.String("operator-image", "", "operator image, e.g. quay.io/coreos/cluster-monitoring-operator")
 
 	flag.Parse()


### PR DESCRIPTION
Currently e2e tests fail with the following panic:
```
go test -v -timeout=20m ./test/e2e/ --operator-image=quay.io/openshift/cluster-monitoring-operator:6329040 --kubeconfig /tmp/admin.kubeconfig
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0xf7cacd]

goroutine 1 [running]:
github.com/openshift/cluster-monitoring-operator/test/e2e.TestMain(0xc420531f00)
	/go/src/github.com/openshift/cluster-monitoring-operator/test/e2e/main_test.go:35 +0x5d
main.main()
	_testmain.go:40 +0xe9
FAIL	github.com/openshift/cluster-monitoring-operator/test/e2e	0.045s
make: *** [test-e2e] Error 1
```

This fixes it by referencing the recommended home file variable from client-go.

cc @squat