### PR TITLE
pkg/client/client.go: update API service using persisted object

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -751,7 +751,7 @@ func (c *Client) CreateOrUpdateIngress(ing *v1betaextensions.Ingress) error {
 
 func (c *Client) CreateOrUpdateAPIService(apiService *apiregistrationv1beta1.APIService) error {
 	apsc := c.aggclient.ApiregistrationV1beta1().APIServices()
-	_, err := apsc.Get(apiService.GetName(), metav1.GetOptions{})
+	apiService, err := apsc.Get(apiService.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = apsc.Create(apiService)
 		return errors.Wrap(err, "creating APIService object failed")


### PR DESCRIPTION
Currently an API service object update fails, because we don't use the
persisted object. This fails because the resource version is missing
causing the following error:

```
E1221 15:31:51.753825       1 operator.go:211] Syncing "openshift-monitoring/cluster-monitoring-config" failed
E1221 15:31:51.753844       1 operator.go:212] sync "openshift-monitoring/cluster-monitoring-config" failed: running task Updating prometheus-adapter failed: reconciling PrometheusAdapter APIService failed: updating APIService object failed: apiservices.apiregistration.k8s.io "v1beta1.metrics.k8s.io" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
```

cc @squat @brancz @metalmatze  @mxinden whoever is out there :-)