### PR TITLE
assets: fix KubeControllerManagerDown and KubeSchedulerDown alerts

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -386,7 +386,7 @@ spec:
       annotations:
         message: KubeControllerManager has disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="kube-controllers"} == 1)
+        absent(up{job="kube-controller-manager"} == 1)
       for: 15m
       labels:
         severity: critical
@@ -394,7 +394,7 @@ spec:
       annotations:
         message: KubeScheduler has disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="kube-controllers"} == 1)
+        absent(up{job="scheduler"} == 1)
       for: 15m
       labels:
         severity: critical


### PR DESCRIPTION
fix queries for `KubeControllerManagerDown` and `KubeSchedulerDown` alerts