### PR TITLE
configmap-reloader is usually published as 'reloader', not 'reload'

### DIFF
--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - "-v=4"
         - "-images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest"
         - "-images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest"
-        - "-images=configmap-reload=quay.io/openshift/origin-configmap-reload:latest"
+        - "-images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest"
         - "-images=prometheus=quay.io/openshift/origin-prometheus:latest"
         - "-images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest"
         - "-images=grafana=quay.io/openshift/origin-grafana:latest"

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -14,10 +14,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-prometheus-config-reloader:latest
-  - name: configmap-reload
+  - name: configmap-reloader
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-configmap-reload:latest
+      name: quay.io/openshift/origin-configmap-reloader:latest
   - name: prometheus
     from:
       kind: DockerImage

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -40,7 +40,7 @@ type Images struct {
 	PromLabelProxy           string
 	PrometheusOperator       string
 	PrometheusConfigReloader string
-	ConfigmapReload          string
+	ConfigmapReloader        string
 	Prometheus               string
 	Alertmanager             string
 	Grafana                  string
@@ -185,7 +185,7 @@ func (c *Config) applyDefaults() {
 func (c *Config) SetImages(images map[string]string) {
 	c.Images.PrometheusOperator = images["prometheus-operator"]
 	c.Images.PrometheusConfigReloader = images["prometheus-config-reloader"]
-	c.Images.ConfigmapReload = images["configmap-reload"]
+	c.Images.ConfigmapReloader = images["configmap-reloader"]
 	c.Images.Prometheus = images["prometheus"]
 	c.Images.Alertmanager = images["alertmanager"]
 	c.Images.Grafana = images["grafana"]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -956,7 +956,7 @@ func (f *Factory) PrometheusOperatorDeployment(namespaces []string) (*appsv1.Dep
 		}
 
 		if strings.HasPrefix(args[i], ConfigReloaderImageFlag) {
-			args[i] = ConfigReloaderImageFlag + f.config.Images.ConfigmapReload
+			args[i] = ConfigReloaderImageFlag + f.config.Images.ConfigmapReloader
 		}
 	}
 	d.Spec.Template.Spec.Containers[0].Args = args
@@ -1571,7 +1571,7 @@ func (f *Factory) TelemeterClientDeployment() (*appsv1.Deployment, error) {
 	}
 
 	d.Spec.Template.Spec.Containers[0].Image = f.config.Images.TelemeterClient
-	d.Spec.Template.Spec.Containers[1].Image = f.config.Images.ConfigmapReload
+	d.Spec.Template.Spec.Containers[1].Image = f.config.Images.ConfigmapReloader
 	d.Spec.Template.Spec.Containers[2].Image = f.config.Images.KubeRbacProxy
 	if len(f.config.TelemeterClientConfig.NodeSelector) > 0 {
 		d.Spec.Template.Spec.NodeSelector = f.config.TelemeterClientConfig.NodeSelector

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -515,7 +515,7 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 	c.SetImages(map[string]string{
 		"prometheus-operator":        "docker.io/openshift/origin-prometheus-operator:latest",
 		"prometheus-config-reloader": "docker.io/openshift/origin-prometheus-config-reloader:latest",
-		"configmap-reload":           "docker.io/openshift/origin-configmap-reload:latest",
+		"configmap-reloader":         "docker.io/openshift/origin-configmap-reloader:latest",
 	})
 
 	if err != nil {
@@ -549,7 +549,7 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusConfigReloaderFlag+"docker.io/openshift/origin-prometheus-config-reloader:latest") {
 			prometheusReloaderFound = true
 		}
-		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], ConfigReloaderImageFlag+"docker.io/openshift/origin-configmap-reload:latest") {
+		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], ConfigReloaderImageFlag+"docker.io/openshift/origin-configmap-reloader:latest") {
 			configReloaderFound = true
 		}
 		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusOperatorNamespaceFlag+"default,openshift-monitoring") {


### PR DESCRIPTION
OCP was created with `configmap-reloader` and that is more readable.
Origin is being changed to publish as configmap-reloader, and this
changes CMO to also be updated.

The v3.11 image location is not updated.

See https://github.com/openshift/release/pull/2603