### PR TITLE
test: Enable real e2e tests again

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -740,6 +740,7 @@
     "github.com/openshift/api/security/v1",
     "github.com/openshift/client-go/config/clientset/versioned",
     "github.com/openshift/client-go/route/clientset/versioned",
+    "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1",
     "github.com/openshift/client-go/security/clientset/versioned",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,3 +62,7 @@
 [[constraint]]
   name = "k8s.io/kube-aggregator"
   version = "kubernetes-1.12.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/openshift/client-go"

--- a/test/e2e/framework/prometheus_client.go
+++ b/test/e2e/framework/prometheus_client.go
@@ -1,0 +1,109 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"crypto/tls"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+
+	"github.com/Jeffail/gabs"
+)
+
+// PrometheusClient provides access to the prometheus-k8s statefulset via its
+// public facing route.
+type PrometheusClient struct {
+	// Host address of Prometheus public route.
+	host string
+	// ServiceAccount bearer token to pass through Openshift oauth proxy.
+	token string
+}
+
+// NewPrometheusClient returns creates and returns a new PrometheusClient.
+func NewPrometheusClient(
+	routeClient routev1.RouteV1Interface,
+	kubeClient kubernetes.Interface,
+) (*PrometheusClient, error) {
+	route, err := routeClient.Routes("openshift-monitoring").Get("prometheus-k8s", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	host := route.Spec.Host
+
+	secrets, err := kubeClient.CoreV1().Secrets("openshift-monitoring").List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var token string
+
+	for _, secret := range secrets.Items {
+		if strings.Contains(secret.Name, "cluster-monitoring-operator-e2e-token-") {
+			token = string(secret.Data["token"])
+		}
+	}
+
+	return &PrometheusClient{
+		host:  host,
+		token: token,
+	}, nil
+}
+
+// Query makes a request against the Prometheus /api/v1/query endpoint.
+func (c *PrometheusClient) Query(query string) (int, error) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client := &http.Client{Transport: tr}
+
+	req, err := http.NewRequest("GET", "https://"+c.host+"/api/v1/query", nil)
+	if err != nil {
+		return 0, err
+	}
+
+	q := req.URL.Query()
+	q.Add("query", query)
+	req.URL.RawQuery = q.Encode()
+
+	req.Header.Add("Authorization", "Bearer "+c.token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	res, err := gabs.ParseJSON(body)
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := res.ArrayCountP("data.result")
+	return n, err
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -31,8 +31,24 @@ import (
 var f *framework.Framework
 
 func TestMain(m *testing.M) {
-	kubeConfigPath := flag.String("kubeconfig", clientcmd.RecommendedHomeFile, "kube config path, default: $HOME/.kube/config")
-	opImageName := flag.String("operator-image", "", "operator image, e.g. quay.io/coreos/cluster-monitoring-operator")
+	os.Exit(testMain(m))
+}
+
+// testMain circumvents the issue, that one can not call `defer` in TestMain, as
+// `os.Exit` does not honor `defer` statements. For more details see:
+// http://blog.englund.nu/golang,/testing/2017/03/12/using-defer-in-testmain.html
+func testMain(m *testing.M) int {
+	kubeConfigPath := flag.String(
+		"kubeconfig",
+		clientcmd.RecommendedHomeFile,
+		"kube config path, default: $HOME/.kube/config",
+	)
+
+	opImageName := flag.String(
+		"operator-image",
+		"",
+		"operator image, e.g. quay.io/coreos/cluster-monitoring-operator",
+	)
 
 	flag.Parse()
 
@@ -42,7 +58,16 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	// Wait for Prometheus operator
+	cleanUp, err := f.Setup()
+	// Check cleanUp first, in case of an err, we still want to clean up.
+	if cleanUp != nil {
+		defer cleanUp()
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Wait for Prometheus operator.
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
 		_, err := f.KubeClient.Apps().Deployments(f.Ns).Get("prometheus-operator", metav1.GetOptions{})
 		if err != nil {
@@ -54,11 +79,17 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	os.Exit(m.Run())
+	return m.Run()
 }
 
 func TestQueryPrometheus(t *testing.T) {
 	t.Parallel()
+
+	promClient, err := framework.NewPrometheusClient(f.OpenshiftRouteClient, f.KubeClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	queries := []struct {
 		query   string
 		expectN int
@@ -70,7 +101,7 @@ func TestQueryPrometheus(t *testing.T) {
 			query:   `up{job="kubelet"} == 1`,
 			expectN: 1,
 		}, {
-			query:   `up{job="kube-scheduler"} == 1`,
+			query:   `up{job="scheduler"} == 1`,
 			expectN: 1,
 		}, {
 			query:   `up{job="kube-controller-manager"} == 1`,
@@ -82,7 +113,7 @@ func TestQueryPrometheus(t *testing.T) {
 			query:   `up{job="kube-state-metrics"} == 1`,
 			expectN: 1,
 		}, {
-			query:   `up{job="prometheus"} == 1`,
+			query:   `up{job="prometheus-k8s"} == 1`,
 			expectN: 1,
 		}, {
 			query:   `up{job="prometheus-operator"} == 1`,
@@ -98,19 +129,19 @@ func TestQueryPrometheus(t *testing.T) {
 
 	// Wait for pod to respond at queries at all. Then start verifying their results.
 	var loopErr error
-	err := wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
-		_, loopErr := f.QueryPrometheus("prometheus-k8s-0", "up")
+	err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+		_, loopErr := promClient.Query("up")
 		return loopErr == nil, nil
 	})
 	if err != nil {
 		t.Fatal(errors.Wrapf(err, "wait for prometheus-k8s: %v", loopErr))
 	}
 
-	err = wait.Poll(5*time.Second, 10*time.Minute, func() (bool, error) {
+	err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
 		defer t.Log("---------------------------\n")
 
 		for _, q := range queries {
-			n, err := f.QueryPrometheus("prometheus-k8s-0", q.query)
+			n, err := promClient.Query(q.query)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
> We want to bring back the end to end tests that @mxinden started and continue working on them.
This PR reverts some of the changes made in #185.

Supersedes https://github.com/openshift/cluster-monitoring-operator/pull/206