### PR TITLE
pkg/tasks: More verbose task logging

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -33,12 +33,13 @@ func NewTaskRunner(client *client.Client, tasks []*TaskSpec) *TaskRunner {
 }
 
 func (tl *TaskRunner) RunAll() error {
-	for _, ts := range tl.tasks {
-		glog.V(4).Infof("running task %v", ts.Name)
+	for i, ts := range tl.tasks {
+		glog.V(4).Infof("running task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
 		err := tl.ExecuteTask(ts)
 		if err != nil {
 			return errors.Wrapf(err, "running task %v failed", ts.Name)
 		}
+		glog.V(4).Infof("ran task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
 	}
 
 	return nil


### PR DESCRIPTION
Current master logs look like:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cloud-credential-operator/21/pull-ci-openshift-cloud-credential-operator-master-e2e-aws/102/artifacts/e2e-aws/pods/openshift-monitoring_cluster-monitoring-operator-5f4c54c8c4-2hnqz_cluster-monitoring-operator.log.gz | gunzip | grep 'running task'
I0123 17:15:38.849228       1 tasks.go:37] running task Updating Prometheus Operator
I0123 17:16:10.316708       1 tasks.go:37] running task Updating Cluster Monitoring Operator
I0123 17:16:10.412633       1 tasks.go:37] running task Updating Grafana
I0123 17:16:31.052395       1 tasks.go:37] running task Updating Prometheus-k8s
I0123 17:17:09.241802       1 tasks.go:37] running task Updating Alertmanager
I0123 17:17:40.563233       1 tasks.go:37] running task Updating node-exporter
```

but it's not immediately obvious from those logs whether the node-exporter task succeeded or if it's still running.  And even if it's succeeded, it's not clear whether there are additional tasks in the queue or not.  This commit adds more logging to make it easier with folks unfamiliar with this operator to monitor this progress.