### PR TITLE
*: Rename cluster-operator object to "monitoring"

### DIFF
--- a/manifests/05-clusteroperator.yaml
+++ b/manifests/05-clusteroperator.yaml
@@ -1,5 +1,5 @@
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
-  name: cluster-monitoring-operator
+  name: monitoring
 spec: {}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -57,6 +57,7 @@ const (
 )
 
 type Client struct {
+	version           string
 	namespace         string
 	namespaceSelector string
 	appVersionName    string
@@ -69,7 +70,7 @@ type Client struct {
 	aggclient         aggregatorclient.Interface
 }
 
-func New(cfg *rest.Config, namespace string, namespaceSelector string, appVersionName string) (*Client, error) {
+func New(cfg *rest.Config, version string, namespace string, namespaceSelector string, appVersionName string) (*Client, error) {
 	mclient, err := monitoring.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -106,6 +107,7 @@ func New(cfg *rest.Config, namespace string, namespaceSelector string, appVersio
 	}
 
 	return &Client{
+		version:           version,
 		namespace:         namespace,
 		namespaceSelector: namespaceSelector,
 		appVersionName:    appVersionName,
@@ -815,5 +817,5 @@ func (c *Client) CRDReady(crd *extensionsobj.CustomResourceDefinition) (bool, er
 }
 
 func (c *Client) StatusReporter() *StatusReporter {
-	return NewStatusReporter(c.oscclient.Config().ClusterOperators(), "cluster-monitoring-operator", "0.0.1")
+	return NewStatusReporter(c.oscclient.Config().ClusterOperators(), "monitoring", c.version)
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -61,7 +61,7 @@ type Operator struct {
 }
 
 func New(config *rest.Config, namespace, namespaceSelector, configMapName string, images map[string]string) (*Operator, error) {
-	c, err := client.New(config, namespace, namespaceSelector, configMapName)
+	c, err := client.New(config, Version, namespace, namespaceSelector, configMapName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
ClusterOperator objects are supposed to be normalized to be just the components name. No "openshift" prefix or "operator" suffix.

@squat @s-urbaniak @metalmatze @mxinden 