### PR TITLE
manifests: Add OperatorGroup

### DIFF
--- a/manifests/06-operatorgroup.yaml
+++ b/manifests/06-operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: openshift-cluster-monitoring
+  namespace: openshift-monitoring
+spec:
+  selector:
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
Creating this OperatorGroup will allow preventing having another Prometheus Operator that reconciles on the same objects, which would yield undefined behavior. As the cluster-monitoring-operator is a higher run level than OLM, we can just put this object in our payload.

@metalmatze @squat @s-urbaniak @mxinden 

cc @alecmerdler @njhale @ecordell @jwforres 