### PR TITLE
*: Enable etcd monitoring by default

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	AlertmanagerMainConfig   *AlertmanagerMainConfig   `json:"alertmanagerMain"`
 	KubeStateMetricsConfig   *KubeStateMetricsConfig   `json:"kubeStateMetrics"`
 	GrafanaConfig            *GrafanaConfig            `json:"grafana"`
-	EtcdConfig               *EtcdConfig               `json:"etcd"`
+	EtcdConfig               *EtcdConfig               `json:"-"`
 	HTTPConfig               *HTTPConfig               `json:"http"`
 	TelemeterClientConfig    *TelemeterClientConfig    `json:"telemeterClient"`
 	K8sPrometheusAdapter     *K8sPrometheusAdapter     `json:"k8sPrometheusAdapter"`
@@ -96,8 +96,7 @@ type K8sPrometheusAdapter struct {
 }
 
 type EtcdConfig struct {
-	Enabled    *bool  `json:"enabled"`
-	ServerName string `json:"serverName"`
+	Enabled *bool `json:"-"`
 }
 
 // IsEnabled returns the underlying value of the `Enabled` boolean pointer.

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -631,9 +631,6 @@ func (f *Factory) PrometheusK8sEtcdServiceMonitor() (*monv1.ServiceMonitor, erro
 		return nil, err
 	}
 
-	if f.config.EtcdConfig.ServerName != "" {
-		s.Spec.Endpoints[0].TLSConfig.ServerName = f.config.EtcdConfig.ServerName
-	}
 	s.Namespace = f.namespace
 
 	return s, nil

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -861,11 +861,9 @@ func TestPrometheusEtcdRulesFiltered(t *testing.T) {
 }
 
 func TestPrometheusEtcdRules(t *testing.T) {
-	c, err := NewConfigFromString(`etcd: {enabled: true}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	enabled := true
+	c := NewDefaultConfig()
+	c.EtcdConfig.Enabled = &enabled
 	f := NewFactory("openshift-monitoring", c)
 
 	r, err := f.PrometheusK8sRules()
@@ -903,11 +901,9 @@ func TestEtcdGrafanaDashboardFiltered(t *testing.T) {
 }
 
 func TestEtcdGrafanaDashboard(t *testing.T) {
-	c, err := NewConfigFromString(`etcd: {enabled: true}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	enabled := true
+	c := NewDefaultConfig()
+	c.EtcdConfig.Enabled = &enabled
 	f := NewFactory("openshift-monitoring", c)
 
 	cms, err := f.GrafanaDashboardDefinitions()


### PR DESCRIPTION
This PR removes the leftover configuration options, that are unnecessary now as etcd is always setup as static pods and we consistently monitor it.

As discussed on slack, we can either merge this as soon as e2e goes green on this, giving the etcd team an easier path to test this, or wait for them to provision the `openshift-monitoring/kube-etcd-client-certs` Secret with the appropriate client certificates, and then verify this works. I favor the first, as we can treat everything else as follow up/bugfix, but have no strong opinion (this is also a bugfix as we have an open bug, that these configurations don't work).

@mxinden @s-urbaniak @squat @metalmatze 

cc @hexfusion 