### PR TITLE
fix(operatorgroup): add missing static configuration

### DIFF
--- a/manifests/06-operatorgroup.yaml
+++ b/manifests/06-operatorgroup.yaml
@@ -3,6 +3,9 @@ kind: OperatorGroup
 metadata:
   name: openshift-cluster-monitoring
   namespace: openshift-monitoring
+  annotations:
+    olm.providedAPIs: Alertmanager.v1.monitoring.coreos.com,Prometheus.v1.monitoring.coreos.com,PrometheusRule.v1.monitoring.coreos.com,ServiceMonitor.v1.monitoring.coreos.com
 spec:
+  staticProvidedAPIs: true
   selector:
     openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
It looks like there are some missing fields on the OperatorGroup manifest. I've added them here:

- olm.providedAPIs: An annotation that contains a comma delimited list of GVKs provided by members of the OperatorGroup
- staticProvidedAPIs: True if OLM should not mutate the `olm.providedAPIs` annotation

Together, these fields prevent other intersecting OperatorGroups from installing any operators that provide the same GVKs, even if there are no CSVs that provide operators in the OperatorGroup's namespace.

The fix that provides this feature was merged early this week, staticProvidedAPIs is an additional field that was added to address CMO's specific usecase.
