### PR TITLE
Fix OLM `OperatorGroup`

### DIFF
--- a/manifests/06-operatorgroup.yaml
+++ b/manifests/06-operatorgroup.yaml
@@ -8,4 +8,5 @@ metadata:
 spec:
   staticProvidedAPIs: true
   selector:
-    openshift.io/cluster-monitoring: "true"
+    matchLabels:
+      openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
### Description

The `spec.selector` was missing `matchLabels`, and causing the `OperatorGroup` to target `all-namespaces` on the cluster instead of a subset.

Addresses https://jira.coreos.com/browse/ALM-913