### PR TITLE
Makefile: Don't run generate container as root

### DIFF
--- a/Dockerfile.generate
+++ b/Dockerfile.generate
@@ -2,3 +2,6 @@ FROM golang:1.9.2
 
 RUN apt-get update && \
     apt-get install -y python-yaml jq gawk
+
+RUN mkdir -p /go/src/github.com
+RUN chmod -R 777 /go

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ generate: clean
 		--rm \
 		--security-opt label=disable \
 		-v `pwd`:/go/src/github.com/openshift/cluster-monitoring-operator \
+		-u=$(shell id -u $(USER)):$(shell id -g $(USER)) \
 		-w /go/src/github.com/openshift/cluster-monitoring-operator \
 		tpo-generate \
 		make dependencies pkg/manifests/bindata.go merge-cluster-roles docs


### PR DESCRIPTION
Instead of running the Makefile `generate` target as root, run it as the
local user. Main benefit would be, that created files are not owned by
root, but by the local user instead.

Let me know what you think team.