### PR TITLE
manifests: Fix grafana and oauth-proxy image-references

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -29,11 +29,11 @@ spec:
   - name: grafana
     from:
       kind: DockerImage
-      name: quay.io/openshift/grafana:latest
+      name: quay.io/openshift/origin-grafana:latest
   - name: oauth-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/oauth-proxy:latest
+      name: quay.io/openshift/origin-oauth-proxy:latest
   - name: prometheus-node-exporter
     from:
       kind: DockerImage


### PR DESCRIPTION
These image-references don't seem to align with the images specified in the cluster-monitoring-operator deployment, so this PR fixes that. Hopefully this fixes the last issues regarding getting the right images replaced by the CVO.

https://bugzilla.redhat.com/show_bug.cgi?id=1678645

@squat @s-urbaniak @metalmatze @mxinden @smarterclayton 