### PR TITLE
pkg/operator: set creationTimestamp for PVCs, add e2e tests

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/api/apps/v1beta2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestAlertmanagerVolumeClaim(t *testing.T) {
+	err := f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alertmanager-main",
+			Namespace: f.Ns,
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-monitoring-config",
+			Namespace: f.Ns,
+		},
+		Data: map[string]string{
+			"config.yaml": `alertmanagerMain:
+  volumeClaimTemplate:
+    spec:
+      storageClassName: gp2
+      resources:
+        requests:
+          storage: 2Gi
+`,
+		},
+	}
+
+	if err := f.OperatorClient.CreateOrUpdateConfigMap(cm); err != nil {
+		log.Fatal(err)
+	}
+
+	var lastErr error
+	// Wait for persistent volume claim
+	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+		_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.Ns).Get("alertmanager-main-db-alertmanager-main-0", metav1.GetOptions{})
+		lastErr = errors.Wrap(err, "getting alertmanager persistent volume claim failed")
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		if err == wait.ErrWaitTimeout && lastErr != nil {
+			err = lastErr
+		}
+		log.Fatal(err)
+	}
+
+	err = f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alertmanager-main",
+			Namespace: f.Ns,
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/api/apps/v1beta2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestPrometheusVolumeClaim(t *testing.T) {
+	err := f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-k8s",
+			Namespace: f.Ns,
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-monitoring-config",
+			Namespace: f.Ns,
+		},
+		Data: map[string]string{
+			"config.yaml": `prometheusK8s:
+  volumeClaimTemplate:
+    spec:
+      storageClassName: gp2
+      resources:
+        requests:
+          storage: 2Gi
+`,
+		},
+	}
+
+	if err := f.OperatorClient.CreateOrUpdateConfigMap(cm); err != nil {
+		log.Fatal(err)
+	}
+
+	var lastErr error
+	// Wait for persistent volume claim
+	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+		_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.Ns).Get("prometheus-k8s-db-prometheus-k8s-0", metav1.GetOptions{})
+		lastErr = errors.Wrap(err, "getting prometheus persistent volume claim failed")
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		if err == wait.ErrWaitTimeout && lastErr != nil {
+			err = lastErr
+		}
+		log.Fatal(err)
+	}
+
+	err = f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-k8s",
+			Namespace: f.Ns,
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Currently, when a volume claim template is specified for either
prometheus or alertmanager, a CRD validation error is generated.

See
https://github.com/coreos/prometheus-operator/issues/2399#issuecomment-466320464
for an envisioned resolution in prometheus operator.

Until then an upstream fix is ready, this is a bandaid.

Fixes MON-579

cc @brancz @mxinden @metalmatze