### PR TITLE
 test/e2e: Make sure Prometheus only fires Watchdog alert 

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -709,7 +709,7 @@ func (c *Client) CreateOrUpdateNamespace(n *v1.Namespace) error {
 	return errors.Wrap(err, "updating ConfigMap object failed")
 }
 
-func (c *Client) DeleteIfExists(nsName string) error {
+func (c *Client) DeleteNamespaceIfExists(nsName string) error {
 	nClient := c.kclient.CoreV1().Namespaces()
 	_, err := nClient.Get(nsName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
@@ -721,7 +721,7 @@ func (c *Client) DeleteIfExists(nsName string) error {
 	}
 
 	err = nClient.Delete(nsName, &metav1.DeleteOptions{})
-	return errors.Wrap(err, "deleting ConfigMap object failed")
+	return errors.Wrap(err, "deleting Namespace object failed")
 }
 
 func (c *Client) CreateIfNotExistConfigMap(cm *v1.ConfigMap) error {

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -42,7 +42,7 @@ func TestMultinamespacePrometheusRule(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer f.OperatorClient.DeleteIfExists(nsName)
+	defer f.OperatorClient.DeleteNamespaceIfExists(nsName)
 
 	err = f.OperatorClient.CreateOrUpdatePrometheusRule(&monv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -85,3 +85,17 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 		log.Fatal(err)
 	}
 }
+
+func TestPrometheusOnlyFiringWatchdogAlert(t *testing.T) {
+	f.PrometheusK8sClient.WaitForQueryReturnOne(
+		t,
+		time.Minute,
+		`count(ALERTS{alertstate="firing"} == 1)`,
+	)
+
+	f.PrometheusK8sClient.WaitForQueryReturnOne(
+		t,
+		time.Minute,
+		`count(ALERTS{alertname="Watchdog",alertstate="firing"} == 1)`,
+	)
+}


### PR DESCRIPTION
In my local cluster Prometheus fires the `KubeClientCertificateExpiration` alert. Once we resolved that we can continue here. Opening it up for early feedback.