### PR TITLE
*: Clean test invocation and documenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Run `make pkg/manifests/bindata.go` after you modify the files and make sure to 
 
 ## Testing
 
-### End-to-end tests
+- **Unit tests**: `make test-unit`
 
-Run e2e-tests with `make e2e-test`.
-Clean up after e2e-tests with `make e2e-clean`
+- **End-to-end tests**: `make test-e2e`

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -42,10 +42,9 @@ type Framework struct {
 
 	MonitoringClient *monClient.MonitoringV1Client
 	Ns               string
-	OpImageName      string
 }
 
-func New(kubeConfigPath string, opImageName string) (*Framework, error) {
+func New(kubeConfigPath string) (*Framework, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	if err != nil {
 		return nil, err
@@ -84,7 +83,6 @@ func New(kubeConfigPath string, opImageName string) (*Framework, error) {
 		CRDClient:            crdClient,
 		MonitoringClient:     mClient,
 		Ns:                   namespaceName,
-		OpImageName:          opImageName,
 	}
 
 	return f, nil

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -44,16 +44,10 @@ func testMain(m *testing.M) int {
 		"kube config path, default: $HOME/.kube/config",
 	)
 
-	opImageName := flag.String(
-		"operator-image",
-		"",
-		"operator image, e.g. quay.io/coreos/cluster-monitoring-operator",
-	)
-
 	flag.Parse()
 
 	var err error
-	f, err = framework.New(*kubeConfigPath, *opImageName)
+	f, err = framework.New(*kubeConfigPath)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
- Remove outdated `e2e-clean` and `run-docker-test-minikube` Makefile
target from Tectonic times.

- Clean up Makefile Phony entries.

- Remove `--operator-image` flag for end-to-end test invocation. This
flag is not used anymore and can't be inferred from the repository at
hand.

- Update `README.md` `## Testing` section.