### PR TITLE
pkg/tasks/prometheus: update kubelet serving CA if it changed

### DIFF
--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -59,7 +59,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing kubelet serving CA Bundle ConfigMap failed")
 	}
 
-	err = t.client.CreateIfNotExistConfigMap(cacm)
+	err = t.client.CreateOrUpdateConfigMap(cacm)
 	if err != nil {
 		return errors.Wrap(err, "creating kubelet serving CA Bundle ConfigMap failed")
 	}


### PR DESCRIPTION
Currently, we only initially create the kubelet serving CA. This results
in outdated worker CA certificates causing prometheus to fail scraping
worker node kubelets.

This fixes it by create-or-updating the kubelet-serving-ca.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1679500#c12

cc @squat @mxinden @brancz

I am a bit sceptical here though. I verified locally that cert change are being synced down to the prometheus pod, but the targets still failed. Rekicking prometheus helped obviously.