### PR TITLE
pkg/tasks: create service monitor at the end of each tasks.

### DIFF
--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -48,16 +48,6 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "waiting for Alertmanager Route to become ready failed")
 	}
 
-	smam, err := t.factory.AlertmanagerServiceMonitor()
-	if err != nil {
-		return errors.Wrap(err, "initializing Alertmanager ServiceMonitor failed")
-	}
-
-	err = t.client.CreateOrUpdateServiceMonitor(smam)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Alertmanager ServiceMonitor failed")
-	}
-
 	s, err := t.factory.AlertmanagerConfig()
 	if err != nil {
 		return errors.Wrap(err, "initializing Alertmanager configuration Secret failed")
@@ -129,5 +119,15 @@ func (t *AlertmanagerTask) Run() error {
 	}
 
 	err = t.client.WaitForAlertmanager(a)
-	return errors.Wrap(err, "waiting for Alertmanager object changes failed")
+	if err != nil {
+		return errors.Wrap(err, "waiting for Alertmanager object changes failed")
+	}
+
+	smam, err := t.factory.AlertmanagerServiceMonitor()
+	if err != nil {
+		return errors.Wrap(err, "initializing Alertmanager ServiceMonitor failed")
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(smam)
+	return errors.Wrap(err, "reconciling Alertmanager ServiceMonitor failed")
 }

--- a/pkg/tasks/clustermonitoringoperator.go
+++ b/pkg/tasks/clustermonitoringoperator.go
@@ -43,21 +43,21 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 		return errors.Wrap(err, "reconciling Cluster Monitoring Operator Service failed")
 	}
 
-	smcmo, err := t.factory.ClusterMonitoringOperatorServiceMonitor()
-	if err != nil {
-		return errors.Wrap(err, "initializing Cluster Monitoring Operator ServiceMonitor failed")
-	}
-
-	err = t.client.CreateOrUpdateServiceMonitor(smcmo)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Cluster Monitoring Operator ServiceMonitor failed")
-	}
-
 	cr, err := t.factory.ClusterMonitoringClusterRole()
 	if err != nil {
 		return errors.Wrap(err, "initializing cluster-monitoring ClusterRole failed")
 	}
 
 	err = t.client.CreateOrUpdateClusterRole(cr)
-	return errors.Wrap(err, "reconciling cluster-monitoring ClusterRole failed")
+	if err != nil {
+		return errors.Wrap(err, "reconciling cluster-monitoring ClusterRole failed")
+	}
+
+	smcmo, err := t.factory.ClusterMonitoringOperatorServiceMonitor()
+	if err != nil {
+		return errors.Wrap(err, "initializing Cluster Monitoring Operator ServiceMonitor failed")
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(smcmo)
+	return errors.Wrap(err, "reconciling Cluster Monitoring Operator ServiceMonitor failed")
 }

--- a/pkg/tasks/grafana.go
+++ b/pkg/tasks/grafana.go
@@ -138,21 +138,21 @@ func (t *GrafanaTask) Run() error {
 		return errors.Wrap(err, "reconciling Grafana Service failed")
 	}
 
-	sm, err := t.factory.GrafanaServiceMonitor()
-	if err != nil {
-		return errors.Wrap(err, "initializing Grafana ServiceMonitor failed")
-	}
-
-	err = t.client.CreateOrUpdateServiceMonitor(sm)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Grafana ServiceMonitor failed")
-	}
-
 	d, err := t.factory.GrafanaDeployment()
 	if err != nil {
 		return errors.Wrap(err, "initializing Grafana Deployment failed")
 	}
 
 	err = t.client.CreateOrUpdateDeployment(d)
-	return errors.Wrap(err, "reconciling Grafana Deployment failed")
+	if err != nil {
+		return errors.Wrap(err, "reconciling Grafana Deployment failed")
+	}
+
+	sm, err := t.factory.GrafanaServiceMonitor()
+	if err != nil {
+		return errors.Wrap(err, "initializing Grafana ServiceMonitor failed")
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(sm)
+	return errors.Wrap(err, "reconciling Grafana ServiceMonitor failed")
 }

--- a/pkg/tasks/kubestatemetrics.go
+++ b/pkg/tasks/kubestatemetrics.go
@@ -33,16 +33,6 @@ func NewKubeStateMetricsTask(client *client.Client, factory *manifests.Factory) 
 }
 
 func (t *KubeStateMetricsTask) Run() error {
-	sm, err := t.factory.KubeStateMetricsServiceMonitor()
-	if err != nil {
-		return errors.Wrap(err, "initializing kube-state-metrics ServiceMonitor failed")
-	}
-
-	err = t.client.CreateOrUpdateServiceMonitor(sm)
-	if err != nil {
-		return errors.Wrap(err, "reconciling kube-state-metrics ServiceMonitor failed")
-	}
-
 	sa, err := t.factory.KubeStateMetricsServiceAccount()
 	if err != nil {
 		return errors.Wrap(err, "initializing kube-state-metrics Service failed")
@@ -89,5 +79,15 @@ func (t *KubeStateMetricsTask) Run() error {
 	}
 
 	err = t.client.CreateOrUpdateDeployment(dep)
-	return errors.Wrap(err, "reconciling kube-state-metrics Deployment failed")
+	if err != nil {
+		return errors.Wrap(err, "reconciling kube-state-metrics Deployment failed")
+	}
+
+	sm, err := t.factory.KubeStateMetricsServiceMonitor()
+	if err != nil {
+		return errors.Wrap(err, "initializing kube-state-metrics ServiceMonitor failed")
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(sm)
+	return errors.Wrap(err, "reconciling kube-state-metrics ServiceMonitor failed")
 }

--- a/pkg/tasks/nodeexporter.go
+++ b/pkg/tasks/nodeexporter.go
@@ -33,16 +33,6 @@ func NewNodeExporterTask(client *client.Client, factory *manifests.Factory) *Nod
 }
 
 func (t *NodeExporterTask) Run() error {
-	smn, err := t.factory.NodeExporterServiceMonitor()
-	if err != nil {
-		return errors.Wrap(err, "initializing node-exporter ServiceMonitor failed")
-	}
-
-	err = t.client.CreateOrUpdateServiceMonitor(smn)
-	if err != nil {
-		return errors.Wrap(err, "reconciling node-exporter ServiceMonitor failed")
-	}
-
 	scc, err := t.factory.NodeExporterSecurityContextConstraints()
 	if err != nil {
 		return errors.Wrap(err, "initializing node-exporter SecurityContextConstraints failed")
@@ -99,5 +89,15 @@ func (t *NodeExporterTask) Run() error {
 	}
 
 	err = t.client.CreateOrUpdateDaemonSet(ds)
-	return errors.Wrap(err, "reconciling node-exporter DaemonSet failed")
+	if err != nil {
+		return errors.Wrap(err, "reconciling node-exporter DaemonSet failed")
+	}
+
+	smn, err := t.factory.NodeExporterServiceMonitor()
+	if err != nil {
+		return errors.Wrap(err, "initializing node-exporter ServiceMonitor failed")
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(smn)
+	return errors.Wrap(err, "reconciling node-exporter ServiceMonitor failed")
 }

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -201,6 +201,34 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "reconciling Prometheus rules PrometheusRule failed")
 	}
 
+	svc, err := t.factory.PrometheusK8sService()
+	if err != nil {
+		return errors.Wrap(err, "initializing Prometheus Service failed")
+	}
+
+	err = t.client.CreateOrUpdateService(svc)
+	if err != nil {
+		return errors.Wrap(err, "reconciling Prometheus Service failed")
+	}
+
+	glog.V(4).Info("initializing Prometheus object")
+	p, err := t.factory.PrometheusK8s(host)
+	if err != nil {
+		return errors.Wrap(err, "initializing Prometheus object failed")
+	}
+
+	glog.V(4).Info("reconciling Prometheus object")
+	err = t.client.CreateOrUpdatePrometheus(p)
+	if err != nil {
+		return errors.Wrap(err, "reconciling Prometheus object failed")
+	}
+
+	glog.V(4).Info("waiting for Prometheus object changes")
+	err = t.client.WaitForPrometheus(p)
+	if err != nil {
+		return errors.Wrap(err, "waiting for Prometheus object changes failed")
+	}
+
 	smk, err := t.factory.PrometheusK8sKubeletServiceMonitor()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus kubelet ServiceMonitor failed")
@@ -284,33 +312,5 @@ func (t *PrometheusTask) Run() error {
 	}
 
 	err = t.client.CreateOrUpdateServiceMonitor(smp)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Prometheus Prometheus ServiceMonitor failed")
-	}
-
-	svc, err := t.factory.PrometheusK8sService()
-	if err != nil {
-		return errors.Wrap(err, "initializing Prometheus Service failed")
-	}
-
-	err = t.client.CreateOrUpdateService(svc)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Prometheus Service failed")
-	}
-
-	glog.V(4).Info("initializing Prometheus object")
-	p, err := t.factory.PrometheusK8s(host)
-	if err != nil {
-		return errors.Wrap(err, "initializing Prometheus object failed")
-	}
-
-	glog.V(4).Info("reconciling Prometheus object")
-	err = t.client.CreateOrUpdatePrometheus(p)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Prometheus object failed")
-	}
-
-	glog.V(4).Info("waiting for Prometheus object changes")
-	err = t.client.WaitForPrometheus(p)
-	return errors.Wrap(err, "waiting for Prometheus object changes failed")
+	return errors.Wrap(err, "reconciling Prometheus Prometheus ServiceMonitor failed")
 }

--- a/pkg/tasks/telemeter.go
+++ b/pkg/tasks/telemeter.go
@@ -53,16 +53,6 @@ func (t *TelemeterClientTask) create() error {
 		return errors.Wrap(err, "creating Telemeter Client serving certs CA Bundle ConfigMap failed")
 	}
 
-	sm, err := t.factory.TelemeterClientServiceMonitor()
-	if err != nil {
-		return errors.Wrap(err, "initializing Telemeter client ServiceMonitor failed")
-	}
-
-	err = t.client.CreateOrUpdateServiceMonitor(sm)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Telemeter client ServiceMonitor failed")
-	}
-
 	sa, err := t.factory.TelemeterClientServiceAccount()
 	if err != nil {
 		return errors.Wrap(err, "initializing Telemeter client Service failed")
@@ -129,7 +119,17 @@ func (t *TelemeterClientTask) create() error {
 	}
 
 	err = t.client.CreateOrUpdateDeployment(dep)
-	return errors.Wrap(err, "reconciling Telemeter client Deployment failed")
+	if err != nil {
+		return errors.Wrap(err, "reconciling Telemeter client Deployment failed")
+	}
+
+	sm, err := t.factory.TelemeterClientServiceMonitor()
+	if err != nil {
+		return errors.Wrap(err, "initializing Telemeter client ServiceMonitor failed")
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(sm)
+	return errors.Wrap(err, "reconciling Telemeter client ServiceMonitor failed")
 }
 
 func (t *TelemeterClientTask) destroy() error {


### PR DESCRIPTION
This gives the possibility to postpone waiting for the prometheus
operator is actually available before proceeding with the actual
deployment artifacts of the task at hand.

This should give another performance gain during installation time.

Another potential improvement for https://bugzilla.redhat.com/show_bug.cgi?id=1678475

cc @mxinden @brancz @squat