### PR TITLE
hack: Adapt generate etcd secret script to 4.0

### DIFF
--- a/hack/generate-etcd-secret.sh
+++ b/hack/generate-etcd-secret.sh
@@ -4,17 +4,18 @@ set -x
 # only exit with zero if all commands of the pipeline exit successfully
 set -o pipefail
 
-IP=${1}
+NAMESPACE=openshift-kube-apiserver
+APISERVERPODNAME="$(kubectl -n ${NAMESPACE} get pod -lapp=openshift-kube-apiserver -ojsonpath='{.items[0].metadata.name}')"
 
 cat <<-EOF
 apiVersion: v1
-data:
-  etcd-client-ca.crt: "$(ssh -i ~/go/src/github.com/openshift/release/cluster/test-deploy/gcp-dev/ssh-privatekey cloud-user@$IP sudo -E cat /etc/origin/master/master.etcd-ca.crt | base64 --wrap=0)"
-  etcd-client.crt: "$(ssh -i ~/go/src/github.com/openshift/release/cluster/test-deploy/gcp-dev/ssh-privatekey cloud-user@$IP sudo -E cat /etc/origin/master/master.etcd-client.crt | base64 --wrap=0)"
-  etcd-client.key: "$(ssh -i ~/go/src/github.com/openshift/release/cluster/test-deploy/gcp-dev/ssh-privatekey cloud-user@$IP sudo -E cat /etc/origin/master/master.etcd-client.key | base64 --wrap=0)"
 kind: Secret
 metadata:
   name: kube-etcd-client-certs
   namespace: openshift-monitoring
 type: Opaque
+data:
+  etcd-client-ca.crt: "$(oc rsh -n ${NAMESPACE} ${APISERVERPODNAME} cat /etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt | base64 --wrap=0)"
+  etcd-client.crt: "$(oc rsh -n ${NAMESPACE} ${APISERVERPODNAME} cat /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt | base64 --wrap=0)"
+  etcd-client.key: "$(oc rsh -n ${NAMESPACE} ${APISERVERPODNAME} cat /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key | base64 --wrap=0)"
 EOF


### PR DESCRIPTION
This adapt the `hack/` script we have to OpenShift 4.0, to immitate what the etcd management should do, so we can test the etcd integration out of band of the team doing this work.

(note there is more to getting etcd working, like the etcd team creating the right `Service` entries, but this is what enables etcd monitoring on our side so sufficient for testing https://bugzilla.redhat.com/show_bug.cgi?id=1662114 for example)

@s-urbaniak @squat @mxinden 