### PR TITLE
*: Cleanup release version plumbing

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -83,6 +83,7 @@ func Main() int {
 	configMapName := flagset.String("configmap", "cluster-monitoring-config", "ConfigMap name to configure the cluster monitoring stack.")
 	kubeconfigPath := flagset.String("kubeconfig", "", "The path to the kubeconfig to connect to the apiserver with.")
 	apiserver := flagset.String("apiserver", "", "The address of the apiserver to talk to.")
+	releaseVersion := flagset.String("release-version", "", "Currently targeted release version to be reconciled against.")
 	images := images{}
 	flag.Var(&images, "images", "Images to use for containers managed by the cluster-monitoring-operator.")
 	flag.Parse()
@@ -96,6 +97,13 @@ func Main() int {
 	if *configMapName == "" {
 		ok = false
 		fmt.Fprint(os.Stderr, "`--configmap` flag is required, but not specified.")
+	}
+
+	if releaseVersion == nil || *releaseVersion == "" {
+		fmt.Fprint(os.Stderr, "`--release-version` flag is not set.")
+	}
+	if releaseVersion != nil {
+		glog.V(4).Infof("Release version set to %v", *releaseVersion)
 	}
 
 	if !ok {
@@ -114,7 +122,7 @@ func Main() int {
 		return 1
 	}
 
-	o, err := cmo.New(config, *namespace, *namespaceSelector, *configMapName, images.asMap())
+	o, err := cmo.New(config, *releaseVersion, *namespace, *namespaceSelector, *configMapName, images.asMap())
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
 		return 1

--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         args:
         - "-namespace=openshift-monitoring"
         - "-configmap=cluster-monitoring-config"
+        - "-release-version=$(RELEASE_VERSION)"
         - "-logtostderr=true"
         - "-v=4"
         - "-images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest"

--- a/pkg/client/clusteroperator.go
+++ b/pkg/client/clusteroperator.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"os"
 
 	v1 "github.com/openshift/api/config/v1"
 	clientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -45,11 +44,11 @@ func (r *StatusReporter) SetDone() error {
 	// If we have reached "level" for the operator, report that we are at the version
 	// injected into us during update. We require that all components be rolled out
 	// and available at the new version before reporting this value.
-	if releaseVersion := os.Getenv("RELEASE_VERSION"); len(releaseVersion) > 0 {
+	if len(r.version) > 0 {
 		co.Status.Versions = []v1.OperandVersion{
 			{
 				Name:    "operator",
-				Version: releaseVersion,
+				Version: r.version,
 			},
 		}
 	} else {
@@ -82,7 +81,6 @@ func (r *StatusReporter) SetInProgress() error {
 	conditions := newConditions(co.Status.Conditions, time)
 	conditions.setCondition(v1.OperatorProgressing, v1.ConditionTrue, "Rolling out the stack.", time)
 	co.Status.Conditions = conditions.entries()
-	//co.Status.Version = r.version
 
 	_, err = r.client.UpdateStatus(co)
 	return err
@@ -105,7 +103,6 @@ func (r *StatusReporter) SetFailed(statusErr error) error {
 	conditions.setCondition(v1.OperatorProgressing, v1.ConditionFalse, "", time)
 	conditions.setCondition(v1.OperatorFailing, v1.ConditionTrue, fmt.Sprintf("Failed to rollout the stack. Error: %v", statusErr), time)
 	co.Status.Conditions = conditions.entries()
-	//co.Status.Version = r.version
 
 	_, err = r.client.UpdateStatus(co)
 	return err

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -34,11 +34,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/tasks"
 )
 
-var (
-	// This variable is intended to be overridden at build time.
-	Version = "dev"
-)
-
 const (
 	resyncPeriod = 5 * time.Minute
 
@@ -69,8 +64,8 @@ type Operator struct {
 	reconcileErrors   prometheus.Counter
 }
 
-func New(config *rest.Config, namespace, namespaceSelector, configMapName string, images map[string]string) (*Operator, error) {
-	c, err := client.New(config, Version, namespace, namespaceSelector)
+func New(config *rest.Config, version, namespace, namespaceSelector, configMapName string, images map[string]string) (*Operator, error) {
+	c, err := client.New(config, version, namespace, namespaceSelector)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#278 introduced the actual mechanism that reports status as configured by the CVO. As we had previously created some plumbing for setting the version through a compiler flag, we should clean up our mechanism and align it with what's actually being done.

I'm putting a hold label on this, just so we can explicitly verify in the logs, that the right version is being reported. As this is dynamically set via the CVO I have a hard time coming up with a test for this, but if you have an idea, I'm more than happy to add a test.

/hold

@s-urbaniak @mxinden @squat 