### PR TITLE
manifests: operator has system-cluster-critical priority

### DIFF
--- a/manifests/04-deployment.yaml
+++ b/manifests/04-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists
       - effect: NoSchedule


### PR DESCRIPTION
specifies system-cluster-critical priority for operator.

blocks passing smoke tests for ensuring control plane pods always schedule.

see: openshift/origin#22217