### PR TITLE
operator: fetch the pull-secret directly from secret than cluster-config-v1

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -364,8 +364,8 @@ func (o *Operator) Config(key string) *manifests.Config {
 			glog.Warningf("Could not fetch cluster version from API. Proceeding without it: %v", err)
 		}
 
-		err = c.LoadToken(func() (*v1.ConfigMap, error) {
-			return o.client.KubernetesInterface().CoreV1().ConfigMaps("kube-system").Get("cluster-config-v1", metav1.GetOptions{})
+		err = c.LoadToken(func() (*v1.Secret, error) {
+			return o.client.KubernetesInterface().CoreV1().Secrets("kube-system").Get("coreos-pull-secret", metav1.GetOptions{})
 		})
 
 		if err != nil {


### PR DESCRIPTION
The installer already creates a secret in the cluster [1] and there is no requirement to fetch the pull secret from cluster-config-v1 config map.

This also unblocks https://github.com/openshift/installer/pull/1379 to fix https://bugzilla.redhat.com/show_bug.cgi?id=1686119

[1]: https://github.com/openshift/installer/blob/13a752ea0fcae927cba6795782f87ffa332d5b75/data/data/manifests/bootkube/pull.yaml.template

/cc @deads2k 