### PR TITLE
pkg/client/condition: respect current and target version

### DIFF
--- a/pkg/client/clusteroperator.go
+++ b/pkg/client/clusteroperator.go
@@ -35,7 +35,7 @@ func (r *StatusReporter) SetDone() error {
 
 	time := metav1.Now()
 
-	conditions := newConditions(co.Status.Conditions, time)
+	conditions := newConditions(co.Status, r.version, time)
 	conditions.setCondition(v1.OperatorAvailable, v1.ConditionTrue, "Successfully rolled out the stack.", time)
 	conditions.setCondition(v1.OperatorProgressing, v1.ConditionFalse, "", time)
 	conditions.setCondition(v1.OperatorFailing, v1.ConditionFalse, "", time)
@@ -78,7 +78,7 @@ func (r *StatusReporter) SetInProgress() error {
 
 	time := metav1.Now()
 
-	conditions := newConditions(co.Status.Conditions, time)
+	conditions := newConditions(co.Status, r.version, time)
 	conditions.setCondition(v1.OperatorProgressing, v1.ConditionTrue, "Rolling out the stack.", time)
 	co.Status.Conditions = conditions.entries()
 
@@ -98,7 +98,7 @@ func (r *StatusReporter) SetFailed(statusErr error) error {
 
 	time := metav1.Now()
 
-	conditions := newConditions(co.Status.Conditions, time)
+	conditions := newConditions(co.Status, r.version, time)
 	conditions.setCondition(v1.OperatorAvailable, v1.ConditionFalse, "", time)
 	conditions.setCondition(v1.OperatorProgressing, v1.ConditionFalse, "", time)
 	conditions.setCondition(v1.OperatorFailing, v1.ConditionTrue, fmt.Sprintf("Failed to rollout the stack. Error: %v", statusErr), time)
@@ -121,7 +121,7 @@ func (r *StatusReporter) newClusterOperator() *v1.ClusterOperator {
 		Spec:   v1.ClusterOperatorSpec{},
 		Status: v1.ClusterOperatorStatus{},
 	}
-	co.Status.Conditions = newConditions(co.Status.Conditions, time).entries()
+	co.Status.Conditions = newConditions(co.Status, r.version, time).entries()
 
 	return co
 }

--- a/pkg/client/condition_test.go
+++ b/pkg/client/condition_test.go
@@ -68,7 +68,7 @@ func TestConditions(t *testing.T) {
 		{
 			name: "initial nil conditions",
 			conditions: func() *conditions {
-				return newConditions(nil, v1.Time{})
+				return newConditions(configv1.ClusterOperatorStatus{}, "", v1.Time{})
 			},
 			check: allUnknown,
 		},
@@ -76,7 +76,7 @@ func TestConditions(t *testing.T) {
 			name: "initial empty conditions",
 			conditions: func() *conditions {
 				return newConditions(
-					[]configv1.ClusterOperatorStatusCondition{}, v1.Time{},
+					configv1.ClusterOperatorStatus{Conditions: []configv1.ClusterOperatorStatusCondition{}}, "", v1.Time{},
 				)
 			},
 			check: allUnknown,
@@ -85,12 +85,14 @@ func TestConditions(t *testing.T) {
 			name: "initial failing condition",
 			conditions: func() *conditions {
 				return newConditions(
-					[]configv1.ClusterOperatorStatusCondition{
-						{
-							Type:   configv1.OperatorFailing,
-							Status: configv1.ConditionTrue,
+					configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorFailing,
+								Status: configv1.ConditionTrue,
+							},
 						},
-					}, v1.Time{},
+					}, "", v1.Time{},
 				)
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -115,10 +117,10 @@ func TestConditions(t *testing.T) {
 			}),
 		},
 		{
-			name: "progressing, previously available=unknown",
+			name: "progressing, previously unknown availability",
 			conditions: func() *conditions {
 				cs := newConditions(
-					[]configv1.ClusterOperatorStatusCondition{}, v1.Time{},
+					configv1.ClusterOperatorStatus{}, "", v1.Time{},
 				)
 				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
 				return cs
@@ -144,10 +146,10 @@ func TestConditions(t *testing.T) {
 				},
 			}),
 		}, {
-			name: "progressing, previously available=false",
+			name: "progressing, previously unavailable",
 			conditions: func() *conditions {
 				cs := newConditions(
-					[]configv1.ClusterOperatorStatusCondition{}, v1.Time{},
+					configv1.ClusterOperatorStatus{}, "", v1.Time{},
 				)
 				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "", v1.Time{})
 				cs.setCondition(configv1.OperatorFailing, configv1.ConditionFalse, "", v1.Time{})
@@ -175,23 +177,26 @@ func TestConditions(t *testing.T) {
 				},
 			}),
 		}, {
-			name: "not progressing, previously available=true",
+			name: "not progressing, previously available",
 			conditions: func() *conditions {
 				cs := newConditions(
-					[]configv1.ClusterOperatorStatusCondition{
-						{
-							Type:   configv1.OperatorFailing,
-							Status: configv1.ConditionFalse,
+					configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorFailing,
+								Status: configv1.ConditionFalse,
+							},
+							{
+								Type:   configv1.OperatorAvailable,
+								Status: configv1.ConditionTrue,
+							},
+							{
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionFalse,
+							},
 						},
-						{
-							Type:   configv1.OperatorAvailable,
-							Status: configv1.ConditionTrue,
-						},
-						{
-							Type:   configv1.OperatorProgressing,
-							Status: configv1.ConditionFalse,
-						},
-					}, v1.Time{},
+					},
+					"", v1.Time{},
 				)
 				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
 				return cs
@@ -217,17 +222,203 @@ func TestConditions(t *testing.T) {
 				},
 			}),
 		}, {
+			name: "not progressing, previously available, same version",
+			conditions: func() *conditions {
+				cs := newConditions(
+					configv1.ClusterOperatorStatus{
+						Versions: []configv1.OperandVersion{{Version: "1.0"}},
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorFailing,
+								Status: configv1.ConditionFalse,
+							},
+							{
+								Type:   configv1.OperatorAvailable,
+								Status: configv1.ConditionTrue,
+							},
+							{
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionFalse,
+							},
+						},
+					},
+					"1.0", v1.Time{},
+				)
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				return cs
+			},
+			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionFalse,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+				{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionTrue,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+				{
+					Type:               configv1.OperatorFailing,
+					Status:             configv1.ConditionFalse,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+			}),
+		}, {
+			name: "progressing, previously available, different version",
+			conditions: func() *conditions {
+				cs := newConditions(
+					configv1.ClusterOperatorStatus{
+						Versions: []configv1.OperandVersion{{Version: "1.0"}},
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorFailing,
+								Status: configv1.ConditionFalse,
+							},
+							{
+								Type:   configv1.OperatorAvailable,
+								Status: configv1.ConditionTrue,
+							},
+							{
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionFalse,
+							},
+						},
+					},
+					"1.1", v1.Time{},
+				)
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				return cs
+			},
+			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionTrue,
+					LastTransitionTime: v1.Unix(0, 0),
+					Message:            "",
+				},
+				{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionTrue,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+				{
+					Type:               configv1.OperatorFailing,
+					Status:             configv1.ConditionFalse,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+			}),
+		}, {
+			name: "progressing, previously unavailable, different version",
+			conditions: func() *conditions {
+				cs := newConditions(
+					configv1.ClusterOperatorStatus{
+						Versions: []configv1.OperandVersion{{Version: "1.0"}},
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorFailing,
+								Status: configv1.ConditionFalse,
+							},
+							{
+								Type:   configv1.OperatorAvailable,
+								Status: configv1.ConditionFalse,
+							},
+							{
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionFalse,
+							},
+						},
+					},
+					"1.1", v1.Time{},
+				)
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				return cs
+			},
+			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionTrue,
+					LastTransitionTime: v1.Unix(0, 0),
+					Message:            "",
+				},
+				{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionFalse,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+				{
+					Type:               configv1.OperatorFailing,
+					Status:             configv1.ConditionFalse,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+			}),
+		}, {
+			name: "progressing, previously unavailable, same version",
+			conditions: func() *conditions {
+				cs := newConditions(
+					configv1.ClusterOperatorStatus{
+						Versions: []configv1.OperandVersion{{Version: "1.0"}},
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorFailing,
+								Status: configv1.ConditionFalse,
+							},
+							{
+								Type:   configv1.OperatorAvailable,
+								Status: configv1.ConditionFalse,
+							},
+							{
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionFalse,
+							},
+						},
+					},
+					"1.0", v1.Time{},
+				)
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				return cs
+			},
+			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionTrue,
+					LastTransitionTime: v1.Unix(0, 0),
+					Message:            "",
+				},
+				{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionFalse,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+				{
+					Type:               configv1.OperatorFailing,
+					Status:             configv1.ConditionFalse,
+					LastTransitionTime: v1.Time{},
+					Message:            "",
+				},
+			}),
+		}, {
 			name: "change due to message change",
 			conditions: func() *conditions {
 				cs := newConditions(
-					[]configv1.ClusterOperatorStatusCondition{
-						{
-							Type:               configv1.OperatorAvailable,
-							Status:             configv1.ConditionTrue,
-							Message:            "foo",
-							LastTransitionTime: v1.Time{},
+					configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:               configv1.OperatorAvailable,
+								Status:             configv1.ConditionTrue,
+								Message:            "foo",
+								LastTransitionTime: v1.Time{},
+							},
 						},
-					}, v1.Time{},
+					}, "", v1.Time{},
 				)
 				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "bar", v1.Unix(0, 0))
 				return cs
@@ -256,14 +447,16 @@ func TestConditions(t *testing.T) {
 			name: "change due to status change",
 			conditions: func() *conditions {
 				cs := newConditions(
-					[]configv1.ClusterOperatorStatusCondition{
-						{
-							Type:               configv1.OperatorAvailable,
-							Status:             configv1.ConditionTrue,
-							Message:            "foo",
-							LastTransitionTime: v1.Time{},
+					configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:               configv1.OperatorAvailable,
+								Status:             configv1.ConditionTrue,
+								Message:            "foo",
+								LastTransitionTime: v1.Time{},
+							},
 						},
-					}, v1.Time{},
+					}, "", v1.Time{},
 				)
 				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "foo", v1.Unix(0, 0))
 				return cs
@@ -292,14 +485,16 @@ func TestConditions(t *testing.T) {
 			name: "no change due to no message/status change",
 			conditions: func() *conditions {
 				cs := newConditions(
-					[]configv1.ClusterOperatorStatusCondition{
-						{
-							Type:               configv1.OperatorAvailable,
-							Status:             configv1.ConditionTrue,
-							Message:            "foo",
-							LastTransitionTime: v1.Time{},
+					configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:               configv1.OperatorAvailable,
+								Status:             configv1.ConditionTrue,
+								Message:            "foo",
+								LastTransitionTime: v1.Time{},
+							},
 						},
-					}, v1.Time{},
+					}, "", v1.Time{},
 				)
 				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "foo", v1.Unix(0, 0))
 				return cs


### PR DESCRIPTION
Currently, we ignore the versions of the operator
and only set to progressing if the operator has been failing before.

This fixes it by also also respecting the current version of the operator.
If the target version is the same, the existing rules apply.
If the current version is different, we always set to progressing.

Fixes a part of https://bugzilla.redhat.com/show_bug.cgi?id=1690162
where the operator was launched with a new version but did not report
a progressing state.

cc @brancz @squat @metalmatze