### PR TITLE
use new instructions on how to build go-jsonnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ $(JB_BIN):
 	go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 
 $(JSONNET_BIN):
-	go get -u github.com/google/go-jsonnet/jsonnet
+	go get -u github.com/google/go-jsonnet/cmd/jsonnet
 
 test-unit:
 	go test $(PKGS)


### PR DESCRIPTION
Change needed due to https://github.com/google/go-jsonnet/pull/266