### PR TITLE
Bug 1697644: operator: use openshift-config/pull-secret to fetch the pull secret for cloud.openshift.com

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -365,7 +365,7 @@ func (o *Operator) Config(key string) *manifests.Config {
 		}
 
 		err = c.LoadToken(func() (*v1.Secret, error) {
-			return o.client.KubernetesInterface().CoreV1().Secrets("kube-system").Get("coreos-pull-secret", metav1.GetOptions{})
+			return o.client.KubernetesInterface().CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
 		})
 
 		if err != nil {


### PR DESCRIPTION
The operator should be using the openshift-config/pull-secret as the kube-system/coreos-pull-secret has been marked deprecated.

/cc @derekwaynecarr @smarterclayton 