### PR TITLE
Support previous bash versions (Mac included)

### DIFF
--- a/hack/build-jsonnet.sh
+++ b/hack/build-jsonnet.sh
@@ -13,7 +13,11 @@ mkdir tmp
 
 jsonnet -J jsonnet/vendor jsonnet/main.jsonnet > tmp/main.json
 
-mapfile -t files < <(jq -r 'keys[]' tmp/main.json)
+# Replace mapfile with while loop so it works with previous bash versions (Mac included)
+#mapfile -t files < <(jq -r 'keys[]' tmp/main.json)
+while IFS= read -r line; do
+    files+=("$line")
+done < <(jq -r 'keys[]' tmp/main.json)
 
 for file in "${files[@]}"
 do


### PR DESCRIPTION
This change makes the script work on previous Bash versions, including the one shipped on MacOs.

To be able to run on Macs, the script also needs gawk installed since default awk errors out. One can install with `brew install gawk`.