### PR TITLE
Update cluster-monitoring-operator image

### DIFF
--- a/manifests/cluster-monitoring-operator.yaml
+++ b/manifests/cluster-monitoring-operator.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       serviceAccountName: cluster-monitoring-operator
       containers:
-      - image: quay.io/coreos/cluster-monitoring-operator:v0.0.6
+      - image: quay.io/coreos/cluster-monitoring-operator:v0.1.1
         name: cluster-monitoring-operator
         args:
         - "-namespace=openshift-monitoring"


### PR DESCRIPTION
With previous version (v0.0.6) when the CMO got deployed into a `oc cluster up` cluster, Grafana was not deployed. With version v0.1.1, the monitoring stack was correctly deployed.

This was tested on a "Openshift on Footloose" that is a Docker in Docker deployment for it. Ref. https://github.com/carlosedp/openshift-on-footloose