### PR TITLE
pkg/client: compare Service object before updating it

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -750,6 +750,11 @@ func (c *Client) CreateOrUpdateService(svc *v1.Service) error {
 	if svc.Spec.Type == v1.ServiceTypeClusterIP {
 		svc.Spec.ClusterIP = s.Spec.ClusterIP
 	}
+
+	if reflect.DeepEqual(svc, s) {
+		return nil
+	}
+
 	_, err = sclient.Update(svc)
 	return errors.Wrap(err, "updating Service object failed")
 }


### PR DESCRIPTION
Currently we are updating Service resource every 5 minutes which causes certificate renewal and in turn recreation of prometheus-adapter. This change prevents unnecessary updates of Service resource.

https://bugzilla.redhat.com/show_bug.cgi?id=1700037

Verification steps taken:

1. Disabled CVO and CMO in openshift cluster
2. Built and ran cluster-monitoring-operator from my machine
3. Got a prometheus-adapter secret just after starting cmo
```
$ oc -n openshift-monitoring get secrets | grep prometheus-adapter            
prometheus-adapter-dockercfg-4mbd9                kubernetes.io/dockercfg               1         2d
prometheus-adapter-f3opuef14ihn0                  Opaque                                4         24h
prometheus-adapter-tls                            kubernetes.io/tls                     2         2d
prometheus-adapter-token-5wcb2                    kubernetes.io/service-account-token   4         2d
prometheus-adapter-token-n528w                    kubernetes.io/service-account-token   4         2d
```
4. Waited 6 minutes and repeated previous step to check if secret changed
```
$ sleep 6m; oc -n openshift-monitoring get secrets | grep prometheus-adapter
prometheus-adapter-dockercfg-4mbd9                kubernetes.io/dockercfg               1         2d
prometheus-adapter-f3opuef14ihn0                  Opaque                                4         24h
prometheus-adapter-tls                            kubernetes.io/tls                     2         2d
prometheus-adapter-token-5wcb2                    kubernetes.io/service-account-token   4         2d
prometheus-adapter-token-n528w                    kubernetes.io/service-account-token   4         2d
```

prometheus-adapter pod also wasn't automatically redeployed during whole test

@brancz @metalmatze @mxinden @s-urbaniak @squat