### PR TITLE
pkg/client: compare only parts of Service resource instead of full object

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -751,7 +751,7 @@ func (c *Client) CreateOrUpdateService(svc *v1.Service) error {
 		svc.Spec.ClusterIP = s.Spec.ClusterIP
 	}
 
-	if reflect.DeepEqual(svc, s) {
+	if reflect.DeepEqual(svc.Spec, s.Spec) && reflect.DeepEqual(svc.Annotations, s.Annotations) && reflect.DeepEqual(svc.Labels, s.Labels) {
 		return nil
 	}
 


### PR DESCRIPTION
Follow up to #328.

Check only spec, labels, and annotations instead of whole object.

@brancz @s-urbaniak @squat 