### PR TITLE
pkg/tasks/prometheusadapter: deploy aggregated cluster role

### DIFF
--- a/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
+++ b/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "2357f04d0532b0846f2aae85854d5932db6c4160"
+            "version": "c61a7f0f9ce2e78eb4e7eb575b792d8207983a3d"
         },
         {
             "name": "ksonnet",

--- a/manifests/02-role.yaml
+++ b/manifests/02-role.yaml
@@ -9,6 +9,7 @@
 # 	assets/kube-state-metrics/cluster-role.yaml
 # 	assets/kube-state-metrics/role.yaml
 # 	assets/node-exporter/cluster-role.yaml
+# 	assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
 # 	assets/prometheus-adapter/cluster-role-server-resources.yaml
 # 	assets/prometheus-adapter/cluster-role.yaml
 # 	assets/prometheus-k8s/cluster-role.yaml
@@ -223,6 +224,14 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - metrics.k8s.io
   resources:

--- a/pkg/manifests/bindata.go
+++ b/pkg/manifests/bindata.go
@@ -40,6 +40,7 @@
 // assets/node-exporter/service-monitor.yaml
 // assets/node-exporter/service.yaml
 // assets/prometheus-adapter/api-service.yaml
+// assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
 // assets/prometheus-adapter/cluster-role-binding-delegator.yaml
 // assets/prometheus-adapter/cluster-role-binding-view.yaml
 // assets/prometheus-adapter/cluster-role-binding.yaml
@@ -953,6 +954,26 @@ func assetsPrometheusAdapterApiServiceYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "assets/prometheus-adapter/api-service.yaml", size: 373, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _assetsPrometheusAdapterClusterRoleAggregatedMetricsReaderYaml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x8f\x3d\x4b\x04\x41\x0c\x86\xfb\xf9\x15\xe1\xfa\x59\xb1\x93\x69\x2d\xec\x2d\xec\xb3\x3b\x2f\x7b\xe1\xe6\x63\x49\x32\x7b\xe8\xaf\x17\xcf\x45\xac\x04\xaf\xca\x4b\xf2\x3c\x09\xe1\x4d\xde\xa0\x26\xbd\x25\xd2\x99\x97\x89\x87\x9f\xbb\xca\x07\xbb\xf4\x36\x5d\x9e\x6c\x92\xfe\xb0\x3f\x86\x8b\xb4\x9c\xe8\xb9\x0c\x73\xe8\x6b\x2f\x08\x15\xce\x99\x9d\x53\x20\x2a\x3c\xa3\xd8\x57\xa2\x3f\xd6\xf0\xba\x2a\x56\x76\x44\xef\x91\x73\x95\x96\xe8\xe4\x3a\x70\xfa\x8f\x88\x2c\x7e\x8f\xb7\x0b\xae\xbf\xbc\xc6\x15\x89\xec\xdd\x1c\x35\xfd\x80\x39\x56\xb8\xca\x62\x51\xc1\x19\x1a\x74\x14\x58\x0a\x91\x78\x93\x17\xed\x63\xbb\x7d\x19\xe9\xc0\x8e\x4b\x81\x48\x61\x7d\xe8\x82\x63\xbe\xf5\x6c\x81\x68\x87\xce\x47\x67\x85\xdf\x6a\x11\xfb\x0e\x57\xf6\xe5\x1c\x3e\x03\x00\x00\xff\xff\x06\xc1\x51\xa4\x82\x01\x00\x00")
+
+func assetsPrometheusAdapterClusterRoleAggregatedMetricsReaderYamlBytes() ([]byte, error) {
+	return bindataRead(
+		_assetsPrometheusAdapterClusterRoleAggregatedMetricsReaderYaml,
+		"assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml",
+	)
+}
+
+func assetsPrometheusAdapterClusterRoleAggregatedMetricsReaderYaml() (*asset, error) {
+	bytes, err := assetsPrometheusAdapterClusterRoleAggregatedMetricsReaderYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml", size: 386, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2049,6 +2070,7 @@ var _bindata = map[string]func() (*asset, error){
 	"assets/node-exporter/service-monitor.yaml": assetsNodeExporterServiceMonitorYaml,
 	"assets/node-exporter/service.yaml": assetsNodeExporterServiceYaml,
 	"assets/prometheus-adapter/api-service.yaml": assetsPrometheusAdapterApiServiceYaml,
+	"assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml": assetsPrometheusAdapterClusterRoleAggregatedMetricsReaderYaml,
 	"assets/prometheus-adapter/cluster-role-binding-delegator.yaml": assetsPrometheusAdapterClusterRoleBindingDelegatorYaml,
 	"assets/prometheus-adapter/cluster-role-binding-view.yaml": assetsPrometheusAdapterClusterRoleBindingViewYaml,
 	"assets/prometheus-adapter/cluster-role-binding.yaml": assetsPrometheusAdapterClusterRoleBindingYaml,
@@ -2193,6 +2215,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		}},
 		"prometheus-adapter": &bintree{nil, map[string]*bintree{
 			"api-service.yaml": &bintree{assetsPrometheusAdapterApiServiceYaml, map[string]*bintree{}},
+			"cluster-role-aggregated-metrics-reader.yaml": &bintree{assetsPrometheusAdapterClusterRoleAggregatedMetricsReaderYaml, map[string]*bintree{}},
 			"cluster-role-binding-delegator.yaml": &bintree{assetsPrometheusAdapterClusterRoleBindingDelegatorYaml, map[string]*bintree{}},
 			"cluster-role-binding-view.yaml": &bintree{assetsPrometheusAdapterClusterRoleBindingViewYaml, map[string]*bintree{}},
 			"cluster-role-binding.yaml": &bintree{assetsPrometheusAdapterClusterRoleBindingYaml, map[string]*bintree{}},

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -91,18 +91,19 @@ var (
 	PrometheusK8sServingCertsCABundle                 = "assets/prometheus-k8s/serving-certs-ca-bundle.yaml"
 	PrometheusK8sKubeletServingCABundle               = "assets/prometheus-k8s/kubelet-serving-ca-bundle.yaml"
 
-	PrometheusAdapterAPIService                  = "assets/prometheus-adapter/api-service.yaml"
-	PrometheusAdapterClusterRole                 = "assets/prometheus-adapter/cluster-role.yaml"
-	PrometheusAdapterClusterRoleBinding          = "assets/prometheus-adapter/cluster-role-binding.yaml"
-	PrometheusAdapterClusterRoleBindingDelegator = "assets/prometheus-adapter/cluster-role-binding-delegator.yaml"
-	PrometheusAdapterClusterRoleBindingView      = "assets/prometheus-adapter/cluster-role-binding-view.yaml"
-	PrometheusAdapterClusterRoleServerResources  = "assets/prometheus-adapter/cluster-role-server-resources.yaml"
-	PrometheusAdapterConfigMap                   = "assets/prometheus-adapter/config-map.yaml"
-	PrometheusAdapterConfigMapPrometheus         = "assets/prometheus-adapter/configmap-prometheus.yaml"
-	PrometheusAdapterDeployment                  = "assets/prometheus-adapter/deployment.yaml"
-	PrometheusAdapterRoleBindingAuthReader       = "assets/prometheus-adapter/role-binding-auth-reader.yaml"
-	PrometheusAdapterService                     = "assets/prometheus-adapter/service.yaml"
-	PrometheusAdapterServiceAccount              = "assets/prometheus-adapter/service-account.yaml"
+	PrometheusAdapterAPIService                         = "assets/prometheus-adapter/api-service.yaml"
+	PrometheusAdapterClusterRole                        = "assets/prometheus-adapter/cluster-role.yaml"
+	PrometheusAdapterClusterRoleBinding                 = "assets/prometheus-adapter/cluster-role-binding.yaml"
+	PrometheusAdapterClusterRoleBindingDelegator        = "assets/prometheus-adapter/cluster-role-binding-delegator.yaml"
+	PrometheusAdapterClusterRoleBindingView             = "assets/prometheus-adapter/cluster-role-binding-view.yaml"
+	PrometheusAdapterClusterRoleServerResources         = "assets/prometheus-adapter/cluster-role-server-resources.yaml"
+	PrometheusAdapterClusterRoleAggregatedMetricsReader = "assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml"
+	PrometheusAdapterConfigMap                          = "assets/prometheus-adapter/config-map.yaml"
+	PrometheusAdapterConfigMapPrometheus                = "assets/prometheus-adapter/configmap-prometheus.yaml"
+	PrometheusAdapterDeployment                         = "assets/prometheus-adapter/deployment.yaml"
+	PrometheusAdapterRoleBindingAuthReader              = "assets/prometheus-adapter/role-binding-auth-reader.yaml"
+	PrometheusAdapterService                            = "assets/prometheus-adapter/service.yaml"
+	PrometheusAdapterServiceAccount                     = "assets/prometheus-adapter/service-account.yaml"
 
 	PrometheusOperatorClusterRoleBinding = "assets/prometheus-operator/cluster-role-binding.yaml"
 	PrometheusOperatorClusterRole        = "assets/prometheus-operator/cluster-role.yaml"
@@ -834,6 +835,10 @@ func (f *Factory) PrometheusAdapterClusterRole() (*rbacv1beta1.ClusterRole, erro
 
 func (f *Factory) PrometheusAdapterClusterRoleServerResources() (*rbacv1beta1.ClusterRole, error) {
 	return f.NewClusterRole(MustAssetReader(PrometheusAdapterClusterRoleServerResources))
+}
+
+func (f *Factory) PrometheusAdapterClusterRoleAggregatedMetricsReader() (*rbacv1beta1.ClusterRole, error) {
+	return f.NewClusterRole(MustAssetReader(PrometheusAdapterClusterRoleAggregatedMetricsReader))
 }
 
 func (f *Factory) PrometheusAdapterClusterRoleBinding() (*rbacv1beta1.ClusterRoleBinding, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -192,6 +192,11 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = f.PrometheusAdapterClusterRoleAggregatedMetricsReader()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = f.PrometheusAdapterClusterRoleBinding()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/tasks/prometheusadapter.go
+++ b/pkg/tasks/prometheusadapter.go
@@ -45,6 +45,17 @@ func (t *PrometheusAdapterTask) Run() error {
 		}
 	}
 	{
+		cr, err := t.factory.PrometheusAdapterClusterRoleAggregatedMetricsReader()
+		if err != nil {
+			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRole aggregating resource metrics read permissions failed")
+		}
+
+		err = t.client.CreateOrUpdateClusterRole(cr)
+		if err != nil {
+			return errors.Wrap(err, "reconciling PrometheusAdapter ClusterRole aggregating resource metrics read permissions failed")
+		}
+	}
+	{
 		crb, err := t.factory.PrometheusAdapterClusterRoleBinding()
 		if err != nil {
 			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRoleBinding failed")

--- a/test/e2e/prometheusadapter_test.go
+++ b/test/e2e/prometheusadapter_test.go
@@ -17,14 +17,82 @@ package e2e
 import (
 	"fmt"
 	"log"
+	"sort"
 	"testing"
 	"time"
+
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+func TestAggregatedMetricPermissions(t *testing.T) {
+	present := func(where []string, what string) bool {
+		sort.Strings(where)
+		i := sort.SearchStrings(where, what)
+		return i < len(where) && where[i] == what
+	}
+
+	type checkFunc func(clusterRole string) error
+
+	hasRule := func(apiGroup, resource, verb string) checkFunc {
+		return func(clusterRole string) error {
+			return framework.Poll(time.Second, 5*time.Minute, func() error {
+				viewRole, err := f.KubeClient.RbacV1().ClusterRoles().Get(clusterRole, metav1.GetOptions{})
+				if err != nil {
+					return errors.Wrapf(err, "getting %s cluster role failed", clusterRole)
+				}
+
+				for _, rule := range viewRole.Rules {
+					if !present(rule.APIGroups, apiGroup) {
+						continue
+					}
+
+					if !present(rule.Resources, resource) {
+						continue
+					}
+
+					if !present(rule.Verbs, verb) {
+						continue
+					}
+
+					return nil
+				}
+
+				return fmt.Errorf("could not find metrics in cluster role %s", clusterRole)
+			})
+		}
+	}
+
+	canGetPodMetrics := hasRule("metrics.k8s.io", "pods", "get")
+
+	for _, tc := range []struct {
+		clusterRole string
+		check       checkFunc
+	}{
+		{
+			clusterRole: "view",
+			check:       canGetPodMetrics,
+		},
+		{
+			clusterRole: "edit",
+			check:       canGetPodMetrics,
+		},
+		{
+			clusterRole: "admin",
+			check:       canGetPodMetrics,
+		},
+	} {
+		t.Run(tc.clusterRole, func(t *testing.T) {
+			if err := tc.check(tc.clusterRole); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
 
 func TestPrometheusAdapterCARotation(t *testing.T) {
 	var lastErr error


### PR DESCRIPTION
Currently, only cluster wide admins have the permissions to view metrics 
resources. This fixes it by adding a read-only cluster role which includes 
aggregation labels to synthesize permission rules for standard user-facing 
roles according to [1].

Note that only the "pods" resource is granted as reading "nodes" metrics 
requires a cluster wide permission.

[1] https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1701343