### PR TITLE
test/e2e: use built-in logger insted of 'log'

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -34,7 +33,7 @@ func TestAlertmanagerVolumeClaim(t *testing.T) {
 		},
 	})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	cm := &v1.ConfigMap{
@@ -55,7 +54,7 @@ func TestAlertmanagerVolumeClaim(t *testing.T) {
 	}
 
 	if err := f.OperatorClient.CreateOrUpdateConfigMap(cm); err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	var lastErr error
@@ -72,7 +71,7 @@ func TestAlertmanagerVolumeClaim(t *testing.T) {
 		if err == wait.ErrWaitTimeout && lastErr != nil {
 			err = lastErr
 		}
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	err = f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
@@ -82,6 +81,6 @@ func TestAlertmanagerVolumeClaim(t *testing.T) {
 		},
 	})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 }

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -15,13 +15,12 @@
 package e2e
 
 import (
-	"log"
 	"strconv"
 	"testing"
 	"time"
 
 	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -40,7 +39,7 @@ func TestMultinamespacePrometheusRule(t *testing.T) {
 		},
 	})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	defer f.OperatorClient.DeleteIfExists(nsName)
 
@@ -64,7 +63,7 @@ func TestMultinamespacePrometheusRule(t *testing.T) {
 		},
 	})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	f.PrometheusK8sClient.WaitForQueryReturnOne(

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -34,7 +33,7 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 		},
 	})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	cm := &v1.ConfigMap{
@@ -55,7 +54,7 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 	}
 
 	if err := f.OperatorClient.CreateOrUpdateConfigMap(cm); err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	var lastErr error
@@ -72,7 +71,7 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 		if err == wait.ErrWaitTimeout && lastErr != nil {
 			err = lastErr
 		}
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	err = f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
@@ -82,6 +81,6 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 		},
 	})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 }

--- a/test/e2e/prometheusadapter_test.go
+++ b/test/e2e/prometheusadapter_test.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"testing"
 	"time"
@@ -109,17 +108,17 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 		if err == wait.ErrWaitTimeout && lastErr != nil {
 			err = lastErr
 		}
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	apiAuth, err := f.KubeClient.CoreV1().ConfigMaps("kube-system").Get("extension-apiserver-authentication", metav1.GetOptions{})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	tls, err := f.KubeClient.CoreV1().Secrets("openshift-monitoring").Get("prometheus-adapter-tls", metav1.GetOptions{})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	// Simulate rotation by simply adding a newline to existing certs.
@@ -128,13 +127,13 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 	apiAuth.Data["requestheader-client-ca-file"] = apiAuth.Data["requestheader-client-ca-file"] + "\n"
 	apiAuth, err = f.KubeClient.CoreV1().ConfigMaps("kube-system").Update(apiAuth)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	factory := manifests.NewFactory("openshift-monitoring", nil)
 	newSecret, err := factory.PrometheusAdapterSecret(tls, apiAuth)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	// Wait for the new secret to be created
@@ -150,7 +149,7 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 		if err == wait.ErrWaitTimeout && lastErr != nil {
 			err = lastErr
 		}
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	// Wait for new Prometheus adapter to roll out
@@ -168,6 +167,6 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 		if err == wait.ErrWaitTimeout && lastErr != nil {
 			err = lastErr
 		}
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Since testing framework supports logging we should use it instead of using golang log module.

Spawned by #314