### PR TITLE
test/e2e: Remove tests for components this repo is not responsible for

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -114,17 +114,11 @@ func TestTargetsUp(t *testing.T) {
 
 	targets := []string{
 		"node-exporter",
-		"kubelet",
-		//"scheduler",
-		//"kube-controller-manager",
-		"apiserver",
 		"kube-state-metrics",
 		"prometheus-k8s",
 		"prometheus-operator",
 		"alertmanager-main",
-		"crio",
 		"telemeter-client",
-		"etcd",
 	}
 
 	for _, target := range targets {


### PR DESCRIPTION
Removing these components to block our own e2e tests, as we don't control these components here and they're already being tested for in the e2e-aws job. Opening a PR to test for etcd metrics to be tested additionally in the e2e-aws job.

@s-urbaniak @squat @mxinden @metalmatze @paulfantom 