### PR TITLE
client: force JSON client for security client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -90,7 +90,12 @@ func New(cfg *rest.Config, version string, namespace string, namespaceSelector s
 		return nil, errors.Wrap(err, "creating openshift config client")
 	}
 
-	ossclient, err := openshiftsecurityclientset.NewForConfig(cfg)
+	// SCC moved to CRD and CRD does not handle protobuf. Force the SCC client to use JSON instead.
+	jsonClientConfig := rest.CopyConfig(cfg)
+	jsonClientConfig.ContentConfig.AcceptContentTypes = "application/json"
+	jsonClientConfig.ContentConfig.ContentType = "application/json"
+
+	ossclient, err := openshiftsecurityclientset.NewForConfig(jsonClientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating openshift security client")
 	}


### PR DESCRIPTION
As SCC is moving to CRD resource we need to force the `application/json` content type for the client that create the SCC manifests in order for it to create the SCC.

/cc @deads2k 
/cc @sallyom 