### PR TITLE
BUG 1707477: manifests: label namespace

### DIFF
--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -6,3 +6,5 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"
+    name: openshift-monitoring
+    network.openshift.io/policy-group: monitoring


### PR DESCRIPTION
Add some labels to the openshift-monitoring namespace so people can select with network policies.

(Network policies don't let you select by name - only by labels).