### PR TITLE
Refactor build system and use pre-built container image for make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ operator
 
 jsonnet/vendor/
 tmp/
+
+# These are empty target files, created on every docker build. Their sole
+# purpose is to track the last target execution time to evalualte, whether the
+# container needds to be rebuild
+.hack-*-image

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
+---
 sudo: required
+dist: xenial
 language: go
 go:
 - "1.10"
+# TODO(paulfantom): uncomment when moving to go 1.12
+#- "1.12.x"
+go_import_path: github.com/openshift/cluster-monitoring-operator
+# TODO(paulfantom): uncomment when moving to go 1.12
+#env:
+#  - GO111MODULE=on
+cache:
+  directories:
+  - $GOCACHE
+  - $GOPATH/pkg/mod
 services:
 - docker
 jobs:
@@ -9,6 +21,6 @@ jobs:
   - script: ./hack/yamllint.sh .
   - script: make test-unit
   - stage: Build
-    script: make dependencies build
-  - script: make generate && git diff --exit-code
-  - script: make container
+    script: make build-in-docker
+  - script: make generate-in-docker && git diff --exit-code
+  - script: make image

--- a/Dockerfile.generate
+++ b/Dockerfile.generate
@@ -1,7 +1,0 @@
-FROM golang:1.11-stretch
-
-RUN apt-get update && \
-    apt-get install -y python-yaml jq gawk
-
-RUN mkdir -p /go/src/github.com
-RUN chmod -R 777 /go


### PR DESCRIPTION
Running `go get` in every CI pipeline leads to unpredictable problems due to lack of ability of locking version of downloaded binary. Instead of relying on `go get` we can use pre-built container image with already installed binaries. This is an attempt on using such container. 

Container is build from https://github.com/paulfantom/dockerfiles/blob/master/jsonnet/Dockerfile and stored in [quay.io](https://quay.io/repository/paulfantom/jsonnet-ci)

PR is built on top of #350

/cc @metalmatze @s-urbaniak 