### PR TITLE
Bug 1721919: Pin kube-prometheus and telemeter to release branches

### DIFF
--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "master"
+            "version": "release-0.1"
         },
         {
             "name": "telemeter-client",
@@ -18,7 +18,7 @@
                     "subdir": "jsonnet/telemeter"
                 }
             },
-            "version": "master"
+            "version": "release-4.1"
         }
     ]
 }


### PR DESCRIPTION
This will pin the currently used kube-prometheus and telemter branches to a compatible version for the cluster monitoring operator to make it as easy as running `jb update` to get bug fixes in.

/cc @squat @s-urbaniak @brancz @paulfantom 