### PR TITLE
the sudo key is no longer needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: required
 dist: xenial
 language: go
 go:


### PR DESCRIPTION
see: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration