### PR TITLE
[BUG 1717634] pkg/client: add support for relatedObjects in status report

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -958,5 +958,5 @@ func (c *Client) CRDReady(crd *extensionsobj.CustomResourceDefinition) (bool, er
 }
 
 func (c *Client) StatusReporter() *StatusReporter {
-	return NewStatusReporter(c.oscclient.Config().ClusterOperators(), "monitoring", c.version)
+	return NewStatusReporter(c.oscclient.Config().ClusterOperators(), "monitoring", c.namespace, c.version)
 }

--- a/pkg/client/clusteroperator.go
+++ b/pkg/client/clusteroperator.go
@@ -12,13 +12,15 @@ import (
 type StatusReporter struct {
 	client              clientv1.ClusterOperatorInterface
 	clusterOperatorName string
+	namespace           string
 	version             string
 }
 
-func NewStatusReporter(client clientv1.ClusterOperatorInterface, name, version string) *StatusReporter {
+func NewStatusReporter(client clientv1.ClusterOperatorInterface, name, namespace, version string) *StatusReporter {
 	return &StatusReporter{
 		client:              client,
 		clusterOperatorName: name,
+		namespace:           namespace,
 		version:             version,
 	}
 }
@@ -121,6 +123,11 @@ func (r *StatusReporter) newClusterOperator() *v1.ClusterOperator {
 		Spec:   v1.ClusterOperatorSpec{},
 		Status: v1.ClusterOperatorStatus{},
 	}
+	co.Status.RelatedObjects = []v1.ObjectReference{
+		{Group: "operator.openshift.io", Resource: "monitoring", Name: "cluster"},
+		{Resource: "namespaces", Name: r.namespace},
+	}
+
 	co.Status.Conditions = newConditions(co.Status, r.version, time).entries()
 
 	return co


### PR DESCRIPTION
Status report based on https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/pkg/operator/starter.go#L123-L129

This should pass following test: https://github.com/openshift/origin/blob/master/test/extended/operators/clusteroperators.go#L60-L77

After merging this should be cherry-picked to release-4.1 branch.

/cc @s-urbaniak