### PR TITLE
manifests: Allow configuring remote write endpoint

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	v1 "k8s.io/api/core/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -73,6 +74,7 @@ type PrometheusK8sConfig struct {
 	ExternalLabels      map[string]string         `json:"externalLabels"`
 	VolumeClaimTemplate *v1.PersistentVolumeClaim `json:"volumeClaimTemplate"`
 	Hostport            string                    `json:"hostport"`
+	RemoteWrite         []monv1.RemoteWriteSpec   `json:"remoteWrite"`
 }
 
 type AlertmanagerMainConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -739,6 +739,10 @@ func (f *Factory) PrometheusK8s(host string) (*monv1.Prometheus, error) {
 		}
 	}
 
+	if len(f.config.PrometheusK8sConfig.RemoteWrite) > 0 {
+		p.Spec.RemoteWrite = f.config.PrometheusK8sConfig.RemoteWrite
+	}
+
 	if !f.config.EtcdConfig.IsEnabled() {
 		secrets := []string{}
 		for _, s := range p.Spec.Secrets {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -607,6 +607,8 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
       memory: 750Mi
   externalLabels:
     datacenter: eu-west
+  remoteWrite:
+  - url: "https://test.remotewrite.com/api/write"
 ingress:
   baseAddress: monitoring-demo.staging.core-os.net
 `)
@@ -685,6 +687,10 @@ ingress:
 	storageRequestPtr := &storageRequest
 	if storageRequestPtr.String() != "15Gi" {
 		t.Fatal("Prometheus volumeClaimTemplate not configured correctly, expected 15Gi storage request, but found", storageRequestPtr.String())
+	}
+
+	if p.Spec.RemoteWrite[0].URL != "https://test.remotewrite.com/api/write" {
+		t.Fatal("Prometheus remote-write is not configured correctly")
 	}
 }
 


### PR DESCRIPTION
This adds the ability to configure remote write endpoints for the cluster-monitoring Prometheus server to replicate its data to a remote write backend.

@squat @sichvoge 