### PR TITLE
Add gosec for security code analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,11 @@ test-e2e: KUBECONFIG?=$(HOME)/.kube/config
 test-e2e:
 	go test -v -timeout=20m ./test/e2e/ --kubeconfig $(KUBECONFIG)
 
+.PHONY: test-sec
+test-sec:
+	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
+	gosec -severity medium --confidence medium -quiet ./...
+
 ############
 # Binaries #
 ############

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -16,6 +16,7 @@ package manifests
 
 import (
 	"bytes"
+	// #nosec
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
@@ -587,6 +588,8 @@ func (f *Factory) PrometheusK8sHtpasswdSecret(password string) (*v1.Secret, erro
 		return nil, err
 	}
 
+	// #nosec
+	// TODO: Replace this with a safer algorithm
 	h := sha1.New()
 	h.Write([]byte(password))
 	s.Data["auth"] = []byte("internal:{SHA}" + base64.StdEncoding.EncodeToString(h.Sum(nil)))

--- a/test/e2e/framework/prometheus_client.go
+++ b/test/e2e/framework/prometheus_client.go
@@ -76,6 +76,7 @@ func NewPrometheusClient(
 // Query runs an http get request against the Prometheus query api and returns
 // the response body.
 func (c *PrometheusClient) Query(query string) ([]byte, error) {
+	// #nosec
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}


### PR DESCRIPTION
This adds a "test-sec" target to the Makefile, which will trigger gosec. gosec will do static analysis on the go code to check for common security issues.

This PR also tags some low priority warnings so they don't appear as errors when triggering this test.