### PR TITLE
Makefile: fix openshift-state-metrics role rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,9 @@ pkg/manifests/bindata.go: $(GOBINDATA_BIN) $(ASSETS)
 	# Using "-modtime 1" to make generate target deterministic. It sets all file time stamps to unix timestamp 1
 	go-bindata -mode 420 -modtime 1 -pkg manifests -o $@ assets/...
 
-merge-cluster-roles: manifests/02-role.yaml
-manifests/02-role.yaml: $(ASSETS) hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in
-	python2 hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in `find assets | grep role | grep -v "role-binding" | sort` > manifests/02-role.yaml
+merge-cluster-roles: manifests/0000_50_cluster_monitoring_operator_02-role.yaml
+manifests/0000_50_cluster_monitoring_operator_02-role.yaml: $(ASSETS) hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in
+	python2 hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in `find assets | grep role | grep -v "role-binding" | sort` > $@
 
 .PHONY: docs
 docs:

--- a/manifests/0000_50_cluster_monitoring_operator_02-role.yaml
+++ b/manifests/0000_50_cluster_monitoring_operator_02-role.yaml
@@ -10,7 +10,6 @@
 # 	assets/kube-state-metrics/role.yaml
 # 	assets/node-exporter/cluster-role.yaml
 # 	assets/openshift-state-metrics/cluster-role.yaml
-# 	assets/openshift-state-metrics/role.yaml
 # 	assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
 # 	assets/prometheus-adapter/cluster-role-server-resources.yaml
 # 	assets/prometheus-adapter/cluster-role.yaml
@@ -255,24 +254,6 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups:
-  - extensions
-  resourceNames:
-  - openshift-state-metrics
-  resources:
-  - deployments
-  verbs:
-  - get
-  - update
-- apiGroups:
-  - apps
-  resourceNames:
-  - openshift-state-metrics
-  resources:
-  - deployments
-  verbs:
-  - get
-  - update
 - apiGroups:
   - metrics.k8s.io
   resources:


### PR DESCRIPTION
This commit fixes the rules added by the openshift-state-metics rule. It
seems like this file was built by hand instead of using the build
script. This is a result of the renaming of the generated role file: now
that the file has a different name, the make target was wrong.

This fixes the name of the target in the Makefile and regenerates the
file.

cc @paulfantom @wanghaoran1988