### PR TITLE
hack: add script to run shellcheck in a container and outside of it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ go-fmt:
 
 .PHONY: shellcheck
 shellcheck:
-	docker run -v "${PWD}:/mnt" koalaman/shellcheck:stable $(shell find . -type f -name "*.sh" -not -path "*vendor*")
+	hack/shellcheck.sh
 
 ###########
 # Testing #

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+if [ "$IS_CONTAINER" != "" ]; then
+  TOP_DIR="${1:-.}"
+  find "${TOP_DIR}" \
+    -path "${TOP_DIR}/vendor" -prune \
+    -o -path "${TOP_DIR}/jsonnet/vendor" -prune \
+    -o -type f -name '*.sh' -exec shellcheck --format=gcc {} \+
+else
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:ro,z" \
+    --entrypoint sh \
+    --workdir /workdir \
+    koalaman/shellcheck-alpine:stable \
+    /workdir/hack/shellcheck.sh "${@}"
+fi;


### PR DESCRIPTION
We need a way of running shellcheck out of container to allow its usage in our CI system. This is providing such feature based on similar script from installer repo.

Needed by https://github.com/openshift/release/pull/4437

/cc @s-urbaniak @squat 