### PR TITLE
manifests: reduce logs verbosity for cluster-monitoring-operator

### DIFF
--- a/manifests/0000_50_cluster_monitoring_operator_04-deployment.yaml
+++ b/manifests/0000_50_cluster_monitoring_operator_04-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - "-configmap=cluster-monitoring-config"
         - "-release-version=$(RELEASE_VERSION)"
         - "-logtostderr=true"
-        - "-v=4"
+        - "-v=3"
         - "-images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest"
         - "-images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest"
         - "-images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest"


### PR DESCRIPTION
This will reduce number of log messages in CMO logs and allow faster debugging. Especially message like one below won't show up anymore:

> Throttling request took 394.097693ms, request: PUT:https://172.30.0.1:443/api/v1/namespaces/openshift-monitoring/configmaps/grafana-dashboard-k8s-resources-workload

/cc @LiliC @s-urbaniak