### PR TITLE
pkg/client,pkg/manifests: bump to k8s.io/api/apps/v1

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,7 +33,7 @@ import (
 	openshiftrouteclientset "github.com/openshift/client-go/route/clientset/versioned"
 	openshiftsecurityclientset "github.com/openshift/client-go/security/clientset/versioned"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	v1betaextensions "k8s.io/api/extensions/v1beta1"
@@ -328,7 +328,7 @@ func (c *Client) DeleteConfigMap(cm *v1.ConfigMap) error {
 
 func (c *Client) DeleteDeployment(d *appsv1.Deployment) error {
 	p := metav1.DeletePropagationForeground
-	err := c.kclient.AppsV1beta2().Deployments(d.GetNamespace()).Delete(d.GetName(), &metav1.DeleteOptions{PropagationPolicy: &p})
+	err := c.kclient.AppsV1().Deployments(d.GetNamespace()).Delete(d.GetName(), &metav1.DeleteOptions{PropagationPolicy: &p})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -368,7 +368,7 @@ func (c *Client) DeletePrometheus(p *monv1.Prometheus) error {
 
 func (c *Client) DeleteDaemonSet(d *v1beta1.DaemonSet) error {
 	orphanDependents := false
-	err := c.kclient.AppsV1beta2().DaemonSets(d.GetNamespace()).Delete(d.GetName(), &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
+	err := c.kclient.AppsV1().DaemonSets(d.GetNamespace()).Delete(d.GetName(), &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -488,7 +488,7 @@ func (c *Client) WaitForAlertmanager(a *monv1.Alertmanager) error {
 }
 
 func (c *Client) CreateOrUpdateDeployment(dep *appsv1.Deployment) error {
-	d, err := c.kclient.AppsV1beta2().Deployments(dep.GetNamespace()).Get(dep.GetName(), metav1.GetOptions{})
+	d, err := c.kclient.AppsV1().Deployments(dep.GetNamespace()).Get(dep.GetName(), metav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
 		err = c.CreateDeployment(dep)
@@ -508,7 +508,7 @@ func (c *Client) CreateOrUpdateDeployment(dep *appsv1.Deployment) error {
 }
 
 func (c *Client) CreateDeployment(dep *appsv1.Deployment) error {
-	d, err := c.kclient.AppsV1beta2().Deployments(dep.GetNamespace()).Create(dep)
+	d, err := c.kclient.AppsV1().Deployments(dep.GetNamespace()).Create(dep)
 	if err != nil {
 		return err
 	}
@@ -517,7 +517,7 @@ func (c *Client) CreateDeployment(dep *appsv1.Deployment) error {
 }
 
 func (c *Client) UpdateDeployment(dep *appsv1.Deployment) error {
-	updated, err := c.kclient.AppsV1beta2().Deployments(dep.GetNamespace()).Update(dep)
+	updated, err := c.kclient.AppsV1().Deployments(dep.GetNamespace()).Update(dep)
 	if err != nil {
 		return err
 	}
@@ -528,7 +528,7 @@ func (c *Client) UpdateDeployment(dep *appsv1.Deployment) error {
 func (c *Client) WaitForDeploymentRollout(dep *appsv1.Deployment) error {
 	var lastErr error
 	if err := wait.Poll(time.Second, deploymentCreateTimeout, func() (bool, error) {
-		d, err := c.kclient.AppsV1beta2().Deployments(dep.GetNamespace()).Get(dep.GetName(), metav1.GetOptions{})
+		d, err := c.kclient.AppsV1().Deployments(dep.GetNamespace()).Get(dep.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -599,7 +599,7 @@ func (c *Client) WaitForRouteReady(r *routev1.Route) (string, error) {
 }
 
 func (c *Client) CreateOrUpdateDaemonSet(ds *appsv1.DaemonSet) error {
-	_, err := c.kclient.AppsV1beta2().DaemonSets(ds.GetNamespace()).Get(ds.GetName(), metav1.GetOptions{})
+	_, err := c.kclient.AppsV1().DaemonSets(ds.GetNamespace()).Get(ds.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		err = c.CreateDaemonSet(ds)
 		return errors.Wrap(err, "creating DaemonSet object failed")
@@ -613,7 +613,7 @@ func (c *Client) CreateOrUpdateDaemonSet(ds *appsv1.DaemonSet) error {
 }
 
 func (c *Client) CreateDaemonSet(ds *appsv1.DaemonSet) error {
-	d, err := c.kclient.AppsV1beta2().DaemonSets(ds.GetNamespace()).Create(ds)
+	d, err := c.kclient.AppsV1().DaemonSets(ds.GetNamespace()).Create(ds)
 	if err != nil {
 		return err
 	}
@@ -622,7 +622,7 @@ func (c *Client) CreateDaemonSet(ds *appsv1.DaemonSet) error {
 }
 
 func (c *Client) UpdateDaemonSet(ds *appsv1.DaemonSet) error {
-	updated, err := c.kclient.AppsV1beta2().DaemonSets(ds.GetNamespace()).Update(ds)
+	updated, err := c.kclient.AppsV1().DaemonSets(ds.GetNamespace()).Update(ds)
 	if err != nil {
 		return err
 	}
@@ -633,7 +633,7 @@ func (c *Client) UpdateDaemonSet(ds *appsv1.DaemonSet) error {
 func (c *Client) WaitForDaemonSetRollout(ds *appsv1.DaemonSet) error {
 	var lastErr error
 	if err := wait.Poll(time.Second, deploymentCreateTimeout, func() (bool, error) {
-		d, err := c.kclient.AppsV1beta2().DaemonSets(ds.GetNamespace()).Get(ds.GetName(), metav1.GetOptions{})
+		d, err := c.kclient.AppsV1().DaemonSets(ds.GetNamespace()).Get(ds.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -32,7 +32,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -19,14 +19,14 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestAlertmanagerVolumeClaim(t *testing.T) {
-	err := f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
+	err := f.OperatorClient.WaitForStatefulsetRollout(&appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "alertmanager-main",
 			Namespace: f.Ns,
@@ -74,7 +74,7 @@ func TestAlertmanagerVolumeClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
+	err = f.OperatorClient.WaitForStatefulsetRollout(&appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "alertmanager-main",
 			Namespace: f.Ns,

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -19,14 +19,14 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestPrometheusVolumeClaim(t *testing.T) {
-	err := f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
+	err := f.OperatorClient.WaitForStatefulsetRollout(&appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "prometheus-k8s",
 			Namespace: f.Ns,
@@ -74,7 +74,7 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = f.OperatorClient.WaitForStatefulsetRollout(&v1beta2.StatefulSet{
+	err = f.OperatorClient.WaitForStatefulsetRollout(&appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "prometheus-k8s",
 			Namespace: f.Ns,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -150,12 +150,12 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0-20190313235455-40a48860b5ab => k8s.io/api v0.0.0-20190606204050-af9c91bd2759
-k8s.io/api/apps/v1beta2
+k8s.io/api/apps/v1
 k8s.io/api/core/v1
 k8s.io/api/extensions/v1beta1
 k8s.io/api/rbac/v1
-k8s.io/api/apps/v1
 k8s.io/api/apps/v1beta1
+k8s.io/api/apps/v1beta2
 k8s.io/api/authentication/v1
 k8s.io/api/autoscaling/v1
 k8s.io/api/policy/v1beta1


### PR DESCRIPTION
The Daemonset, and Deployment API promoted to apps/v1
but we are still referencing v1beta2.

This fixes it

/cc @LiliC 