### PR TITLE
pkg/client: Set Reason in ClusterOperatorStatusCondition

### DIFF
--- a/pkg/client/condition.go
+++ b/pkg/client/condition.go
@@ -30,21 +30,25 @@ func newConditions(cos v1.ClusterOperatorStatus, targetVersion string, time meta
 			Type:               v1.OperatorAvailable,
 			Status:             v1.ConditionUnknown,
 			LastTransitionTime: time,
+			Reason:             "",
 		},
 		v1.OperatorProgressing: {
 			Type:               v1.OperatorProgressing,
 			Status:             v1.ConditionUnknown,
 			LastTransitionTime: time,
+			Reason:             "",
 		},
 		v1.OperatorDegraded: {
 			Type:               v1.OperatorDegraded,
 			Status:             v1.ConditionUnknown,
 			LastTransitionTime: time,
+			Reason:             "",
 		},
 		v1.OperatorUpgradeable: {
 			Type:               v1.OperatorUpgradeable,
 			Status:             v1.ConditionUnknown,
 			LastTransitionTime: time,
+			Reason:             "",
 		},
 	}
 
@@ -65,7 +69,7 @@ func newConditions(cos v1.ClusterOperatorStatus, targetVersion string, time meta
 	return cs
 }
 
-func (cs *conditions) setCondition(condition v1.ClusterStatusConditionType, status v1.ConditionStatus, message string, time metav1.Time) {
+func (cs *conditions) setCondition(condition v1.ClusterStatusConditionType, status v1.ConditionStatus, message, reason string, time metav1.Time) {
 	entries := make(map[v1.ClusterStatusConditionType]v1.ClusterOperatorStatusCondition)
 	for k, v := range cs.entryMap {
 		entries[k] = v
@@ -79,6 +83,7 @@ func (cs *conditions) setCondition(condition v1.ClusterStatusConditionType, stat
 			Status:             status,
 			LastTransitionTime: time,
 			Message:            message,
+			Reason:             reason,
 		}
 	}
 

--- a/pkg/client/condition_test.go
+++ b/pkg/client/condition_test.go
@@ -45,24 +45,28 @@ func TestConditions(t *testing.T) {
 			Status:             configv1.ConditionUnknown,
 			LastTransitionTime: v1.Time{},
 			Message:            "",
+			Reason:             "",
 		},
 		{
 			Type:               configv1.OperatorAvailable,
 			Status:             configv1.ConditionUnknown,
 			LastTransitionTime: v1.Time{},
 			Message:            "",
+			Reason:             "",
 		},
 		{
 			Type:               configv1.OperatorDegraded,
 			Status:             configv1.ConditionUnknown,
 			LastTransitionTime: v1.Time{},
 			Message:            "",
+			Reason:             "",
 		},
 		{
 			Type:               configv1.OperatorUpgradeable,
 			Status:             configv1.ConditionUnknown,
 			LastTransitionTime: v1.Time{},
 			Message:            "",
+			Reason:             "",
 		},
 	})
 
@@ -107,24 +111,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		},
@@ -134,7 +142,7 @@ func TestConditions(t *testing.T) {
 				cs := newConditions(
 					configv1.ClusterOperatorStatus{}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -143,24 +151,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -169,10 +181,10 @@ func TestConditions(t *testing.T) {
 				cs := newConditions(
 					configv1.ClusterOperatorStatus{}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "", v1.Time{})
-				cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, "", v1.Time{})
-				cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, "", v1.Time{})
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "", "", v1.Time{})
+				cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, "", "", v1.Time{})
+				cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, "", "", v1.Time{})
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -181,24 +193,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -227,7 +243,7 @@ func TestConditions(t *testing.T) {
 					},
 					"", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -236,24 +252,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -283,7 +303,7 @@ func TestConditions(t *testing.T) {
 					},
 					"1.0", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -292,24 +312,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -339,8 +363,8 @@ func TestConditions(t *testing.T) {
 					},
 					"1.1", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
-				cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -349,24 +373,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -396,8 +424,8 @@ func TestConditions(t *testing.T) {
 					},
 					"1.1", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
-				cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -406,24 +434,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -453,7 +485,7 @@ func TestConditions(t *testing.T) {
 					},
 					"1.0", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -468,18 +500,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -497,7 +532,7 @@ func TestConditions(t *testing.T) {
 						},
 					}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "bar", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "bar", "foo", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -506,24 +541,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "bar",
+					Reason:             "foo",
 				},
 				{
 					Type:               configv1.OperatorProgressing,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -541,7 +580,7 @@ func TestConditions(t *testing.T) {
 						},
 					}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "foo", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "foo", "bar", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -550,24 +589,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "foo",
+					Reason:             "bar",
 				},
 				{
 					Type:               configv1.OperatorProgressing,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -580,12 +623,13 @@ func TestConditions(t *testing.T) {
 								Type:               configv1.OperatorAvailable,
 								Status:             configv1.ConditionTrue,
 								Message:            "foo",
+								Reason:             "bar",
 								LastTransitionTime: v1.Time{},
 							},
 						},
 					}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "foo", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "foo", "bar", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -594,24 +638,28 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "foo",
+					Reason:             "bar",
 				},
 				{
 					Type:               configv1.OperatorProgressing,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorUpgradeable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		},

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (

--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -286,7 +286,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 				w(mock)
 			}
 
-			got := sr.SetFailed(tc.given.err)
+			got := sr.SetFailed(tc.given.err, "")
 
 			for _, check := range tc.check {
 				if err := check(mock, got); err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -311,12 +312,13 @@ func (o *Operator) sync(key string) error {
 		klog.Errorf("error occurred while setting status to in progress: %v", err)
 	}
 
-	err = tl.RunAll()
+	taskName, err := tl.RunAll()
 	if err != nil {
 		klog.Infof("Updating ClusterOperator status to failed. Err: %v", err)
-		reportErr := o.client.StatusReporter().SetFailed(err)
+		failedTaskReason := strings.Join(strings.Fields(taskName+"Failed"), "")
+		reportErr := o.client.StatusReporter().SetFailed(err, failedTaskReason)
 		if reportErr != nil {
-			klog.Errorf("error occurred while setting status to in progress: %v", reportErr)
+			klog.Errorf("error occurred while setting status to failed: %v", reportErr)
 		}
 		return err
 	}

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -1,0 +1,69 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"regexp"
+	stdlib_strings "strings"
+)
+
+var (
+	numberSequence    = regexp.MustCompile(`([a-zA-Z])(\d+)([a-zA-Z]?)`)
+	numberReplacement = []byte(`$1 $2 $3`)
+	wordMapping       = map[string]string{
+		"http": "HTTP",
+		"url":  "URL",
+		"ip":   "IP",
+	}
+)
+
+func addWordBoundariesToNumbers(s string) string {
+	b := []byte(s)
+	b = numberSequence.ReplaceAll(b, numberReplacement)
+	return string(b)
+}
+
+func translateWord(word string, initCase bool) string {
+	if val, ok := wordMapping[word]; ok {
+		return val
+	}
+	if initCase {
+		return stdlib_strings.Title(word)
+	}
+	return word
+}
+
+// ToPascalCase converts a string to PascalCase string.
+func ToPascalCase(s string) string {
+	s = addWordBoundariesToNumbers(s)
+	s = stdlib_strings.Trim(s, " ")
+	n := ""
+	bits := []string{}
+	for _, v := range s {
+		if v == '_' || v == ' ' || v == '-' {
+			bits = append(bits, n)
+			n = ""
+		} else {
+			n += string(v)
+		}
+	}
+	bits = append(bits, n)
+
+	ret := ""
+	for i, substr := range bits {
+		ret += translateWord(substr, i != 0)
+	}
+	return stdlib_strings.Title(ret)
+}

--- a/pkg/strings/strings_test.go
+++ b/pkg/strings/strings_test.go
@@ -1,0 +1,43 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"testing"
+)
+
+func TestToPascalCase(t *testing.T) {
+	cases := [][]string{
+		{"taskNumber- one", "TaskNumberOne"},
+		{"foo_bar", "FooBar"},
+		{"foo", "Foo"},
+		{"FooBar", "FooBar"},
+		{"   foo bar   ", "FooBar"},
+		{"", ""},
+		{"foooo_foo_bar", "FooooFooBar"},
+		{"AnyKind of_string", "AnyKindOfString"},
+		{"foo-barRa", "FooBarRa"},
+		{"numbers2And55with000", "Numbers2And55With000"},
+	}
+	for n, i := range cases {
+		in := i[0]
+		expected := i[1]
+		result := ToPascalCase(in)
+		if result != expected {
+			t.Errorf("test case number: %d got: "+result+" expected: "+expected+"", n)
+		}
+	}
+
+}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -33,9 +33,8 @@ func NewTaskRunner(client *client.Client, tasks []*TaskSpec) *TaskRunner {
 	}
 }
 
-func (tl *TaskRunner) RunAll() error {
+func (tl *TaskRunner) RunAll() (string, error) {
 	var g errgroup.Group
-
 	for i, ts := range tl.tasks {
 		// shadow vars due to concurrency
 		ts := ts
@@ -45,11 +44,19 @@ func (tl *TaskRunner) RunAll() error {
 			klog.V(3).Infof("running task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
 			err := tl.ExecuteTask(ts)
 			klog.V(3).Infof("ran task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
-			return errors.Wrapf(err, "running task %v failed", ts.Name)
+			return taskErr{error: errors.Wrapf(err, "running task %v failed", ts.Name), name: ts.Name}
 		})
 	}
+	if err := g.Wait(); err != nil {
+		taskName := ""
+		if tErr, ok := err.(taskErr); ok {
+			taskName = tErr.name
+			err = tErr.error
 
-	return g.Wait()
+		}
+		return taskName, err
+	}
+	return "", nil
 }
 
 func (tl *TaskRunner) ExecuteTask(ts *TaskSpec) error {
@@ -70,4 +77,9 @@ type TaskSpec struct {
 
 type Task interface {
 	Run() error
+}
+
+type taskErr struct {
+	error
+	name string
 }


### PR DESCRIPTION
As mentioned in the https://bugzilla.redhat.com/show_bug.cgi?id=1732939, we are not setting the `Reason`.
