### PR TITLE
Bug 1741055: pkg/client: Set Reason in ClusterOperatorStatusCondition

### DIFF
--- a/pkg/client/clusteroperator.go
+++ b/pkg/client/clusteroperator.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (

--- a/pkg/client/condition.go
+++ b/pkg/client/condition.go
@@ -30,16 +30,19 @@ func newConditions(cos v1.ClusterOperatorStatus, targetVersion string, time meta
 			Type:               v1.OperatorAvailable,
 			Status:             v1.ConditionUnknown,
 			LastTransitionTime: time,
+			Reason:             "",
 		},
 		v1.OperatorProgressing: {
 			Type:               v1.OperatorProgressing,
 			Status:             v1.ConditionUnknown,
 			LastTransitionTime: time,
+			Reason:             "",
 		},
 		v1.OperatorDegraded: {
 			Type:               v1.OperatorDegraded,
 			Status:             v1.ConditionUnknown,
 			LastTransitionTime: time,
+			Reason:             "",
 		},
 	}
 
@@ -60,7 +63,7 @@ func newConditions(cos v1.ClusterOperatorStatus, targetVersion string, time meta
 	return cs
 }
 
-func (cs *conditions) setCondition(condition v1.ClusterStatusConditionType, status v1.ConditionStatus, message string, time metav1.Time) {
+func (cs *conditions) setCondition(condition v1.ClusterStatusConditionType, status v1.ConditionStatus, message, reason string, time metav1.Time) {
 	entries := make(map[v1.ClusterStatusConditionType]v1.ClusterOperatorStatusCondition)
 	for k, v := range cs.entryMap {
 		entries[k] = v
@@ -74,6 +77,7 @@ func (cs *conditions) setCondition(condition v1.ClusterStatusConditionType, stat
 			Status:             status,
 			LastTransitionTime: time,
 			Message:            message,
+			Reason:             reason,
 		}
 	}
 

--- a/pkg/client/condition_test.go
+++ b/pkg/client/condition_test.go
@@ -45,18 +45,21 @@ func TestConditions(t *testing.T) {
 			Status:             configv1.ConditionUnknown,
 			LastTransitionTime: v1.Time{},
 			Message:            "",
+			Reason:             "",
 		},
 		{
 			Type:               configv1.OperatorAvailable,
 			Status:             configv1.ConditionUnknown,
 			LastTransitionTime: v1.Time{},
 			Message:            "",
+			Reason:             "",
 		},
 		{
 			Type:               configv1.OperatorDegraded,
 			Status:             configv1.ConditionUnknown,
 			LastTransitionTime: v1.Time{},
 			Message:            "",
+			Reason:             "",
 		},
 	})
 
@@ -101,18 +104,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		},
@@ -122,7 +128,7 @@ func TestConditions(t *testing.T) {
 				cs := newConditions(
 					configv1.ClusterOperatorStatus{}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -131,18 +137,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -151,9 +160,9 @@ func TestConditions(t *testing.T) {
 				cs := newConditions(
 					configv1.ClusterOperatorStatus{}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "", v1.Time{})
-				cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, "", v1.Time{})
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "", "", v1.Time{})
+				cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, "", "", v1.Time{})
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -162,18 +171,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -198,7 +210,7 @@ func TestConditions(t *testing.T) {
 					},
 					"", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -207,18 +219,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -244,7 +259,7 @@ func TestConditions(t *testing.T) {
 					},
 					"1.0", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -253,18 +268,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -290,7 +308,7 @@ func TestConditions(t *testing.T) {
 					},
 					"1.1", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -299,18 +317,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -336,7 +357,7 @@ func TestConditions(t *testing.T) {
 					},
 					"1.1", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -345,18 +366,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorAvailable,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -382,7 +406,7 @@ func TestConditions(t *testing.T) {
 					},
 					"1.0", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "", "", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -397,12 +421,14 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -420,7 +446,7 @@ func TestConditions(t *testing.T) {
 						},
 					}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "bar", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "bar", "foo", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -429,18 +455,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "bar",
+					Reason:             "foo",
 				},
 				{
 					Type:               configv1.OperatorProgressing,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -458,7 +487,7 @@ func TestConditions(t *testing.T) {
 						},
 					}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "foo", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, "foo", "bar", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -467,18 +496,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionFalse,
 					LastTransitionTime: v1.Unix(0, 0),
 					Message:            "foo",
+					Reason:             "bar",
 				},
 				{
 					Type:               configv1.OperatorProgressing,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		}, {
@@ -491,12 +523,13 @@ func TestConditions(t *testing.T) {
 								Type:               configv1.OperatorAvailable,
 								Status:             configv1.ConditionTrue,
 								Message:            "foo",
+								Reason:             "bar",
 								LastTransitionTime: v1.Time{},
 							},
 						},
 					}, "", v1.Time{},
 				)
-				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "foo", v1.Unix(0, 0))
+				cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "foo", "bar", v1.Unix(0, 0))
 				return cs
 			},
 			check: hasConditions([]configv1.ClusterOperatorStatusCondition{
@@ -505,18 +538,21 @@ func TestConditions(t *testing.T) {
 					Status:             configv1.ConditionTrue,
 					LastTransitionTime: v1.Time{},
 					Message:            "foo",
+					Reason:             "bar",
 				},
 				{
 					Type:               configv1.OperatorProgressing,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 				{
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: v1.Time{},
 					Message:            "",
+					Reason:             "",
 				},
 			}),
 		},

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -310,12 +311,13 @@ func (o *Operator) sync(key string) error {
 		glog.Errorf("error occurred while setting status to in progress: %v", err)
 	}
 
-	err = tl.RunAll()
+	taskName, err := tl.RunAll()
 	if err != nil {
 		glog.Infof("Updating ClusterOperator status to failed. Err: %v", err)
-		reportErr := o.client.StatusReporter().SetFailed(err)
+		failedTaskReason := strings.Join(strings.Fields(taskName+"Failed"), "")
+		reportErr := o.client.StatusReporter().SetFailed(err, failedTaskReason)
 		if reportErr != nil {
-			glog.Errorf("error occurred while setting status to in progress: %v", reportErr)
+			glog.Errorf("error occurred while setting status to failed: %v", reportErr)
 		}
 		return err
 	}

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -1,0 +1,69 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"regexp"
+	stdlib_strings "strings"
+)
+
+var (
+	numberSequence    = regexp.MustCompile(`([a-zA-Z])(\d+)([a-zA-Z]?)`)
+	numberReplacement = []byte(`$1 $2 $3`)
+	wordMapping       = map[string]string{
+		"http": "HTTP",
+		"url":  "URL",
+		"ip":   "IP",
+	}
+)
+
+func addWordBoundariesToNumbers(s string) string {
+	b := []byte(s)
+	b = numberSequence.ReplaceAll(b, numberReplacement)
+	return string(b)
+}
+
+func translateWord(word string, initCase bool) string {
+	if val, ok := wordMapping[word]; ok {
+		return val
+	}
+	if initCase {
+		return stdlib_strings.Title(word)
+	}
+	return word
+}
+
+// ToPascalCase converts a string to PascalCase string.
+func ToPascalCase(s string) string {
+	s = addWordBoundariesToNumbers(s)
+	s = stdlib_strings.Trim(s, " ")
+	n := ""
+	bits := []string{}
+	for _, v := range s {
+		if v == '_' || v == ' ' || v == '-' {
+			bits = append(bits, n)
+			n = ""
+		} else {
+			n += string(v)
+		}
+	}
+	bits = append(bits, n)
+
+	ret := ""
+	for i, substr := range bits {
+		ret += translateWord(substr, i != 0)
+	}
+	return stdlib_strings.Title(ret)
+}

--- a/pkg/strings/strings_test.go
+++ b/pkg/strings/strings_test.go
@@ -1,0 +1,43 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"testing"
+)
+
+func TestToPascalCase(t *testing.T) {
+	cases := [][]string{
+		{"taskNumber- one", "TaskNumberOne"},
+		{"foo_bar", "FooBar"},
+		{"foo", "Foo"},
+		{"FooBar", "FooBar"},
+		{"   foo bar   ", "FooBar"},
+		{"", ""},
+		{"foooo_foo_bar", "FooooFooBar"},
+		{"AnyKind of_string", "AnyKindOfString"},
+		{"foo-barRa", "FooBarRa"},
+		{"numbers2And55with000", "Numbers2And55With000"},
+	}
+	for n, i := range cases {
+		in := i[0]
+		expected := i[1]
+		result := ToPascalCase(in)
+		if result != expected {
+			t.Errorf("test case number: %d got: "+result+" expected: "+expected+"", n)
+		}
+	}
+
+}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -33,9 +33,8 @@ func NewTaskRunner(client *client.Client, tasks []*TaskSpec) *TaskRunner {
 	}
 }
 
-func (tl *TaskRunner) RunAll() error {
+func (tl *TaskRunner) RunAll() (string, error) {
 	var g errgroup.Group
-
 	for i, ts := range tl.tasks {
 		// shadow vars due to concurrency
 		ts := ts
@@ -45,11 +44,19 @@ func (tl *TaskRunner) RunAll() error {
 			glog.V(4).Infof("running task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
 			err := tl.ExecuteTask(ts)
 			glog.V(4).Infof("ran task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
-			return errors.Wrapf(err, "running task %v failed", ts.Name)
+			return taskErr{error: errors.Wrapf(err, "running task %v failed", ts.Name), name: ts.Name}
 		})
 	}
+	if err := g.Wait(); err != nil {
+		taskName := ""
+		if tErr, ok := err.(taskErr); ok {
+			taskName = tErr.name
+			err = tErr.error
 
-	return g.Wait()
+		}
+		return taskName, err
+	}
+	return "", nil
 }
 
 func (tl *TaskRunner) ExecuteTask(ts *TaskSpec) error {
@@ -70,4 +77,9 @@ type TaskSpec struct {
 
 type Task interface {
 	Run() error
+}
+
+type taskErr struct {
+	error
+	name string
 }

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -44,7 +44,10 @@ func (tl *TaskRunner) RunAll() (string, error) {
 			glog.V(4).Infof("running task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
 			err := tl.ExecuteTask(ts)
 			glog.V(4).Infof("ran task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
-			return taskErr{error: errors.Wrapf(err, "running task %v failed", ts.Name), name: ts.Name}
+			if err != nil {
+				return taskErr{error: errors.Wrapf(err, "running task %v failed", ts.Name), name: ts.Name}
+			}
+			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {


### PR DESCRIPTION
This backports the setting of the `Reason` field to release-4.1 branch. See PR https://github.com/openshift/cluster-monitoring-operator/pull/431 for the background.

cc @s-urbaniak @paulfantom 