### PR TITLE
Bug 1743257: pkg/client/status_reporter.go: Set OperatorUpgradeable to true

### DIFF
--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -106,7 +106,7 @@ func (r *StatusReporter) SetInProgress() error {
 	reasonInProgress := "RollOutInProgress"
 	conditions := newConditions(co.Status, r.version, time)
 	conditions.setCondition(v1.OperatorProgressing, v1.ConditionTrue, "Rolling out the stack.", reasonInProgress, time)
-	conditions.setCondition(v1.OperatorUpgradeable, v1.ConditionFalse,
+	conditions.setCondition(v1.OperatorUpgradeable, v1.ConditionTrue,
 		"Rollout of the monitoring stack is in progress. Please wait until it finishes.",
 		reasonInProgress,
 		time,
@@ -136,7 +136,7 @@ func (r *StatusReporter) SetFailed(statusErr error, reason string) error {
 	conditions.setCondition(v1.OperatorAvailable, v1.ConditionFalse, "", "", time)
 	conditions.setCondition(v1.OperatorProgressing, v1.ConditionFalse, "", "", time)
 	conditions.setCondition(v1.OperatorDegraded, v1.ConditionTrue, fmt.Sprintf("Failed to rollout the stack. Error: %v", statusErr), reason, time)
-	conditions.setCondition(v1.OperatorUpgradeable, v1.ConditionFalse,
+	conditions.setCondition(v1.OperatorUpgradeable, v1.ConditionTrue,
 		"Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error.",
 		reason,
 		time,

--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -150,7 +150,7 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 					"Available", "Unknown",
 					"Degraded", "Unknown",
 					"Progressing", "True",
-					"Upgradeable", "False",
+					"Upgradeable", "True",
 				),
 			},
 		},
@@ -176,7 +176,7 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 					"Available", "Unknown",
 					"Degraded", "Unknown",
 					"Progressing", "True",
-					"Upgradeable", "False",
+					"Upgradeable", "True",
 				),
 			},
 		},
@@ -199,7 +199,7 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 
 			for _, check := range tc.check {
 				if err := check(mock, got); err != nil {
-					t.Error(err)
+					t.Errorf("test case name '%s' failed with error: %v", tc.name, err)
 				}
 			}
 		})
@@ -241,7 +241,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 					"Available", "False",
 					"Degraded", "True",
 					"Progressing", "False",
-					"Upgradeable", "False",
+					"Upgradeable", "True",
 				),
 			},
 		},
@@ -267,7 +267,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 					"Available", "False",
 					"Degraded", "True",
 					"Progressing", "False",
-					"Upgradeable", "False",
+					"Upgradeable", "True",
 				),
 			},
 		},
@@ -290,7 +290,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 
 			for _, check := range tc.check {
 				if err := check(mock, got); err != nil {
-					t.Error(err)
+					t.Errorf("test case name '%s' failed with error: %v", tc.name, err)
 				}
 			}
 		})


### PR DESCRIPTION
We should not set OperatorUpgradeable to false during rollout.
As per the docs:
An operator reports Upgradeable as false when it wishes to prevent
an upgrade for an admin-correctable condition. The component should
include a message that describes what must be fixed.

See docs for [this](https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md
). From what I understand we should *never* really set upgradable to false. As this prevents an upgrade and even if we fail with any reason in CMO operator, we will always be able to upgrade as well we just reconcile to the desired state anyways. But I could be missing something?

CVO seems to be backporting the new ClusterOperatorFlapping to 4.1 but from what I could tell we did not backport the Upgradeable status to 4.1 in CMO?

cc @s-urbaniak @paulfantom 

https://bugzilla.redhat.com/show_bug.cgi?id=1743257