### PR TITLE
Bug 1746793: manifests: Bump operators.coreos.com API version to v1

### DIFF
--- a/manifests/0000_90_cluster_monitoring_operator_00-operatorgroup.yaml
+++ b/manifests/0000_90_cluster_monitoring_operator_00-operatorgroup.yaml
@@ -1,4 +1,4 @@
-apiVersion: operators.coreos.com/v1alpha2
+apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: openshift-cluster-monitoring


### PR DESCRIPTION
We have been seeing errors when trying to create OperatorGroup resource when using the old API version, I think that API bug might already be fixed in 4.2, but nonetheless we can bump to using the `v1` API. See [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1740838) for background.

I asked the OLM devs and they said there should be no differences between the two versions so we are safe to bump to using the newer API version.

cc @s-urbaniak @paulfantom 