### PR TITLE
changes apiversion of the deployment to apps/v1

### DIFF
--- a/manifests/0000_50_cluster_monitoring_operator_04-deployment.yaml
+++ b/manifests/0000_50_cluster_monitoring_operator_04-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cluster-monitoring-operator


### PR DESCRIPTION
`extensions/v1beta1` has been deprecated and might be removed in the future versions