### PR TITLE
pkg/client/client: Fix "unavailable" -> "available" typo in daemonset error

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -663,7 +663,7 @@ func (c *Client) WaitForDaemonSetRollout(ds *appsv1.DaemonSet) error {
 		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedNumberScheduled == d.Status.DesiredNumberScheduled && d.Status.NumberUnavailable == 0 {
 			return true, nil
 		}
-		lastErr = fmt.Errorf("daemonset %s is not ready. status: (desired: %d, updated: %d, ready: %d, unavailable: %d)",
+		lastErr = fmt.Errorf("daemonset %s is not ready. status: (desired: %d, updated: %d, ready: %d, available: %d)",
 			d.Name, d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled, d.Status.NumberReady, d.Status.NumberAvailable)
 		return false, nil
 	}); err != nil {


### PR DESCRIPTION
Typo from 62a22a3097 (#240).