### PR TITLE
pkg/tasks/configsharing: add thanos route

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -990,7 +990,7 @@ func (f *Factory) ThanosQuerierRoute() (*routev1.Route, error) {
 	return r, nil
 }
 
-func (f *Factory) SharingConfig(promHost, amHost, grafanaHost *url.URL) *v1.ConfigMap {
+func (f *Factory) SharingConfig(promHost, amHost, grafanaHost, thanosHost *url.URL) *v1.ConfigMap {
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sharing-config",
@@ -1000,6 +1000,7 @@ func (f *Factory) SharingConfig(promHost, amHost, grafanaHost *url.URL) *v1.Conf
 			"grafanaURL":      grafanaHost.String(),
 			"prometheusURL":   promHost.String(),
 			"alertmanagerURL": amHost.String(),
+			"thanosURL":       thanosHost.String(),
 		},
 	}
 }

--- a/pkg/tasks/configsharing.go
+++ b/pkg/tasks/configsharing.go
@@ -63,7 +63,17 @@ func (t *ConfigSharingTask) Run() error {
 		return errors.Wrap(err, "failed to retrieve Grafana host")
 	}
 
-	cm := t.factory.SharingConfig(promURL, amURL, grafanaURL)
+	thanosRoute, err := t.factory.ThanosQuerierRoute()
+	if err != nil {
+		return errors.Wrap(err, "initializing Thanos Querier Route failed")
+	}
+
+	thanosURL, err := t.client.GetRouteURL(thanosRoute)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve Thanos Querier host")
+	}
+
+	cm := t.factory.SharingConfig(promURL, amURL, grafanaURL, thanosURL)
 	err = t.client.CreateOrUpdateConfigMap(cm)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Sharing Config ConfigMap failed")


### PR DESCRIPTION
This is important for the OpenShift console is it reads that configmap,
sourcing route URLs for monitoring components.

/cc @LiliC @paulfantom @kyoto 