### PR TITLE
Bug 1763046: manifests: remove setting limits on CMO

### DIFF
--- a/manifests/cluster-monitoring-operator.yaml
+++ b/manifests/cluster-monitoring-operator.yaml
@@ -38,9 +38,6 @@ spec:
         - containerPort: 8080
           name: http
         resources:
-          limits:
-            cpu: 20m
-            memory: 50Mi
           requests:
             cpu: 20m
             memory: 50Mi


### PR DESCRIPTION
We already removed limits in 4.x, so I don't see any reason not to do that in 3.11.

/cc @brancz @s-urbaniak 