### PR TITLE
manifests/config: name user workload settings as tech preview

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	HTTPConfig             *HTTPConfig                  `json:"http"`
 	TelemeterClientConfig  *TelemeterClientConfig       `json:"telemeterClient"`
 	K8sPrometheusAdapter   *K8sPrometheusAdapter        `json:"k8sPrometheusAdapter"`
-	UserWorkloadConfig     *UserWorkloadConfig          `json:"userWorkload"`
+	UserWorkloadConfig     *UserWorkloadConfig          `json:"techPreviewUserWorkload"`
 }
 
 type Images struct {


### PR DESCRIPTION
This prefixes user workload settings explicitly as tech preview.

/cc @bparees @paulfantom @LiliC @brancz 