### PR TITLE
jsonnet: bump kubernetes-mixin to latest version

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -85,8 +85,8 @@
           "subdir": ""
         }
       },
-      "version": "325f8a46fac9605f1de8bc20ca811cb92d1ef7e5",
-      "sum": "qfm0EpLrEZ1+fe93LFLa9tyOalK6JehpholxO2d0xXU="
+      "version": "5adb282a9d5936d47df9f5f9186519c8d4f15025",
+      "sum": "4vNXfxusClzfvyVAbwVLKIjbRmBauPIBQRjjexuVhrE="
     },
     {
       "name": "node-mixin",


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/294