### PR TITLE
Bug 1741685: pkg/client: add more relatedObjects to improve data from must-gather

### DIFF
--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -43,8 +43,14 @@ func NewStatusReporter(client clientv1.ClusterOperatorInterface, name, namespace
 
 func newRelatedObjects(namespace string) []v1.ObjectReference {
 	return []v1.ObjectReference{
-		{Group: "operator.openshift.io", Resource: "monitoring", Name: "cluster"},
 		{Resource: "namespaces", Name: namespace},
+		// Gather pods, services, daemonsets, deployments, replocasets, statefulsets, and routes
+		{Resource: "all", Name: namespace},
+		// Gather all ServiceMonitors, PrometheusRules, Alertmanagers, and Prometheus CRs
+		{Group: "monitoring.coreos.com", Resource: "servicemonitors"},
+		{Group: "monitoring.coreos.com", Resource: "prometheusrules"},
+		{Group: "monitoring.coreos.com", Resource: "alertmanagers"},
+		{Group: "monitoring.coreos.com", Resource: "prometheuses"},
 	}
 }
 


### PR DESCRIPTION
This should collect all data in `openshift-monitoring` namespace as well as all ServiceMonitor, PrometheusRule, Alertmanager, Prometheus CR across namespaces.

Checked it locally and we gather much more information.

/cc @s-urbaniak 