### PR TITLE
test/e2e/prometheusadapter: disable rotation test

### DIFF
--- a/test/e2e/prometheusadapter_test.go
+++ b/test/e2e/prometheusadapter_test.go
@@ -221,7 +221,7 @@ func TestAggregatedMetricPermissions(t *testing.T) {
 	}
 }
 
-func TestPrometheusAdapterCARotation(t *testing.T) {
+func DisabledTestPrometheusAdapterCARotation(t *testing.T) {
 	var lastErr error
 	// Wait for Prometheus adapter
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {


### PR DESCRIPTION
/cc @openshift/openshift-team-monitoring 

Let's disable that test for now as something has changed in origin that quickly reconciles away the changes we do on the `requestheader-client-ca-file` content of `kube-system/extension-apiserver-authentication`.

Generally this is good, but renders this test intrinsically racy and thus flaky.