### PR TITLE
Bug 1776085: pkg/manifests: mount trustedCA bundle in grafana-proxy container

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1887,7 +1887,7 @@ func (f *Factory) GrafanaDeployment(proxyCABundleCM *v1.ConfigMap) (*appsv1.Depl
 
 	if proxyCABundleCM != nil {
 		volumeName := "grafana-trusted-ca-bundle"
-		d.Spec.Template.Spec.Containers[0].VolumeMounts = append(d.Spec.Template.Spec.Containers[0].VolumeMounts, trustedCABundleVolumeMount(volumeName, "/etc/pki/ca-trust/extracted/pem/"))
+		d.Spec.Template.Spec.Containers[1].VolumeMounts = append(d.Spec.Template.Spec.Containers[1].VolumeMounts, trustedCABundleVolumeMount(volumeName, "/etc/pki/ca-trust/extracted/pem/"))
 		volume := trustedCABundleVolume(proxyCABundleCM.Name, volumeName)
 		volume.VolumeSource.ConfigMap.Items = append(volume.VolumeSource.ConfigMap.Items, v1.KeyToPath{
 			Key:  "ca-bundle.crt",


### PR DESCRIPTION
Fix mounting trusted CA bundle by mounting it in grafana-proxy container (where it is needed) instead of grafana one.

Fixing mistake from https://github.com/openshift/cluster-monitoring-operator/pull/530

Tested manually on 4.3.0-0.ci-2019-11-22-122829 with proxy configuration enabled and grafana UI is accessible.

/cc @s-urbaniak