### PR TITLE
test/e2e/prometheusadapter: reenable CA rotation test

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -82,11 +82,13 @@ func testMain(m *testing.M) error {
 		)
 		body, loopErr = f.ThanosQuerierClient.PrometheusQuery("count(up{job=\"prometheus-k8s\"})")
 		if loopErr != nil {
+			loopErr = errors.Wrap(loopErr, "error executing prometheus query")
 			return false, nil
 		}
 
 		v, loopErr = framework.GetFirstValueFromPromQuery(body)
 		if loopErr != nil {
+			loopErr = errors.Wrapf(loopErr, "error getting first value from prometheus response %q", string(body))
 			return false, nil
 		}
 


### PR DESCRIPTION
This reenables the requestheader CA rotation e2e test
by using a different method.

It deletes the CSR signer secrets causing the extension-apiserver-authentication
configmap to be reissued.

/cc @openshift/openshift-team-monitoring 