### PR TITLE
SREP-2140: alert when sre stays in cluster-admin more than 2 hours

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -1262,6 +1262,15 @@ spec:
       expr: vector(1)
       labels:
         severity: none
+    - alert: sreElevatedMoreThan2Hours
+      annotations:
+        message: SRE "{{ $labels.user }}"
+        elevated to cluster-admin({{ $labels.group }}) more than 2 hours.
+      expr: |
+        openshift_group_user_account{group="osd-sre-cluster-admins"} == 1
+      for: 130m
+      labels:
+        severity: warning
   - name: node-time
     rules:
     - alert: ClockSkewDetected


### PR DESCRIPTION
Fixes: SREP-2140

Currently, SRE can temporarily elevate permissions to cluster-admin by adding themselves to the 'osd-sre-cluster-admins' group.
The alert will be fired if SRE stays in `cluster admin` role for more than 2 hours.