### PR TITLE
pkg/manifests: don't overwrite telemetry remote write

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1165,8 +1165,9 @@ func (f *Factory) PrometheusK8s(host string, grpcTLS *v1.Secret, trustedCABundle
 	}
 
 	if len(f.config.PrometheusK8sConfig.RemoteWrite) > 0 {
-		p.Spec.RemoteWrite = f.config.PrometheusK8sConfig.RemoteWrite
+		p.Spec.RemoteWrite = append(p.Spec.RemoteWrite, f.config.PrometheusK8sConfig.RemoteWrite...)
 	}
+
 	for _, rw := range p.Spec.RemoteWrite {
 		if f.config.HTTPConfig.HTTPProxy != "" {
 			rw.ProxyURL = f.config.HTTPConfig.HTTPProxy

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -16,8 +16,11 @@ package manifests
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
+
+	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -688,6 +691,133 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 
 	if !namespacesFound {
 		t.Fatal("Configuring the namespaces to watch failed")
+	}
+}
+
+func TestPrometheusK8sRemoteWrite(t *testing.T) {
+	for _, tc := range []struct {
+		name                    string
+		config                  func() *Config
+		expectedRemoteWriteURLs []string
+	}{
+		{
+			name: "default config",
+
+			config: func() *Config {
+				c, err := NewConfigFromString("")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return c
+			},
+
+			expectedRemoteWriteURLs: nil,
+		},
+		{
+			name: "legacy telemetry",
+
+			config: func() *Config {
+				c, err := NewConfigFromString("")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				c.TelemeterClientConfig.ClusterID = "123"
+				c.TelemeterClientConfig.Token = "secret"
+
+				return c
+			},
+
+			expectedRemoteWriteURLs: nil,
+		},
+		{
+			name: "legacy telemetry and custom remote write",
+
+			config: func() *Config {
+				c, err := NewConfigFromString("")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				c.TelemeterClientConfig.ClusterID = "123"
+				c.TelemeterClientConfig.Token = "secret"
+				c.PrometheusK8sConfig.RemoteWrite = []monv1.RemoteWriteSpec{{URL: "http://custom"}}
+
+				return c
+			},
+
+			expectedRemoteWriteURLs: []string{
+				"http://custom",
+			},
+		},
+		{
+			name: "remote write telemetry",
+
+			config: func() *Config {
+				c, err := NewConfigFromString("")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				c.RemoteWrite = true
+				c.TelemeterClientConfig.ClusterID = "123"
+				c.TelemeterClientConfig.Token = "secret"
+
+				return c
+			},
+
+			expectedRemoteWriteURLs: []string{
+				"https://infogw.api.openshift.com/metrics/v1/receive",
+			},
+		},
+		{
+			name: "remote write telemetry and custom remote write",
+
+			config: func() *Config {
+				c, err := NewConfigFromString("")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				c.RemoteWrite = true
+				c.TelemeterClientConfig.ClusterID = "123"
+				c.TelemeterClientConfig.Token = "secret"
+				c.PrometheusK8sConfig.RemoteWrite = []monv1.RemoteWriteSpec{{URL: "http://custom"}}
+
+				return c
+			},
+
+			expectedRemoteWriteURLs: []string{
+				"http://custom",
+				"https://infogw.api.openshift.com/metrics/v1/receive",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.config()
+
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c)
+			p, err := f.PrometheusK8s(
+				"prometheus-k8s.openshift-monitoring.svc",
+				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var got []string
+			for _, rw := range p.Spec.RemoteWrite {
+				got = append(got, rw.URL)
+			}
+			sort.Strings(got)
+			sort.Strings(tc.expectedRemoteWriteURLs)
+
+			if !reflect.DeepEqual(got, tc.expectedRemoteWriteURLs) {
+				t.Errorf("want remote write URLs %v, got %v", tc.expectedRemoteWriteURLs, got)
+			}
+		})
 	}
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -793,6 +793,29 @@ func TestPrometheusK8sRemoteWrite(t *testing.T) {
 				"https://infogw.api.openshift.com/metrics/v1/receive",
 			},
 		},
+		{
+			name: "remote write telemetry with custom url and custom remote write",
+
+			config: func() *Config {
+				c, err := NewConfigFromString("")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				c.RemoteWrite = true
+				c.TelemeterClientConfig.TelemeterServerURL = "http://custom-telemeter"
+				c.TelemeterClientConfig.ClusterID = "123"
+				c.TelemeterClientConfig.Token = "secret"
+				c.PrometheusK8sConfig.RemoteWrite = []monv1.RemoteWriteSpec{{URL: "http://custom-remote-write"}}
+
+				return c
+			},
+
+			expectedRemoteWriteURLs: []string{
+				"http://custom-remote-write",
+				"http://custom-telemeter",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := tc.config()


### PR DESCRIPTION
Currently, if a custom remote write configuration is provided
and telemetry remote write is enabled,
the latter is overwritten by the custom remote write configuration.

This fixes it by appending the custom remote write configuration
to the telemetry remote write configuration.

/cc @openshift/openshift-team-monitoring 