### PR TITLE
pkg/manifests: Correctly default telemeter URL

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -219,7 +219,7 @@ func (c *Config) applyDefaults() {
 	}
 	if c.TelemeterClientConfig == nil {
 		c.TelemeterClientConfig = &TelemeterClientConfig{
-			TelemeterServerURL: "https://infogw.api.openshift.com/metrics/v1/receive",
+			TelemeterServerURL: "https://infogw.api.openshift.com/",
 		}
 	}
 	if c.K8sPrometheusAdapter == nil {
@@ -257,6 +257,9 @@ func (c *Config) SetTelemetryMatches(matches []string) {
 
 func (c *Config) SetRemoteWrite(rw bool) {
 	c.RemoteWrite = rw
+	if c.RemoteWrite && c.TelemeterClientConfig.TelemeterServerURL == "https://infogw.api.openshift.com/" {
+		c.TelemeterClientConfig.TelemeterServerURL = "https://infogw.api.openshift.com/metrics/v1/receive"
+	}
 }
 
 func (c *Config) LoadClusterID(load func() (*configv1.ClusterVersion, error)) error {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -760,7 +760,7 @@ func TestPrometheusK8sRemoteWrite(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				c.RemoteWrite = true
+				c.SetRemoteWrite(true)
 				c.TelemeterClientConfig.ClusterID = "123"
 				c.TelemeterClientConfig.Token = "secret"
 
@@ -780,7 +780,7 @@ func TestPrometheusK8sRemoteWrite(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				c.RemoteWrite = true
+				c.SetRemoteWrite(true)
 				c.TelemeterClientConfig.ClusterID = "123"
 				c.TelemeterClientConfig.Token = "secret"
 				c.PrometheusK8sConfig.RemoteWrite = []monv1.RemoteWriteSpec{{URL: "http://custom"}}
@@ -802,7 +802,7 @@ func TestPrometheusK8sRemoteWrite(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				c.RemoteWrite = true
+				c.SetRemoteWrite(true)
 				c.TelemeterClientConfig.TelemeterServerURL = "http://custom-telemeter"
 				c.TelemeterClientConfig.ClusterID = "123"
 				c.TelemeterClientConfig.Token = "secret"


### PR DESCRIPTION
We were incorrectly defaulting the telemeter URL since we merged #617. 

@LiliC @s-urbaniak 