### PR TITLE
Bug 1798941: added record rule for workload type deploymentconfig

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -171,6 +171,16 @@ spec:
       labels:
         workload_type: statefulset
       record: mixin_pod_workload
+    - expr: |
+        sum(
+          label_replace(
+            kube_pod_owner{job="kube-state-metrics", owner_kind="DeploymentConfig"},
+            "workload", "$1", "owner_name", "(.*)"
+          )
+        ) by (cluster, namespace, workload, pod)
+      labels:
+        workload_type: deploymentconfig
+      record: mixin_pod_workload
   - name: kube-scheduler.rules
     rules:
     - expr: |


### PR DESCRIPTION
Metric queries for `DeploymentConfig` resources return with ZERO results due to missing `record` rule for `workload_type` `deploymentconfig`. Hence `record` rule has been added for `deploymentconfig` to resolve this issue.