### PR TITLE
Bug 1794616: pkg/manifests: set modified telemeter-client command line arguments

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2541,6 +2541,7 @@ func (f *Factory) TelemeterClientDeployment(proxyCABundleCM *v1.ConfigMap) (*app
 	for _, m := range f.config.PrometheusK8sConfig.TelemetryMatches {
 		cmd = append(cmd, fmt.Sprintf("--match=%s", m))
 	}
+	d.Spec.Template.Spec.Containers[0].Command = cmd
 
 	if len(f.config.TelemeterClientConfig.NodeSelector) > 0 {
 		d.Spec.Template.Spec.NodeSelector = f.config.TelemeterClientConfig.NodeSelector


### PR DESCRIPTION
Currently we are manipulating but not changing them. This fixes it.
The current symptom is that the new metrics configuration scheme
is effectively not enabled.

/cc @openshift/openshift-team-monitoring 