### PR TITLE
Bug 1809353: ROKS - remove control plane alerts

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	Images      *Images `json:"-"`
 	RemoteWrite bool    `json:"-"`
 
+	ExcludeKubernetesControlPlaneRules bool `json:"excludeKubernetesControlPlaneRules"`
+
 	PrometheusOperatorConfig             *PrometheusOperatorConfig `json:"prometheusOperator"`
 	PrometheusOperatorUserWorkloadConfig *PrometheusOperatorConfig `json:"prometheusOperatorUserWorkload"`
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -787,6 +787,21 @@ func (f *Factory) PrometheusK8sRules() (*monv1.PrometheusRule, error) {
 		r.Spec.Groups = groups
 	}
 
+	if f.config.ExcludeKubernetesControlPlaneRules {
+		groups := []monv1.RuleGroup{}
+		for _, g := range r.Spec.Groups {
+			switch g.Name {
+			case "kubernetes-system-apiserver",
+				"kubernetes-system-controller-manager",
+				"kubernetes-system-scheduler":
+				// skip
+			default:
+				groups = append(groups, g)
+			}
+		}
+		r.Spec.Groups = groups
+	}
+
 	return r, nil
 }
 


### PR DESCRIPTION
In a ROKS hosted control plane cluster, the Kubernetes apiserver, controller manager and scheduler exist outside of the cluster. Alerts currently fire for those missing components.

This PR adds a configuration field that allows excluding those Kubernetes control plane rules.