### PR TITLE
expose /metrics only on localhost

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -163,7 +163,7 @@ func Main() int {
 	o.RegisterMetrics(r)
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
-	go http.ListenAndServe(":8080", mux)
+	go http.ListenAndServe("127.0.0.1:8080", mux)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	wg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Follow-up to https://github.com/openshift/cluster-monitoring-operator/pull/686

127.0.0.1 also works with IPv6 networks due to some kernel magic and usage of a hostname (localhost) is not recommended by [golang docs](https://golang.org/pkg/net/#Listen).

/cc @s-urbaniak 