### PR TITLE
Bug 1809353: Exclude Kubernetes control plane rules when running on IBM Cloud

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -239,6 +239,10 @@ func (c *Client) GetProxy(name string) (*configv1.Proxy, error) {
 	return c.oscclient.ConfigV1().Proxies().Get(name, metav1.GetOptions{})
 }
 
+func (c *Client) GetInfrastructure(name string) (*configv1.Infrastructure, error) {
+	return c.oscclient.ConfigV1().Infrastructures().Get(name, metav1.GetOptions{})
+}
+
 func (c *Client) GetConfigmap(namespace, name string) (*v1.ConfigMap, error) {
 	return c.kclient.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
 }

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -27,8 +27,9 @@ import (
 )
 
 type Config struct {
-	Images      *Images `json:"-"`
-	RemoteWrite bool    `json:"-"`
+	Images      *Images               `json:"-"`
+	RemoteWrite bool                  `json:"-"`
+	Platform    configv1.PlatformType `json:"-"`
 
 	PrometheusOperatorConfig             *PrometheusOperatorConfig `json:"prometheusOperator"`
 	PrometheusOperatorUserWorkloadConfig *PrometheusOperatorConfig `json:"prometheusOperatorUserWorkload"`
@@ -342,6 +343,15 @@ func (c *Config) LoadProxy(load func() (*configv1.Proxy, error)) error {
 	c.HTTPConfig.HTTPSProxy = p.Status.HTTPSProxy
 	c.HTTPConfig.NoProxy = p.Status.NoProxy
 
+	return nil
+}
+
+func (c *Config) LoadPlatform(load func() (*configv1.Infrastructure, error)) error {
+	i, err := load()
+	if err != nil {
+		return fmt.Errorf("error loading platform: %v", err)
+	}
+	c.Platform = i.Status.Platform
 	return nil
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	configv1 "github.com/openshift/api/config/v1"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1173,6 +1175,63 @@ func TestOpenShiftStateMetrics(t *testing.T) {
 	}
 	if d.Spec.Template.Spec.Containers[2].Image != "docker.io/openshift/origin-openshift-state-metrics:latest" {
 		t.Fatal("openshift-state-metrics image incorrectly configured")
+	}
+}
+
+func TestPrometheusK8sControlPlaneRulesFiltered(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+		verify func(bool, bool, bool)
+	}{
+		{
+			name: "default config",
+			config: func() *Config {
+				c := NewDefaultConfig()
+				c.Platform = configv1.AWSPlatformType
+				return c
+			}(),
+			verify: func(api, cm, sched bool) {
+				if !api || !cm || !sched {
+					t.Fatal("did not get all expected kubernetes control plane rules")
+				}
+			},
+		},
+		{
+			name: "hosted control plane",
+			config: func() *Config {
+				c := NewDefaultConfig()
+				c.Platform = IBMCloudPlatformType
+				return c
+			}(),
+			verify: func(api, cm, sched bool) {
+				if api || cm || sched {
+					t.Fatalf("kubernetes control plane rules found, none expected")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", tc.config)
+		r, err := f.PrometheusK8sRules()
+		if err != nil {
+			t.Fatal(err)
+		}
+		apiServerRulesFound := false
+		controllerManagerRulesFound := false
+		schedulerRulesFound := false
+		for _, g := range r.Spec.Groups {
+			switch g.Name {
+			case "kubernetes-system-apiserver":
+				apiServerRulesFound = true
+			case "kubernetes-system-controller-manager":
+				controllerManagerRulesFound = true
+			case "kubernetes-system-scheduler":
+				schedulerRulesFound = true
+			}
+		}
+		tc.verify(apiServerRulesFound, controllerManagerRulesFound, schedulerRulesFound)
 	}
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -410,6 +410,13 @@ func (o *Operator) Config(key string) *manifests.Config {
 		klog.Warningf("Could not load proxy configuration from API. This is expected and message can be ignored when proxy configuration doesn't exist. Proceeding without it: %v", err)
 	}
 
+	err = c.LoadPlatform(func() (*configv1.Infrastructure, error) {
+		return o.client.GetInfrastructure("cluster")
+	})
+	if err != nil {
+		klog.Warningf("Could not load platform from infrastructure resource: %v. This may result in alerts that are not appropriate for the platform.", err)
+	}
+
 	cm, err := o.client.GetConfigmap("openshift-config", "etcd-metric-serving-ca")
 	if err != nil {
 		klog.Warningf("Error loading etcd CA certificates for Prometheus. Proceeding with etcd disabled. Error: %v", err)


### PR DESCRIPTION
If the current cluster's platform is `IBMCloud`, Kubernetes control plane rules are skipped.