### PR TITLE
pkg: Remove thanos ruler server TLS cert

### DIFF
--- a/pkg/manifests/tls.go
+++ b/pkg/manifests/tls.go
@@ -125,21 +125,5 @@ func (f *Factory) GRPCSecret(s *v1.Secret) (*v1.Secret, error) {
 		s.Data["prometheus-server.key"] = key
 	}
 
-	{
-		cfg, err := ca.MakeServerCert(
-			sets.NewString("thanos-ruler-grpc"),
-			crypto.DefaultCertificateLifetimeInDays,
-		)
-		if err != nil {
-			return nil, errors.Wrap(err, "error making thanos ruler server certificate")
-		}
-		crt, key, err := cfg.GetPEMBytes()
-		if err != nil {
-			return nil, errors.Wrap(err, "error getting PEM bytes for thanos ruler server certificate")
-		}
-		s.Data["thanos-ruler-server.crt"] = crt
-		s.Data["thanos-ruler-server.key"] = key
-	}
-
 	return s, nil
 }

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -186,8 +186,8 @@ func (t *ThanosRulerUserWorkloadTask) create() error {
 
 		s, err = t.factory.HashSecret(s,
 			"ca.crt", string(grpcTLS.Data["ca.crt"]),
-			"server.crt", string(grpcTLS.Data["thanos-ruler-server.crt"]),
-			"server.key", string(grpcTLS.Data["thanos-ruler-server.key"]),
+			"server.crt", string(grpcTLS.Data["prometheus-server.crt"]),
+			"server.key", string(grpcTLS.Data["prometheus-server.key"]),
 		)
 		if err != nil {
 			return errors.Wrap(err, "error hashing UserWorkload Thanos Ruler GRPC TLS secret")


### PR DESCRIPTION
Instead let thanos ruler use the existing Prometheus tls server cert.
This is due to the thanos restriction of only being able to pass one
grpc-client-server-name.

cc @openshift/openshift-team-monitoring 