### PR TITLE
Bug 1817938: Do not report 'all' in relatedObjects

### DIFF
--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -43,9 +43,8 @@ func NewStatusReporter(client clientv1.ClusterOperatorInterface, name, namespace
 
 func newRelatedObjects(namespace string) []v1.ObjectReference {
 	return []v1.ObjectReference{
-		{Resource: "namespaces", Name: namespace},
 		// Gather pods, services, daemonsets, deployments, replocasets, statefulsets, and routes
-		{Resource: "all", Name: namespace},
+		{Resource: "namespaces", Name: namespace},
 		// Gather all ServiceMonitors, PrometheusRules, Alertmanagers, and Prometheus CRs
 		{Group: "monitoring.coreos.com", Resource: "servicemonitors"},
 		{Group: "monitoring.coreos.com", Resource: "prometheusrules"},


### PR DESCRIPTION
We don't have such resource so it shouldn't be reported. Everything necessary is already covered by `{Resource: "namespaces", Name: namespace},`

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1817860