### PR TITLE
Bug 1819565: pkg/manifests: set correct server name for UWM prom-op service monitor

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1712,7 +1712,7 @@ func (f *Factory) PrometheusOperatorUserWorkloadServiceMonitor() (*monv1.Service
 	}
 
 	sm.Namespace = f.namespaceUserWorkload
-	sm.Spec.Endpoints[0].TLSConfig.ServerName = fmt.Sprintf("prometheus-operator-user-workload.%s.svc", f.namespace)
+	sm.Spec.Endpoints[0].TLSConfig.ServerName = fmt.Sprintf("prometheus-operator.%s.svc", f.namespaceUserWorkload)
 
 	return sm, nil
 }


### PR DESCRIPTION
As in title

/cc @openshift/openshift-team-monitoring 