### PR TITLE
pkg/manifests: remove Hostport from Thanos ruler config

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -104,7 +104,6 @@ type ThanosRulerConfig struct {
 	Tolerations         []v1.Toleration           `json:"tolerations"`
 	Resources           *v1.ResourceRequirements  `json:"resources"`
 	VolumeClaimTemplate *v1.PersistentVolumeClaim `json:"volumeClaimTemplate"`
-	Hostport            string                    `json:"hostport"`
 }
 
 type ThanosQuerierConfig struct {


### PR DESCRIPTION
This isn't used anywhere and most probably a copy/paste from the Prometheus/Alertmanager configuration.

cc @pgier @lilic who worked on this part before.