### PR TITLE
test/e2e: log errors from port forwarding

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -226,7 +226,7 @@ func TestAlertmanagerKubeRbacProxy(t *testing.T) {
 
 	// The tenancy port (9092) is only exposed in-cluster so we need to use
 	// port forwarding to access kube-rbac-proxy.
-	host, cleanUp, err := f.ForwardPort("alertmanager-main", 9092)
+	host, cleanUp, err := f.ForwardPort(t, "alertmanager-main", 9092)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -450,7 +450,7 @@ func assertTenancyForMetrics(t *testing.T) {
 
 	// The tenancy port (9092) is only exposed in-cluster so we need to use
 	// port forwarding to access kube-rbac-proxy.
-	host, cleanUp, err := f.ForwardPort("thanos-querier", 9092)
+	host, cleanUp, err := f.ForwardPort(t, "thanos-querier", 9092)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is to help debugging failures for tests that rely on port forwarding.