### PR TITLE
pkg/operator/operator.go: Bump resync interval to 15 minutes

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	resyncPeriod = 5 * time.Minute
+	resyncPeriod = 15 * time.Minute
 
 	// see https://github.com/kubernetes/apiserver/blob/b571c70e6e823fd78910c3f5b9be895a756f4cbb/pkg/server/options/authentication.go#L239
 	apiAuthenticationConfigMap    = "kube-system/extension-apiserver-authentication"


### PR DESCRIPTION
We already react on changes on any resources we need to reconcile on,
the resync interval should be there to just reconcile. Every 5 minutes
is too much, as we most of the time don't do anything.

We have been seeing a lot of CPU usage on every resync, this at least
lowers how often we spike.

@openshift/openshift-team-monitoring 