### PR TITLE
Create versions-check.sh

### DIFF
--- a/hack/versions-check.sh
+++ b/hack/versions-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+REPOS="prometheus prometheus-alertmanager node_exporter prometheus-operator kube-state-metrics kube-rbac-proxy k8s-prometheus-adapter thanos"
+
+NOW=${1}
+if [ "$NOW" == "" ]; then
+        echo "You need to pass current release version"
+        exit 1
+fi
+
+PREV="release-$(awk "BEGIN{printf \"%.1f\", ($NOW-0.1)}")"
+NOW="release-${NOW}"
+
+for r in ${REPOS}; do
+        echo "$r: version update:"
+        curl "https://github.com/openshift/$r/compare/${PREV}..${NOW}.diff" 2>/dev/null | grep "+++ b/VERSION" -A3 | tail -n2
+        echo ""
+done
+
+echo "Version of openshift/grafana needs to be checked manually as there is no VERSION file in repository"


### PR DESCRIPTION
Provide a simple script to check version upgrades in other monitoring team repositories.

Example execution and output:
```
$ ./versions-check.sh 4.4
prometheus: version update:
-2.14.0
+2.15.2

prometheus-alertmanager: version update:
-0.19.0
+0.20.0

node_exporter: version update:

prometheus-operator: version update:
-0.34.0
+0.35.1

kube-state-metrics: version update:
-1.8.0
+1.9.5

thanos: version update:

Version of openshift/grafana needs to be checked manually as there is no VERSION file in repository
```

/cc @s-urbaniak @lilic 