### PR TITLE
test/e2e/framework: log HTTP response body on non-OK status code

### DIFF
--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -79,6 +79,15 @@ func (c *PrometheusClient) injectQueryParameters(req *http.Request, kvs ...strin
 	return
 }
 
+func clampMax(b []byte) string {
+	const maxLength = 1000
+	s := string(b)
+	if len(s) <= maxLength {
+		return s
+	}
+	return s[0:maxLength-3] + "..."
+}
+
 // PrometheusQuery runs an HTTP GET request against the Prometheus query API and returns
 // the response body.
 func (c *PrometheusClient) PrometheusQuery(query string) ([]byte, error) {
@@ -104,13 +113,13 @@ func (c *PrometheusClient) PrometheusQuery(query string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code response, want %d, got %d", http.StatusOK, resp.StatusCode)
-	}
-
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code response, want %d, got %d (%q)", http.StatusOK, resp.StatusCode, clampMax(body))
 	}
 
 	return body, nil
@@ -139,13 +148,13 @@ func (c *PrometheusClient) PrometheusRules() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code response, want %d, got %d", http.StatusOK, resp.StatusCode)
-	}
-
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code response, want %d, got %d (%q)", http.StatusOK, resp.StatusCode, clampMax(body))
 	}
 
 	return body, nil


### PR DESCRIPTION
The e2e tests sometimes fail while [waiting](https://github.com/openshift/cluster-monitoring-operator/blob/bb01b7d11bc965a908be5135a34607fd109d3c45/test/e2e/main_test.go#L103) for the stack to be deployed.

```
 go test -v -timeout=20m ./test/e2e/ --kubeconfig /tmp/admin.kubeconfig
2020/04/10 16:07:22 wait for prometheus-k8s: error executing prometheus query: unexpected status code response, want 200, got 403: timed out waiting for the condition
FAIL	github.com/openshift/cluster-monitoring-operator/test/e2e	63.161s
FAIL
make: *** [test-e2e] Error 1 
```

Logging the HTTP response might help to identify the issue.