### PR TITLE
Bug 1827489: pkg/tasks: do not remove GRPC secret as it is used by querier

### DIFF
--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -388,16 +388,6 @@ func (t *ThanosRulerUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "deleting Thanos Ruler query config Secret failed")
 	}
 
-	grpcTLS, err := t.factory.GRPCSecret(nil)
-	if err != nil {
-		return errors.Wrap(err, "initializing UserWorkload Thanos Ruler GRPC secret failed")
-	}
-
-	err = t.client.DeleteSecret(grpcTLS)
-	if err != nil {
-		return errors.Wrap(err, "deleting Thanos Ruler GRPC secret failed")
-	}
-
 	acs, err := t.factory.ThanosRulerAlertmanagerConfigSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing Thanos Ruler Alertmanager config Secret failed")


### PR DESCRIPTION
We cannot remove this secret as it is also used by thanos querier.