### PR TITLE
Bug 1828702: wait for trusted CA bundle to be created

### DIFF
--- a/pkg/tasks/grafana.go
+++ b/pkg/tasks/grafana.go
@@ -144,27 +144,14 @@ func (t *GrafanaTask) Run() error {
 			return errors.Wrap(err, "initializing Grafana CA bundle ConfigMap failed")
 		}
 
-		trustedCA, err = t.client.CreateIfNotExistConfigMap(trustedCA)
-		if err != nil {
-			return errors.Wrap(err, " creating Grafana CA bundle ConfigMap failed")
+		cbs := &caBundleSyncer{
+			client:  t.client,
+			factory: t.factory,
+			prefix:  "grafana",
 		}
-
-		// In the case when there is no data but the ConfigMap is there, we just continue.
-		// We will catch this on the next loop.
-		trustedCA = t.factory.HashTrustedCA(trustedCA, "grafana")
-		if trustedCA != nil {
-			err = t.client.CreateOrUpdateConfigMap(trustedCA)
-			if err != nil {
-				return errors.Wrap(err, "reconciling Grafana CA bundle ConfigMap failed")
-			}
-
-			err = t.client.DeleteHashedConfigMap(
-				string(trustedCA.Labels["monitoring.openshift.io/hash"]),
-				"grafana",
-			)
-			if err != nil {
-				return errors.Wrap(err, "deleting old Grafana configmaps failed")
-			}
+		trustedCA, err = cbs.syncTrustedCABundle(trustedCA)
+		if err != nil {
+			return errors.Wrap(err, "syncing Grafana CA bundle ConfigMap failed")
 		}
 
 		d, err := t.factory.GrafanaDeployment(trustedCA)

--- a/pkg/tasks/helpers.go
+++ b/pkg/tasks/helpers.go
@@ -1,0 +1,86 @@
+// Copyright 2020 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"time"
+
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type caBundleSyncer struct {
+	prefix  string
+	client  *client.Client
+	factory *manifests.Factory
+}
+
+func (cbs *caBundleSyncer) syncTrustedCABundle(trustedCA *v1.ConfigMap) (*v1.ConfigMap, error) {
+	trustedCA, err := cbs.client.CreateIfNotExistConfigMap(trustedCA)
+	if err != nil {
+		return nil, errors.Wrap(err, " creating root trusted CA bundle ConfigMap failed")
+	}
+
+	var (
+		lastErr error
+		lastCM  *v1.ConfigMap
+	)
+	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+		var err error
+		lastCM, err = cbs.client.GetConfigmap(trustedCA.GetNamespace(), trustedCA.GetName())
+
+		if err != nil {
+			lastErr = errors.Wrap(err, "retrieving ConfigMap object failed")
+			return false, nil
+		}
+
+		v, ok := lastCM.Data[manifests.TrustedCABundleKey]
+		if !ok {
+			lastErr = errors.New("key missing")
+			return false, nil
+		}
+		if v == "" {
+			lastErr = errors.New("empty value")
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		if err == wait.ErrWaitTimeout && lastErr != nil {
+			err = errors.Errorf("%v: %v", err, lastErr)
+		}
+		return nil, errors.Wrapf(err, "waiting for config map key %q in %s/%s ConfigMap object failed", manifests.TrustedCABundleKey, trustedCA.GetNamespace(), trustedCA.GetName())
+	}
+
+	hashedCM, err := cbs.factory.HashTrustedCA(lastCM, cbs.prefix)
+	if err != nil {
+		return nil, errors.Wrap(err, "hashing trusted CA bundle failed")
+	}
+
+	err = cbs.client.CreateOrUpdateConfigMap(hashedCM)
+	if err != nil {
+		return nil, errors.Wrap(err, "reconciling trusted CA bundle ConfigMap failed")
+	}
+
+	err = cbs.client.DeleteHashedConfigMap(
+		string(hashedCM.Labels["monitoring.openshift.io/hash"]),
+		cbs.prefix,
+	)
+	return hashedCM, errors.Wrap(err, "deleting old trusted CA bundle configmaps failed")
+}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -110,9 +110,9 @@ func TestAlertmanagerTrustedCA(t *testing.T) {
 			return false, nil
 		}
 
-		newCM = factory.HashTrustedCA(cm, "alertmanager")
-		if newCM == nil {
-			lastErr = errors.New("no trusted CA bundle data available")
+		newCM, err = factory.HashTrustedCA(cm, "alertmanager")
+		lastErr = errors.Wrap(err, "no trusted CA bundle data available")
+		if err != nil {
 			return false, nil
 		}
 

--- a/test/e2e/thanos_querier_test.go
+++ b/test/e2e/thanos_querier_test.go
@@ -41,9 +41,9 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 			return false, nil
 		}
 
-		newCM = factory.HashTrustedCA(cm, "thanos-querier")
-		if newCM == nil {
-			lastErr = errors.New("no trusted CA bundle data available")
+		newCM, err = factory.HashTrustedCA(cm, "thanos-querier")
+		lastErr = errors.Wrap(err, "no trusted CA bundle data available")
+		if err != nil {
 			return false, nil
 		}
 


### PR DESCRIPTION
This change ensures that the operator waits for the trusted CA bundle
ConfigMap to be populated before proceeding with the deployment of the
monitoring components.

Note that it should fail the `e2e-aws-operator` until https://bugzilla.redhat.com/show_bug.cgi?id=1827530 is fixed.

Update May 6: https://bugzilla.redhat.com/show_bug.cgi?id=1827530 is now fixed and the CI passes.