### PR TITLE
Bug 1829974: wait for grafana datasource secret

### DIFF
--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -100,6 +100,9 @@ func (t *PrometheusTask) Run() error {
 
 	d := &manifests.GrafanaDatasources{}
 	err = json.Unmarshal(gs.Data["prometheus.yaml"], d)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling grafana datasource failed")
+	}
 
 	hs, err := t.factory.PrometheusK8sHtpasswdSecret(d.Datasources[0].BasicAuthPassword)
 	if err != nil {

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
 
@@ -89,13 +88,18 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "creating Prometheus proxy Secret failed")
 	}
 
-	c := t.client.KubernetesInterface()
-	cm, err := c.CoreV1().Secrets(t.client.Namespace()).Get("grafana-datasources", metav1.GetOptions{})
+	gs, err := t.factory.GrafanaDatasources()
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve Grafana datasources config")
+		return errors.Wrap(err, "initializing Grafana Datasources Secret failed")
 	}
+
+	gs, err = t.client.WaitForSecret(gs)
+	if err != nil {
+		return errors.Wrap(err, "waiting for Grafana Datasources Secret failed")
+	}
+
 	d := &manifests.GrafanaDatasources{}
-	err = json.Unmarshal(cm.Data["prometheus.yaml"], d)
+	err = json.Unmarshal(gs.Data["prometheus.yaml"], d)
 
 	hs, err := t.factory.PrometheusK8sHtpasswdSecret(d.Datasources[0].BasicAuthPassword)
 	if err != nil {

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -84,6 +84,9 @@ func (t *ThanosQuerierTask) Run() error {
 
 	d := &manifests.GrafanaDatasources{}
 	err = json.Unmarshal(gs.Data["prometheus.yaml"], d)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling grafana datasource failed")
+	}
 
 	hs, err := t.factory.ThanosQuerierHtpasswdSecret(d.Datasources[0].BasicAuthPassword)
 	if err != nil {

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ThanosQuerierTask struct {
@@ -73,13 +72,18 @@ func (t *ThanosQuerierTask) Run() error {
 		return errors.Wrap(err, "creating Thanos Querier OAuth Cookie Secret failed")
 	}
 
-	c := t.client.KubernetesInterface()
-	cm, err := c.CoreV1().Secrets(t.client.Namespace()).Get("grafana-datasources", metav1.GetOptions{})
+	gs, err := t.factory.GrafanaDatasources()
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve Grafana datasources config")
+		return errors.Wrap(err, "initializing Grafana Datasources Secret failed")
 	}
+
+	gs, err = t.client.WaitForSecret(gs)
+	if err != nil {
+		return errors.Wrap(err, "waiting for Grafana Datasources Secret failed")
+	}
+
 	d := &manifests.GrafanaDatasources{}
-	err = json.Unmarshal(cm.Data["prometheus.yaml"], d)
+	err = json.Unmarshal(gs.Data["prometheus.yaml"], d)
 
 	hs, err := t.factory.ThanosQuerierHtpasswdSecret(d.Datasources[0].BasicAuthPassword)
 	if err != nil {

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ThanosRulerUserWorkloadTask struct {
@@ -121,13 +120,18 @@ func (t *ThanosRulerUserWorkloadTask) create() error {
 		return errors.Wrap(err, "creating Thanos Ruler OAuth Cookie Secret failed")
 	}
 
-	c := t.client.KubernetesInterface()
-	cm, err := c.CoreV1().Secrets(t.client.Namespace()).Get("grafana-datasources", metav1.GetOptions{})
+	gs, err := t.factory.GrafanaDatasources()
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve Grafana datasources config")
+		return errors.Wrap(err, "initializing Grafana Datasources Secret failed")
 	}
+
+	gs, err = t.client.WaitForSecret(gs)
+	if err != nil {
+		return errors.Wrap(err, "waiting for Grafana Datasources Secret failed")
+	}
+
 	d := &manifests.GrafanaDatasources{}
-	err = json.Unmarshal(cm.Data["prometheus.yaml"], d)
+	err = json.Unmarshal(gs.Data["prometheus.yaml"], d)
 
 	hs, err := t.factory.ThanosRulerHtpasswdSecret(d.Datasources[0].BasicAuthPassword)
 	if err != nil {
@@ -337,13 +341,18 @@ func (t *ThanosRulerUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "deleting Thanos Ruler OAuth Cookie Secret failed")
 	}
 
-	c := t.client.KubernetesInterface()
-	cm, err := c.CoreV1().Secrets(t.client.Namespace()).Get("grafana-datasources", metav1.GetOptions{})
+	gs, err := t.factory.GrafanaDatasources()
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve Grafana datasources config")
+		return errors.Wrap(err, "initializing Grafana Datasources Secret failed")
 	}
+
+	gs, err = t.client.WaitForSecret(gs)
+	if err != nil {
+		return errors.Wrap(err, "waiting for Grafana Datasources Secret failed")
+	}
+
 	d := &manifests.GrafanaDatasources{}
-	err = json.Unmarshal(cm.Data["prometheus.yaml"], d)
+	err = json.Unmarshal(gs.Data["prometheus.yaml"], d)
 
 	hs, err := t.factory.ThanosRulerHtpasswdSecret(d.Datasources[0].BasicAuthPassword)
 	if err != nil {

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -132,6 +132,9 @@ func (t *ThanosRulerUserWorkloadTask) create() error {
 
 	d := &manifests.GrafanaDatasources{}
 	err = json.Unmarshal(gs.Data["prometheus.yaml"], d)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling grafana datasource failed")
+	}
 
 	hs, err := t.factory.ThanosRulerHtpasswdSecret(d.Datasources[0].BasicAuthPassword)
 	if err != nil {
@@ -353,6 +356,9 @@ func (t *ThanosRulerUserWorkloadTask) destroy() error {
 
 	d := &manifests.GrafanaDatasources{}
 	err = json.Unmarshal(gs.Data["prometheus.yaml"], d)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling grafana datasource failed")
+	}
 
 	hs, err := t.factory.ThanosRulerHtpasswdSecret(d.Datasources[0].BasicAuthPassword)
 	if err != nil {


### PR DESCRIPTION
The grafana-datasource secret can be created in parallel with other resources which depend on it.  This might be causing test flakes.