### PR TITLE
Bug 1821666: pkg/tasks: thanos ruler cleanup

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -360,13 +360,13 @@ func (c *Client) DeleteHashedConfigMap(namespace, prefix, newHash string) error 
 		LabelSelector: ls,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "error listing configmaps with label selector %s", ls)
+		return errors.Wrapf(err, "error listing configmaps in namespace %s with label selector %s", namespace, ls)
 	}
 
 	for _, cm := range configMaps.Items {
 		err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Delete(cm.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "error deleting configmap: %s", cm.Name)
+			return errors.Wrapf(err, "error deleting configmap: %s/%s", namespace, cm.Name)
 		}
 	}
 
@@ -381,13 +381,13 @@ func (c *Client) DeleteHashedSecret(namespace, prefix, newHash string) error {
 		LabelSelector: ls,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "error listing secrets with label selector %s", ls)
+		return errors.Wrapf(err, "error listing secrets in namespace %s with label selector %s", namespace, ls)
 	}
 
 	for _, s := range secrets.Items {
 		err := c.KubernetesInterface().CoreV1().Secrets(namespace).Delete(s.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "error deleting secret: %s", s.Name)
+			return errors.Wrapf(err, "error deleting secret: %s/%s", namespace, s.Name)
 		}
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -352,38 +352,42 @@ func (c *Client) DeleteConfigMap(cm *v1.ConfigMap) error {
 	return err
 }
 
-func (c *Client) DeleteHashedConfigMap(newHash, prefix string) error {
+// DeleteHashedConfigMap deletes all configmaps in the given namespace which have
+// the specified prefix, and DO NOT have the given hash.
+func (c *Client) DeleteHashedConfigMap(namespace, prefix, newHash string) error {
 	ls := "monitoring.openshift.io/name=" + prefix + ",monitoring.openshift.io/hash!=" + newHash
-	configMaps, err := c.KubernetesInterface().CoreV1().ConfigMaps(c.namespace).List(metav1.ListOptions{
+	configMaps, err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).List(metav1.ListOptions{
 		LabelSelector: ls,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "error listing configmaps with label selector %s", ls)
 	}
 
-	for i := range configMaps.Items {
-		err := c.KubernetesInterface().CoreV1().ConfigMaps(c.namespace).Delete(configMaps.Items[i].Name, &metav1.DeleteOptions{})
+	for _, cm := range configMaps.Items {
+		err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Delete(cm.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "error deleting configmap: %s", configMaps.Items[i].Name)
+			return errors.Wrapf(err, "error deleting configmap: %s", cm.Name)
 		}
 	}
 
 	return nil
 }
 
-func (c *Client) DeleteHashedSecret(newHash, prefix string) error {
+// DeleteHashedSecret deletes all secrets in the given namespace which have
+// the specified prefix, and DO NOT have the given hash.
+func (c *Client) DeleteHashedSecret(namespace, prefix, newHash string) error {
 	ls := "monitoring.openshift.io/name=" + prefix + ",monitoring.openshift.io/hash!=" + newHash
-	configMaps, err := c.KubernetesInterface().CoreV1().Secrets(c.namespace).List(metav1.ListOptions{
+	secrets, err := c.KubernetesInterface().CoreV1().Secrets(namespace).List(metav1.ListOptions{
 		LabelSelector: ls,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "error listing secrets with label selector %s", ls)
 	}
 
-	for i := range configMaps.Items {
-		err := c.KubernetesInterface().CoreV1().Secrets(c.namespace).Delete(configMaps.Items[i].Name, &metav1.DeleteOptions{})
+	for _, s := range secrets.Items {
+		err := c.KubernetesInterface().CoreV1().Secrets(namespace).Delete(s.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "error deleting secret: %s", configMaps.Items[i].Name)
+			return errors.Wrapf(err, "error deleting secret: %s", s.Name)
 		}
 	}
 

--- a/pkg/tasks/helpers.go
+++ b/pkg/tasks/helpers.go
@@ -79,8 +79,9 @@ func (cbs *caBundleSyncer) syncTrustedCABundle(trustedCA *v1.ConfigMap) (*v1.Con
 	}
 
 	err = cbs.client.DeleteHashedConfigMap(
-		string(hashedCM.Labels["monitoring.openshift.io/hash"]),
+		trustedCA.GetNamespace(),
 		cbs.prefix,
+		string(hashedCM.Labels["monitoring.openshift.io/hash"]),
 	)
 	return hashedCM, errors.Wrap(err, "deleting old trusted CA bundle configmaps failed")
 }

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -270,8 +270,9 @@ func (t *PrometheusTask) Run() error {
 	}
 
 	err = t.client.DeleteHashedSecret(
-		string(s.Labels["monitoring.openshift.io/hash"]),
+		s.GetNamespace(),
 		"prometheus-k8s-grpc-tls",
+		string(s.Labels["monitoring.openshift.io/hash"]),
 	)
 	if err != nil {
 		return errors.Wrap(err, "error creating Prometheus Client GRPC TLS secret")

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -169,8 +169,9 @@ func (t *PrometheusUserWorkloadTask) create() error {
 	}
 
 	err = t.client.DeleteHashedSecret(
-		string(s.Labels["monitoring.openshift.io/hash"]),
+		s.GetNamespace(),
 		"prometheus-user-workload-grpc-tls",
+		string(s.Labels["monitoring.openshift.io/hash"]),
 	)
 	if err != nil {
 		return errors.Wrap(err, "error creating UserWorkload Prometheus Client GRPC TLS secret")

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -168,8 +168,9 @@ func (t *ThanosQuerierTask) Run() error {
 	}
 
 	err = t.client.DeleteHashedSecret(
-		string(s.Labels["monitoring.openshift.io/hash"]),
+		s.GetNamespace(),
 		"thanos-querier-grpc-tls",
+		string(s.Labels["monitoring.openshift.io/hash"]),
 	)
 	if err != nil {
 		return errors.Wrap(err, "error creating Thanos Querier Client GRPC TLS secret")


### PR DESCRIPTION
Thanos ruler should cleanup hashed ca bundle configmaps.
In order to do this, the client library needs to handle deleting
hashed configmaps in namespaces other than the one currently set in the
k8s client.