### PR TITLE
CHANGELOG.md,.github/: Add CHANGELOG process for monitoring stack

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--
+    Don't forget about CHANGELOG if this affects the end user!
+
+    Changelog entry format:
+    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...
+
+    <PR-id> Id of your pull request.
+    <PR-URL> URL of your PR
+    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.
+
+    Example:
+    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
+-->
+
+* [ ] I added CHANGELOG entry for this change.
+* [ ] No user facing changes, so no entry in CHANGELOG was needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
+
+## Next release - 4.6
+


### PR DESCRIPTION
This makes it easier for us to track what we changed in the current
release, and saves us time when writing release notes and talking
with customer support or writing docs. This is informational only and
OpenShift release notes should serve as the official changelog.

Also adds a reminder to fill in the CHANGELOG as part of PR templates.

cc @openshift/openshift-team-monitoring 