### PR TITLE
*: cleanup OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,7 @@ component: "Monitoring"
 
 reviewers:
 - brancz
-- squat
 - s-urbaniak
-- metalmatze
 - paulfantom
 - LiliC
 - pgier
@@ -13,10 +11,12 @@ reviewers:
 approvers:
 - brancz
 - bparees
-- squat
 - s-urbaniak
-- metalmatze
 - paulfantom
 - LiliC
 - pgier
 - simonpasquier
+
+emeritus_approvers:
+- squat
+- metalmatze


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Move squat and metalmatze to [emeritus_approvers](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#emeritus) to stop assigning them as reviewers of PRs.

/cc @openshift/openshift-team-monitoring 

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
