### PR TITLE
Bug 1845825: Cleanup thanos ruler route when user workload monitoring is disabled

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -552,6 +552,14 @@ func (c *Client) DeleteService(svc *v1.Service) error {
 	return err
 }
 
+func (c *Client) DeleteRoute(r *routev1.Route) error {
+	err := c.osrclient.RouteV1().Routes(r.GetNamespace()).Delete(r.GetName(), &metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 func (c *Client) DeletePrometheusRule(rule *monv1.PrometheusRule) error {
 	err := c.mclient.MonitoringV1().PrometheusRules(rule.GetNamespace()).Delete(rule.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -254,6 +254,16 @@ func (t *ThanosRulerUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "reconciling Thanos Ruler PrometheusRule failed")
 	}
 
+	route, err := t.factory.ThanosRulerRoute()
+	if err != nil {
+		return errors.Wrap(err, "initializing Thanos Ruler Route failed")
+	}
+
+	err = t.client.DeleteRoute(route)
+	if err != nil {
+		return errors.Wrap(err, "deleting Thanos Ruler Route failed")
+	}
+
 	svc, err := t.factory.ThanosRulerService()
 	if err != nil {
 		return errors.Wrap(err, "initializing Thanos Ruler Service failed")

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -251,7 +251,7 @@ func (t *ThanosRulerUserWorkloadTask) destroy() error {
 
 	err = t.client.DeletePrometheusRule(prmrl)
 	if err != nil {
-		return errors.Wrap(err, "reconciling Thanos Ruler PrometheusRule failed")
+		return errors.Wrap(err, "deleting Thanos Ruler PrometheusRule failed")
 	}
 
 	route, err := t.factory.ThanosRulerRoute()
@@ -281,12 +281,12 @@ func (t *ThanosRulerUserWorkloadTask) destroy() error {
 
 	err = t.client.DeleteClusterRole(cr)
 	if err != nil {
-		return errors.Wrap(err, "reconciling Thanos Ruler ClusterRole failed")
+		return errors.Wrap(err, "deleting Thanos Ruler ClusterRole failed")
 	}
 
 	crb, err := t.factory.ThanosRulerClusterRoleBinding()
 	if err != nil {
-		return errors.Wrap(err, "deleting Thanos Ruler ClusterRoleBinding failed")
+		return errors.Wrap(err, "initializing Thanos Ruler ClusterRoleBinding failed")
 	}
 
 	err = t.client.DeleteClusterRoleBinding(crb)


### PR DESCRIPTION

* [ X ] No user facing changes, so no entry in CHANGELOG was needed.
