### PR TITLE
pkg/manifests: rotate grpc key material gracefully

### DIFF
--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -240,7 +240,7 @@ func (t *PrometheusTask) Run() error {
 		}
 	}
 
-	grpcTLS, err := t.factory.GRPCSecret(nil)
+	grpcTLS, err := t.factory.GRPCSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus GRPC secret failed")
 	}

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -139,7 +139,7 @@ func (t *PrometheusUserWorkloadTask) create() error {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Service failed")
 	}
 
-	grpcTLS, err := t.factory.GRPCSecret(nil)
+	grpcTLS, err := t.factory.GRPCSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus GRPC secret failed")
 	}
@@ -215,7 +215,7 @@ func (t *PrometheusUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus ServiceMonitor failed")
 	}
 
-	grpcTLS, err := t.factory.GRPCSecret(nil)
+	grpcTLS, err := t.factory.GRPCSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus GRPC secret failed")
 	}

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -138,7 +138,7 @@ func (t *ThanosQuerierTask) Run() error {
 		return errors.Wrap(err, "reconciling Thanos Querier ClusterRoleBinding failed")
 	}
 
-	grpcTLS, err := t.factory.GRPCSecret(nil)
+	grpcTLS, err := t.factory.GRPCSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing Thanos Querier GRPC secret failed")
 	}

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -161,7 +161,7 @@ func (t *ThanosRulerUserWorkloadTask) create() error {
 			return errors.Wrap(err, "syncing Thanos Ruler trusted CA bundle ConfigMap failed")
 		}
 
-		grpcTLS, err := t.factory.GRPCSecret(nil)
+		grpcTLS, err := t.factory.GRPCSecret()
 		if err != nil {
 			return errors.Wrap(err, "initializing UserWorkload Thanos Ruler GRPC secret failed")
 		}
@@ -319,7 +319,7 @@ func (t *ThanosRulerUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "deleting all hashed Thanos Ruler trusted CA bundle ConfigMap failed")
 	}
 
-	grpcTLS, err := t.factory.GRPCSecret(nil)
+	grpcTLS, err := t.factory.GRPCSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Thanos Ruler GRPC secret failed")
 	}


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This is the initial implementation for a graceful rotation based on the simplified scheme. Please take a look. It still misses a small e2e test which enforces rotation.

/cc @openshift/openshift-team-monitoring 