### PR TITLE
Bug 1813221: pkg/manifests: use alertmanager container names instead of index

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -365,36 +365,42 @@ func (f *Factory) AlertmanagerMain(host string, trustedCABundleCM *v1.ConfigMap)
 		a.Spec.Tolerations = f.config.AlertmanagerMainConfig.Tolerations
 	}
 
-	a.Spec.Containers[0].Image = f.config.Images.OauthProxy
-	setEnv := func(name, value string) {
-		for i := range a.Spec.Containers[0].Env {
-			if a.Spec.Containers[0].Env[i].Name == name {
-				a.Spec.Containers[0].Env[i].Value = value
-				break
+	setEnv := func(container *v1.Container, name, value string) {
+		for i := range container.Env {
+			if container.Env[i].Name == name {
+				container.Env[i].Value = value
 			}
 		}
 	}
-	if f.config.HTTPConfig.HTTPProxy != "" {
-		setEnv("HTTP_PROXY", f.config.HTTPConfig.HTTPProxy)
-	}
-	if f.config.HTTPConfig.HTTPSProxy != "" {
-		setEnv("HTTPS_PROXY", f.config.HTTPConfig.HTTPSProxy)
-	}
-	if f.config.HTTPConfig.NoProxy != "" {
-		setEnv("NO_PROXY", f.config.HTTPConfig.NoProxy)
-	}
+	for i, c := range a.Spec.Containers {
+		switch c.Name {
+		case "alertmanager-proxy":
+			a.Spec.Containers[i].Image = f.config.Images.OauthProxy
+			if f.config.HTTPConfig.HTTPProxy != "" {
+				setEnv(&a.Spec.Containers[i], "HTTP_PROXY", f.config.HTTPConfig.HTTPProxy)
+			}
+			if f.config.HTTPConfig.HTTPSProxy != "" {
+				setEnv(&a.Spec.Containers[i], "HTTPS_PROXY", f.config.HTTPConfig.HTTPSProxy)
+			}
+			if f.config.HTTPConfig.NoProxy != "" {
+				setEnv(&a.Spec.Containers[i], "NO_PROXY", f.config.HTTPConfig.NoProxy)
+			}
 
-	if trustedCABundleCM != nil {
-		volumeName := "alertmanager-trusted-ca-bundle"
-		a.Spec.VolumeMounts = append(a.Spec.VolumeMounts, trustedCABundleVolumeMount(volumeName))
-		volume := trustedCABundleVolume(trustedCABundleCM.Name, volumeName)
-		volume.VolumeSource.ConfigMap.Items = append(volume.VolumeSource.ConfigMap.Items, v1.KeyToPath{
-			Key:  "ca-bundle.crt",
-			Path: "tls-ca-bundle.pem",
-		})
-		a.Spec.Volumes = append(a.Spec.Volumes, volume)
-		// We have only one container in Alertmanager CR spec and this is oauth-proxy
-		a.Spec.Containers[0].VolumeMounts = append(a.Spec.Containers[0].VolumeMounts, trustedCABundleVolumeMount(volumeName))
+			if trustedCABundleCM != nil {
+				volumeName := "alertmanager-trusted-ca-bundle"
+				a.Spec.VolumeMounts = append(a.Spec.VolumeMounts, trustedCABundleVolumeMount(volumeName))
+				volume := trustedCABundleVolume(trustedCABundleCM.Name, volumeName)
+				volume.VolumeSource.ConfigMap.Items = append(volume.VolumeSource.ConfigMap.Items, v1.KeyToPath{
+					Key:  "ca-bundle.crt",
+					Path: "tls-ca-bundle.pem",
+				})
+				a.Spec.Volumes = append(a.Spec.Volumes, volume)
+				a.Spec.Containers[i].VolumeMounts = append(
+					a.Spec.Containers[i].VolumeMounts,
+					trustedCABundleVolumeMount(volumeName),
+				)
+			}
+		}
 	}
 
 	a.Namespace = f.namespace


### PR DESCRIPTION
Backporting single commit from #701 
Prerequisite for the fix for bug 1813221.  See #818 
* [X] No user facing changes, so no entry in CHANGELOG was needed.
