### PR TITLE
examples/user-workload/README.md: Detail user workload monitoring flow

### DIFF
--- a/examples/user-workload/README.md
+++ b/examples/user-workload/README.md
@@ -1,0 +1,42 @@
+# Enable user workload monitoring
+
+Admin has to first enable user workload monitoring via the main cluster-monitoring `ConfigMap`:
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+```
+
+`ConfigMap` called `user-workload-monitoring-config` in the `openshift-user-workload-monitoring` namespace can then be used to configure the user workload monitoring stack. A user who's granted the `user-workload-monitoring-config-edit` `Role` in the `openshift-user-workload-monitoring` namespace gets full permissions on this `ConfigMap`.
+
+Configuration example is located in this directory, with the following supported configuration fields:
+```
+prometheusOperator:
+logLevel     string
+nodeSelector map[string]string
+tolerations  []v1.Toleration
+
+thanosRuler:
+logLevel     string
+nodeSelector map[string]string
+tolerations  []v1.Toleration
+resources           *v1.ResourceRequirements
+volumeClaimTemplate *v1.PersistentVolumeClaim
+
+prometheus:
+logLevel     string
+nodeSelector map[string]string
+tolerations  []v1.Toleration
+retention string
+resources           *v1.ResourceRequirements
+externalLabels      map[string]string
+volumeClaimTemplate *v1.PersistentVolumeClaim
+hostport            string
+remoteWrite         []monv1.RemoteWriteSpec
+```

--- a/examples/user-workload/configmap.yaml
+++ b/examples/user-workload/configmap.yaml
@@ -5,11 +5,6 @@ metadata:
   namespace: openshift-user-workload-monitoring
 data:
   config.yaml: |
-    prometheusOperator:
-      resources:
-        requests:
-          cpu: 200m
-          memory: 2Gi
     prometheus:
       retention: 24h
       resources:


### PR DESCRIPTION
@s-urbaniak As per your suggestion, PTAL

* [X] No user facing changes, so no entry in CHANGELOG was needed.
