### PR TITLE
Bug 1852767: set user workload prometheus retention

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -196,6 +196,10 @@ func NewConfig(content io.Reader) (*Config, error) {
 	return res, nil
 }
 
+const (
+	defaultPrometheusRetention = "15d"
+)
+
 func (c *Config) applyDefaults() {
 	if c.Images == nil {
 		c.Images = &Images{}
@@ -213,13 +217,13 @@ func (c *Config) applyDefaults() {
 		c.ClusterMonitoringConfiguration.PrometheusK8sConfig = &PrometheusK8sConfig{}
 	}
 	if c.ClusterMonitoringConfiguration.PrometheusK8sConfig.Retention == "" {
-		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.Retention = "15d"
+		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.Retention = defaultPrometheusRetention
 	}
 	if c.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig == nil {
 		c.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig = &PrometheusK8sConfig{}
 	}
 	if c.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention == "" {
-		c.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention = "15d"
+		c.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention = defaultPrometheusRetention
 	}
 	if c.ClusterMonitoringConfiguration.AlertmanagerMainConfig == nil {
 		c.ClusterMonitoringConfiguration.AlertmanagerMainConfig = &AlertmanagerMainConfig{}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1462,7 +1462,7 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		p.Spec.LogLevel = f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.LogLevel
 	}
 
-	if f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention != "" {
+	if f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention != defaultPrometheusRetention {
 		p.Spec.Retention = f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention
 	}
 


### PR DESCRIPTION
Allows the user workload prometheus retention setting to override
the cluster monitoring settings only if the cluster monitoring
setting is not set to the default.  Before this change the user workload
setting is never used because the cluster monitoring setting is
compared to an empty string instead of the default value.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
