### PR TITLE
pkg: remove 'hostport' configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@
 - [#800](https://github.com/openshift/cluster-monitoring-operator/pull/800) Collect metrics and implement alerting rules for Thanos querier.
 - [#804](https://github.com/openshift/cluster-monitoring-operator/pull/804) Allow user workload monitoring configuration ConfigMap to be created in openshift-user-workload-monitoring namespace.
 - [#736](https://github.com/openshift/cluster-monitoring-operator/pull/800) Expose /api/v1/rules endpoint of Thanos Querier via the 9093 TCP port with multi-tenancy support.
-- [#854](https://github.com/openshift/cluster-monitoring-operator/pull/854) Change KubeQuotaExceeded to KubeQuotaFullyUsed
+- [#854](https://github.com/openshift/cluster-monitoring-operator/pull/854) Change KubeQuotaExceeded to KubeQuotaFullyUsed.
+- [#859](https://github.com/openshift/cluster-monitoring-operator/pull/859) Remove the `hostport` parameter from the configuration.

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -93,7 +93,6 @@ type PrometheusK8sConfig struct {
 	Resources           *v1.ResourceRequirements  `json:"resources"`
 	ExternalLabels      map[string]string         `json:"externalLabels"`
 	VolumeClaimTemplate *v1.PersistentVolumeClaim `json:"volumeClaimTemplate"`
-	Hostport            string                    `json:"hostport"`
 	RemoteWrite         []monv1.RemoteWriteSpec   `json:"remoteWrite"`
 	TelemetryMatches    []string                  `json:"-"`
 }
@@ -103,7 +102,6 @@ type AlertmanagerMainConfig struct {
 	Tolerations         []v1.Toleration           `json:"tolerations"`
 	Resources           *v1.ResourceRequirements  `json:"resources"`
 	VolumeClaimTemplate *v1.PersistentVolumeClaim `json:"volumeClaimTemplate"`
-	Hostport            string                    `json:"hostport"`
 }
 
 type ThanosRulerConfig struct {
@@ -123,7 +121,6 @@ type ThanosQuerierConfig struct {
 type GrafanaConfig struct {
 	NodeSelector map[string]string `json:"nodeSelector"`
 	Tolerations  []v1.Toleration   `json:"tolerations"`
-	Hostport     string            `json:"hostport"`
 }
 
 type KubeStateMetricsConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -255,10 +255,6 @@ func NewFactory(namespace, namespaceUserWorkload string, c *Config) *Factory {
 }
 
 func (f *Factory) PrometheusExternalURL(host string) *url.URL {
-	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Hostport != "" {
-		host = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Hostport
-	}
-
 	return &url.URL{
 		Scheme: "https",
 		Host:   host,
@@ -267,10 +263,6 @@ func (f *Factory) PrometheusExternalURL(host string) *url.URL {
 }
 
 func (f *Factory) AlertmanagerExternalURL(host string) *url.URL {
-	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Hostport != "" {
-		host = f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Hostport
-	}
-
 	return &url.URL{
 		Scheme: "https",
 		Host:   host,
@@ -457,9 +449,6 @@ func (f *Factory) AlertmanagerRoute() (*routev1.Route, error) {
 		return nil, err
 	}
 
-	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Hostport != "" {
-		r.Spec.Host = f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Hostport
-	}
 	r.Namespace = f.namespace
 
 	return r, nil
@@ -1151,9 +1140,6 @@ func (f *Factory) PrometheusK8sRoute() (*routev1.Route, error) {
 		return nil, err
 	}
 
-	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Hostport != "" {
-		r.Spec.Host = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Hostport
-	}
 	r.Namespace = f.namespace
 
 	return r, nil
@@ -1165,10 +1151,6 @@ func (f *Factory) ThanosQuerierRoute() (*routev1.Route, error) {
 		return nil, err
 	}
 
-	// apply hostport configuration to thanos
-	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Hostport != "" {
-		r.Spec.Host = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Hostport
-	}
 	r.Namespace = f.namespace
 
 	return r, nil
@@ -2204,9 +2186,6 @@ func (f *Factory) GrafanaRoute() (*routev1.Route, error) {
 		return nil, err
 	}
 
-	if f.config.ClusterMonitoringConfiguration.GrafanaConfig.Hostport != "" {
-		r.Spec.Host = f.config.ClusterMonitoringConfiguration.GrafanaConfig.Hostport
-	}
 	r.Namespace = f.namespace
 
 	return r, nil


### PR DESCRIPTION
The 'hostport' parameter should be removed because it has no use in
OpenShift.

* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
