### PR TITLE
[release-3.11] Added Prometheus K8S parameters remote write

### DIFF
--- a/Documentation/user-guides/configuring-cluster-monitoring.md
+++ b/Documentation/user-guides/configuring-cluster-monitoring.md
@@ -80,6 +80,8 @@ resources: [v1.ResourceRequirements](https://kubernetes.io/docs/api-reference/v1
 # specified by users
 externalLabels:
   [ - <labelname>: <labelvalue> ]
+remoteWrite:
+  - [RemoteWriteSpec](https://github.com/coreos/prometheus-operator/blob/v0.23.2/Documentation/api.md#remotewritespec)
 ```
 
 ### AlertmanagerMainConfig

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io"
 
+	monv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -60,6 +61,7 @@ type PrometheusK8sConfig struct {
 	ExternalLabels      map[string]string         `json:"externalLabels"`
 	VolumeClaimTemplate *v1.PersistentVolumeClaim `json:"volumeClaimTemplate"`
 	Hostport            string                    `json:"hostport"`
+	RemoteWrite         []monv1.RemoteWriteSpec   `json:"remoteWrite"`
 }
 
 type AlertmanagerMainConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -730,6 +730,10 @@ func (f *Factory) PrometheusK8s(host string) (*monv1.Prometheus, error) {
 		}
 	}
 
+	if len(f.config.PrometheusK8sConfig.RemoteWrite) > 0 {
+		p.Spec.RemoteWrite = f.config.PrometheusK8sConfig.RemoteWrite
+	}
+
 	if f.config.EtcdConfig == nil {
 		secrets := []string{}
 		for _, s := range p.Spec.Secrets {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -515,6 +515,8 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
       memory: 750Mi
   externalLabels:
     datacenter: eu-west
+  remoteWrite:
+  - url: "https://test.remotewrite.com/api/write"
 ingress:
   baseAddress: monitoring-demo.staging.core-os.net
 `)
@@ -568,6 +570,10 @@ ingress:
 	storageRequestPtr := &storageRequest
 	if storageRequestPtr.String() != "15Gi" {
 		t.Fatal("Prometheus volumeClaimTemplate not configured correctly, expected 15Gi storage request, but found", storageRequestPtr.String())
+	}
+
+	if p.Spec.RemoteWrite[0].URL != "https://test.remotewrite.com/api/write" {
+		t.Fatal("Prometheus remote-write is not configured correctly")
 	}
 }
 


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->
Added Prometheus K8S parameters remote write, updated documentation

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
