### PR TITLE
pkg: delete deprecated configmap

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1156,6 +1156,7 @@ func (f *Factory) ThanosQuerierRoute() (*routev1.Route, error) {
 	return r, nil
 }
 
+// TODO: remove in 4.7
 func (f *Factory) SharingConfigDeprecated(promHost, amHost, grafanaHost, thanosHost *url.URL) *v1.ConfigMap {
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1170,6 +1171,8 @@ func (f *Factory) SharingConfigDeprecated(promHost, amHost, grafanaHost, thanosH
 		},
 	}
 }
+
+// End of remove
 
 func (f *Factory) SharingConfig(promHost, amHost, grafanaHost, thanosHost *url.URL) *v1.ConfigMap {
 	return &v1.ConfigMap{

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -677,10 +677,12 @@ func TestSharingConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// TODO: remove in 4.7
 	cm := f.SharingConfigDeprecated(u, u, u, u)
 	if cm.Namespace != "openshift-monitoring" {
 		t.Fatalf("expecting %q namespace, got %q", "openshift-monitoring", cm.Namespace)
 	}
+	// End of remove
 
 	cm = f.SharingConfig(u, u, u, u)
 	if cm.Namespace == "openshift-monitoring" {

--- a/pkg/tasks/configsharing.go
+++ b/pkg/tasks/configsharing.go
@@ -73,12 +73,14 @@ func (t *ConfigSharingTask) Run() error {
 		return errors.Wrap(err, "failed to retrieve Thanos Querier host")
 	}
 
-	// TODO(spasquie): to be removed once the console uses the configmap from the "openshift-config-managed" namespace.
+	// TODO: remove in 4.7
+	// The sharing-config configmap isn't used anymore by the console in 4.6 and should be deleted if present.
 	cm := t.factory.SharingConfigDeprecated(promURL, amURL, grafanaURL, thanosURL)
-	err = t.client.CreateOrUpdateConfigMap(cm)
+	err = t.client.DeleteConfigMap(cm)
 	if err != nil {
-		return errors.Wrapf(err, "reconciling %s/%s ConfigMap failed", cm.Namespace, cm.Name)
+		return errors.Wrapf(err, "failed to delete %s/%s ConfigMap", cm.Namespace, cm.Name)
 	}
+	// End of remove
 
 	cm = t.factory.SharingConfig(promURL, amURL, grafanaURL, thanosURL)
 	err = t.client.CreateOrUpdateConfigMap(cm)


### PR DESCRIPTION
The `sharing-config` configmap in the `openshift-monitoring` namespace
isn't needed anymore and it should be deleted by CMO.

In 4.7, the code managing this configmap can be removed.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

cc @lilic what we discussed already a few minutes ago.