### PR TITLE
bump operator role apiVersion

### DIFF
--- a/manifests/0000_50_cluster_monitoring_operator_02-role.yaml
+++ b/manifests/0000_50_cluster_monitoring_operator_02-role.yaml
@@ -27,7 +27,7 @@
 # 	assets/telemeter-client/cluster-role.yaml
 # 	assets/thanos-querier/cluster-role.yaml
 # 	assets/thanos-ruler/cluster-role.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cluster-monitoring-operator


### PR DESCRIPTION
Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1beta1

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
