### PR TITLE
fix lose WaitForCacheSync

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -182,7 +182,7 @@ func (o *Operator) Run(stopc <-chan struct{}) error {
 	go o.kubeSystemCmapInf.Run(stopc)
 
 	klog.V(4).Info("Waiting for initial cache sync.")
-	ok := cache.WaitForCacheSync(stopc, o.cmapInf.HasSynced, o.kubeSystemCmapInf.HasSynced)
+	ok := cache.WaitForCacheSync(stopc, o.cmapInf.HasSynced, o.secretInf.HasSynced, o.kubeSystemCmapInf.HasSynced)
 	if !ok {
 		return errors.New("failed to sync informers")
 	}


### PR DESCRIPTION
similarly, also need to wait for the synchronization of secret Shared Index Informer.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
