### PR TITLE
pkg/manifests: update containers consistently

### DIFF
--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -967,16 +967,18 @@ ingress:
 		t.Fatal("Prometheus image is not configured correctly")
 	}
 
-	if p.Spec.Containers[K8S_CONTAINER_OAUTH_PROXY].Image != "docker.io/openshift/origin-oauth-proxy:latest" {
-		t.Fatal("oauth-proxy image is not configured correctly")
-	}
+	for _, container := range p.Spec.Containers {
+		if container.Name == "oauth-proxy" && container.Image != "docker.io/openshift/origin-oauth-proxy:latest" {
+			t.Fatalf("image for %s is not configured correctly: %s", container.Name, container.Image)
+		}
 
-	if p.Spec.Containers[K8S_CONTAINER_KUBE_RBAC_PROXY].Image != "docker.io/openshift/origin-kube-rbac-proxy:latest" {
-		t.Fatal("kube-rbac-proxy image is not configured correctly")
-	}
+		if container.Name == "kube-rbac-proxy" && container.Image != "docker.io/openshift/origin-kube-rbac-proxy:latest" {
+			t.Fatalf("image for %s is not configured correctly: %s", container.Name, container.Image)
+		}
 
-	if p.Spec.Containers[K8S_CONTAINER_PROM_LABEL_PROXY].Image != "docker.io/openshift/origin-prom-label-proxy:latest" {
-		t.Fatal("prom-label-proxy image is not configured correctly")
+		if container.Name == "prom-label-proxy" && container.Image != "docker.io/openshift/origin-prom-label-proxy:latest" {
+			t.Fatalf("image for %s is not configured correctly: %s", container.Name, container.Image)
+		}
 	}
 
 	cpuLimit := p.Spec.Resources.Limits[v1.ResourceCPU]


### PR DESCRIPTION
We were not consistent when CMO had to update containers from
deployments, daemonsets, and so on. Containers were either accessed by
index or by name.

This change standardizes on names because it's more obvious to
understand what is being modified.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
