### PR TITLE
Bug 1853253: remove expired TLS secret for Thanos Ruler

### DIFF
--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -192,7 +192,7 @@ func (t *ThanosRulerUserWorkloadTask) create() error {
 
 		err = t.client.DeleteHashedSecret(
 			grpcSecret.GetNamespace(),
-			"thanos-ruler-user-workload-grpc-tls",
+			"thanos-ruler-grpc-tls",
 			string(grpcSecret.Labels["monitoring.openshift.io/hash"]),
 		)
 		if err != nil {


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
