### PR TITLE
pkg/operator: add informer on configmap in user-workload namespace

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -132,11 +132,6 @@ func (c *Client) Namespace() string {
 	return c.namespace
 }
 
-// ConfigMapListWatch returns a new ListWatch on the ConfigMap resource.
-func (c *Client) ConfigMapListWatch() *cache.ListWatch {
-	return c.ConfigMapListWatchForNamespace(c.namespace)
-}
-
 func (c *Client) ConfigMapListWatchForNamespace(ns string) *cache.ListWatch {
 	return cache.NewListWatchFromClient(c.kclient.CoreV1().RESTClient(), "configmaps", ns, fields.Everything())
 }


### PR DESCRIPTION
The operator didn't trigger the reconciliation loop when the
"user-workload-monitoring-config" configmap was changed because it
didn't watch for configmap resources in the
"openshift-user-workload-monitoring" namespace.

This change also ensures that the additional informers on the
"kube-system", "openshift-config-managed" and "openshift-config"
namespaces are started and synced.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

This explains why the e2e test for the `TestUserWorkloadMonitoringNewConfig` test was frequently failing: because CMO wasn't triggered when changes were made to the `user-workload-monitoring-config` configmap`, the test relied on the fact that the reconciliation loop wakes up every 5 minutes even without change.

cc @openshift/openshift-team-monitoring