### PR TITLE
Bug 1862896: add requirements section and generate-in-docker target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,18 @@ These steps outline the general contribution workflow:
 * Make sure the tests pass, and add any new tests as appropriate.
 * Submit a pull request to the original repository. (see [Format of Pull Requests](#format-of-pull-requests))
 
+## Required tools
+To allow scripts and `make` targets working correctly, ensure you have following tools installed in your system:
+
+* golang (see `go.mod` file for minimum required go version)
+* `awk` (GNU variant)
+* `sed` (GNU variant)
+* `make`
+* `curl`
+* python and pyyaml package
+
+All other tools are downloaded automatically by `make` and put into `tmp/bin` directory.
+
 ## Working with jsonnet
 This project is making use of a lot of upstream projects and imports them.
 
@@ -89,6 +101,9 @@ At this point, you should follow a standard git workflow:
 * push to your branch
 * open a Pull Request (see [Format of Pull Requests](#format-of-pull-requests))
 
+## Troubleshooting
+
+In case generation step or CI `ci/prow/generate` check fails, try running `make clean` to remove stale jsonnet vendor directory.
 
 ## Coding Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ To allow scripts and `make` targets working correctly, ensure you have following
 * `sed` (GNU variant)
 * `make`
 * `curl`
-* python and pyyaml package
+* python2 and pyyaml package
 
 All other tools are downloaded automatically by `make` and put into `tmp/bin` directory.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,11 @@ At this point, you should follow a standard git workflow:
 
 ## Troubleshooting
 
-In case generation step or CI `ci/prow/generate` check fails, try running `make clean` to remove stale jsonnet vendor directory.
+- In case generation step or CI `ci/prow/generate` check fails, try running `make clean` to remove stale jsonnet vendor directory.
+
+- In case you have problems with `make generate` due to problems with system-wide tooling, you can use slower
+`make generate-in-docker` target which will install necessary tools in containerized environment and will generate assets.
+This targets needs `docker` to be installed on host and was not tested with other container runtime environments.
 
 ## Coding Style
 

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,15 @@ vendor:
 .PHONY: generate
 generate: pkg/manifests/bindata.go manifests/0000_50_cluster_monitoring_operator_02-role.yaml docs
 
+.PHONY: generate-in-docker
+generate-in-docker:
+	echo -e "FROM golang:1.14 \n RUN apt update && apt install python-yaml jq -y" | docker build -t cmo-tooling -
+	docker run -it --user $(shell id -u):$(shell id -g) \
+		-w /go/src/github.com/openshift/cluster-monitoring-operator \
+		-v ${PWD}:/go/src/github.com/openshift/cluster-monitoring-operator \
+		cmo-tooling make generate
+
+
 $(JSONNET_VENDOR): $(JB_BIN) jsonnet/jsonnetfile.json
 	cd jsonnet && $(JB_BIN) install
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-monitoring-operator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Jeffail/gabs v1.4.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # github.com/Jeffail/gabs v1.4.0
+## explicit
 github.com/Jeffail/gabs
 # github.com/PuerkitoBio/purell v1.1.1
 github.com/PuerkitoBio/purell
@@ -15,6 +16,7 @@ github.com/cespare/xxhash
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/coreos/prometheus-operator v0.40.0
+## explicit
 github.com/coreos/prometheus-operator/pkg/alertmanager
 github.com/coreos/prometheus-operator/pkg/apis/monitoring
 github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1
@@ -32,6 +34,7 @@ github.com/coreos/prometheus-operator/test/framework
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/ghodss/yaml v1.0.0
+## explicit
 github.com/ghodss/yaml
 # github.com/go-kit/kit v0.10.0
 github.com/go-kit/kit/log
@@ -71,6 +74,7 @@ github.com/go-openapi/validate
 # github.com/go-stack/stack v1.8.0
 github.com/go-stack/stack
 # github.com/gogo/protobuf v1.3.1
+## explicit
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
 # github.com/golang/protobuf v1.4.2
@@ -115,10 +119,12 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
 # github.com/openshift/api v0.0.0-20200623075207-eb651a5bb0ad
+## explicit
 github.com/openshift/api/config/v1
 github.com/openshift/api/route/v1
 github.com/openshift/api/security/v1
 # github.com/openshift/client-go v0.0.0-20200623090625-83993cebb5ae
+## explicit
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
@@ -129,8 +135,10 @@ github.com/openshift/client-go/security/clientset/versioned
 github.com/openshift/client-go/security/clientset/versioned/scheme
 github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
 # github.com/openshift/library-go v0.0.0-20200120084036-bb27e57e2f2b
+## explicit
 github.com/openshift/library-go/pkg/crypto
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/prometheus-community/prom-label-proxy v0.1.1-0.20200616110844-0fbfa11fa8f3
 github.com/prometheus-community/prom-label-proxy/injectproxy
@@ -144,6 +152,7 @@ github.com/prometheus/alertmanager/api/v2/client/silence
 github.com/prometheus/alertmanager/api/v2/models
 github.com/prometheus/alertmanager/pkg/labels
 # github.com/prometheus/client_golang v1.7.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -158,6 +167,7 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/prometheus/prometheus v1.8.2-0.20200609102542-5d7e3e970602
+## explicit
 github.com/prometheus/prometheus/pkg/labels
 github.com/prometheus/prometheus/pkg/value
 github.com/prometheus/prometheus/promql/parser
@@ -193,8 +203,10 @@ golang.org/x/net/idna
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
 # golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
+## explicit
 golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6
+## explicit
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 golang.org/x/sys/windows
@@ -250,6 +262,7 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.3.0
 gopkg.in/yaml.v2
 # k8s.io/api v0.18.4 => k8s.io/api v0.18.3
+## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -291,6 +304,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.18.3
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
@@ -299,6 +313,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 # k8s.io/apimachinery v0.18.4 => k8s.io/apimachinery v0.18.3
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -343,8 +358,10 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/apiserver v0.18.3
+## explicit
 k8s.io/apiserver/pkg/authentication/user
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.18.3
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
@@ -414,10 +431,12 @@ k8s.io/client-go/util/workqueue
 # k8s.io/component-base v0.18.3
 k8s.io/component-base/cli/flag
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/klog/v2 v2.0.0
 k8s.io/klog/v2
 # k8s.io/kube-aggregator v0.18.3
+## explicit
 k8s.io/kube-aggregator/pkg/apis/apiregistration
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
@@ -428,6 +447,7 @@ k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistr
 # k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 => k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/metrics v0.18.4
+## explicit
 k8s.io/metrics/pkg/apis/metrics
 k8s.io/metrics/pkg/apis/metrics/v1alpha1
 k8s.io/metrics/pkg/apis/metrics/v1beta1
@@ -444,3 +464,8 @@ k8s.io/utils/trace
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# k8s.io/api => k8s.io/api v0.18.3
+# k8s.io/apimachinery => k8s.io/apimachinery v0.18.3
+# k8s.io/client-go => k8s.io/client-go v0.18.3
+# k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269
+# k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Putting requirements section into CONTRIBUTING.md to show which packages are needed to be installed before doing a contribution.

Re-adding `make generate-in-docker` as a workaround solution until we remove python dependency.

/cc @s-urbaniak @lilic 

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
