### PR TITLE
Bug 1862896: bring back containerized generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,15 @@ vendor:
 .PHONY: generate
 generate: pkg/manifests/bindata.go manifests/0000_50_cluster_monitoring_operator_02-role.yaml docs
 
+.PHONY: generate-in-docker
+generate-in-docker:
+	echo -e "FROM golang:1.14 \n RUN apt update && apt install python-yaml jq -y" | docker build -t cmo-tooling -
+	docker run -it --user $(shell id -u):$(shell id -g) \
+		-w /go/src/github.com/openshift/cluster-monitoring-operator \
+		-v ${PWD}:/go/src/github.com/openshift/cluster-monitoring-operator \
+		cmo-tooling make generate
+
+
 $(JSONNET_VENDOR): $(JB_BIN) jsonnet/jsonnetfile.json
 	cd jsonnet && $(JB_BIN) install
 


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

To simplify one time contributions and remove the need for installing tooling on the host. This target is slower than having tools on the host but deals with installing dependencies.

Note: Inline building of a container image is necessary to prevent generating all assets with root ownership.

~This PR depends on https://github.com/openshift/cluster-monitoring-operator/pull/887 so putting on hold
/hold~ apparently it doesn't :shrug: 

/cc @openshift/openshift-team-monitoring 

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.