### PR TITLE
Bug 1857192: test/e2e: don't count central grpc-tls

### DIFF
--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -849,12 +849,14 @@ func assertGRPCTLSRotation(t *testing.T) {
 	// We know the amount of expected secrets in forehand.
 	// We should not calculate it on-the-fly as the calculation could be racy.
 	//
-	// 1. openshift-monitoring/grpc-tls
-	// 2. openshift-monitoring/prometheus-k8s-grpc-tls-[hash]
-	// 3. openshift-user-workload-monitoring/prometheus-user-workload-grpc-tls-[hash]
-	// 4. openshift-monitoring/thanos-querier-grpc-tls-[hash]
-	// 5. openshift-user-workload-monitoring/thanos-ruler-grpc-tls-[hash]
-	const expectedGRPCSecretCount = 5
+	// 1. openshift-monitoring/prometheus-k8s-grpc-tls-[hash]
+	// 2. openshift-user-workload-monitoring/prometheus-user-workload-grpc-tls-[hash]
+	// 3. openshift-monitoring/thanos-querier-grpc-tls-[hash]
+	// 4. openshift-user-workload-monitoring/thanos-ruler-grpc-tls-[hash]
+	//
+	// The central grpc-tls secret is verified independently by getting it directly
+	// and verifying if the force-rotation annotation has been removed.
+	const expectedGRPCSecretCount = 4
 
 	err = framework.Poll(time.Second, 5*time.Minute, func() error {
 		s, err := f.KubeClient.CoreV1().Secrets(f.Ns).Get(context.TODO(), "grpc-tls", metav1.GetOptions{})


### PR DESCRIPTION
We expect a constant number of 5 secrets
as per https://github.com/openshift/cluster-monitoring-operator/blob/f9567c5be644a867e41e2312f93c7183d5aa9c10/test/e2e/user_workload_monitoring_test.go#L894

However the underlying `countGRPCSecrets` method only lists secrets
having the `monitoring.openshift.io/hash` label set
which excludes `grpc-tls`.

It is flaky because, during GRPC TLS rotation, there are indeed
sometimes 5 secrets with the above hash label (pre- and post-rotation secrets).

The fix is to expect 4 secrets only which is the what the rotation has to converge against.

/cc @openshift/openshift-team-monitoring 

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
