### PR TITLE
Makefile: fix invalid -mod argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,4 +147,4 @@ $(BIN_DIR):
 
 $(TOOLING): $(BIN_DIR)
 	@echo Installing tools from hack/tools.go
-	@cd hack/tools && go list -mod=mod -tags tools -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %
+	@cd hack/tools && go list -mod=readonly -tags tools -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=readonly -o $(BIN_DIR) %


### PR DESCRIPTION
Before this change, executing the instructions in CONTRIBUTING.md produces the following error:

    $ make jsonnet/vendor --always-make
    mkdir -p /cmo/tmp/bin
    Installing tools from hack/tools.go
    -mod=mod not supported (can be '', 'readonly', or 'vendor')
    make: *** [Makefile:150: /cmo/tmp/bin/jb] Error 1

This patch fixes the `-mod` argument to use the valid `readonly` value.
