### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
 # When bumping the Go version, don't forget to update the configuration of the
 # CI jobs in openshift/release.
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-monitoring-operator
 COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN make operator-no-deps
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/cluster-monitoring-operator/operator /usr/bin/
-COPY manifests /manifests
-USER 1001
-ENTRYPOINT ["/usr/bin/operator"]
 LABEL io.k8s.display-name="OpenShift cluster-monitoring-operator" \
       io.k8s.description="This is a component of OpenShift and manages the lifecycle of the Prometheus based cluster monitoring stack." \
       io.openshift.tags="openshift" \
       io.openshift.release.operator=true \
-      maintainer="Frederic Branczyk <fbranczy@redhat.com>"
+      summary="This is a component of OpenShift and manages the lifecycle of the Prometheus based cluster monitoring stack." \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
+
+COPY --from=builder /go/src/github.com/openshift/cluster-monitoring-operator/operator /usr/bin/
+COPY manifests /manifests
+USER 1001
+ENTRYPOINT ["/usr/bin/operator"]
+


### PR DESCRIPTION
- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value
- explicit switch to golang 1.14 in Dockerfile
- rearranged Dockerfile layout to be similar to others

/cc @openshift/openshift-team-monitoring