### PR TITLE
Bug 1858198: manifests: fix ciphers for CMO kube-rbac-proxy

### DIFF
--- a/manifests/0000_50_cluster_monitoring_operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster_monitoring_operator_05-deployment.yaml
@@ -47,7 +47,7 @@ spec:
       - args:
         - --logtostderr
         - --secure-listen-address=:8443
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:8080/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key


### PR DESCRIPTION
Follow-up to https://github.com/openshift/cluster-monitoring-operator/pull/900

/cc @openshift/openshift-team-monitoring 