### PR TITLE
Bug 1822442: Note about telemeter config

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2893,6 +2893,10 @@ func (f *Factory) TelemeterClientDeployment(proxyCABundleCM *v1.ConfigMap) (*app
 			}
 
 			cmd := []string{}
+			// Note: matchers are read only during CMO bootstrap. This mechanism was chosen as CMO image will be reloaded during upgrades
+			// and matchers shouldn't change during runtime. It offers similar amount of protection against unwanted configuration changes
+			// while not having any performace penalty. However it should be changed to usual reconciliation mechanism after CMO performance
+			// issues are solved.
 			for _, a := range d.Spec.Template.Spec.Containers[i].Command {
 				if !strings.HasPrefix(a, "--match=") {
 					cmd = append(cmd, a)


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

As discussed in the architecture call.

I am using a bug name just to circumvent bugzilla bug requirements. After this is merged I'll close a bug as WONTFIX.

/cc @openshift/openshift-team-monitoring 
