### PR TITLE
Bug 1881061: Add UWM namespace to the operator's related objects

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -57,19 +57,20 @@ const (
 )
 
 type Client struct {
-	version           string
-	namespace         string
-	namespaceSelector string
-	kclient           kubernetes.Interface
-	oscclient         openshiftconfigclientset.Interface
-	ossclient         openshiftsecurityclientset.Interface
-	osrclient         openshiftrouteclientset.Interface
-	mclient           monitoring.Interface
-	eclient           apiextensionsclient.Interface
-	aggclient         aggregatorclient.Interface
+	version               string
+	namespace             string
+	userWorkloadNamespace string
+	namespaceSelector     string
+	kclient               kubernetes.Interface
+	oscclient             openshiftconfigclientset.Interface
+	ossclient             openshiftsecurityclientset.Interface
+	osrclient             openshiftrouteclientset.Interface
+	mclient               monitoring.Interface
+	eclient               apiextensionsclient.Interface
+	aggclient             aggregatorclient.Interface
 }
 
-func New(cfg *rest.Config, version string, namespace string, namespaceSelector string) (*Client, error) {
+func New(cfg *rest.Config, version string, namespace, userWorkloadNamespace string, namespaceSelector string) (*Client, error) {
 	mclient, err := monitoring.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -111,16 +112,17 @@ func New(cfg *rest.Config, version string, namespace string, namespaceSelector s
 	}
 
 	return &Client{
-		version:           version,
-		namespace:         namespace,
-		namespaceSelector: namespaceSelector,
-		kclient:           kclient,
-		oscclient:         oscclient,
-		ossclient:         ossclient,
-		osrclient:         osrclient,
-		mclient:           mclient,
-		eclient:           eclient,
-		aggclient:         aggclient,
+		version:               version,
+		namespace:             namespace,
+		userWorkloadNamespace: userWorkloadNamespace,
+		namespaceSelector:     namespaceSelector,
+		kclient:               kclient,
+		oscclient:             oscclient,
+		ossclient:             ossclient,
+		osrclient:             osrclient,
+		mclient:               mclient,
+		eclient:               eclient,
+		aggclient:             aggclient,
 	}, nil
 }
 
@@ -1228,7 +1230,7 @@ func (c *Client) CRDReady(crd *extensionsobj.CustomResourceDefinition) (bool, er
 }
 
 func (c *Client) StatusReporter() *StatusReporter {
-	return NewStatusReporter(c.oscclient.ConfigV1().ClusterOperators(), "monitoring", c.namespace, c.version)
+	return NewStatusReporter(c.oscclient.ConfigV1().ClusterOperators(), "monitoring", c.namespace, c.userWorkloadNamespace, c.version)
 }
 
 func (c *Client) DeleteRoleBinding(binding *rbacv1.RoleBinding) error {

--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -42,9 +42,10 @@ func TestStatusReporterSetDone(t *testing.T) {
 			name: "not found",
 
 			given: givenStatusReporter{
-				operatorName: "foo",
-				namespace:    "bar",
-				version:      "1.0",
+				operatorName:          "foo",
+				namespace:             "bar",
+				userWorkloadNamespace: "fred",
+				version:               "1.0",
 			},
 
 			when: []whenFunc{
@@ -71,9 +72,10 @@ func TestStatusReporterSetDone(t *testing.T) {
 			name: "found",
 
 			given: givenStatusReporter{
-				operatorName: "foo",
-				namespace:    "bar",
-				version:      "1.0",
+				operatorName:          "foo",
+				namespace:             "bar",
+				userWorkloadNamespace: "fred",
+				version:               "1.0",
 			},
 
 			when: []whenFunc{
@@ -101,6 +103,7 @@ func TestStatusReporterSetDone(t *testing.T) {
 				mock,
 				tc.given.operatorName,
 				tc.given.namespace,
+				tc.given.userWorkloadNamespace,
 				tc.given.version,
 			)
 
@@ -130,9 +133,10 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 			name: "not found",
 
 			given: givenStatusReporter{
-				operatorName: "foo",
-				namespace:    "bar",
-				version:      "1.0",
+				operatorName:          "foo",
+				namespace:             "bar",
+				userWorkloadNamespace: "fred",
+				version:               "1.0",
 			},
 
 			when: []whenFunc{
@@ -159,9 +163,10 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 			name: "found",
 
 			given: givenStatusReporter{
-				operatorName: "foo",
-				namespace:    "bar",
-				version:      "1.0",
+				operatorName:          "foo",
+				namespace:             "bar",
+				userWorkloadNamespace: "fred",
+				version:               "1.0",
 			},
 
 			when: []whenFunc{
@@ -189,6 +194,7 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 				mock,
 				tc.given.operatorName,
 				tc.given.namespace,
+				tc.given.userWorkloadNamespace,
 				tc.given.version,
 			)
 
@@ -220,10 +226,11 @@ func TestStatusReporterSetFailed(t *testing.T) {
 			name: "not found",
 
 			given: givenStatusReporter{
-				operatorName: "foo",
-				namespace:    "bar",
-				version:      "1.0",
-				err:          failedErr,
+				operatorName:          "foo",
+				namespace:             "bar",
+				userWorkloadNamespace: "fred",
+				version:               "1.0",
+				err:                   failedErr,
 			},
 
 			when: []whenFunc{
@@ -250,9 +257,10 @@ func TestStatusReporterSetFailed(t *testing.T) {
 			name: "found",
 
 			given: givenStatusReporter{
-				operatorName: "foo",
-				namespace:    "bar",
-				version:      "1.0",
+				operatorName:          "foo",
+				namespace:             "bar",
+				userWorkloadNamespace: "fred",
+				version:               "1.0",
 			},
 
 			when: []whenFunc{
@@ -280,6 +288,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 				mock,
 				tc.given.operatorName,
 				tc.given.namespace,
+				tc.given.userWorkloadNamespace,
 				tc.given.version,
 			)
 
@@ -299,8 +308,8 @@ func TestStatusReporterSetFailed(t *testing.T) {
 }
 
 type givenStatusReporter struct {
-	operatorName, namespace, version string
-	err                              error
+	operatorName, namespace, userWorkloadNamespace, version string
+	err                                                     error
 }
 
 type checkFunc func(*clusterOperatorMock, error) error

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -71,7 +71,7 @@ type Operator struct {
 }
 
 func New(config *rest.Config, version, namespace, namespaceUserWorkload, namespaceSelector, configMapName, userWorkloadConfigMapName string, remoteWrite bool, images map[string]string, telemetryMatches []string) (*Operator, error) {
-	c, err := client.New(config, version, namespace, namespaceSelector)
+	c, err := client.New(config, version, namespace, namespaceUserWorkload, namespaceSelector)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -88,7 +88,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		return nil, nil, errors.Wrap(err, "creating monitoring client failed")
 	}
 
-	operatorClient, err := client.New(config, "", namespaceName, "")
+	operatorClient, err := client.New(config, "", namespaceName, userWorkloadNamespaceName, "")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating operator client failed")
 	}


### PR DESCRIPTION
Previously CMO was only referencing the "openshift-monitoring" namespace
as a related object.

This change adds "openshift-user-workload-monitoring" namespace as well
as all the ThanosRuler and PodMonitor objects.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
