### PR TITLE
pkg/operator: fix log msg about reconciliation interval

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -213,7 +213,7 @@ func (o *Operator) Run(stopc <-chan struct{}) error {
 	key := o.namespace + "/" + o.configMapName
 	_, exists, _ := o.cmapInf.GetStore().GetByKey(key)
 	if !exists {
-		klog.Info("ConfigMap to configure stack does not exist. Reconciling with default config every 5 minutes.")
+		klog.Infof("ConfigMap to configure stack does not exist. Reconciling with default config every %d minutes.", resyncPeriod)
 		o.enqueue(key)
 	}
 
@@ -224,7 +224,7 @@ func (o *Operator) Run(stopc <-chan struct{}) error {
 		case <-ticker.C:
 			_, exists, _ := o.cmapInf.GetStore().GetByKey(key)
 			if !exists {
-				klog.Info("ConfigMap to configure stack does not exist. Reconciling with default config every 5 minutes.")
+				klog.Infof("ConfigMap to configure stack does not exist. Reconciling with default config every %d minutes.", resyncPeriod)
 				o.enqueue(key)
 			}
 		}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

Our reconciliation period is 15 minutes now and it seems we forgot to update our log msg. This should fix the issue.