### PR TITLE
Updating cluster-monitoring-operator builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # When bumping the Go version, don't forget to update the configuration of the
 # CI jobs in openshift/release.
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-monitoring-operator
 COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN make operator-no-deps
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 LABEL io.k8s.display-name="OpenShift cluster-monitoring-operator" \
       io.k8s.description="This is a component of OpenShift and manages the lifecycle of the Prometheus based cluster monitoring stack." \
       io.openshift.tags="openshift" \


### PR DESCRIPTION
Updating cluster-monitoring-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/cluster-monitoring-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.