### PR TITLE
Bug 1888542: decrease CMO log verbosity from 3 to 2

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,22 +1,21 @@
 component: "Monitoring"
 
 reviewers:
-- brancz
-- squat
 - s-urbaniak
-- metalmatze
 - paulfantom
 - LiliC
 - pgier
 - simonpasquier
 
 approvers:
-- brancz
 - bparees
-- squat
 - s-urbaniak
-- metalmatze
 - paulfantom
 - LiliC
 - pgier
 - simonpasquier
+
+emeritus_approvers:
+- brancz
+- squat
+- metalmatze

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -155,6 +155,11 @@ func Main() int {
 	}
 
 	o, err := cmo.New(config, *releaseVersion, *namespace, *namespaceUserWorkload, *namespaceSelector, *configMapName, *remoteWrite, images.asMap(), telemetryConfig.Matches)
+
+	// CMO runs many tasks in parallel and the default values for rate limiting are too low.
+	config.QPS = 20
+	config.Burst = 40
+
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
 		return 1

--- a/manifests/0000_50_cluster_monitoring_operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster_monitoring_operator_05-deployment.yaml
@@ -71,7 +71,7 @@ spec:
         - "-configmap=cluster-monitoring-config"
         - "-release-version=$(RELEASE_VERSION)"
         - "-logtostderr=true"
-        - "-v=3"
+        - "-v=2"
         - "-images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest"
         - "-images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest"
         - "-images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -702,7 +702,7 @@ func (c *Client) WaitForDeploymentRollout(dep *appsv1.Deployment) error {
 		}
 		if d.Status.UnavailableReplicas != 0 {
 			lastErr = errors.Errorf("got %d unavailable replicas",
-				d.Status.UpdatedReplicas)
+				d.Status.UnavailableReplicas)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -41,9 +41,9 @@ func (tl *TaskRunner) RunAll() (string, error) {
 		i := i
 
 		g.Go(func() error {
-			klog.V(3).Infof("running task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
+			klog.V(2).Infof("running task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
 			err := tl.ExecuteTask(ts)
-			klog.V(3).Infof("ran task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
+			klog.V(2).Infof("ran task %d of %d: %v", i+1, len(tl.tasks), ts.Name)
 			if err != nil {
 				return taskErr{error: errors.Wrapf(err, "running task %v failed", ts.Name), name: ts.Name}
 			}


### PR DESCRIPTION
Manual cherry-pick of #913. The automatic cherry-pick [didn't work](https://github.com/openshift/cluster-monitoring-operator/pull/913#issuecomment-708961885).

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
