### PR TITLE
Bug 1903464: jsonnet: fix recording rules with many-to-many matching errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ vendor:
 	go mod verify
 
 .PHONY: generate
-generate: manifests/0000_50_cluster-monitoring-operator_02-role.yaml docs
+generate: build-jsonnet manifests/0000_50_cluster-monitoring-operator_02-role.yaml docs
 
 .PHONY: generate-in-docker
 generate-in-docker:

--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -937,13 +937,25 @@ spec:
     - expr: sum(cluster:master_nodes or on(node) kube_node_labels ) BY (label_beta_kubernetes_io_instance_type,
         label_node_role_kubernetes_io, label_kubernetes_io_arch, label_node_openshift_io_os_id)
       record: cluster:node_instance_type_count:sum
-    - expr: sum  by (provisioner) (kube_persistentvolumeclaim_resource_requests_storage_bytes
-        * on (namespace,persistentvolumeclaim) group_right() (kube_persistentvolumeclaim_info
-        * on (storageclass)  group_left(provisioner) kube_storageclass_info))
+    - expr: |
+        sum by(provisioner) (
+          topk by (namespace, persistentvolumeclaim) (
+            1, kube_persistentvolumeclaim_resource_requests_storage_bytes
+          ) * on(namespace, persistentvolumeclaim) group_right()
+          topk by(namespace, persistentvolumeclaim) (
+            1, kube_persistentvolumeclaim_info * on(storageclass) group_left(provisioner) topk by(storageclass) (1, max by(storageclass, provisioner) (kube_storageclass_info))
+          )
+        )
       record: cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum
-    - expr: sum  by (provisioner) (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim)
-        group_right() (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner)
-        kube_storageclass_info))
+    - expr: |
+        sum  by (provisioner) (
+          topk by (namespace, persistentvolumeclaim) (
+            1, kubelet_volume_stats_used_bytes
+          ) * on (namespace,persistentvolumeclaim) group_right()
+          topk by (namespace, persistentvolumeclaim) (
+            1, kube_persistentvolumeclaim_info * on(storageclass) group_left(provisioner) topk by(storageclass) (1, max by(storageclass, provisioner) (kube_storageclass_info))
+          )
+        )
       record: cluster:kubelet_volume_stats_used_bytes:provisioner:sum
     - expr: sum(etcd_object_counts) BY (instance)
       record: instance:etcd_object_counts:sum

--- a/test/rules/bz1879520.yaml
+++ b/test/rules/bz1879520.yaml
@@ -1,0 +1,40 @@
+# Tests for https://bugzilla.redhat.com/show_bug.cgi?id=1879520.
+# Having many instance labels for the same volume can lead to problems 
+# with many-to-many matching. Recording rule need to account for this.
+
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'kube_storageclass_info{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="openshift-monitoring",pod="kube-state-metrics-6674fd6cfd-4crcl",provisioner="kubernetes.io/gce-pd",reclaimPolicy="Delete",service="kube-state-metrics",storageclass="standard",volumeBindingMode="WaitForFirstConsumer"}'
+        values: '1+0x5'
+      - series: 'kube_persistentvolumeclaim_info{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="xiuwang",persistentvolumeclaim="jenkins",pod="kube-state-metrics-6674fd6cfd-4crcl",service="kube-state-metrics",storageclass="standard",volumename="pvc-555e1a2c-326d-42f6-a914-512a720574e0"}'
+        values: '1+0x5'
+      - series: 'kubelet_volume_stats_used_bytes{endpoint="https-metrics",instance="10.0.32.5:10250",job="kubelet",metrics_path="/metrics",namespace="xiuwang",node="dyan-upg0916-09160342-w-a-l-rhel-0",persistentvolumeclaim="jenkins",service="kubelet"}'
+        values: '336764928+0x5'
+    promql_expr_test:
+      - expr: cluster:kubelet_volume_stats_used_bytes:provisioner:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:kubelet_volume_stats_used_bytes:provisioner:sum{provisioner="kubernetes.io/gce-pd"}'
+            value: 3.36764928E+08
+  - interval: 1m
+    input_series:
+      - series: 'kube_storageclass_info{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="openshift-monitoring",pod="kube-state-metrics-6674fd6cfd-4crcl",prometheus="openshift-monitoring/k8s",provisioner="kubernetes.io/gce-pd",reclaimPolicy="Delete",service="kube-state-metrics",storageclass="standard",volumeBindingMode="WaitForFirstConsumer"}'
+        values: '1+0x5'
+      - series: 'kube_persistentvolumeclaim_info{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="xiuwang",persistentvolumeclaim="jenkins",pod="kube-state-metrics-6674fd6cfd-4crcl",prometheus="openshift-monitoring/k8s",service="kube-state-metrics",storageclass="standard",volumename="pvc-555e1a2c-326d-42f6-a914-512a720574e0"}'
+        values: '1+0x5'
+      - series: 'kubelet_volume_stats_used_bytes{endpoint="https-metrics",instance="192.168.101.30:10250",job="kubelet",metrics_path="/metrics",namespace="xiuwang",node="scdosw1054.ocpnpr01.npr.isaq.app",persistentvolumeclaim="jenkins",prometheus="openshift-monitoring/k8s",service="kubelet"}'
+        values: '336764921+0x5'
+      - series: 'kubelet_volume_stats_used_bytes{endpoint="https-metrics",instance="192.168.101.23:10250",job="kubelet",metrics_path="/metrics",namespace="xiuwang",node="scdosw1051.ocpnpr01.npr.isaq.app",persistentvolumeclaim="jenkins",prometheus="openshift-monitoring/k8s",service="kubelet"}'
+        values: '336764928+0x5'
+    promql_expr_test:
+      - expr: cluster:kubelet_volume_stats_used_bytes:provisioner:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:kubelet_volume_stats_used_bytes:provisioner:sum{provisioner="kubernetes.io/gce-pd"}'
+            value: 3.36764928E+08

--- a/test/rules/bz1903464.yaml
+++ b/test/rules/bz1903464.yaml
@@ -1,0 +1,39 @@
+# Tests for https://bugzilla.redhat.com/show_bug.cgi?id=1903464
+# Having many instance labels for the same volume can lead to problems 
+# with many-to-many matching. Recording rule need to account for this.
+
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'kube_storageclass_info{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="openshift-monitoring",pod="kube-state-metrics-6674fd6cfd-4crcl",prometheus="openshift-monitoring/k8s",provisioner="kubernetes.io/gce-pd",reclaimPolicy="Delete",service="kube-state-metrics",storageclass="standard",volumeBindingMode="WaitForFirstConsumer"}'
+        values: '1+0x5'
+      - series: 'kube_persistentvolumeclaim_info{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="xiuwang",persistentvolumeclaim="jenkins",pod="kube-state-metrics-6674fd6cfd-4crcl",prometheus="openshift-monitoring/k8s",service="kube-state-metrics",storageclass="standard",volumename="pvc-555e1a2c-326d-42f6-a914-512a720574e0"}'
+        values: '1+0x5'
+      - series: 'kube_persistentvolumeclaim_resource_requests_storage_bytes{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="xiuwang",node="dyan-upg0916-09160342-w-a-l-rhel-0",persistentvolumeclaim="jenkins"}'
+        values: '0.31363677978515625+0x5'
+    promql_expr_test:
+      - expr: cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum{provisioner="kubernetes.io/gce-pd"}'
+            value: 3.1363677978515625E-01
+  - interval: 1m
+    input_series:
+      - series: 'kube_storageclass_info{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="openshift-monitoring",pod="kube-state-metrics-6674fd6cfd-4crcl",prometheus="openshift-monitoring/k8s",provisioner="kubernetes.io/gce-pd",reclaimPolicy="Delete",service="kube-state-metrics",storageclass="standard",volumeBindingMode="WaitForFirstConsumer"}'
+      - series: 'kube_storageclass_info{endpoint="https-main",instance="10.130.2.10:8443",job="kube-state-metrics",namespace="openshift-monitoring",pod="kube-state-metrics-6674fd6cfd-4324",prometheus="openshift-monitoring/k8s",provisioner="kubernetes.io/gce-pd",reclaimPolicy="Delete",service="kube-state-metrics",storageclass="standard",volumeBindingMode="WaitForFirstConsumer"}'
+        values: '1+0x5'
+      - series: 'kube_persistentvolumeclaim_info{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="xiuwang",persistentvolumeclaim="jenkins",pod="kube-state-metrics-6674fd6cfd-4crcl",prometheus="openshift-monitoring/k8s",service="kube-state-metrics",storageclass="standard",volumename="pvc-555e1a2c-326d-42f6-a914-512a720574e0"}'
+        values: '1+0x5'
+      - series: 'kube_persistentvolumeclaim_resource_requests_storage_bytes{endpoint="https-main",instance="10.130.2.7:8443",job="kube-state-metrics",namespace="xiuwang",node="dyan-upg0916-09160342-w-a-l-rhel-0",persistentvolumeclaim="jenkins"}'
+        values: '0.31363677978515625+0x5'
+    promql_expr_test:
+      - expr: cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum{provisioner="kubernetes.io/gce-pd"}'
+            value: 3.1363677978515625E-01


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

Fixing many-to-many matching. Following rules are fixed:
- `cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum`
- `cluster:kubelet_volume_stats_used_bytes:provisioner:sum`

Still working on unit tests. I will rebase it on top of https://github.com/openshift/cluster-monitoring-operator/pull/953 once it is merged.