### PR TITLE
make role manifest sort stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ pkg/manifests/bindata.go: $(GOBINDATA_BIN) $(ASSETS)
 
 # Merge cluster roles
 manifests/0000_50_cluster-monitoring-operator_02-role.yaml: hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in $(ASSETS)
-	python2 hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in `find assets | grep role | grep -v "role-binding" | sort` > $@
+	python2 hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in `find assets | grep role | grep -v "role-binding"` > $@
 
 .PHONY: docs
 docs: $(EMBEDMD_BIN) Documentation/telemeter_query

--- a/hack/merge_cluster_roles.py
+++ b/hack/merge_cluster_roles.py
@@ -28,7 +28,7 @@ def main():
         base = ClusterRole(yaml.load(f, Loader=yaml.SafeLoader))
 
     manifests = sys.argv[2:]
-    for manifest in manifests:
+    for manifest in sorted(manifests):
         with open(manifest, 'r') as f:
             y = yaml.load(f, Loader=yaml.SafeLoader)
             if y['kind'].endswith('RoleList'):


### PR DESCRIPTION
The sort command produces different output on my system than in the CI
job, reversing the order of
`assets/prometheus-operator-user-workload/cluster-role.yaml` and
`assets/prometheus-operator/cluster-role.yaml`. This seems to be
caused by a difference in evaluating the `-` and `/`
characters. Moving the filename sort into python produces stable
output.

See early versions of #971 for an example of the difference in output
caused by the unstable sort.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.