### PR TITLE
Remove deprecated user workload configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#969](https://github.com/openshift/cluster-monitoring-operator/pull/969) Bump Thanos v0.16.0
 - [#970](https://github.com/openshift/cluster-monitoring-operator/pull/970) Bump prometheus-operator v0.43.0.
 - [#971](https://github.com/openshift/cluster-monitoring-operator/pull/971) Enable `hwmon` in node-exporter for hardware sensor data collection
+- [#983](https://github.com/openshift/cluster-monitoring-operator/pull/983) Remove deprecated user workload configuration
 
 ## 4.6
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1176,24 +1176,6 @@ func (f *Factory) ThanosQuerierRoute() (*routev1.Route, error) {
 	return r, nil
 }
 
-// TODO: remove in 4.7
-func (f *Factory) SharingConfigDeprecated(promHost, amHost, grafanaHost, thanosHost *url.URL) *v1.ConfigMap {
-	return &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sharing-config",
-			Namespace: f.namespace,
-		},
-		Data: map[string]string{
-			"grafanaURL":      grafanaHost.String(),
-			"prometheusURL":   promHost.String(),
-			"alertmanagerURL": amHost.String(),
-			"thanosURL":       thanosHost.String(),
-		},
-	}
-}
-
-// End of remove
-
 func (f *Factory) SharingConfig(promHost, amHost, grafanaHost, thanosHost *url.URL) *v1.ConfigMap {
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1450,40 +1432,6 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		p.Spec.EnforcedSampleLimit = f.config.UserWorkloadConfiguration.Prometheus.EnforcedSampleLimit
 	}
 
-	// TODO: remove after 4.7
-
-	if f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.LogLevel != "" {
-		p.Spec.LogLevel = f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.LogLevel
-	}
-
-	if f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention != "" && f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention != DefaultRetentionValue {
-		p.Spec.Retention = f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Retention
-	}
-
-	if f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Resources != nil {
-		p.Spec.Resources = *f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Resources
-	}
-
-	if f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.NodeSelector != nil {
-		p.Spec.NodeSelector = f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.NodeSelector
-	}
-
-	if len(f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Tolerations) > 0 {
-		p.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.Tolerations
-	}
-
-	if f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.ExternalLabels != nil {
-		p.Spec.ExternalLabels = f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.ExternalLabels
-	}
-
-	if f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.VolumeClaimTemplate != nil {
-		p.Spec.Storage = &monv1.StorageSpec{
-			VolumeClaimTemplate: *f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.VolumeClaimTemplate,
-		}
-	}
-	if len(f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.RemoteWrite) > 0 {
-		p.Spec.RemoteWrite = f.config.ClusterMonitoringConfiguration.PrometheusUserWorkloadConfig.RemoteWrite
-	}
 	// end removal
 	if f.config.Images.Thanos != "" {
 		p.Spec.Thanos.Image = &f.config.Images.Thanos
@@ -1913,17 +1861,6 @@ func (f *Factory) PrometheusOperatorUserWorkloadDeployment(denyNamespaces []stri
 	if len(f.config.UserWorkloadConfiguration.PrometheusOperator.Tolerations) > 0 {
 		d.Spec.Template.Spec.Tolerations = f.config.UserWorkloadConfiguration.PrometheusOperator.Tolerations
 	}
-
-	// TODO: remove in 4.7
-	if len(f.config.ClusterMonitoringConfiguration.PrometheusOperatorUserWorkloadConfig.NodeSelector) > 0 {
-		d.Spec.Template.Spec.NodeSelector = f.config.ClusterMonitoringConfiguration.PrometheusOperatorUserWorkloadConfig.NodeSelector
-	}
-
-	if len(f.config.ClusterMonitoringConfiguration.PrometheusOperatorUserWorkloadConfig.Tolerations) > 0 {
-		d.Spec.Template.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.PrometheusOperatorUserWorkloadConfig.Tolerations
-	}
-
-	// end of remove
 
 	for i, container := range d.Spec.Template.Spec.Containers {
 		switch container.Name {
@@ -3113,30 +3050,6 @@ func (f *Factory) ThanosRulerCustomResource(queryURL string, trustedCA *v1.Confi
 	if len(f.config.UserWorkloadConfiguration.ThanosRuler.Tolerations) > 0 {
 		t.Spec.Tolerations = f.config.UserWorkloadConfiguration.ThanosRuler.Tolerations
 	}
-
-	// TODO: remove in 4.7
-	if f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.LogLevel != "" {
-		t.Spec.LogLevel = f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.LogLevel
-	}
-
-	if f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.Resources != nil {
-		t.Spec.Resources = *f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.Resources
-	}
-
-	if f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.VolumeClaimTemplate != nil {
-		t.Spec.Storage = &monv1.StorageSpec{
-			VolumeClaimTemplate: *f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.VolumeClaimTemplate,
-		}
-	}
-
-	if f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.NodeSelector != nil {
-		t.Spec.NodeSelector = f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.NodeSelector
-	}
-
-	if len(f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.Tolerations) > 0 {
-		t.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.ThanosRulerConfig.Tolerations
-	}
-	// end of remove
 
 	for i, container := range t.Spec.Containers {
 		switch container.Name {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -682,14 +682,7 @@ func TestSharingConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// TODO: remove in 4.7
-	cm := f.SharingConfigDeprecated(u, u, u, u)
-	if cm.Namespace != "openshift-monitoring" {
-		t.Fatalf("expecting %q namespace, got %q", "openshift-monitoring", cm.Namespace)
-	}
-	// End of remove
-
-	cm = f.SharingConfig(u, u, u, u)
+	cm := f.SharingConfig(u, u, u, u)
 	if cm.Namespace == "openshift-monitoring" {
 		t.Fatalf("expecting namespace other than %q", "openshift-monitoring")
 	}

--- a/pkg/tasks/configsharing.go
+++ b/pkg/tasks/configsharing.go
@@ -73,16 +73,7 @@ func (t *ConfigSharingTask) Run() error {
 		return errors.Wrap(err, "failed to retrieve Thanos Querier host")
 	}
 
-	// TODO: remove in 4.7
-	// The sharing-config configmap isn't used anymore by the console in 4.6 and should be deleted if present.
-	cm := t.factory.SharingConfigDeprecated(promURL, amURL, grafanaURL, thanosURL)
-	err = t.client.DeleteConfigMap(cm)
-	if err != nil {
-		return errors.Wrapf(err, "failed to delete %s/%s ConfigMap", cm.Namespace, cm.Name)
-	}
-	// End of remove
-
-	cm = t.factory.SharingConfig(promURL, amURL, grafanaURL, thanosURL)
+	cm := t.factory.SharingConfig(promURL, amURL, grafanaURL, thanosURL)
 	err = t.client.CreateOrUpdateConfigMap(cm)
 	if err != nil {
 		return errors.Wrapf(err, "reconciling %s/%s Config ConfigMap failed", cm.Namespace, cm.Name)

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -36,8 +36,7 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 			Namespace: f.Ns,
 		},
 		Data: map[string]string{
-			"config.yaml": `techPreviewUserWorkload:
-      enabled: true
+			"config.yaml": `enableUserWorkload: true
 `,
 		},
 	}

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -49,44 +49,6 @@ func TestUserWorkloadMonitoring(t *testing.T) {
 			Namespace: f.Ns,
 		},
 		Data: map[string]string{
-			"config.yaml": `techPreviewUserWorkload:
-      enabled: true
-`,
-		},
-	}
-
-	for _, scenario := range []struct {
-		name string
-		f    func(*testing.T)
-	}{
-		{"enable user workload monitoring, assert prometheus rollout", createUserWorkloadAssets(cm)},
-		{"assert thanos ruler deployment", assertThanosRulerDeployment},
-		{"assert metrics for user workload components", assertMetricsForMonitoringComponents},
-		{"create and assert an user application is deployed", deployUserApplication},
-		{"create prometheus and alertmanager in user namespace", createPrometheusAlertmanagerInUserNamespace},
-		{"assert user workload metrics", assertUserWorkloadMetrics},
-		{"assert user workload rules", assertUserWorkloadRules},
-		{"assert tenancy model is enforced for metrics", assertTenancyForMetrics},
-		{"assert tenancy model is enforced for rules", assertTenancyForRules},
-		{"assert prometheus and alertmanager is not deployed in user namespace", assertPrometheusAlertmanagerInUserNamespace},
-		{"assert grpc tls rotation", assertGRPCTLSRotation},
-		{"assert user workload metrics", assertUserWorkloadMetrics},
-		{"assert user workload rules", assertUserWorkloadRules},
-		{"assert assets are deleted when user workload monitoring is disabled", assertDeletedUserWorkloadAssets(cm)},
-	} {
-		if ok := t.Run(scenario.name, scenario.f); !ok {
-			t.Fatalf("scenario %q failed", scenario.name)
-		}
-	}
-}
-
-func TestUserWorkloadMonitoringNewConfig(t *testing.T) {
-	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cluster-monitoring-config",
-			Namespace: f.Ns,
-		},
-		Data: map[string]string{
 			"config.yaml": `enableUserWorkload: true
 `,
 		},
@@ -108,13 +70,26 @@ func TestUserWorkloadMonitoringNewConfig(t *testing.T) {
 `,
 		},
 	}
-
 	for _, scenario := range []struct {
 		name string
 		f    func(*testing.T)
 	}{
 		{"enable user workload monitoring, assert prometheus rollout", createUserWorkloadAssets(cm)},
+		{"assert thanos ruler deployment", assertThanosRulerDeployment},
+		{"assert metrics for user workload components", assertMetricsForMonitoringComponents},
+		{"create and assert an user application is deployed", deployUserApplication},
+		{"create prometheus and alertmanager in user namespace", createPrometheusAlertmanagerInUserNamespace},
+		{"assert user workload metrics", assertUserWorkloadMetrics},
+		{"assert user workload rules", assertUserWorkloadRules},
+		{"assert tenancy model is enforced for metrics", assertTenancyForMetrics},
+		{"assert tenancy model is enforced for rules", assertTenancyForRules},
+		{"assert prometheus and alertmanager is not deployed in user namespace", assertPrometheusAlertmanagerInUserNamespace},
+		{"assert grpc tls rotation", assertGRPCTLSRotation},
+		{"assert user workload metrics", assertUserWorkloadMetrics},
+		{"assert user workload rules", assertUserWorkloadRules},
+		{"enable user workload monitoring, assert prometheus rollout", createUserWorkloadAssets(cm)},
 		{"set VolumeClaimTemplate for prometheus CR, assert that it is created", assertPrometheusVCConfig(uwmCM)},
+		{"assert assets are deleted when user workload monitoring is disabled", assertDeletedUserWorkloadAssets(cm)},
 		{"assert assets are deleted when user workload monitoring is disabled", assertDeletedUserWorkloadAssets(cm)},
 	} {
 		if ok := t.Run(scenario.name, scenario.f); !ok {
@@ -122,7 +97,6 @@ func TestUserWorkloadMonitoringNewConfig(t *testing.T) {
 		}
 	}
 }
-
 func assertPrometheusVCConfig(cm *v1.ConfigMap) func(*testing.T) {
 	return func(t *testing.T) {
 		if err := f.OperatorClient.CreateOrUpdateConfigMap(cm); err != nil {


### PR DESCRIPTION
With 4.7 onwards we do not support techPreview configuration, so code that handles that can be removed. Users had one release to migrate, as agreed beforehand. I added a log warning users if they still use that that it will simply not work. We will also mention this in the CHANGELOG as well as in the docs for 4.7, in 4.6 we do not mention the old techPreview configuration anyways.

* [X] I added CHANGELOG entry for this change.
