### PR TITLE
pkg/operator/operator.go: Adjust log format of resyncPeriod

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -213,7 +213,7 @@ func (o *Operator) Run(stopc <-chan struct{}) error {
 	key := o.namespace + "/" + o.configMapName
 	_, exists, _ := o.cmapInf.GetStore().GetByKey(key)
 	if !exists {
-		klog.Infof("ConfigMap to configure stack does not exist. Reconciling with default config every %d minutes.", resyncPeriod)
+		klog.Infof("ConfigMap to configure stack does not exist. Reconciling with default config every %s.", resyncPeriod)
 		o.enqueue(key)
 	}
 
@@ -224,7 +224,7 @@ func (o *Operator) Run(stopc <-chan struct{}) error {
 		case <-ticker.C:
 			_, exists, _ := o.cmapInf.GetStore().GetByKey(key)
 			if !exists {
-				klog.Infof("ConfigMap to configure stack does not exist. Reconciling with default config every %d minutes.", resyncPeriod)
+				klog.Infof("ConfigMap to configure stack does not exist. Reconciling with default config every %s.", resyncPeriod)
 				o.enqueue(key)
 			}
 		}


### PR DESCRIPTION
@paulfantom found that now we log the following by :

> ConfigMap to configure stack does not exist. Reconciling with default config every 900000000000 minutes.

This is incorrect, this adjusts it to include minutes and seconds format, see preview [here](https://play.golang.org/p/NAV03uZYEo4).

New format should be:

> ConfigMap to configure stack does not exist. Reconciling with default config every 15m0s.

This should work for all further changes to the resyncPeriod, if we change it to seconds or hours. :) 
 
* [x] No user facing changes, so no entry in CHANGELOG was needed.
