### PR TITLE
IBM Cloud manifest profile patch

### DIFF
--- a/hack/build-jsonnet.sh
+++ b/hack/build-jsonnet.sh
@@ -14,7 +14,7 @@ mkdir $prefix
 TMP=$(mktemp -d -t tmp.XXXXXXXXXX)
 echo "Created temporary directory at $TMP"
 
-jsonnet -J jsonnet/vendor jsonnet/main.jsonnet > "${TMP}/main.json"
+jsonnet -J jsonnet/vendor -J tmp/json-manifests jsonnet/main.jsonnet > "${TMP}/main.json"
 
 # Replace mapfile with while loop so it works with previous bash versions (Mac included)
 #mapfile -t files < <(jq -r 'keys[]' tmp/main.json)
@@ -40,3 +40,7 @@ rm -f "${prefix}/grafana/console-dashboard-definitions.yaml"
 grep -H 'kind: CustomResourceDefinition' assets/prometheus-operator/* | cut -d: -f1 | while IFS= read -r f; do
   mv "$f" "manifests/0000_50_cluster-monitoring-operator_00_$(basename "$f")"
 done
+
+# Move resulting manifests to the manifests directory
+mv assets/manifests/* manifests/
+rmdir assets/manifests || true

--- a/jsonnet/ibm-cloud-managed-profile.libsonnet
+++ b/jsonnet/ibm-cloud-managed-profile.libsonnet
@@ -1,0 +1,42 @@
+{
+  // Generates manifests specific to the ibm-cloud-managed profile for use
+  // in ROKS clusters.
+  // Specifically, it generates a new cluster monitoring operator deployment by
+  // modifiying the original deployment manifest:
+  // - adds the ibm-cloud-managed profile annotation
+  // - removes the master node selector
+  // Contact: cewong@redhat.com
+
+  local removeMasterNodeSelector(sel) = {
+      [if x != "node-role.kubernetes.io/master" then x]: sel[x]
+      for x in std.objectFields(sel)
+    },
+
+  local setProfileAnnotation(metadata,profile) =
+    local annotations = if "annotations" in metadata then metadata.annotations else {};
+    {
+      [if !std.startsWith(x, "include.release.openshift.io/") then x]: annotations[x]
+      for x in std.objectFields(annotations)
+    } +
+    {
+      ["include.release.openshift.io/" + profile]: "true"
+    },
+
+
+  manifests+:: {
+    local operatorDeployment = import 'manifests/0000_50_cluster-monitoring-operator_05-deployment.json',
+    "0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed": operatorDeployment {
+      local originalMetadata = super.metadata,
+      metadata+: {
+        annotations: setProfileAnnotation(originalMetadata,"ibm-cloud-managed"),
+      },
+      spec+: {
+        template+: {
+          spec+: {
+            nodeSelector: removeMasterNodeSelector(super.nodeSelector),
+          },
+        },
+      },
+    },
+  },
+}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -14,13 +14,13 @@ local prometheusOperatorUserWorkload = import './prometheus-operator-user-worklo
 local prometheus = import './prometheus.libsonnet';
 local prometheusUserWorkload = import './prometheus-user-workload.libsonnet';
 local clusterMonitoringOperator = import './cluster-monitoring-operator.libsonnet';
+local ibmCloudManagedProfile = import 'ibm-cloud-managed-profile.libsonnet';
 
 local thanosRuler = import './thanos-ruler.libsonnet';
 local thanosQuerier = import './thanos-querier.libsonnet';
 
 local openshiftStateMetrics = import './openshift-state-metrics.libsonnet';
 local telemeterClient = import './telemeter-client.libsonnet';
-
 
 /*
 TODO(paulfantom):
@@ -320,6 +320,7 @@ local inCluster =
     openshiftStateMetrics: openshiftStateMetrics($.values.openshiftStateMetrics),
   } +
   (import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet') +
+  ibmCloudManagedProfile +
   {};
 
 // objects deployed in openshift-user-workload-monitoring namespace
@@ -389,5 +390,6 @@ removeRunbookUrl(excludeRules(addReleaseAnnotation(removeLimits(
   { ['thanos-querier/' + name]: inCluster.thanosQuerier[name] for name in std.objectFields(inCluster.thanosQuerier) } +
   { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
   { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
+  { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } + 
   {}
 ))))

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+  labels:
+    app: cluster-monitoring-operator
+  name: cluster-monitoring-operator
+  namespace: openshift-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-monitoring-operator
+  template:
+    metadata:
+      labels:
+        app: cluster-monitoring-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:8443
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --upstream=http://127.0.0.1:8080/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 1m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: cluster-monitoring-operator-tls
+          readOnly: false
+      - args:
+        - -namespace=openshift-monitoring
+        - -namespace-user-workload=openshift-user-workload-monitoring
+        - -configmap=cluster-monitoring-config
+        - -release-version=$(RELEASE_VERSION)
+        - -logtostderr=true
+        - -v=2
+        - -images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest
+        - -images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest
+        - -images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest
+        - -images=prometheus=quay.io/openshift/origin-prometheus:latest
+        - -images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest
+        - -images=grafana=quay.io/openshift/origin-grafana:latest
+        - -images=oauth-proxy=quay.io/openshift/origin-oauth-proxy:latest
+        - -images=node-exporter=quay.io/openshift/origin-prometheus-node-exporter:latest
+        - -images=kube-state-metrics=quay.io/openshift/origin-kube-state-metrics:latest
+        - -images=openshift-state-metrics=quay.io/openshift/origin-openshift-state-metrics:latest
+        - -images=kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:latest
+        - -images=telemeter-client=quay.io/openshift/origin-telemeter:latest
+        - -images=prom-label-proxy=quay.io/openshift/origin-prom-label-proxy:latest
+        - -images=k8s-prometheus-adapter=quay.io/openshift/origin-k8s-prometheus-adapter:latest
+        - -images=thanos=quay.io/openshift/origin-thanos:latest
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/origin-cluster-monitoring-operator:latest
+        name: cluster-monitoring-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/cluster-monitoring-operator/telemetry
+          name: telemetry-config
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: cluster-monitoring-operator
+      tolerations:
+      - effect: NoSchedule
+        key: node.kubernetes.io/memory-pressure
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 120
+      volumes:
+      - configMap:
+          name: telemetry-config
+        name: telemetry-config
+      - name: cluster-monitoring-operator-tls
+        secret:
+          optional: true
+          secretName: cluster-monitoring-operator-tls

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: cluster-monitoring-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:


### PR DESCRIPTION
Part 2 of cluster profiles support for IBM Cloud.
Introduces a directory that will contain profile-specific patches.
Profile-specific manifests are generated with 'make profile-manifests'
(which is called by 'make generate'). The generate test should verify
that the profiles are up to date.

On IBM Cloud the monitoring operator needs to run on worker nodes, thus the
master node selector needs to be removed from the operator deployment
manifest.
