### PR TITLE
Bug 1904161: Use alertmanager_integrations metric instead of alertmanager_notifications_total for AlertmanagerReceiversNotConfigured

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ vendor:
 	go mod verify
 
 .PHONY: generate
-generate: manifests/0000_50_cluster-monitoring-operator_02-role.yaml docs
+generate: build-jsonnet manifests/0000_50_cluster-monitoring-operator_02-role.yaml docs
 
 .PHONY: generate-in-docker
 generate-in-docker:

--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -965,7 +965,7 @@ spec:
         label_node_hyperthread_enabled, label_node_openshift_io_os_id,label_node_role_kubernetes_io_master,label_node_role_kubernetes_io_infra)
         ) by (label_kubernetes_io_arch, label_node_hyperthread_enabled, label_node_openshift_io_os_id,label_node_role_kubernetes_io_master,label_node_role_kubernetes_io_infra)
       record: node_role_os_version_machine:cpu_capacity_sockets:sum
-    - expr: clamp_max(sum(alertmanager_notifications_total),1)
+    - expr: clamp_max(sum(alertmanager_integrations),1)
       record: cluster:alertmanager_routing_enabled:max
     - alert: ClusterMonitoringOperatorReconciliationErrors
       annotations:

--- a/jsonnet/rules.jsonnet
+++ b/jsonnet/rules.jsonnet
@@ -243,7 +243,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
             record: 'node_role_os_version_machine:cpu_capacity_sockets:sum',
           },
           {
-            expr: 'clamp_max(sum(alertmanager_notifications_total),1)',
+            expr: 'clamp_max(sum(alertmanager_integrations),1)',
             record: 'cluster:alertmanager_routing_enabled:max',
           },
           {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
