### PR TITLE
test/e2e: Add Thanos Query Watchdog Alert test

### DIFF
--- a/test/e2e/thanos_querier_test.go
+++ b/test/e2e/thanos_querier_test.go
@@ -108,3 +108,15 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestThanosQueryCanQueryWatchdogAlert(t *testing.T) {
+	// The 2 minute timeout is what console CI tests set.
+	// If this test is flaky, we should increase until
+	// we can fix the possible DNS resolve issues.
+	f.ThanosQuerierClient.WaitForRulesReturn(
+		t, 2*time.Minute,
+		func(body []byte) error {
+			return getThanosRules(body, "general.rules", "Watchdog")
+		},
+	)
+}

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -645,36 +645,7 @@ func assertUserWorkloadRules(t *testing.T) {
 	f.ThanosQuerierClient.WaitForRulesReturn(
 		t, 10*time.Minute,
 		func(body []byte) error {
-			j, err := gabs.ParseJSON([]byte(body))
-			if err != nil {
-				return err
-			}
-
-			groups, err := j.Path("data.groups").Children()
-			if err != nil {
-				return err
-			}
-
-			for i := 0; i < len(groups); i++ {
-				groupName := groups[i].S("name").Data().(string)
-				if groupName != "example" {
-					continue
-				}
-
-				rules, err := groups[i].Path("rules").Children()
-				if err != nil {
-					return err
-				}
-
-				for j := 0; j < len(rules); j++ {
-					ruleName := rules[j].S("name").Data().(string)
-					if ruleName == "VersionAlert" {
-						return nil
-					}
-				}
-			}
-
-			return errors.New("VersionAlert alert not found")
+			return getThanosRules(body, "example", "VersionAlert")
 		},
 	)
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/Jeffail/gabs"
+)
+
+func getThanosRules(body []byte, expGroupName, expRuleName string) error {
+	j, err := gabs.ParseJSON([]byte(body))
+	if err != nil {
+		return err
+	}
+
+	groups, err := j.Path("data.groups").Children()
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(groups); i++ {
+		groupName := groups[i].S("name").Data().(string)
+		if groupName != expGroupName {
+			continue
+		}
+
+		rules, err := groups[i].Path("rules").Children()
+		if err != nil {
+			return err
+		}
+
+		for j := 0; j < len(rules); j++ {
+			ruleName := rules[j].S("name").Data().(string)
+			if ruleName == expRuleName {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("'%s' alert not found in '%s' group", expRuleName, expGroupName)
+}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
