### PR TITLE
Add missing default cluster profile annotation

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_00_0user-priority-class.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0user-priority-class.yaml
@@ -2,6 +2,8 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: openshift-user-critical
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 value: 1000000000
 globalDefault: false
 description: "This priority class should be used for user facing OpenShift workload pods only."


### PR DESCRIPTION
Apparently this file is generated by hand. I tried to run make generate and it didnt changed.