### PR TITLE
Bug 1899582: Increase rest config burst and QPS rate limits

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -155,9 +155,13 @@ func Main() int {
 		return 1
 	}
 
-	// CMO runs many tasks in parallel and the default values for rate limiting are too low.
-	config.QPS = 20
-	config.Burst = 40
+	// CMO runs many tasks in parallel and the default values for rate limiting
+	// are too low. Thus, we need to align the QPS limit with what is set in
+	// upstream prometheus-operator. As for the burst limit, a significant
+	// increase needs to be made as in large environnements with a lot of CRDs,
+	// the limit set upstream is too low.
+	config.QPS = 100
+	config.Burst = 200
 
 	userWorkloadConfigMapName := "user-workload-monitoring-config"
 	o, err := cmo.New(config, *releaseVersion, *namespace, *namespaceUserWorkload, *namespaceSelector, *configMapName, userWorkloadConfigMapName, *remoteWrite, images.asMap(), telemetryConfig.Matches)


### PR DESCRIPTION
Increase rest config QPS value to reflect what is set in upstream
prometheus-operator.
Also, it was reported that CMO is producing a lot of throttling error
logs when it is run in an environnement with a lot CRDs. To fix that, we
can align with the value set in other component that encountered the
same issue. For instance, in `oc` the burst value was set to 200.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
