### PR TITLE
Bug 1915473: Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/Documentation/data-collection.md
+++ b/Documentation/data-collection.md
@@ -249,6 +249,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 ```
 
 These attributes provide a snapshot of the health, usage, and size of a cluster. From this we can determine the functionality of the framework components. This information helps Red Hat to identify correlations between issues experienced across many OpenShift 4 clusters that have similar environmental characteristics. This enables Red Hat to rapidly develop changes in OpenShift 4 to improve software resilience and customer experience.

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -1867,6 +1867,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-cluster-total
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -3100,6 +3101,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-etcd
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -5669,6 +5671,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-k8s-resources-cluster
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -7942,6 +7945,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-k8s-resources-namespace
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -8907,6 +8911,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-k8s-resources-node
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -10666,6 +10671,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-k8s-resources-pod
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -12687,6 +12693,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-k8s-resources-workload
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -14869,6 +14876,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-k8s-resources-workloads-namespace
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -16320,6 +16328,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-namespace-by-pod
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -17271,6 +17280,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-node-cluster-rsrc-use
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -18249,6 +18259,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-node-rsrc-use
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -19464,6 +19475,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-pod-total
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -20678,6 +20690,7 @@ items:
     annotations:
       include.release.openshift.io/ibm-cloud-managed: "true"
       include.release.openshift.io/self-managed-high-availability: "true"
+      include.release.openshift.io/single-node-developer: "true"
     name: grafana-dashboard-prometheus
     namespace: openshift-monitoring
 kind: ConfigMapList

--- a/hack/cluster-monitoring-operator-role.yaml.in
+++ b/hack/cluster-monitoring-operator-role.yaml.in
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]

--- a/jsonnet/add-release-annotation.libsonnet
+++ b/jsonnet/add-release-annotation.libsonnet
@@ -4,7 +4,8 @@
       [if (o.kind == 'CustomResourceDefinition') then 'metadata']+: {
         annotations+: {
           'include.release.openshift.io/ibm-cloud-managed': "true",
-          'include.release.openshift.io/self-managed-high-availability': "true"
+          'include.release.openshift.io/self-managed-high-availability': "true",
+          'include.release.openshift.io/single-node-developer': "true"
         },
       },
       [if (o.kind == 'ConfigMapList') then 'items']: [
@@ -12,7 +13,8 @@
           metadata+: {
             annotations+: {
               'include.release.openshift.io/ibm-cloud-managed': "true",
-              'include.release.openshift.io/self-managed-high-availability': "true"
+              'include.release.openshift.io/self-managed-high-availability': "true",
+              'include.release.openshift.io/single-node-developer': "true"
             }
           },
         }

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0user-priority-class.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0user-priority-class.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-user-critical
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 value: 1000000000
 globalDefault: false
 description: "This priority class should be used for user facing OpenShift workload pods only."

--- a/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
     name: openshift-monitoring
@@ -19,6 +20,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
     name: openshift-user-workload-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -33,6 +33,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
   name: cluster-monitoring-operator
 rules:
 - apiGroups:

--- a/manifests/0000_50_cluster-monitoring-operator_03-role-binding.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_03-role-binding.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -15,6 +16,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
@@ -241,3 +241,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/0000_50_cluster-monitoring-operator_06-clusteroperator.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_06-clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec: {}
 status:
   versions:

--- a/manifests/0000_90_cluster-monitoring-operator_00-operatorgroup.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_00-operatorgroup.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     olm.providedAPIs: Alertmanager.v1.monitoring.coreos.com,PodMonitor.v1.monitoring.coreos.com,Probe.v1.monitoring.coreos.com,Prometheus.v1.monitoring.coreos.com,PrometheusRule.v1.monitoring.coreos.com,ServiceMonitor.v1.monitoring.coreos.com,ThanosRuler.v1.monitoring.coreos.com,AlertmanagerConfig.v1alpha1.monitoring.coreos.com
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   staticProvidedAPIs: true
   selector:

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1866,6 +1866,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-cluster-total
@@ -3102,6 +3103,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-etcd
@@ -5674,6 +5676,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-cluster
@@ -7950,6 +7953,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-namespace
@@ -8918,6 +8922,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-node
@@ -10680,6 +10685,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-pod
@@ -12704,6 +12710,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-workload
@@ -14889,6 +14896,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-workloads-namespace
@@ -16343,6 +16351,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-namespace-by-pod
@@ -17297,6 +17306,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-node-cluster-rsrc-use
@@ -18278,6 +18288,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-node-rsrc-use
@@ -19496,6 +19507,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-pod-total
@@ -20713,6 +20725,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-prometheus


### PR DESCRIPTION
This partially implements phase 1 of
   https://github.com/openshift/enhancements#482 and does not change behavior.
   Initially, all cluster-monitoring-operator manifests are included in the
   single-node-developer cluster profile. Follow-on PRs may exclude any of
   these that are not needed in the profile.



<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.