### PR TITLE
Bug 1905647: Calculate physical CPU core seconds used for consumption and report via telemetry

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -859,6 +859,15 @@ spec:
           )
         )
       record: cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum
+    - expr: (sum(node_role_os_version_machine:cpu_capacity_cores:sum{label_node_role_kubernetes_io_master="",label_node_role_kubernetes_io_infra=""}
+        or absent(__does_not_exist__)*0)) + ((sum(node_role_os_version_machine:cpu_capacity_cores:sum{label_node_role_kubernetes_io_master="true"}
+        or absent(__does_not_exist__)*0) * ((max(cluster_master_schedulable == 1)*0+1)
+        or (absent(cluster_master_schedulable == 1)*0))))
+      record: workload:capacity_physical_cpu_cores:sum
+    - expr: min_over_time(workload:capacity_physical_cpu_cores:sum[5m:15s])
+      record: cluster:usage:workload:capacity_physical_cpu_cores:min:5m
+    - expr: max_over_time(workload:capacity_physical_cpu_cores:sum[5m:15s])
+      record: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
     - expr: |
         sum  by (provisioner) (
           topk by (namespace, persistentvolumeclaim) (
@@ -929,6 +938,13 @@ spec:
       record: cluster:usage:openshift:kube_running_pod_ready:avg
     - expr: avg(kube_running_pod_ready{namespace!~"openshift-.*"})
       record: cluster:usage:workload:kube_running_pod_ready:avg
+  - interval: 30s
+    name: kubernetes-recurring.rules
+    rules:
+    - expr: sum_over_time(workload:capacity_physical_cpu_cores:sum[30s:1s]) + ((cluster:usage:workload:capacity_physical_cpu_core_seconds
+        offset 25s) or (absent(cluster:usage:workload:capacity_physical_cpu_core_seconds
+        offset 25s)*0))
+      record: cluster:usage:workload:capacity_physical_cpu_core_seconds
   - name: openshift-ingress.rules
     rules:
     - expr: sum by (code) (rate(haproxy_server_http_responses_total[5m]) > 0)

--- a/test/rules/workload_cpu_usage.yaml
+++ b/test/rules/workload_cpu_usage.yaml
@@ -1,0 +1,131 @@
+# Tests for workload:capacity_physical_cpu_cores:sum
+# Verifying that we have the correct logic for calculating basic usage
+# of billable core seconds.
+
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+  # worker capacity is the only series (hypershift-style)
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos"}'
+        values: '3'
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 3
+  # multiple worker capacity buckets
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos"}'
+        values: '3'
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos",example="1"}'
+        values: '4'
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 7
+  # infra capacity is ignored
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos"}'
+        values: '3'
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_infra="true"}'
+        values: '4'
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 3
+  # master role capacity ignored unless schedulable
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true"}'
+        values: '12'
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos"}'
+        values: '3'
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 3
+  # master role capacity ignored unless schedulable == 1
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true"}'
+        values: '12'
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos"}'
+        values: '3'
+      - series: 'cluster_master_schedulable{endpoint="https",instance="10.128.0.16:8443",job="metrics",namespace="openshift-kube-scheduler-operator",pod="openshift-kube-scheduler-operator-75bf7fd45c-bpqx7",service="metrics"}'
+        values: '0'
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 3
+  # master role capacity considered if schedulable
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true"}'
+        values: '12'
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos"}'
+        values: '3'
+      - series: 'cluster_master_schedulable{endpoint="https",instance="10.128.0.16:8443",job="metrics",namespace="openshift-kube-scheduler-operator",pod="openshift-kube-scheduler-operator-75bf7fd45c-bpqx7",service="metrics"}'
+        values: '1'
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 15
+  # master role capacity considered if schedulable, even if tagged with infra
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true",label_node_role_kubernetes_io_infra="true"}'
+        values: '12'
+      - series: 'cluster_master_schedulable{endpoint="https",instance="10.128.0.16:8443",job="metrics",namespace="openshift-kube-scheduler-operator",pod="openshift-kube-scheduler-operator-75bf7fd45c-bpqx7",service="metrics"}'
+        values: '1'
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 12
+  # master role capacity considered if schedulable and no workers
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true"}'
+        values: '12'
+      - series: 'cluster_master_schedulable{endpoint="https",instance="10.128.0.16:8443",job="metrics",namespace="openshift-kube-scheduler-operator",pod="openshift-kube-scheduler-operator-75bf7fd45c-bpqx7",service="metrics"}'
+        values: '1'
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 12
+  # schedulable must have a value of 1
+  - interval: 1m
+    input_series:
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true"}'
+        values: '12'
+      - series: 'node_role_os_version_machine:cpu_capacity_cores:sum{label_kubernetes_io_arch="amd64",label_node_hyperthread_enabled="true",label_node_openshift_io_os_id="rhcos"}'
+        values: '3'
+      - series: 'cluster_master_schedulable{endpoint="https",instance="10.128.0.16:8443",job="metrics",namespace="openshift-kube-scheduler-operator",pod="openshift-kube-scheduler-operator-75bf7fd45c-bpqx7",service="metrics"}'
+        values: '2' # only 1 is considered schedulable
+    promql_expr_test:
+      - expr: workload:capacity_physical_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'workload:capacity_physical_cpu_cores:sum{}'
+            value: 3


### PR DESCRIPTION
These recording rules report in a standard fashion the CPU available
for workloads on cluster, including generating a counter metric that
is more resilient to service disruptions and makes aggregation at
higher levels off cluster easier.

The rolling min, max, and counter rules are exposed to telemetry via
cluster:usage:* naming to indicate that these become "official" APIs
for tracking usage of the cluster.

Note that the counter is still experimental while we identify and fix issues in prometheus and thanos that make it non-optimal.  If necessary we would remove it in a subsequent change, but the cost is low and the two rolling bounds allow us to identify where gaps exist in large scale deployment.

End users will be able to compare these calculations to the values assessed in usage scenarios.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.