### PR TITLE
Bug 1904985: fix TLS secrets for Thanos sidecars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export GOPROXY
 
 PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test|/examples')
 GOLANG_FILES:=$(shell find . -name \*.go -print)
-ASSETS=$(shell grep -oh 'assets/.*\.yaml' pkg/manifests/manifests.go)
+ASSETS=$(shell grep -oh '[^"]*/.*\.yaml' pkg/manifests/manifests.go | sed 's/^/assets\//')
 
 BIN_DIR ?= $(shell pwd)/tmp/bin
 

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -136,7 +136,7 @@ spec:
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /etc/tls/private
-      name: secret-prometheus-k8s-tls
+      name: secret-prometheus-k8s-thanos-sidecar-tls
   - args:
     - sidecar
     - --prometheus.url=http://localhost:9090/
@@ -180,6 +180,7 @@ spec:
   - prometheus-k8s-tls
   - prometheus-k8s-proxy
   - prometheus-k8s-htpasswd
+  - prometheus-k8s-thanos-sidecar-tls
   - kube-rbac-proxy
   securityContext:
     fsGroup: 65534

--- a/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
@@ -13,7 +13,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: prometheus-k8s
+      serverName: prometheus-k8s-thanos-sidecar
   selector:
     matchLabels:
       app: thanos-sidecar

--- a/assets/prometheus-k8s/service-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-thanos-sidecar.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls
+    service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-thanos-sidecar-tls
   labels:
     app: thanos-sidecar
     prometheus: k8s

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -80,7 +80,7 @@ spec:
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /etc/tls/private
-      name: secret-prometheus-user-workload-tls
+      name: secret-prometheus-user-workload-thanos-sidecar-tls
   - args:
     - sidecar
     - --prometheus.url=http://localhost:9090/
@@ -127,6 +127,7 @@ spec:
       openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
   secrets:
   - prometheus-user-workload-tls
+  - prometheus-user-workload-thanos-sidecar-tls
   securityContext:
     fsGroup: 65534
     runAsNonRoot: true

--- a/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
@@ -13,7 +13,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: prometheus-user-workload-monitoring
+      serverName: prometheus-user-workload-thanos-sidecar
   selector:
     matchLabels:
       app: thanos-sidecar

--- a/assets/prometheus-user-workload/service-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-thanos-sidecar.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: prometheus-user-workload-tls
+    service.beta.openshift.io/serving-cert-secret-name: prometheus-user-workload-thanos-sidecar-tls
   labels:
     app: thanos-sidecar
     prometheus: user-workload

--- a/hack/local-cmo.sh
+++ b/hack/local-cmo.sh
@@ -25,4 +25,4 @@ kubectl -n openshift-monitoring scale --replicas=0 deployment/cluster-monitoring
 cat manifests/0000_50_cluster-monitoring-operator_04-config.yaml | gojsontoyaml -yamltojson | jq -r '.data["metrics.yaml"]' > /tmp/telemetry-config.yaml
 
 # shellcheck disable=SC2086
-./operator ${IMAGES} -telemetry-config /tmp/telemetry-config.yaml -kubeconfig "${KUBECONFIG}" -namespace=openshift-monitoring -configmap=cluster-monitoring-config -logtostderr=true -v=4 2>&1 | tee operator.log
+./operator ${IMAGES} -assets assets/ -telemetry-config /tmp/telemetry-config.yaml -kubeconfig "${KUBECONFIG}" -namespace=openshift-monitoring -configmap=cluster-monitoring-config -logtostderr=true -v=4 2>&1 | tee operator.log

--- a/jsonnet/prometheus-user-workload.jsonnet
+++ b/jsonnet/prometheus-user-workload.jsonnet
@@ -162,7 +162,7 @@ local podIPEnvVar =
 
     serviceThanosSidecar+:
       service.mixin.metadata.withAnnotations({
-        'service.beta.openshift.io/serving-cert-secret-name': 'prometheus-user-workload-tls',
+        'service.beta.openshift.io/serving-cert-secret-name': 'prometheus-user-workload-thanos-sidecar-tls',
       }) +
       service.mixin.spec.withPorts([
         servicePort.newNamed('thanos-proxy', 10902, 'thanos-proxy'),
@@ -179,7 +179,7 @@ local podIPEnvVar =
               scheme: 'https',
               tlsConfig: {
                 caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-                serverName: 'prometheus-user-workload-monitoring',
+                serverName: 'prometheus-user-workload-thanos-sidecar',
               },
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
             },
@@ -245,6 +245,7 @@ local podIPEnvVar =
           },
           secrets: [
             'prometheus-user-workload-tls',
+            'prometheus-user-workload-thanos-sidecar-tls',
           ],
           configMaps: ['serving-certs-ca-bundle'],
           serviceMonitorSelector: {},
@@ -312,7 +313,7 @@ local podIPEnvVar =
               volumeMounts: [
                 {
                   mountPath: '/etc/tls/private',
-                  name: 'secret-prometheus-user-workload-tls',
+                  name: 'secret-prometheus-user-workload-thanos-sidecar-tls',
                 },
               ],
             },

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -266,7 +266,7 @@ local podIPEnvVar =
 
     serviceThanosSidecar+:
       service.mixin.metadata.withAnnotations({
-        'service.beta.openshift.io/serving-cert-secret-name': 'prometheus-k8s-tls',
+        'service.beta.openshift.io/serving-cert-secret-name': 'prometheus-k8s-thanos-sidecar-tls',
       }) +
       service.mixin.spec.withPorts([
         servicePort.newNamed('thanos-proxy', 10902, 'thanos-proxy'),
@@ -283,7 +283,7 @@ local podIPEnvVar =
               scheme: 'https',
               tlsConfig: {
                 caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-                serverName: 'prometheus-k8s',
+                serverName: 'prometheus-k8s-thanos-sidecar',
               },
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
             },
@@ -340,6 +340,7 @@ local podIPEnvVar =
             'prometheus-k8s-tls',
             'prometheus-k8s-proxy',
             'prometheus-k8s-htpasswd',
+            'prometheus-k8s-thanos-sidecar-tls',
             'kube-rbac-proxy',
           ],
           configMaps: ['serving-certs-ca-bundle', 'kubelet-serving-ca-bundle'],
@@ -495,7 +496,7 @@ local podIPEnvVar =
               volumeMounts: [
                 {
                   mountPath: '/etc/tls/private',
-                  name: 'secret-prometheus-k8s-tls',
+                  name: 'secret-prometheus-k8s-thanos-sidecar-tls',
                 },
               ],
             },

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1126,7 +1126,7 @@ func (f *Factory) PrometheusK8sThanosSidecarServiceMonitor() (*monv1.ServiceMoni
 		return nil, err
 	}
 
-	s.Spec.Endpoints[0].TLSConfig.ServerName = fmt.Sprintf("prometheus-k8s.%s.svc", f.namespace)
+	s.Spec.Endpoints[0].TLSConfig.ServerName = fmt.Sprintf("prometheus-k8s-thanos-sidecar.%s.svc", f.namespace)
 	s.Namespace = f.namespace
 
 	return s, nil
@@ -1768,7 +1768,7 @@ func (f *Factory) PrometheusUserWorkloadThanosSidecarServiceMonitor() (*monv1.Se
 	}
 
 	sm.Namespace = f.namespaceUserWorkload
-	sm.Spec.Endpoints[0].TLSConfig.ServerName = fmt.Sprintf("prometheus-user-workload.%s.svc", f.namespaceUserWorkload)
+	sm.Spec.Endpoints[0].TLSConfig.ServerName = fmt.Sprintf("prometheus-user-workload-thanos-sidecar.%s.svc", f.namespaceUserWorkload)
 
 	return sm, nil
 }

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -43,10 +43,10 @@ func TestPrometheusMetrics(t *testing.T) {
 	} {
 		t.Run(service, func(t *testing.T) {
 			f.ThanosQuerierClient.WaitForQueryReturn(
-				t, 10*time.Minute, fmt.Sprintf(`count(up{service="%s",namespace="openshift-monitoring"})`, service),
+				t, 10*time.Minute, fmt.Sprintf(`count(up{service="%s",namespace="openshift-monitoring"} == 1)`, service),
 				func(i int) error {
 					if i != expected {
-						return fmt.Errorf("expected %d targets but got %d", expected, i)
+						return fmt.Errorf("expected %d targets to be up but got %d", expected, i)
 					}
 
 					return nil

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -299,13 +299,13 @@ func assertMetricsForMonitoringComponents(t *testing.T) {
 	} {
 		t.Run(service, func(t *testing.T) {
 			f.ThanosQuerierClient.WaitForQueryReturn(
-				t, 10*time.Minute, fmt.Sprintf(`count(up{service="%s",namespace="openshift-user-workload-monitoring"})`, service),
+				t, 10*time.Minute, fmt.Sprintf(`count(up{service="%s",namespace="openshift-user-workload-monitoring"} == 1)`, service),
 				func(i int) error {
 					if i == expected {
 						return nil
 					}
 
-					return fmt.Errorf("expected %d targets but got %d", expected, i)
+					return fmt.Errorf("expected %d targets to be up but got %d", expected, i)
 				},
 			)
 		})


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
