### PR TITLE
jsonnet: bump prometheus-operator to v0.44.0

### DIFF
--- a/assets/prometheus-operator-user-workload/cluster-role-binding.yaml
+++ b/assets/prometheus-operator-user-workload/cluster-role-binding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-user-workload-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-operator-user-workload/cluster-role.yaml
+++ b/assets/prometheus-operator-user-workload/cluster-role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-user-workload-operator
 rules:
 - apiGroups:

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:
@@ -18,19 +18,18 @@ spec:
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
-        app.kubernetes.io/version: v0.43.0
+        app.kubernetes.io/version: v0.44.0
     spec:
       containers:
       - args:
-        - --logtostderr=true
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.44.0
         - --deny-namespaces=openshift-monitoring
         - --prometheus-instance-namespaces=openshift-user-workload-monitoring
         - --alertmanager-instance-namespaces=openshift-user-workload-monitoring
         - --thanos-ruler-instance-namespaces=openshift-user-workload-monitoring
         - --config-reloader-cpu=0
         - --config-reloader-memory=0
-        image: quay.io/prometheus-operator/prometheus-operator:v0.43.0
+        image: quay.io/prometheus-operator/prometheus-operator:v0.44.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/assets/prometheus-operator-user-workload/service-account.yaml
+++ b/assets/prometheus-operator-user-workload/service-account.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-operator-user-workload/service-monitor.yaml
+++ b/assets/prometheus-operator-user-workload/service-monitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:
@@ -20,4 +20,4 @@ spec:
     matchLabels:
       app.kubernetes.io/component: controller
       app.kubernetes.io/name: prometheus-operator
-      app.kubernetes.io/version: v0.43.0
+      app.kubernetes.io/version: v0.44.0

--- a/assets/prometheus-operator-user-workload/service.yaml
+++ b/assets/prometheus-operator-user-workload/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/prometheus-operator/cluster-role-binding.yaml
+++ b/assets/prometheus-operator/cluster-role-binding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-operator/cluster-role.yaml
+++ b/assets/prometheus-operator/cluster-role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
 rules:
 - apiGroups:

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:
@@ -18,13 +18,12 @@ spec:
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
-        app.kubernetes.io/version: v0.43.0
+        app.kubernetes.io/version: v0.44.0
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - --logtostderr=true
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.44.0
         - --namespaces=openshift-monitoring
         - --prometheus-instance-namespaces=openshift-monitoring
         - --thanos-ruler-instance-namespaces=openshift-monitoring
@@ -34,7 +33,7 @@ spec:
         - --web.enable-tls=true
         - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --web.tls-min-version=VersionTLS12
-        image: quay.io/prometheus-operator/prometheus-operator:v0.43.0
+        image: quay.io/prometheus-operator/prometheus-operator:v0.44.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/assets/prometheus-operator/prometheus-rule-validating-webhook.yaml
+++ b/assets/prometheus-operator/prometheus-rule-validating-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheusrules.openshift.io
 webhooks:
 - admissionReviewVersions:

--- a/assets/prometheus-operator/service-account.yaml
+++ b/assets/prometheus-operator/service-account.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
   namespace: openshift-monitoring

--- a/assets/prometheus-operator/service-monitor.yaml
+++ b/assets/prometheus-operator/service-monitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:
@@ -20,4 +20,4 @@ spec:
     matchLabels:
       app.kubernetes.io/component: controller
       app.kubernetes.io/name: prometheus-operator
-      app.kubernetes.io/version: v0.43.0
+      app.kubernetes.io/version: v0.44.0

--- a/assets/prometheus-operator/service.yaml
+++ b/assets/prometheus-operator/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.43.0
+    app.kubernetes.io/version: v0.44.0
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "release-0.43"
+      "version": "release-0.44"
     },
     {
       "source": {

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -151,8 +151,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "633ea519b2ce86396f6e006f7fd967c04bc45bda",
-      "sum": "P8EcWO33RCyVTfwMdpy4S4jFZjJVHiu190j8yd/CGfs="
+      "version": "47a73189d3c9b799c7fc59bfc2da9d0b2fd4921f",
+      "sum": "FQ9b6gpDjB47y5wk7QFJlORNdBYNZYVLAk8gT6kABLY="
     },
     {
       "source": {

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null
@@ -20,7 +20,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: AlertmanagerConfig defines a namespaced AlertmanagerConfig to
-          be aggregated across multiple namespaces configuring one Alertmanager.
+          be aggregated across multiple namespaces configuring one Alertmanager cluster.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -35,22 +35,40 @@ spec:
           metadata:
             type: object
           spec:
+            description: AlertmanagerConfigSpec is a specification of the desired
+              behavior of the Alertmanager configuration. By definition, the Alertmanager
+              configuration only applies to alerts for which the `namespace` label
+              is equal to the namespace of the AlertmanagerConfig resource.
             properties:
               inhibitRules:
+                description: List of inhibition rules. The rules will only apply to
+                  alerts matching the resource’s namespace.
                 items:
+                  description: InhibitRule defines an inhibition rule that allows
+                    to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
                   properties:
                     equal:
+                      description: Labels that must have an equal value in the source
+                        and target alert for the inhibition to take effect.
                       items:
                         type: string
                       type: array
                     sourceMatch:
+                      description: Matchers for which one or more alerts have to exist
+                        for the inhibition to take effect. The operator enforces that
+                        the alert matches the resource’s namespace.
                       items:
+                        description: Matcher defines how to match on alert's labels.
                         properties:
                           name:
+                            description: Label to match.
                             type: string
                           regex:
+                            description: Whether to match on equality (false) or regular-expression
+                              (true).
                             type: boolean
                           value:
+                            description: Label value to match.
                             type: string
                         required:
                         - name
@@ -58,13 +76,21 @@ spec:
                         type: object
                       type: array
                     targetMatch:
+                      description: Matchers that have to be fulfilled in the alerts
+                        to be muted. The operator enforces that the alert matches
+                        the resource’s namespace.
                       items:
+                        description: Matcher defines how to match on alert's labels.
                         properties:
                           name:
+                            description: Label to match.
                             type: string
                           regex:
+                            description: Whether to match on equality (false) or regular-expression
+                              (true).
                             type: boolean
                           value:
+                            description: Label value to match.
                             type: string
                         required:
                         - name
@@ -74,14 +100,18 @@ spec:
                   type: object
                 type: array
               receivers:
+                description: List of receivers.
                 items:
+                  description: Receiver defines one or more notification integrations.
                   properties:
-                    name:
-                      type: string
-                    opsgenieConfigs:
+                    emailConfigs:
+                      description: List of Email configurations.
                       items:
+                        description: EmailConfig configures notifications via Email.
                         properties:
-                          apiKey:
+                          authIdentity:
+                            type: string
+                          authPassword:
                             description: SecretKeySelector selects a key of a Secret.
                             properties:
                               key:
@@ -100,16 +130,245 @@ spec:
                             required:
                             - key
                             type: object
-                          apiURL:
+                          authSecret:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          authUsername:
+                            description: SMTP authentication information.
                             type: string
-                          description:
+                          from:
+                            description: The sender address.
                             type: string
-                          details:
+                          headers:
+                            description: Further headers email header key/value pairs.
+                              Overrides any headers previously set by the notification
+                              implementation.
                             items:
+                              description: KeyValue defines a (key, value) tuple.
                               properties:
                                 key:
+                                  description: Key of the tuple.
                                   type: string
                                 value:
+                                  description: Value of the tuple.
+                                  type: string
+                              required:
+                              - key
+                              - value
+                              type: object
+                            type: array
+                          hello:
+                            description: The hostname to identify to the SMTP server.
+                            type: string
+                          html:
+                            description: The HTML body of the email notification.
+                            type: string
+                          requireTLS:
+                            description: The SMTP TLS requirement. Note that Go does
+                              not support unencrypted connections to remote SMTP endpoints.
+                            type: boolean
+                          sendResolved:
+                            description: Whether or not to notify about resolved alerts.
+                            type: boolean
+                          smarthost:
+                            description: The SMTP host through which emails are sent.
+                            type: string
+                          text:
+                            description: The text body of the email notification.
+                            type: string
+                          tlsConfig:
+                            description: TLS configuration
+                            properties:
+                              ca:
+                                description: Struct containing the CA cert to use
+                                  for the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              cert:
+                                description: Struct containing the client cert file
+                                  for the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              insecureSkipVerify:
+                                description: Disable target certificate validation.
+                                type: boolean
+                              keySecret:
+                                description: Secret containing the client key file
+                                  for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              serverName:
+                                description: Used to verify the hostname for the targets.
+                                type: string
+                            type: object
+                          to:
+                            description: The email address to send notifications to.
+                            type: string
+                        type: object
+                      type: array
+                    name:
+                      description: Name of the receiver. Must be unique across all
+                        items from the list.
+                      type: string
+                    opsgenieConfigs:
+                      description: List of OpsGenie configurations.
+                      items:
+                        description: OpsGenieConfig configures notifications via OpsGenie.
+                          See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
+                        properties:
+                          apiKey:
+                            description: The secret's key that contains the OpsGenie
+                              API key. The secret needs to be in the same namespace
+                              as the AlertmanagerConfig object and accessible by the
+                              Prometheus Operator.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          apiURL:
+                            description: The URL to send OpsGenie API requests to.
+                            type: string
+                          description:
+                            description: Description of the incident.
+                            type: string
+                          details:
+                            description: A set of arbitrary key/value pairs that provide
+                              further detail about the incident.
+                            items:
+                              description: KeyValue defines a (key, value) tuple.
+                              properties:
+                                key:
+                                  description: Key of the tuple.
+                                  type: string
+                                value:
+                                  description: Value of the tuple.
                                   type: string
                               required:
                               - key
@@ -117,10 +376,10 @@ spec:
                               type: object
                             type: array
                           httpConfig:
+                            description: HTTP client configuration.
                             properties:
                               basicAuth:
-                                description: 'BasicAuth allow an endpoint to authenticate
-                                  over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                description: BasicAuth for the client.
                                 properties:
                                   password:
                                     description: The secret in the service monitor
@@ -166,8 +425,11 @@ spec:
                                     type: object
                                 type: object
                               bearerTokenSecret:
-                                description: SecretKeySelector selects a key of a
-                                  Secret.
+                                description: The secret's key that contains the bearer
+                                  token to be used by the client for authentication.
+                                  The secret needs to be in the same namespace as
+                                  the AlertmanagerConfig object and accessible by
+                                  the Prometheus Operator.
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must
@@ -187,10 +449,10 @@ spec:
                                 - key
                                 type: object
                               proxyURL:
+                                description: Optional proxy URL.
                                 type: string
                               tlsConfig:
-                                description: SafeTLSConfig specifies safe TLS configuration
-                                  parameters.
+                                description: TLS configuration for the client.
                                 properties:
                                   ca:
                                     description: Struct containing the CA cert to
@@ -317,51 +579,81 @@ spec:
                                 type: object
                             type: object
                           message:
+                            description: Alert text limited to 130 characters.
                             type: string
                           note:
+                            description: Additional alert note.
                             type: string
                           priority:
+                            description: Priority level of alert. Possible values
+                              are P1, P2, P3, P4, and P5.
                             type: string
                           responders:
+                            description: List of responders responsible for notifications.
                             items:
+                              description: OpsGenieConfigResponder defines a responder
+                                to an incident. One of id, name or username has to
+                                be defined.
                               properties:
                                 id:
+                                  description: ID of the responder.
                                   type: string
                                 name:
+                                  description: Name of the responder.
                                   type: string
                                 type:
+                                  description: Type of responder.
                                   type: string
                                 username:
+                                  description: Username of the responder.
                                   type: string
                               type: object
                             type: array
                           sendResolved:
+                            description: Whether or not to notify about resolved alerts.
                             type: boolean
                           source:
+                            description: Backlink to the sender of the notification.
                             type: string
                           tags:
+                            description: Comma separated list of tags attached to
+                              the notifications.
                             type: string
                         type: object
                       type: array
-                    pagerDutyConfigs:
+                    pagerdutyConfigs:
+                      description: List of PagerDuty configurations.
                       items:
+                        description: PagerDutyConfig configures notifications via
+                          PagerDuty. See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
                         properties:
                           class:
+                            description: The class/type of the event.
                             type: string
                           client:
+                            description: Client identification.
                             type: string
                           clientURL:
+                            description: Backlink to the sender of notification.
                             type: string
                           component:
+                            description: The part or component of the affected system
+                              that is broken.
                             type: string
                           description:
+                            description: Description of the incident.
                             type: string
                           details:
+                            description: Arbitrary key/value pairs that provide further
+                              detail about the incident.
                             items:
+                              description: KeyValue defines a (key, value) tuple.
                               properties:
                                 key:
+                                  description: Key of the tuple.
                                   type: string
                                 value:
+                                  description: Value of the tuple.
                                   type: string
                               required:
                               - key
@@ -369,12 +661,13 @@ spec:
                               type: object
                             type: array
                           group:
+                            description: A cluster or grouping of sources.
                             type: string
                           httpConfig:
+                            description: HTTP client configuration.
                             properties:
                               basicAuth:
-                                description: 'BasicAuth allow an endpoint to authenticate
-                                  over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                description: BasicAuth for the client.
                                 properties:
                                   password:
                                     description: The secret in the service monitor
@@ -420,8 +713,11 @@ spec:
                                     type: object
                                 type: object
                               bearerTokenSecret:
-                                description: SecretKeySelector selects a key of a
-                                  Secret.
+                                description: The secret's key that contains the bearer
+                                  token to be used by the client for authentication.
+                                  The secret needs to be in the same namespace as
+                                  the AlertmanagerConfig object and accessible by
+                                  the Prometheus Operator.
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must
@@ -441,10 +737,10 @@ spec:
                                 - key
                                 type: object
                               proxyURL:
+                                description: Optional proxy URL.
                                 type: string
                               tlsConfig:
-                                description: SafeTLSConfig specifies safe TLS configuration
-                                  parameters.
+                                description: TLS configuration for the client.
                                 properties:
                                   ca:
                                     description: Struct containing the CA cert to
@@ -571,7 +867,11 @@ spec:
                                 type: object
                             type: object
                           routingKey:
-                            description: SecretKeySelector selects a key of a Secret.
+                            description: The secret's key that contains the PagerDuty
+                              integration key (when using Events API v2). Either this
+                              field or `serviceKey` needs to be defined. The secret
+                              needs to be in the same namespace as the AlertmanagerConfig
+                              object and accessible by the Prometheus Operator.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must
@@ -590,9 +890,15 @@ spec:
                             - key
                             type: object
                           sendResolved:
+                            description: Whether or not to notify about resolved alerts.
                             type: boolean
                           serviceKey:
-                            description: SecretKeySelector selects a key of a Secret.
+                            description: The secret's key that contains the PagerDuty
+                              service key (when using integration type "Prometheus").
+                              Either this field or `routingKey` needs to be defined.
+                              The secret needs to be in the same namespace as the
+                              AlertmanagerConfig object and accessible by the Prometheus
+                              Operator.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must
@@ -611,19 +917,33 @@ spec:
                             - key
                             type: object
                           severity:
+                            description: Severity of the incident.
                             type: string
                           url:
+                            description: The URL to send requests to.
                             type: string
                         type: object
                       type: array
-                    webhookConfigs:
+                    pushoverConfigs:
+                      description: List of Pushover configurations.
                       items:
+                        description: PushoverConfig configures notifications via Pushover.
+                          See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                         properties:
+                          expire:
+                            description: How long your notification will continue
+                              to be retried for, unless the user acknowledges the
+                              notification.
+                            type: string
+                          html:
+                            description: Whether notification message is HTML or plain
+                              text.
+                            type: boolean
                           httpConfig:
+                            description: HTTP client configuration.
                             properties:
                               basicAuth:
-                                description: 'BasicAuth allow an endpoint to authenticate
-                                  over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                description: BasicAuth for the client.
                                 properties:
                                   password:
                                     description: The secret in the service monitor
@@ -669,8 +989,11 @@ spec:
                                     type: object
                                 type: object
                               bearerTokenSecret:
-                                description: SecretKeySelector selects a key of a
-                                  Secret.
+                                description: The secret's key that contains the bearer
+                                  token to be used by the client for authentication.
+                                  The secret needs to be in the same namespace as
+                                  the AlertmanagerConfig object and accessible by
+                                  the Prometheus Operator.
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must
@@ -690,10 +1013,903 @@ spec:
                                 - key
                                 type: object
                               proxyURL:
+                                description: Optional proxy URL.
                                 type: string
                               tlsConfig:
-                                description: SafeTLSConfig specifies safe TLS configuration
-                                  parameters.
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Struct containing the CA cert to
+                                      use for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          message:
+                            description: Notification message.
+                            type: string
+                          priority:
+                            description: Priority, see https://pushover.net/api#priority
+                            type: string
+                          retry:
+                            description: How often the Pushover servers will send
+                              the same notification to the user. Must be at least
+                              30 seconds.
+                            type: string
+                          sendResolved:
+                            description: Whether or not to notify about resolved alerts.
+                            type: boolean
+                          sound:
+                            description: The name of one of the sounds supported by
+                              device clients to override the user's default sound
+                              choice
+                            type: string
+                          title:
+                            description: Notification title.
+                            type: string
+                          token:
+                            description: Your registered application’s API token,
+                              see https://pushover.net/apps
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          url:
+                            description: A supplementary URL shown alongside the message.
+                            type: string
+                          urlTitle:
+                            description: A title for supplementary URL, otherwise
+                              just the URL is shown
+                            type: string
+                          userKey:
+                            description: The recipient user’s user key.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      type: array
+                    slackConfigs:
+                      description: List of Slack configurations.
+                      items:
+                        description: SlackConfig configures notifications via Slack.
+                          See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
+                        properties:
+                          actions:
+                            description: A list of Slack actions that are sent with
+                              each notification.
+                            items:
+                              description: SlackAction configures a single Slack action
+                                that is sent with each notification. See https://api.slack.com/docs/message-attachments#action_fields
+                                and https://api.slack.com/docs/message-buttons for
+                                more information.
+                              properties:
+                                confirm:
+                                  description: SlackConfirmationField protect users
+                                    from destructive actions or particularly distinguished
+                                    decisions by asking them to confirm their button
+                                    click one more time. See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
+                                    for more information.
+                                  properties:
+                                    dismissText:
+                                      type: string
+                                    okText:
+                                      type: string
+                                    text:
+                                      type: string
+                                    title:
+                                      type: string
+                                  required:
+                                  - text
+                                  type: object
+                                name:
+                                  type: string
+                                style:
+                                  type: string
+                                text:
+                                  type: string
+                                type:
+                                  type: string
+                                url:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - text
+                              - type
+                              type: object
+                            type: array
+                          apiURL:
+                            description: The secret's key that contains the Slack
+                              webhook URL. The secret needs to be in the same namespace
+                              as the AlertmanagerConfig object and accessible by the
+                              Prometheus Operator.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          callbackId:
+                            type: string
+                          channel:
+                            description: The channel or user to send notifications
+                              to.
+                            type: string
+                          color:
+                            type: string
+                          fallback:
+                            type: string
+                          fields:
+                            description: A list of Slack fields that are sent with
+                              each notification.
+                            items:
+                              description: SlackField configures a single Slack field
+                                that is sent with each notification. Each field must
+                                contain a title, value, and optionally, a boolean
+                                value to indicate if the field is short enough to
+                                be displayed next to other fields designated as short.
+                                See https://api.slack.com/docs/message-attachments#fields
+                                for more information.
+                              properties:
+                                short:
+                                  type: boolean
+                                title:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - title
+                              - value
+                              type: object
+                            type: array
+                          footer:
+                            type: string
+                          httpConfig:
+                            description: HTTP client configuration.
+                            properties:
+                              basicAuth:
+                                description: BasicAuth for the client.
+                                properties:
+                                  password:
+                                    description: The secret in the service monitor
+                                      namespace that contains the password for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  username:
+                                    description: The secret in the service monitor
+                                      namespace that contains the username for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearerTokenSecret:
+                                description: The secret's key that contains the bearer
+                                  token to be used by the client for authentication.
+                                  The secret needs to be in the same namespace as
+                                  the AlertmanagerConfig object and accessible by
+                                  the Prometheus Operator.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tlsConfig:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Struct containing the CA cert to
+                                      use for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          iconEmoji:
+                            type: string
+                          iconURL:
+                            type: string
+                          imageURL:
+                            type: string
+                          linkNames:
+                            type: boolean
+                          mrkdwnIn:
+                            items:
+                              type: string
+                            type: array
+                          pretext:
+                            type: string
+                          sendResolved:
+                            description: Whether or not to notify about resolved alerts.
+                            type: boolean
+                          shortFields:
+                            type: boolean
+                          text:
+                            type: string
+                          thumbURL:
+                            type: string
+                          title:
+                            type: string
+                          titleLink:
+                            type: string
+                          username:
+                            type: string
+                        type: object
+                      type: array
+                    victoropsConfigs:
+                      description: List of VictorOps configurations.
+                      items:
+                        description: VictorOpsConfig configures notifications via
+                          VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
+                        properties:
+                          apiKey:
+                            description: The API key to use when talking to the VictorOps
+                              API.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          apiUrl:
+                            description: The VictorOps API URL.
+                            type: string
+                          customFields:
+                            description: Additional custom fields for notification.
+                            items:
+                              description: KeyValue defines a (key, value) tuple.
+                              properties:
+                                key:
+                                  description: Key of the tuple.
+                                  type: string
+                                value:
+                                  description: Value of the tuple.
+                                  type: string
+                              required:
+                              - key
+                              - value
+                              type: object
+                            type: array
+                          entityDisplayName:
+                            description: Contains summary of the alerted problem.
+                            type: string
+                          httpConfig:
+                            description: The HTTP client's configuration.
+                            properties:
+                              basicAuth:
+                                description: BasicAuth for the client.
+                                properties:
+                                  password:
+                                    description: The secret in the service monitor
+                                      namespace that contains the password for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  username:
+                                    description: The secret in the service monitor
+                                      namespace that contains the username for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearerTokenSecret:
+                                description: The secret's key that contains the bearer
+                                  token to be used by the client for authentication.
+                                  The secret needs to be in the same namespace as
+                                  the AlertmanagerConfig object and accessible by
+                                  the Prometheus Operator.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tlsConfig:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Struct containing the CA cert to
+                                      use for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          messageType:
+                            description: Describes the behavior of the alert (CRITICAL,
+                              WARNING, INFO).
+                            type: string
+                          monitoringTool:
+                            description: The monitoring tool the state message is
+                              from.
+                            type: string
+                          routingKey:
+                            description: A key used to map the alert to a team.
+                            type: string
+                          sendResolved:
+                            description: Whether or not to notify about resolved alerts.
+                            type: boolean
+                          stateMessage:
+                            description: Contains long explanation of the alerted
+                              problem.
+                            type: string
+                        required:
+                        - routingKey
+                        type: object
+                      type: array
+                    webhookConfigs:
+                      description: List of webhook configurations.
+                      items:
+                        description: WebhookConfig configures notifications via a
+                          generic receiver supporting the webhook payload. See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+                        properties:
+                          httpConfig:
+                            description: HTTP client configuration.
+                            properties:
+                              basicAuth:
+                                description: BasicAuth for the client.
+                                properties:
+                                  password:
+                                    description: The secret in the service monitor
+                                      namespace that contains the password for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  username:
+                                    description: The secret in the service monitor
+                                      namespace that contains the username for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearerTokenSecret:
+                                description: The secret's key that contains the bearer
+                                  token to be used by the client for authentication.
+                                  The secret needs to be in the same namespace as
+                                  the AlertmanagerConfig object and accessible by
+                                  the Prometheus Operator.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tlsConfig:
+                                description: TLS configuration for the client.
                                 properties:
                                   ca:
                                     description: Struct containing the CA cert to
@@ -820,14 +2036,25 @@ spec:
                                 type: object
                             type: object
                           maxAlerts:
+                            description: Maximum number of alerts to be sent per webhook
+                              message.
                             format: int32
                             type: integer
                           sendResolved:
+                            description: Whether or not to notify about resolved alerts.
                             type: boolean
                           url:
+                            description: The URL to send HTTP POST requests to. `urlSecret`
+                              takes precedence over `url`. One of `urlSecret` and
+                              `url` should be defined.
                             type: string
                           urlSecret:
-                            description: SecretKeySelector selects a key of a Secret.
+                            description: The secret's key that contains the webhook
+                              URL to send HTTP requests to. `urlSecret` takes precedence
+                              over `url`. One of `urlSecret` and `url` should be defined.
+                              The secret needs to be in the same namespace as the
+                              AlertmanagerConfig object and accessible by the Prometheus
+                              Operator.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must
@@ -847,30 +2074,308 @@ spec:
                             type: object
                         type: object
                       type: array
+                    wechatConfigs:
+                      description: List of WeChat configurations.
+                      items:
+                        description: WeChatConfig configures notifications via WeChat.
+                          See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
+                        properties:
+                          agentID:
+                            type: string
+                          apiSecret:
+                            description: The secret's key that contains the WeChat
+                              API key. The secret needs to be in the same namespace
+                              as the AlertmanagerConfig object and accessible by the
+                              Prometheus Operator.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          apiURL:
+                            description: The WeChat API URL.
+                            type: string
+                          corpID:
+                            description: The corp id for authentication.
+                            type: string
+                          httpConfig:
+                            description: HTTP client configuration.
+                            properties:
+                              basicAuth:
+                                description: BasicAuth for the client.
+                                properties:
+                                  password:
+                                    description: The secret in the service monitor
+                                      namespace that contains the password for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  username:
+                                    description: The secret in the service monitor
+                                      namespace that contains the username for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearerTokenSecret:
+                                description: The secret's key that contains the bearer
+                                  token to be used by the client for authentication.
+                                  The secret needs to be in the same namespace as
+                                  the AlertmanagerConfig object and accessible by
+                                  the Prometheus Operator.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tlsConfig:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Struct containing the CA cert to
+                                      use for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          message:
+                            description: API request data as defined by the WeChat
+                              API.
+                            type: string
+                          messageType:
+                            type: string
+                          sendResolved:
+                            description: Whether or not to notify about resolved alerts.
+                            type: boolean
+                          toParty:
+                            type: string
+                          toTag:
+                            type: string
+                          toUser:
+                            type: string
+                        type: object
+                      type: array
                   required:
                   - name
                   type: object
                 type: array
               route:
+                description: The Alertmanager route definition for alerts matching
+                  the resource’s namespace. It will be added to the generated Alertmanager
+                  configuration as a first-level route.
                 properties:
                   continue:
+                    description: Boolean indicating whether an alert should continue
+                      matching subsequent sibling nodes. It will always be overridden
+                      to true for the first-level route by the Prometheus operator.
                     type: boolean
                   groupBy:
+                    description: List of labels to group by.
                     items:
                       type: string
                     type: array
                   groupInterval:
+                    description: How long to wait before sending an updated notification.
+                      Must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds
+                      seconds minutes hours).
                     type: string
                   groupWait:
+                    description: How long to wait before sending the initial notification.
+                      Must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds
+                      seconds minutes hours).
                     type: string
                   matchers:
+                    description: 'List of matchers that the alert’s labels should
+                      match. For the first level route, the operator removes any existing
+                      equality and regexp matcher on the `namespace` label and adds
+                      a `namespace: <object namespace>` matcher.'
                     items:
+                      description: Matcher defines how to match on alert's labels.
                       properties:
                         name:
+                          description: Label to match.
                           type: string
                         regex:
+                          description: Whether to match on equality (false) or regular-expression
+                            (true).
                           type: boolean
                         value:
+                          description: Label value to match.
                           type: string
                       required:
                       - name
@@ -878,12 +2383,19 @@ spec:
                       type: object
                     type: array
                   receiver:
+                    description: Name of the receiver for this route. If present,
+                      it should be listed in the `receivers` field. The field can
+                      be omitted only for nested routes otherwise it is mandatory.
                     type: string
                   repeatInterval:
+                    description: How long to wait before repeating the last notification.
+                      Must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds
+                      seconds minutes hours).
                     type: string
                   routes:
+                    description: Child routes.
                     items:
-                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     type: array
                 type: object
             type: object

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null
@@ -745,6 +745,15 @@ spec:
                   in cluster. Needs to be provided for non RFC1918 [1] (public) addresses.
                   [1] RFC1918: https://tools.ietf.org/html/rfc1918'
                 type: string
+              clusterGossipInterval:
+                description: Interval between gossip attempts.
+                type: string
+              clusterPeerTimeout:
+                description: Timeout for cluster peering.
+                type: string
+              clusterPushpullInterval:
+                description: Interval between pushpull attempts.
+                type: string
               configMaps:
                 description: ConfigMaps is a list of ConfigMaps in the same namespace
                   as the Alertmanager object, which shall be mounted into the Alertmanager
@@ -868,9 +877,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -1305,6 +1318,7 @@ spec:
                               be referred to by services.
                             type: string
                           protocol:
+                            default: TCP
                             description: Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
@@ -1312,6 +1326,10 @@ spec:
                         - containerPort
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
                         Container will be removed from service endpoints if the probe
@@ -1435,13 +1453,21 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
                             resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute
                             resources required. If Requests is omitted for a container,
                             it defaults to Limits if that is explicitly specified,
@@ -1951,9 +1977,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -2388,6 +2418,7 @@ spec:
                               be referred to by services.
                             type: string
                           protocol:
+                            default: TCP
                             description: Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
@@ -2395,6 +2426,10 @@ spec:
                         - containerPort
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
                         Container will be removed from service endpoints if the probe
@@ -2518,13 +2553,21 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
                             resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute
                             resources required. If Requests is omitted for a container,
                             it defaults to Limits if that is explicitly specified,
@@ -2909,7 +2952,7 @@ spec:
                 description: Define which Nodes the Pods are scheduled on.
                 type: object
               paused:
-                description: If set to true all actions on the underlaying managed
+                description: If set to true all actions on the underlying managed
                   objects are not goint to be performed, except for delete actions.
                 type: boolean
               podMetadata:
@@ -2958,13 +3001,21 @@ spec:
                 properties:
                   limits:
                     additionalProperties:
-                      type: string
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     description: 'Limits describes the maximum amount of compute resources
                       allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                   requests:
                     additionalProperties:
-                      type: string
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
@@ -3145,6 +3196,9 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: 'Total amount of local storage required for this
                           EmptyDir volume. The size limit is also applicable for memory
                           medium. The maximum usage on memory medium EmptyDir would
@@ -3152,7 +3206,8 @@ spec:
                           and the sum of memory limits of all containers in a pod.
                           The default is nil which means that the limit is undefined.
                           More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     type: object
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
@@ -3248,13 +3303,21 @@ spec:
                             properties:
                               limits:
                                 additionalProperties:
-                                  type: string
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
                                   of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
-                                  type: string
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount
                                   of compute resources required. If Requests is omitted
                                   for a container, it defaults to Limits if that is
@@ -3334,7 +3397,11 @@ spec:
                             type: array
                           capacity:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: Represents the actual resources of the underlying
                               volume.
                             type: object
@@ -3895,9 +3962,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -3920,6 +3991,9 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
                           description: 'Total amount of local storage required for
                             this EmptyDir volume. The size limit is also applicable
                             for memory medium. The maximum usage on memory medium
@@ -3927,7 +4001,8 @@ spec:
                             specified here and the sum of memory limits of all containers
                             in a pod. The default is nil which means that the limit
                             is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                          type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                       type: object
                     fc:
                       description: FC represents a Fibre Channel resource that is
@@ -4390,10 +4465,14 @@ spec:
                                                 for volumes, optional for env vars'
                                               type: string
                                             divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
                                               description: Specifies the output format
                                                 of the exposed resources, defaults
                                                 to "1"
-                                              type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
                                             resource:
                                               description: 'Required: resource to
                                                 select'
@@ -4778,7 +4857,7 @@ spec:
                 format: int32
                 type: integer
               paused:
-                description: Represents whether any actions on the underlaying managed
+                description: Represents whether any actions on the underlying managed
                   objects are being performed. Only delete actions will be performed.
                 type: boolean
               replicas:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null
@@ -1231,9 +1231,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -1668,6 +1672,7 @@ spec:
                               be referred to by services.
                             type: string
                           protocol:
+                            default: TCP
                             description: Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
@@ -1675,6 +1680,10 @@ spec:
                         - containerPort
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
                         Container will be removed from service endpoints if the probe
@@ -1798,13 +1807,21 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
                             resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute
                             resources required. If Requests is omitted for a container,
                             it defaults to Limits if that is explicitly specified,
@@ -2358,9 +2375,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -2795,6 +2816,7 @@ spec:
                               be referred to by services.
                             type: string
                           protocol:
+                            default: TCP
                             description: Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
@@ -2802,6 +2824,10 @@ spec:
                         - containerPort
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
                         Container will be removed from service endpoints if the probe
@@ -2925,13 +2951,21 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
                             resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute
                             resources required. If Requests is omitted for a container,
                             it defaults to Limits if that is explicitly specified,
@@ -4099,7 +4133,9 @@ spec:
                   will _not_ be added when value is set to empty string (`""`).
                 type: string
               replicas:
-                description: Number of instances to deploy for a Prometheus deployment.
+                description: Number of replicas of each shard to deploy for a Prometheus
+                  deployment. Number of replicas multiplied by shards is the total
+                  number of Pods created.
                 format: int32
                 type: integer
               resources:
@@ -4107,13 +4143,21 @@ spec:
                 properties:
                   limits:
                     additionalProperties:
-                      type: string
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     description: 'Limits describes the maximum amount of compute resources
                       allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                   requests:
                     additionalProperties:
-                      type: string
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
@@ -4490,6 +4534,17 @@ spec:
                   if SHA is set. Deprecated: use ''image'' instead.  The image digest
                   can be specified as part of the image URL.'
                 type: string
+              shards:
+                description: 'EXPERIMENTAL: Number of shards to distribute targets
+                  onto. Number of replicas multiplied by shards is the total number
+                  of Pods created. Note that scaling down shards will not reshard
+                  data onto remaining instances, it must be manually moved. Increasing
+                  shards will not reshard data either but it will continue to be available
+                  from the same instances. To query globally use Thanos sidecar and
+                  Thanos querier or remote write data to a central location. Sharding
+                  is done on the content of the `__address__` target meta-label.'
+                format: int32
+                type: integer
               storage:
                 description: Storage spec to specify how storage shall be used.
                 properties:
@@ -4510,6 +4565,9 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: 'Total amount of local storage required for this
                           EmptyDir volume. The size limit is also applicable for memory
                           medium. The maximum usage on memory medium EmptyDir would
@@ -4517,7 +4575,8 @@ spec:
                           and the sum of memory limits of all containers in a pod.
                           The default is nil which means that the limit is undefined.
                           More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     type: object
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
@@ -4613,13 +4672,21 @@ spec:
                             properties:
                               limits:
                                 additionalProperties:
-                                  type: string
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
                                   of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
-                                  type: string
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount
                                   of compute resources required. If Requests is omitted
                                   for a container, it defaults to Limits if that is
@@ -4699,7 +4766,11 @@ spec:
                             type: array
                           capacity:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: Represents the actual resources of the underlying
                               volume.
                             type: object
@@ -4919,7 +4990,8 @@ spec:
                     type: string
                   objectStorageConfig:
                     description: ObjectStorageConfig configures object storage in
-                      Thanos.
+                      Thanos. Alternative to ObjectStorageConfigFile, and lower order
+                      priority.
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -4936,6 +5008,11 @@ spec:
                     required:
                     - key
                     type: object
+                  objectStorageConfigFile:
+                    description: ObjectStorageConfigFile specifies the path of the
+                      object storage configuration file. When used alongside with
+                      ObjectStorageConfig, ObjectStorageConfigFile takes precedence.
+                    type: string
                   resources:
                     description: Resources defines the resource requirements for the
                       Thanos sidecar. If not provided, no requests/limits will be
@@ -4943,13 +5020,21 @@ spec:
                     properties:
                       limits:
                         additionalProperties:
-                          type: string
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         description: 'Limits describes the maximum amount of compute
                           resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                       requests:
                         additionalProperties:
-                          type: string
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
@@ -5499,9 +5584,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -5524,6 +5613,9 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
                           description: 'Total amount of local storage required for
                             this EmptyDir volume. The size limit is also applicable
                             for memory medium. The maximum usage on memory medium
@@ -5531,7 +5623,8 @@ spec:
                             specified here and the sum of memory limits of all containers
                             in a pod. The default is nil which means that the limit
                             is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                          type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                       type: object
                     fc:
                       description: FC represents a Fibre Channel resource that is
@@ -5994,10 +6087,14 @@ spec:
                                                 for volumes, optional for env vars'
                                               type: string
                                             divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
                                               description: Specifies the output format
                                                 of the exposed resources, defaults
                                                 to "1"
-                                              type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
                                             resource:
                                               description: 'Required: resource to
                                                 select'
@@ -6394,7 +6491,7 @@ spec:
                 format: int32
                 type: integer
               paused:
-                description: Represents whether any actions on the underlaying managed
+                description: Represents whether any actions on the underlying managed
                   objects are being performed. Only delete actions will be performed.
                 type: boolean
               replicas:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null
@@ -19,7 +19,8 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: PrometheusRule defines alerting rules for a Prometheus instance
+        description: PrometheusRule defines recording and alerting rules for a Prometheus
+          instance
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null
@@ -779,9 +779,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -1216,6 +1220,7 @@ spec:
                               be referred to by services.
                             type: string
                           protocol:
+                            default: TCP
                             description: Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
@@ -1223,6 +1228,10 @@ spec:
                         - containerPort
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
                         Container will be removed from service endpoints if the probe
@@ -1346,13 +1355,21 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
                             resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute
                             resources required. If Requests is omitted for a container,
                             it defaults to Limits if that is explicitly specified,
@@ -1981,9 +1998,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -2418,6 +2439,7 @@ spec:
                               be referred to by services.
                             type: string
                           protocol:
+                            default: TCP
                             description: Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
@@ -2425,6 +2447,10 @@ spec:
                         - containerPort
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
                         Container will be removed from service endpoints if the probe
@@ -2548,13 +2574,21 @@ spec:
                       properties:
                         limits:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
                             resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
-                            type: string
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute
                             resources required. If Requests is omitted for a container,
                             it defaults to Limits if that is explicitly specified,
@@ -2946,6 +2980,7 @@ spec:
                 type: object
               objectStorageConfig:
                 description: ObjectStorageConfig configures object storage in Thanos.
+                  Alternative to ObjectStorageConfigFile, and lower order priority.
                 properties:
                   key:
                     description: The key of the secret to select from.  Must be a
@@ -2961,6 +2996,11 @@ spec:
                 required:
                 - key
                 type: object
+              objectStorageConfigFile:
+                description: ObjectStorageConfigFile specifies the path of the object
+                  storage configuration file. When used alongside with ObjectStorageConfig,
+                  ObjectStorageConfigFile takes precedence.
+                type: string
               paused:
                 description: When a ThanosRuler deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
@@ -3057,13 +3097,21 @@ spec:
                 properties:
                   limits:
                     additionalProperties:
-                      type: string
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     description: 'Limits describes the maximum amount of compute resources
                       allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                   requests:
                     additionalProperties:
-                      type: string
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
@@ -3316,6 +3364,9 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: 'Total amount of local storage required for this
                           EmptyDir volume. The size limit is also applicable for memory
                           medium. The maximum usage on memory medium EmptyDir would
@@ -3323,7 +3374,8 @@ spec:
                           and the sum of memory limits of all containers in a pod.
                           The default is nil which means that the limit is undefined.
                           More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     type: object
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
@@ -3419,13 +3471,21 @@ spec:
                             properties:
                               limits:
                                 additionalProperties:
-                                  type: string
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
                                   of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
-                                  type: string
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount
                                   of compute resources required. If Requests is omitted
                                   for a container, it defaults to Limits if that is
@@ -3505,7 +3565,11 @@ spec:
                             type: array
                           capacity:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: Represents the actual resources of the underlying
                               volume.
                             type: object
@@ -4034,9 +4098,13 @@ spec:
                                       optional for env vars'
                                     type: string
                                   divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
-                                    type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     description: 'Required: resource to select'
                                     type: string
@@ -4059,6 +4127,9 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
                           description: 'Total amount of local storage required for
                             this EmptyDir volume. The size limit is also applicable
                             for memory medium. The maximum usage on memory medium
@@ -4066,7 +4137,8 @@ spec:
                             specified here and the sum of memory limits of all containers
                             in a pod. The default is nil which means that the limit
                             is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                          type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                       type: object
                     fc:
                       description: FC represents a Fibre Channel resource that is
@@ -4529,10 +4601,14 @@ spec:
                                                 for volumes, optional for env vars'
                                               type: string
                                             divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
                                               description: Specifies the output format
                                                 of the exposed resources, defaults
                                                 to "1"
-                                              type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
                                             resource:
                                               description: 'Required: resource to
                                                 select'


### PR DESCRIPTION
Bump prometheus-operator to v0.44.0 to unblock https://github.com/openshift/prometheus-operator/pull/101

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.