### PR TITLE
Bug 1904538: hack: filter SCCs for CMO role

### DIFF
--- a/hack/merge_cluster_roles.py
+++ b/hack/merge_cluster_roles.py
@@ -61,14 +61,14 @@ class ClusterRole(object):
             warnings.warn('creating a ClusterRole from a {}'.format(self.manifest['kind']))
         self.rules = {}
         if 'rules' in self.manifest:
-            for r in self.manifest['rules']:
+            for r in filter(withoutSCC, self.manifest['rules']):
                 self.rules[rule_to_string(r)] = r
         else:
             self.manifest['rules'] = []
 
     # merge adds the rules of the passed ClusterRole to the list of rules.
     def merge(self, cr):
-        for s, r in cr.rules.items():
+        for s, r in filter(withoutSCC, cr.rules.items()):
             if s not in self.rules:
                 self.rules[s] = r
                 self.manifest['rules'].append(r)
@@ -87,6 +87,10 @@ def rule_to_string(rule):
         s.append('{}:{}'.format(k, v))
     return ','.join(s)
 
+
+def withoutSCC(rule):
+    nonroot = {'apiGroups': ['security.openshift.io'], 'resourceNames': ['nonroot'], 'resources': ['securitycontextconstraints'], 'verbs': ['use']}
+    return not nonroot == rule
 
 if __name__ == "__main__":
     main()

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -169,14 +169,6 @@ rules:
   verbs:
   - create
 - apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - nonroot
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
-- apiGroups:
   - ''
   resources:
   - namespaces


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

/cc @openshift/openshift-team-monitoring 