### PR TITLE
Bug 1906570: Mount /var/log/wtmp into node_exporter init container

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -104,6 +104,9 @@ spec:
         - mountPath: /var/node_exporter/textfile
           name: node-exporter-textfile
           readOnly: false
+        - mountPath: /var/log/wtmp
+          name: node-exporter-wtmp
+          readOnly: true
         workingDir: /var/node_exporter/textfile
       nodeSelector:
         kubernetes.io/os: linux
@@ -127,6 +130,10 @@ spec:
       - name: node-exporter-tls
         secret:
           secretName: node-exporter-tls
+      - hostPath:
+          path: /var/log/wtmp
+          type: File
+        name: node-exporter-wtmp
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/jsonnet/node-exporter.jsonnet
+++ b/jsonnet/node-exporter.jsonnet
@@ -9,6 +9,8 @@ local containerVolumeMount = container.volumeMountsType;
 local textfileDir = '/var/node_exporter/textfile';
 local textfileVolumeName = 'node-exporter-textfile';
 local tlsVolumeName = 'node-exporter-tls';
+local wtmpPath = '/var/log/wtmp';
+local wtmpVolumeName = 'node-exporter-wtmp';
 
 {
   nodeExporter+:: {
@@ -97,6 +99,7 @@ local tlsVolumeName = 'node-exporter-tls';
                   terminationMessagePolicy: 'FallbackToLogsOnError',
                   volumeMounts+: [
                     containerVolumeMount.new(textfileVolumeName, textfileDir),
+                    containerVolumeMount.new(wtmpVolumeName, wtmpPath).withReadOnly(true),
                   ],
                   workingDir: textfileDir,
                 },
@@ -143,6 +146,7 @@ local tlsVolumeName = 'node-exporter-tls';
               volumes+: [
                 volume.fromEmptyDir(textfileVolumeName),
                 volume.fromSecret(tlsVolumeName, 'node-exporter-tls'),
+                volume.fromHostPath(wtmpVolumeName, wtmpPath).withType('File'),
               ],
               securityContext: {},
               priorityClassName: 'system-cluster-critical',


### PR DESCRIPTION
The init container can now view wtmp so the new node_boots metric
can be read via a text collector. This exposes no additional security
risk except potentially allowing the node_exporter init processes
to see the users who have been logged into the system during startup.

Used by https://github.com/openshift/node_exporter/pull/74


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.