### PR TITLE
Bug 1907475: Add recording rules for ingress traffic and error rate

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -924,12 +924,26 @@ spec:
     rules:
     - expr: sum by (code) (rate(haproxy_server_http_responses_total[5m]) > 0)
       record: code:cluster:ingress_http_request_count:rate5m:sum
-    - expr: sum by (frontend) (rate(haproxy_frontend_bytes_in_total[5m]))
-      record: frontend:cluster:ingress_frontend_bytes_in:rate5m:sum
-    - expr: sum by (frontend) (rate(haproxy_frontend_bytes_out_total[5m]))
-      record: frontend:cluster:ingress_frontend_bytes_out:rate5m:sum
-    - expr: sum by (frontend) (haproxy_frontend_current_sessions)
-      record: frontend:cluster:ingress_frontend_connections:sum
+    - expr: sum (rate(haproxy_frontend_bytes_in_total[5m]))
+      record: cluster:usage:ingress_frontend_bytes_in:rate5m:sum
+    - expr: sum (rate(haproxy_frontend_bytes_out_total[5m]))
+      record: cluster:usage:ingress_frontend_bytes_out:rate5m:sum
+    - expr: sum (haproxy_frontend_current_sessions)
+      record: cluster:usage:ingress_frontend_connections:sum
+    - expr: sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace!~"openshift-.*"}[5m])
+        > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m])))
+        or absent(__does_not_exist__)*0
+      record: cluster:usage:workload:ingress_request_error:fraction5m
+    - expr: sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m])))
+        or absent(__does_not_exist__)*0
+      record: cluster:usage:workload:ingress_request_total:irate5m
+    - expr: sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace=~"openshift-.*"}[5m])
+        > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m])))
+        or absent(__does_not_exist__)*0
+      record: cluster:usage:openshift:ingress_request_error:fraction5m
+    - expr: sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m])))
+        or absent(__does_not_exist__)*0
+      record: cluster:usage:openshift:ingress_request_total:irate5m
   - name: openshift-build.rules
     rules:
     - expr: sum(openshift_build_total{job="kubernetes-apiservers",phase="Error"})/(sum(openshift_build_total{job="kubernetes-apiservers",phase=~"Failed|Complete|Error"}))

--- a/jsonnet/rules.jsonnet
+++ b/jsonnet/rules.jsonnet
@@ -307,16 +307,39 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
             record: 'code:cluster:ingress_http_request_count:rate5m:sum',
           },
           {
-            expr: 'sum by (frontend) (rate(haproxy_frontend_bytes_in_total[5m]))',
-            record: 'frontend:cluster:ingress_frontend_bytes_in:rate5m:sum',
+            expr: 'sum (rate(haproxy_frontend_bytes_in_total[5m]))',
+            record: 'cluster:usage:ingress_frontend_bytes_in:rate5m:sum',
+            # The rate of bytes in through the ingress frontends
           },
           {
-            expr: 'sum by (frontend) (rate(haproxy_frontend_bytes_out_total[5m]))',
-            record: 'frontend:cluster:ingress_frontend_bytes_out:rate5m:sum',
+            expr: 'sum (rate(haproxy_frontend_bytes_out_total[5m]))',
+            record: 'cluster:usage:ingress_frontend_bytes_out:rate5m:sum',
+            # The rate of bytes out through the ingress frontends
           },
           {
-            expr: 'sum by (frontend) (haproxy_frontend_current_sessions)',
-            record: 'frontend:cluster:ingress_frontend_connections:sum',
+            expr: 'sum (haproxy_frontend_current_sessions)',
+            record: 'cluster:usage:ingress_frontend_connections:sum',
+            # The number of open connections on the ingress frontends
+          },
+          {
+            expr: 'sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace!~"openshift-.*"}[5m]) > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m]))) or absent(__does_not_exist__)*0',
+            record: 'cluster:usage:workload:ingress_request_error:fraction5m',
+            # The fraction of workload requests that have errored over the last five minutes, measured at the ingress controllers
+          },
+          {
+            expr: 'sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m]))) or absent(__does_not_exist__)*0',
+            record: 'cluster:usage:workload:ingress_request_total:irate5m',
+            # The instantaneous rate of workload requests per second arriving at the ingress controllers
+          },
+          {
+            expr: 'sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace=~"openshift-.*"}[5m]) > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m]))) or absent(__does_not_exist__)*0',
+            record: 'cluster:usage:openshift:ingress_request_error:fraction5m',
+            # The fraction of openshift requests that have errored over the last five minutes, measured at the ingress controllers
+          },
+          {
+            expr: 'sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m]))) or absent(__does_not_exist__)*0',
+            record: 'cluster:usage:openshift:ingress_request_total:irate5m',
+            # The instantaneous rate of openshift requests per second arriving at the ingress controllers
           },
         ],
       },


### PR DESCRIPTION
The overall rates of ingress traffic to the cluster are relevant in
assessing health and usage - these rules add calculations for the
rate of requests that error (5xx and other types of errors) across
the frontends, the total requests passing across the frontends, the
bandwidth used in both directions, and the number of open connections.
Error rate is split for openshift and workloads (like CPU is) in order
to better categorize trends before, during, and after upgrades.

This data is relevant for both admins and engineering teams to classify
and categorize the overall health and traffic of the cluster. This adds
seven new series to telemetry via the cluster:usage: prefix.


* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.