### PR TITLE
Bug 1908562: Add a recording rule measuring pod readiness

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -920,6 +920,15 @@ spec:
       for: 15m
       labels:
         severity: info
+    - expr: (max without (condition,container,endpoint,instance,job,service) (((kube_pod_status_ready{condition="false"}
+        == 1)*0 or (kube_pod_status_ready{condition="true"} == 1)) * on(pod,namespace)
+        group_left() group by (pod,namespace) (kube_pod_status_phase{phase=~"Running|Unknown|Pending"}
+        == 1)))
+      record: kube_running_pod_ready
+    - expr: avg(kube_running_pod_ready{namespace=~"openshift-.*"})
+      record: cluster:usage:openshift:kube_running_pod_ready:avg
+    - expr: avg(kube_running_pod_ready{namespace!~"openshift-.*"})
+      record: cluster:usage:workload:kube_running_pod_ready:avg
   - name: openshift-ingress.rules
     rules:
     - expr: sum by (code) (rate(haproxy_server_http_responses_total[5m]) > 0)

--- a/jsonnet/rules.jsonnet
+++ b/jsonnet/rules.jsonnet
@@ -297,6 +297,21 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
               severity: 'info',
             },
           },
+          {
+            expr: '(max without (condition,container,endpoint,instance,job,service) (((kube_pod_status_ready{condition="false"} == 1)*0 or (kube_pod_status_ready{condition="true"} == 1)) * on(pod,namespace) group_left() group by (pod,namespace) (kube_pod_status_phase{phase=~"Running|Unknown|Pending"} == 1)))',
+            record: 'kube_running_pod_ready',
+            # For all non-terminal pods, report ready pods with 1 and unready pods with 0
+          },
+          {
+            expr: 'avg(kube_running_pod_ready{namespace=~"openshift-.*"})',
+            record: 'cluster:usage:openshift:kube_running_pod_ready:avg',
+            # Report the percentage (0-1) of pending or running openshift pods reporting ready
+          },
+          {
+            expr: 'avg(kube_running_pod_ready{namespace!~"openshift-.*"})',
+            record: 'cluster:usage:workload:kube_running_pod_ready:avg',
+            # Report the percentage (0-1) of pending or running workload (everything outside of openshift-*) pods reporting ready
+          },
         ],
       },
       {


### PR DESCRIPTION
For all pending, running, or unknown pods report a 0 if the pod is
unready and a 1 if a pod ready. Use that to build two aggregate
average readiness fractions for openshift-* and !openshift-*
namespace pods, which we will use to measure impact of upgrades
on pod availability before, during, and after the change.

The fundamental rule can be used in the future for alerting when
the aggregate readiness drops below a threshold after we identify
a minimum bar.

This adds 2 series to telemetry for monitoring the impact of
upgrades.


* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.