### PR TITLE
Bug 1899839: jsonnet/thanos-ruler.jsonnet: Set resources to the native spec field

### DIFF
--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -11,10 +11,6 @@ spec:
     name: thanos-ruler-alertmanagers-config
   containers:
   - name: thanos-ruler
-    resources:
-      requests:
-        cpu: 1m
-        memory: 21Mi
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /etc/tls/private
@@ -78,6 +74,10 @@ spec:
     key: query.yaml
     name: thanos-ruler-query-config
   replicas: 2
+  resources:
+    requests:
+      cpu: 1m
+      memory: 21Mi
   ruleNamespaceSelector: {}
   ruleSelector:
     matchExpressions:

--- a/jsonnet/thanos-ruler.jsonnet
+++ b/jsonnet/thanos-ruler.jsonnet
@@ -289,6 +289,12 @@ local thanosRulerRules =
             runAsUser: 65534,
           },
           replicas: 2,
+          resources: {
+            requests: {
+              memory: '21Mi',
+              cpu: '1m',
+            },
+          },
           image: $._config.imageRepos.openshiftThanos + ':' + $._config.versions.openshiftThanos,
           grpcServerTlsConfig: {
             certFile: '/etc/tls/grpc/server.crt',
@@ -332,12 +338,6 @@ local thanosRulerRules =
           containers: [
             {
               name: 'thanos-ruler',
-              resources: {
-                requests: {
-                  memory: '21Mi',
-                  cpu: '1m',
-                },
-              },
               terminationMessagePolicy: 'FallbackToLogsOnError',
               volumeMounts: [
                 {

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -69,6 +69,7 @@ func TestUserWorkloadMonitoring(t *testing.T) {
 `,
 		},
 	}
+
 	for _, scenario := range []struct {
 		name string
 		f    func(*testing.T)
@@ -96,6 +97,7 @@ func TestUserWorkloadMonitoring(t *testing.T) {
 		}
 	}
 }
+
 func assertPrometheusVCConfig(cm *v1.ConfigMap) func(*testing.T) {
 	return func(t *testing.T) {
 		if err := f.OperatorClient.CreateOrUpdateConfigMap(cm); err != nil {
@@ -127,7 +129,7 @@ func assertPrometheusVCConfig(cm *v1.ConfigMap) func(*testing.T) {
 
 }
 
-func TestUserWorkloadMonitoringThanosRulerVolumeClaim(t *testing.T) {
+func TestUserWorkloadMonitoringThanosRulerConfigurations(t *testing.T) {
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster-monitoring-config",
@@ -146,6 +148,10 @@ func TestUserWorkloadMonitoringThanosRulerVolumeClaim(t *testing.T) {
 		},
 		Data: map[string]string{
 			"config.yaml": `thanosRuler:
+  resources:
+    requests:
+      cpu: 12m
+      memory: 13Mi
   volumeClaimTemplate:
     spec:
       storageClassName: gp2
@@ -161,7 +167,8 @@ func TestUserWorkloadMonitoringThanosRulerVolumeClaim(t *testing.T) {
 		f    func(*testing.T)
 	}{
 		{"enable user workload monitoring, assert prometheus rollout", createUserWorkloadAssets(cm)},
-		{"set VolumeClaimTemplate for thanosRuler CR, assert that it is created", assertThanosRulerVCConfig(uwmCM)},
+		{"set configurations for thanosRuler CR, assert that PVC is created", assertThanosRulerVCConfig(uwmCM)},
+		{"assert that resource requests are created", assertThanosRulerResourcesConfigured("12m", "13Mi")},
 		{"assert assets are deleted when user workload monitoring is disabled", assertDeletedUserWorkloadAssets(cm)},
 	} {
 		if ok := t.Run(scenario.name, scenario.f); !ok {
@@ -199,6 +206,50 @@ func assertThanosRulerVCConfig(cm *v1.ConfigMap) func(*testing.T) {
 		}
 	}
 
+}
+
+func assertThanosRulerResourcesConfigured(cpu, memory string) func(*testing.T) {
+	return func(t *testing.T) {
+		err := framework.Poll(time.Second, 5*time.Minute, func() error {
+			pods, err := f.KubeClient.CoreV1().Pods(f.UserWorkloadMonitoringNs).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "thanos-ruler=user-workload",
+				FieldSelector: "status.phase=Running"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err != nil {
+				return errors.Wrap(err, "getting Thanos Ruler pods failed")
+			}
+			var (
+				podName       = "thanos-ruler-user-workload-0"
+				containerName = "thanos-ruler"
+			)
+
+			for _, p := range pods.Items {
+				if p.Name == podName {
+					for _, container := range p.Spec.Containers {
+						if container.Name == containerName {
+							containerMemory := container.Resources.Requests[v1.ResourceMemory]
+							actualMemory := containerMemory.String()
+							if actualMemory != memory {
+								return fmt.Errorf("memory requests %s does not match actual %s", memory, actualMemory)
+							}
+							containerCPU := container.Resources.Requests[v1.ResourceCPU]
+							actualCPU := containerCPU.String()
+							if actualCPU != cpu {
+								return fmt.Errorf("CPU requests %s does not match actual %s", cpu, actualCPU)
+							}
+						}
+					}
+
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 func createUserWorkloadAssets(cm *v1.ConfigMap) func(*testing.T) {


### PR DESCRIPTION
The user configuration was not propagated correctly as we were modifying the container resources via merging directly, but thanos ruler CR exposes this configuration so we should use that instead.

Opening PR to test easier, but plan on adding a test for this as well in our e2e UWM stack.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
