### PR TITLE
WIP: assets/node-exporter: SCC should be selinux MustRunAs

### DIFF
--- a/assets/node-exporter/security-context-constraints.yaml
+++ b/assets/node-exporter/security-context-constraints.yaml
@@ -13,5 +13,5 @@ readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:
-  type: RunAsAny
+  type: MustRunAs
 users: []

--- a/jsonnet/node-exporter.jsonnet
+++ b/jsonnet/node-exporter.jsonnet
@@ -61,7 +61,7 @@ local wtmpVolumeName = 'node-exporter-wtmp';
           type: 'RunAsAny',
         },
         seLinuxContext: {
-          type: 'RunAsAny',
+          type: 'MustRunAs',
         },
         users: [],
       },


### PR DESCRIPTION
In Kubernetes an empty dir shared between two containers running at
different privilege levels (like the init container and regular node
exporter container do) without an explicit selinux label will end
up with two different labels, and content cannot be automatically
shared between the volumes. This may be a bug with the Kubelet (some
work is ongoing to address the issue) but the immediate and general
workaround is to have the node-exporter SCC use the `MustRunAs` SCC
policy so the default selinux context of all pods defaults to the
namespace policy. This results in the pod having an explicit selinux
label and both init container and regular container having the same
labels, which means the regular container can read files created by
the init container in the emptydir.


* [ ] I added CHANGELOG entry for this change.
* [x]  No user facing changes, so no entry in CHANGELOG was needed.