### PR TITLE
Bug 1913006: Removing etcd v2 specific alerts

### DIFF
--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -3011,7 +3011,7 @@ items:
           "sharedCrosshair": false,
           "style": "dark",
           "tags": [
-
+              "etcd-mixin"
           ],
           "templating": {
               "list": [

--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -2418,39 +2418,6 @@ spec:
       for: 10m
       labels:
         severity: warning
-    - alert: etcdHighNumberOfFailedHTTPRequests
-      annotations:
-        description: '{{ $value }}% of requests for {{ $labels.method }} failed on
-          etcd instance {{ $labels.instance }}'
-        summary: etcd has high number of failed HTTP requests.
-      expr: |
-        sum(rate(etcd_http_failed_total{job=~".*etcd.*", code!="404"}[5m])) without (code) / sum(rate(etcd_http_received_total{job=~".*etcd.*"}[5m]))
-        without (code) > 0.01
-      for: 10m
-      labels:
-        severity: warning
-    - alert: etcdHighNumberOfFailedHTTPRequests
-      annotations:
-        description: '{{ $value }}% of requests for {{ $labels.method }} failed on
-          etcd instance {{ $labels.instance }}.'
-        summary: etcd has high number of failed HTTP requests.
-      expr: |
-        sum(rate(etcd_http_failed_total{job=~".*etcd.*", code!="404"}[5m])) without (code) / sum(rate(etcd_http_received_total{job=~".*etcd.*"}[5m]))
-        without (code) > 0.05
-      for: 10m
-      labels:
-        severity: critical
-    - alert: etcdHTTPRequestsSlow
-      annotations:
-        description: etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method
-          }} are slow.
-        summary: etcd instance HTTP requests are slow.
-      expr: |
-        histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m]))
-        > 0.15
-      for: 10m
-      labels:
-        severity: warning
     - alert: etcdBackendQuotaLowSpace
       annotations:
         message: 'etcd cluster "{{ $labels.job }}": database size exceeds the defined

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -18,8 +18,8 @@
           "subdir": "Documentation/etcd-mixin"
         }
       },
-      "version": "ca866c02422ff3f3d1f0876898a30c33dd7bcccf",
-      "sum": "bLqTqEr0jky9zz5MV/7ucn6H5mph2NlXas0TVnGNB1Y="
+      "version": "855eeb75c551879fe11b9718bceb8bee9b178905",
+      "sum": "EgKKzxcW3ttt7gjPMX//DNTqNcn/0o2VAIaWJ/HSLEc="
     },
     {
       "source": {
@@ -28,8 +28,8 @@
           "subdir": "Documentation/etcd-mixin"
         }
       },
-      "version": "ca866c02422ff3f3d1f0876898a30c33dd7bcccf",
-      "sum": "bLqTqEr0jky9zz5MV/7ucn6H5mph2NlXas0TVnGNB1Y="
+      "version": "855eeb75c551879fe11b9718bceb8bee9b178905",
+      "sum": "EgKKzxcW3ttt7gjPMX//DNTqNcn/0o2VAIaWJ/HSLEc="
     },
     {
       "source": {

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -3013,7 +3013,7 @@ data:
         "sharedCrosshair": false,
         "style": "dark",
         "tags": [
-
+            "etcd-mixin"
         ],
         "templating": {
             "list": [


### PR DESCRIPTION
Based on upstream etcd PR https://github.com/etcd-io/etcd/pull/12600, removing the etcd v2 specific alerts from CMO as it's no longer referred for OCP 4.x clusters.

* Removed etcd-mixin deps from `jsonnet/jsonnet.lock.json`
* Ran `make jsonnet/vendor --always-make`
* Ran `make generate`

