### PR TITLE
Bug 1913554: Ingress recording rule for error fraction is incorrect

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -958,14 +958,14 @@ spec:
     - expr: sum (haproxy_frontend_current_sessions)
       record: cluster:usage:ingress_frontend_connections:sum
     - expr: sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace!~"openshift-.*"}[5m])
-        > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m])))
+        > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m])))
         or absent(__does_not_exist__)*0
       record: cluster:usage:workload:ingress_request_error:fraction5m
     - expr: sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m])))
         or absent(__does_not_exist__)*0
       record: cluster:usage:workload:ingress_request_total:irate5m
     - expr: sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace=~"openshift-.*"}[5m])
-        > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m])))
+        > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m])))
         or absent(__does_not_exist__)*0
       record: cluster:usage:openshift:ingress_request_error:fraction5m
     - expr: sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m])))

--- a/jsonnet/rules.jsonnet
+++ b/jsonnet/rules.jsonnet
@@ -369,7 +369,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
             # The number of open connections on the ingress frontends
           },
           {
-            expr: 'sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace!~"openshift-.*"}[5m]) > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m]))) or absent(__does_not_exist__)*0',
+            expr: 'sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace!~"openshift-.*"}[5m]) > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{exported_namespace!~"openshift-.*"}[5m]))) or absent(__does_not_exist__)*0',
             record: 'cluster:usage:workload:ingress_request_error:fraction5m',
             # The fraction of workload requests that have errored over the last five minutes, measured at the ingress controllers
           },
@@ -379,7 +379,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
             # The instantaneous rate of workload requests per second arriving at the ingress controllers
           },
           {
-            expr: 'sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace=~"openshift-.*"}[5m]) > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (irate(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m]))) or absent(__does_not_exist__)*0',
+            expr: 'sum(max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{code!~"2xx|1xx|4xx|3xx",exported_namespace=~"openshift-.*"}[5m]) > 0)) / sum (max without(service,endpoint,container,pod,job,namespace) (increase(haproxy_server_http_responses_total{exported_namespace=~"openshift-.*"}[5m]))) or absent(__does_not_exist__)*0',
             record: 'cluster:usage:openshift:ingress_request_error:fraction5m',
             # The fraction of openshift requests that have errored over the last five minutes, measured at the ingress controllers
           },


### PR DESCRIPTION
The denominator of the recording rule should be `increase`, like
the numerator, instead of `irate`. `increase` is more stable over
the intervals we are testing. Introduced due to a copy and paste
error as the rule was being refactored, and when assessing the
impact in 4.7 clusters I realized we had fractions > 1 showing up.


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.