### PR TITLE
Bug 1915003: Add a rule for calculating rolling node readiness

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -931,6 +931,14 @@ spec:
       for: 15m
       labels:
         severity: info
+    - expr: avg_over_time((((count((max by (node) (up{job="kubelet",metrics_path="/metrics"}
+        == 1) and max by (node) (kube_node_status_condition{condition="Ready",status="true"}
+        == 1) and min by (node) (kube_node_spec_unschedulable == 0))) / scalar(count(min
+        by (node) (kube_node_spec_unschedulable == 0))))))[5m:1s])
+      record: cluster:usage:kube_schedulable_node_ready_reachable:avg5m
+    - expr: avg_over_time((count(max by (node) (kube_node_status_condition{condition="Ready",status="true"}
+        == 1)) / scalar(count(max by (node) (kube_node_status_condition{condition="Ready",status="true"}))))[5m:1s])
+      record: cluster:usage:kube_node_ready:avg5m
     - expr: (max without (condition,container,endpoint,instance,job,service) (((kube_pod_status_ready{condition="false"}
         == 1)*0 or (kube_pod_status_ready{condition="true"} == 1)) * on(pod,namespace)
         group_left() group by (pod,namespace) (kube_pod_status_phase{phase=~"Running|Unknown|Pending"}


### PR DESCRIPTION
The number of schedulable nodes reporting ready is a key measurement
of the disruption upgrades incur as well as being an effective way
to assess whether our software is available on the hardware users
provide. Report a rolling average of node readiness measured across
all schedulable nodes and one across all nodes, using both readiness
and reachability. Also report a more general node readiness average
which matches the API view and should be higher than reachability.

This info will help assess more accurately how often we are ready
and identify future areas to improve in both reporting and practice.


* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.