### PR TITLE
Bug 1913386: allow only /metrics for kube-rbac-proxy in front of UWM prometheu

### DIFF
--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -42,6 +42,7 @@ spec:
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    - --allow-paths=/metrics
     image: quay.io/coreos/kube-rbac-proxy:v0.8.0
     name: kube-rbac-proxy
     ports:

--- a/jsonnet/prometheus-user-workload.jsonnet
+++ b/jsonnet/prometheus-user-workload.jsonnet
@@ -262,6 +262,7 @@
                 '--tls-cert-file=/etc/tls/private/tls.crt',
                 '--tls-private-key-file=/etc/tls/private/tls.key',
                 '--tls-cipher-suites=' + std.join(',', $._config.tlsCipherSuites),
+                '--allow-paths=/metrics',
               ],
               terminationMessagePolicy: 'FallbackToLogsOnError',
               volumeMounts: [


### PR DESCRIPTION

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
