### PR TITLE
[WIP] Remove KubeClientCertificateExpiration alert

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -1890,24 +1890,6 @@ spec:
         short: 6h
   - name: kubernetes-system-apiserver
     rules:
-    - alert: KubeClientCertificateExpiration
-      annotations:
-        description: A client certificate used to authenticate to the apiserver is
-          expiring in less than 1.5 hours.
-        summary: Client certificate is about to expire.
-      expr: |
-        apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 5400
-      labels:
-        severity: warning
-    - alert: KubeClientCertificateExpiration
-      annotations:
-        description: A client certificate used to authenticate to the apiserver is
-          expiring in less than 1.0 hours.
-        summary: Client certificate is about to expire.
-      expr: |
-        apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 3600
-      labels:
-        severity: critical
     - alert: AggregatedAPIErrors
       annotations:
         description: An aggregated API {{ $labels.name }}/{{ $labels.namespace }}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -43,7 +43,19 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
                      // Removing CPUThrottlingHigh alert as per https://bugzilla.redhat.com/show_bug.cgi?id=1843346
                      else if ruleGroup.name == 'kubernetes-resources' then
                        ruleGroup { rules: std.filter(function(rule) !('alert' in rule && rule.alert == 'CPUThrottlingHigh'), ruleGroup.rules) }
+                     else if ruleGroup.name == 'kubernetes-system-apiserver' then
+                       // KubeClientCertificateExpiration alert isn't
+                       // actionable because the cluster admin has no way to
+                       // prevent a client from using an expird certificate.
+                       ruleGroup { rules: std.filter(function(rule) !('alert' in rule && (rule.alert == 'KubeClientCertificateExpiration')), ruleGroup.rules) }
                      else if ruleGroup.name == 'kubernetes-system-kubelet' then
+                       // Kubelet*CertificateExpiration alerts are based on absolute thresholds which
+                       // make them prone to failures (e.g. if the lifetime of the certificate is
+                       // decreased, the alert might fire while everything is fine).
+                       // In addition we have alerts to detect that a Kubelet
+                       // can't renew its certificates which makes it redundant
+                       // to alert on certificates being almost expired.
+                       // See https://coreos.slack.com/archives/CB48XQ4KZ/p1603712568136500.
                        ruleGroup { rules: std.filter(function(rule) !('alert' in rule && (rule.alert == 'KubeletClientCertificateExpiration' || rule.alert == 'KubeletServerCertificateExpiration')), ruleGroup.rules) }
                      else if ruleGroup.name == 'prometheus' then
                        ruleGroup {


### PR DESCRIPTION
We already disabled `KubeletServerCertificateExpiration` alerts and IMHO, we should do the same for `KubeClientCertificateExpiration`.
We might even consider removing it from upstream? cc @paulfantom 

~~Putting on hold until master re-opens.~~

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
