### PR TITLE
Bug 1926876: pkg/manifests: fix prometheus-proxy trustedCA

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1391,7 +1391,7 @@ func (f *Factory) PrometheusK8s(host string, grpcTLS *v1.Secret, trustedCABundle
 		// 1. Prometheus, because users might want to configure external remote write.
 		// 2. In OAuth proxy, as that communicates externally when executing the OAuth handshake.
 		for i, container := range p.Spec.Containers {
-			if container.Name == "prometeus-proxy" || container.Name == "prometheus" {
+			if container.Name == "prometheus-proxy" || container.Name == "prometheus" {
 				p.Spec.Containers[i].VolumeMounts = append(
 					p.Spec.Containers[i].VolumeMounts,
 					trustedCABundleVolumeMount(volumeName),


### PR DESCRIPTION
Backport of #1047 to release-4.7.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
