### PR TITLE
bump disk for more iops

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -55,7 +55,7 @@ func TestAlertmanagerVolumeClaim(t *testing.T) {
       storageClassName: gp2
       resources:
         requests:
-          storage: 2Gi
+          storage: 175Gi
 `,
 		},
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -79,7 +79,7 @@ func TestPrometheusVolumeClaim(t *testing.T) {
       storageClassName: gp2
       resources:
         requests:
-          storage: 2Gi
+          storage: 175Gi
 `,
 		},
 	}

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -65,7 +65,7 @@ func TestUserWorkloadMonitoring(t *testing.T) {
       storageClassName: gp2
       resources:
         requests:
-          storage: 2Gi
+          storage: 175Gi
 `,
 		},
 	}
@@ -157,7 +157,7 @@ func TestUserWorkloadMonitoringThanosRulerConfigurations(t *testing.T) {
       storageClassName: gp2
       resources:
         requests:
-          storage: 2Gi
+          storage: 175Gi
 `,
 		},
 	}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
