### PR TITLE
pkg/manifests: fix data race when accessing assets

### DIFF
--- a/pkg/manifests/assets.go
+++ b/pkg/manifests/assets.go
@@ -39,6 +39,9 @@ func NewAssets(assetsDir string) *Assets {
 }
 
 func (a *Assets) GetAsset(name string) ([]byte, error) {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
 	filePath := filepath.Join(a.assetsDir, name)
 
 	// load manifest from memory if available
@@ -49,9 +52,6 @@ func (a *Assets) GetAsset(name string) ([]byte, error) {
 
 	// fallback to loading manifest from disk
 	klog.V(4).Infof("Reading manifest from file: %s\n", filePath)
-
-	a.mtx.Lock()
-	defer a.mtx.Unlock()
 
 	f, err := ioutil.ReadFile(filePath)
 	if err != nil {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

cc @paulfantom I've got a `fatal error: concurrent map read and map write` panic while testing the operator locally.