### PR TITLE
Bug 1929278: [4.7] Adjust priority class of core platform prometheus

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -165,7 +165,7 @@ spec:
     kubernetes.io/os: linux
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
-  priorityClassName: system-cluster-critical
+  priorityClassName: openshift-system-critical
   probeNamespaceSelector: {}
   probeSelector: {}
   replicas: 2

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -395,7 +395,7 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
           ruleSelector: {},
           ruleNamespaceSelector: {},
           listenLocal: true,
-          priorityClassName: 'system-cluster-critical',
+          priorityClassName: 'openshift-system-critical',
           containers: [
             {
               name: 'prometheus-proxy',

--- a/manifests/0000_50_cluster-monitoring-operator_00_0openshift-system-priority-class.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0openshift-system-priority-class.yaml
@@ -1,0 +1,10 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: openshift-system-critical
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+value: 1000000000
+globalDefault: false
+description: "This priority class should be used for addon system facing OpenShift workload pods only. Currently used by monitoring components"

--- a/manifests/0000_50_cluster-monitoring-operator_00_0user-priority-class.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0user-priority-class.yaml
@@ -5,6 +5,6 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-value: 1000000000
+value: 999999999
 globalDefault: false
 description: "This priority class should be used for user facing OpenShift workload pods only."

--- a/test/e2e/priority_class_test.go
+++ b/test/e2e/priority_class_test.go
@@ -23,7 +23,8 @@ import (
 
 // This makes sure that the priority class we create is
 // present and lower than the system priority classes. Example:
-// openshift-user-critical   1000000000   false            66m
+// openshift-user-critical    999999999   false            66m
+// openshift-system-critical 1000000000   false            66m
 // system-cluster-critical   2000000000   false            114m
 // system-node-critical      2000001000   false            114m
 func TestToEnsureUserPriorityClassIsPresentAndLower(t *testing.T) {
@@ -36,6 +37,10 @@ func TestToEnsureUserPriorityClassIsPresentAndLower(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	openshiftSystemPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(context.TODO(), "openshift-system-critical", v1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Get our user priority class value.
 	userPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(context.TODO(), "openshift-user-critical", v1.GetOptions{})
 	if err != nil {
@@ -44,5 +49,11 @@ func TestToEnsureUserPriorityClassIsPresentAndLower(t *testing.T) {
 	// Ensure our is a lower value than the system class' ones.
 	if userPriorityClass.Value >= systemClusterPriorityClass.Value || userPriorityClass.Value >= systemNodePriorityClass.Value {
 		t.Fatalf("openshift-user-critical was higher priority than existing classes: %d", userPriorityClass.Value)
+	}
+	// Ensure openshift-system-critical is a lower value than the system class' ones, but higher than openshift-user-critical.
+	if openshiftSystemPriorityClass.Value < systemClusterPriorityClass.Value ||
+		openshiftSystemPriorityClass.Value < systemNodePriorityClass.Value ||
+		userPriorityClass.Value < openshiftSystemPriorityClass.Value {
+		t.Fatalf("openshift-system-critical was wrong priority class: %d", openshiftSystemPriorityClass.Value)
 	}
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
