### PR TITLE
Bug 1929277: [master] jsonnet/prometheus.jsonnet: Apply openshift-user-critical class to cluster Prometheus 

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -165,7 +165,7 @@ spec:
     kubernetes.io/os: linux
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
-  priorityClassName: system-cluster-critical
+  priorityClassName: openshift-user-critical
   probeNamespaceSelector: {}
   probeSelector: {}
   replicas: 2

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -395,7 +395,7 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
           ruleSelector: {},
           ruleNamespaceSelector: {},
           listenLocal: true,
-          priorityClassName: 'system-cluster-critical',
+          priorityClassName: 'openshift-user-critical',
           containers: [
             {
               name: 'prometheus-proxy',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
