### PR TITLE
jsonnet/rules: Mask KubeDeploymentReplicasMismatch alert for upgrade

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -908,6 +908,10 @@ spec:
       record: cluster:vsphere_esxi_version_total:sum
     - expr: sum by(hw_version)(vsphere_node_hw_version_total)
       record: cluster:vsphere_node_hw_version_total:sum
+    - expr: absent(count(max by (node) (kube_node_role{role="master"}) and (min by
+        (node) (kube_node_status_condition{condition="Ready",status="true"} == 0)))
+        > 0)
+      record: cluster:control_plane:all_nodes_ready
     - alert: ClusterMonitoringOperatorReconciliationErrors
       annotations:
         message: Cluster Monitoring Operator is experiencing reconciliation error
@@ -925,6 +929,31 @@ spec:
           with Alertmanager.
       expr: cluster:alertmanager_routing_enabled:max == 0
       for: 10m
+      labels:
+        severity: warning
+    - alert: KubeDeploymentReplicasMismatch
+      annotations:
+        description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has
+          not matched the expected number of replicas for longer than 15 minutes.
+          This indicates that cluster infrastructure is unable to start or restart
+          the necessary components. This most often occurs when one or more nodes
+          are down or partioned from the cluster, or a fault occurs on the node that
+          prevents the workload from starting. In rare cases this may indicate a new
+          version of a cluster component cannot start due to a bug or configuration
+          error. Assess the pods for this deployment to verify they are running on
+          healthy nodes and then contact support.
+        summary: Deployment has not matched the expected number of replicas
+      expr: |
+        (
+          kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
+            !=
+          kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
+        ) and (
+          changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
+            ==
+          0
+        ) and cluster:control_plane:all_nodes_ready
+      for: 15m
       labels:
         severity: warning
     - alert: MultipleContainersOOMKilled
@@ -1502,24 +1531,6 @@ spec:
         kube_deployment_status_observed_generation{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
           !=
         kube_deployment_metadata_generation{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
-      for: 15m
-      labels:
-        severity: warning
-    - alert: KubeDeploymentReplicasMismatch
-      annotations:
-        description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has
-          not matched the expected number of replicas for longer than 15 minutes.
-        summary: Deployment has not matched the expected number of replicas.
-      expr: |
-        (
-          kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
-            !=
-          kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
-        ) and (
-          changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
-            ==
-          0
-        )
       for: 15m
       labels:
         severity: warning

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -38,6 +38,8 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
                    function(ruleGroup)
                      if ruleGroup.name == 'etcd' then
                        ruleGroup { rules: std.filter(function(rule) !('alert' in rule && (rule.alert == 'etcdHighNumberOfFailedGRPCRequests' || rule.alert == 'etcdInsufficientMembers')), ruleGroup.rules) }
+                     else if ruleGroup.name == 'kubernetes-apps' then
+                       ruleGroup { rules: std.filter(function(rule) !('alert' in rule && rule.alert == 'KubeDeploymentReplicasMismatch'), ruleGroup.rules) }
                      else if ruleGroup.name == 'kubernetes-system' then
                        ruleGroup { rules: std.filter(function(rule) !('alert' in rule && rule.alert == 'KubeVersionMismatch'), ruleGroup.rules) }
                      // Removing CPUThrottlingHigh alert as per https://bugzilla.redhat.com/show_bug.cgi?id=1843346

--- a/jsonnet/rules.jsonnet
+++ b/jsonnet/rules.jsonnet
@@ -296,6 +296,11 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
             record: 'cluster:vsphere_node_hw_version_total:sum',
           },
           {
+            expr: 'absent(count(max by (node) (kube_node_role{role="master"}) and (min by (node) (kube_node_status_condition{condition="Ready",status="true"} == 0))) > 0)',
+            record: 'cluster:control_plane:all_nodes_ready',
+            // Returns 1 if all control plane nodes are ready and is absent otherwise. Should be used to suppress alerts during control plane upgrades or disruption.
+          },
+          {
             expr: 'rate(cluster_monitoring_operator_reconcile_errors_total[15m]) * 100 / rate(cluster_monitoring_operator_reconcile_attempts_total[15m]) > 10',
             alert: 'ClusterMonitoringOperatorReconciliationErrors',
             'for': '30m',
@@ -312,6 +317,28 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
             'for': '10m',
             annotations: {
               message: 'Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager.',
+            },
+            labels: {
+              severity: 'warning',
+            },
+          },
+          {
+            expr: |||
+              (
+                kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
+                  !=
+                kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
+              ) and (
+                changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
+                  ==
+                0
+              ) and cluster:control_plane:all_nodes_ready
+            |||,
+            alert: 'KubeDeploymentReplicasMismatch',
+            'for': '15m',
+            annotations: {
+              description: 'Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes. This indicates that cluster infrastructure is unable to start or restart the necessary components. This most often occurs when one or more nodes are down or partioned from the cluster, or a fault occurs on the node that prevents the workload from starting. In rare cases this may indicate a new version of a cluster component cannot start due to a bug or configuration error. Assess the pods for this deployment to verify they are running on healthy nodes and then contact support.',
+              summary: 'Deployment has not matched the expected number of replicas',
             },
             labels: {
               severity: 'warning',


### PR DESCRIPTION
The KubeDeploymentReplicasMismatch alert fires after 15m, but deployments that run on all three control plane nodes may see disruption that lasts for 3 x 20m = 1h during upgrades of slow to reboot metal hardware. Instead, prevent the alert rule from firing when a control plane nodes are unready (which should be covered by other alerts). While this may mask failures that occur on non control plane nodes, once the control plane is recovered that alert will begin to fire. Provide the alert with a more accurate description.

A future alert may be able to leverage a better metric such as "1 if and only if the control plane is not being upgraded and has been progressing for less than X budget per machine", but that would only be slightly less accurate and simpler may be better.

Found while testing https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-monitoring-operator/1064/pull-ci-openshift-cluster-monitoring-operator-master-e2e-agnostic-upgrade/1362412232272515072 - this is the only alert still firing during this upgrade and will allow https://github.com/openshift/origin/pull/25904 to pass.


* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.