### PR TITLE
Bug 1933805: TargetDown should exclude unschedulable nodes

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -12,6 +12,23 @@ metadata:
   namespace: openshift-monitoring
 spec:
   groups:
+  - name: openshift-general.rules
+    rules:
+    - alert: TargetDown
+      annotations:
+        description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service
+          }} targets in {{ $labels.namespace }} namespace have been unreachable for
+          more than 15 minutes. This may be a symptom of network connectivity issues,
+          down nodes, or failures within these components. Assess the health of the
+          infrastructure and nodes running these targets and then contact support.'
+        summary: Some targets were not reachable from the monitoring server for an
+          extended period of time.
+      expr: |
+        100 * (count(up == 0 unless on (node) max by (node) (kube_node_spec_unschedulable == 1)) BY (job, namespace, service) /
+          count(up unless on (node) max by (node) (kube_node_spec_unschedulable == 1)) BY (job, namespace, service)) > 10
+      for: 15m
+      labels:
+        severity: warning
   - name: openshift-kubernetes.rules
     rules:
     - expr: sum(container_memory_usage_bytes{container="",pod!=""}) BY (pod, namespace)
@@ -379,15 +396,6 @@ spec:
       record: kube_pod_status_ready:image_registry:sum
   - name: general.rules
     rules:
-    - alert: TargetDown
-      annotations:
-        message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service
-          }} targets in {{ $labels.namespace }} namespace are down.'
-      expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job,
-        namespace, service)) > 10
-      for: 10m
-      labels:
-        severity: warning
     - alert: Watchdog
       annotations:
         message: |

--- a/jsonnet/exclude-rules.libsonnet
+++ b/jsonnet/exclude-rules.libsonnet
@@ -41,6 +41,8 @@
                       ruleGroup.rules,
                     ),
                 }
+              else if ruleGroup.name == 'general.rules' then
+                ruleGroup { rules: std.filter(function(rule) !('alert' in rule && (rule.alert == 'TargetDown')), ruleGroup.rules) }
               else
                 ruleGroup,
             super.groups,


### PR DESCRIPTION
The TargetDown alert fires today when multiple nodes are upgraded
in sequence and one or more daemonsets are successively out for
longer than 10m. Since upgrade is normal behavior and we know that
nodes will be upgrading continuously as the control plane rolls
out, alter the alert to exclude unschedulable nodes (a reasonably
accurate proxy for a node being upgraded today that can be improved
later), wait a longer period of time before firing (60m of
continuous availability), and describe the alert in more detail.

TargetDown is still useful as a bedrock symptom-based alert for
target disruption since it is likely to catch a very wide range
of problems related to running in Kubernetes, so we don't restrict
it further. In investigation this alert fires commonly in clusters
(90% of fires last longer than 60m or even 1d) so increasing the
required trigger time will still provide that backstop, while
removing higher frequency noise from normal cluster operations.

This issue was caught by investigating machine-config-daemon -
a node label was added to the daemonset pods which mitigates the
immediate problem. Other daemonset pods should leverage the label
as defined in https://github.com/openshift/machine-config-operator/pull/2446
which will give them better discrimination for node related alerts
in the future.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.