### PR TITLE
*: include all groups when testing prometheus rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ shellcheck:
 tmp/rules.yaml: $(GOJSONTOYAML_BIN) $(ASSETS)
 	mkdir -p tmp/rules
 	for f in $(shell find assets/ -name '*prometheus-rule.yaml'); do $(GOJSONTOYAML_BIN) -yamltojson < "$$f" | jq .spec > "tmp/rules/$$(echo "$$f" | sed 's/\//-/g').json"; done
-	jq -s '[.[]] | { groups: map(.groups[0]) }' $$(ls -d tmp/rules/*) | $(GOJSONTOYAML_BIN) > tmp/rules.yaml
+	jq -s '[.[]] | { groups: map(.groups[]) }' $$(ls -d tmp/rules/*) | $(GOJSONTOYAML_BIN) > tmp/rules.yaml
 
 .PHONY: check-rules
 check-rules: $(PROMTOOL_BIN) tmp/rules.yaml


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

To test alerting rules we create a temporary file `tmp/rules.yaml` with all alerts and recording rules. This file was created incorrectly and it was missing a lot of rules leading to issues like one seen in CI in https://github.com/openshift/cluster-monitoring-operator/pull/1072. This PR should fix that issue.

Before fix:
```
$ make tmp/rules.yaml 
$ wc -l tmp/rules.yaml 
1537 tmp/rules.yaml
```

After fix:
```
$ make tmp/rules.yaml 
$ wc -l tmp/rules.yaml 
2638 tmp/rules.yaml
```