### PR TITLE
hack: add check script for unused rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,7 @@ shellcheck:
 
 tmp/rules.yaml: $(GOJSONTOYAML_BIN) $(ASSETS)
 	mkdir -p tmp/rules
-	for f in $(shell find assets/ -name '*prometheus-rule.yaml'); do $(GOJSONTOYAML_BIN) -yamltojson < "$$f" | jq .spec > "tmp/rules/$$(echo "$$f" | sed 's/\//-/g').json"; done
-	jq -s '[.[]] | { groups: map(.groups[]) }' $$(ls -d tmp/rules/*) | $(GOJSONTOYAML_BIN) > tmp/rules.yaml
+	hack/find-rules.sh | $(GOJSONTOYAML_BIN) > tmp/rules.yaml
 
 .PHONY: check-rules
 check-rules: $(PROMTOOL_BIN) tmp/rules.yaml

--- a/hack/check-rec-rule-usage.sh
+++ b/hack/check-rec-rule-usage.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+TMP=$(mktemp -d)
+echo "Created temporary directory at $TMP"
+
+findrules="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/find-rules.sh"
+
+"$findrules" > "$TMP/rule-groups"
+# extract recording rules
+tmp/bin/gojsontoyaml -yamltojson <  "$TMP/rule-groups" | jq -s '.. | objects | select(.record) | .record' | tr -d '"' | sort -u > "$TMP/rec-rules"
+# and alerting rules
+tmp/bin/gojsontoyaml -yamltojson <  "$TMP/rule-groups" | jq -s '.. | objects | select(.alert) | .expr' | grep "\w\+{" -o | tr -d "{" | sort -u > "$TMP/alert-rules"
+# the first grep outputs all recording rules that are not used in alerts
+# and then greps for the remaining rules in the dashboard defs and outputs the ones that are not found
+grep -Fxvf "$TMP/alert-rules" "$TMP/rec-rules" | while read -r r; do grep "$r" assets/grafana/dashboard-definitions.yaml -q || echo "$r"; done > "$TMP/unused-rules"
+
+echo "Found $(wc -l < "$TMP/unused-rules") unused rules"
+echo "Find the unused rules in $TMP/unused-rules"

--- a/hack/find-rules.sh
+++ b/hack/find-rules.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# find all rule groups and aggregate them
+# returns a json list of groups
+
+find assets/ -type f -name "*prometheus-rule.yaml" | while read -r f
+do
+    tmp/bin/gojsontoyaml -yamltojson < "$f" | jq .spec
+done | jq -s '[.[]] | { groups: map(.groups[]) }'


### PR DESCRIPTION
This script aggregates all recording rules from the assets directory and
checks whether they are used on alerts or dashboards.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
