### PR TITLE
Bug 1940322: jsonnet: update kubernetes mixin

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -69,8 +69,8 @@
           "subdir": ""
         }
       },
-      "version": "3d4f68cead695d2717d606f80246ffcfd7b1f08b",
-      "sum": "u3MNX6g4bWVXQ32c6FFR+tLb9+gu6EZnaf8sxpV13rA="
+      "version": "6c6be0315c04b3d3e9c95f63a327e14f3c570675",
+      "sum": "CHfLnogXhJx3kRl/Hk7NdmJqKUF6TBTIMXTHXzU92YE="
     },
     {
       "source": {
@@ -79,8 +79,8 @@
           "subdir": "lib/promgrafonnet"
         }
       },
-      "version": "ead45674dba3c8712e422d99223453177aac6bf4",
-      "sum": "zv7hXGui6BfHzE9wPatHI/AGZa4A2WKo6pq7ZdqBsps="
+      "version": "6c6be0315c04b3d3e9c95f63a327e14f3c570675",
+      "sum": "CHfLnogXhJx3kRl/Hk7NdmJqKUF6TBTIMXTHXzU92YE="
     },
     {
       "source": {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
