### PR TITLE
Bug 1934163: adjust Thanos querier alerting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.8
+
+- [#1087](https://github.com/openshift/cluster-monitoring-operator/pull/1087) Decrease alert severity to "warning" for ThanosQueryHttpRequestQueryErrorRateHigh and ThanosQueryHttpRequestQueryRangeErrorRateHigh alerts.
+- [#1087](https://github.com/openshift/cluster-monitoring-operator/pull/1087) Increase "for" duration to 1 hour for all Thanos query alerts.
+- [#1087](https://github.com/openshift/cluster-monitoring-operator/pull/1087) Remove ThanosQueryInstantLatencyHigh and ThanosQueryRangeLatencyHigh alerts.
+- [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Decrease alert severity to "warning" for all Thanos sidecar alerts.
+- [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Increase "for" duration to 1 hour for all Thanos sidecar alerts.
+
 ## 4.7
 
 - [#963](https://github.com/openshift/cluster-monitoring-operator/pull/963) bump mixins to include new etcd alerts

--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -23,9 +23,9 @@ spec:
         /
           sum(rate(http_requests_total{job="thanos-querier", handler="query"}[5m]))
         ) * 100 > 5
-      for: 5m
+      for: 1h
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
       annotations:
         description: Thanos Query {{$labels.job}} is failing to handle {{ $value |
@@ -37,9 +37,9 @@ spec:
         /
           sum(rate(http_requests_total{job="thanos-querier", handler="query_range"}[5m]))
         ) * 100 > 5
-      for: 5m
+      for: 1h
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosQueryGrpcServerErrorRate
       annotations:
         description: Thanos Query {{$labels.job}} is failing to handle {{ $value |
@@ -52,7 +52,7 @@ spec:
           sum by (job) (rate(grpc_server_started_total{job="thanos-querier"}[5m]))
         * 100 > 5
         )
-      for: 5m
+      for: 1h
       labels:
         severity: warning
     - alert: ThanosQueryGrpcClientErrorRate
@@ -66,7 +66,7 @@ spec:
         /
           sum by (job) (rate(grpc_client_started_total{job="thanos-querier"}[5m]))
         ) * 100 > 5
-      for: 5m
+      for: 1h
       labels:
         severity: warning
     - alert: ThanosQueryHighDNSFailures
@@ -80,34 +80,6 @@ spec:
         /
           sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job="thanos-querier"}[5m]))
         ) * 100 > 1
-      for: 15m
+      for: 1h
       labels:
         severity: warning
-    - alert: ThanosQueryInstantLatencyHigh
-      annotations:
-        description: Thanos Query {{$labels.job}} has a 99th percentile latency of
-          {{ $value }} seconds for instant queries.
-        summary: Thanos Query has high latency for queries.
-      expr: |
-        (
-          histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job="thanos-querier", handler="query"}[5m]))) > 40
-        and
-          sum by (job) (rate(http_request_duration_seconds_bucket{job="thanos-querier", handler="query"}[5m])) > 0
-        )
-      for: 10m
-      labels:
-        severity: critical
-    - alert: ThanosQueryRangeLatencyHigh
-      annotations:
-        description: Thanos Query {{$labels.job}} has a 99th percentile latency of
-          {{ $value }} seconds for range queries.
-        summary: Thanos Query has high latency for queries.
-      expr: |
-        (
-          histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job="thanos-querier", handler="query_range"}[5m]))) > 90
-        and
-          sum by (job) (rate(http_request_duration_seconds_count{job="thanos-querier", handler="query_range"}[5m])) > 0
-        )
-      for: 10m
-      labels:
-        severity: critical


### PR DESCRIPTION
This change tweaks the upstream alerts to comply with the OpenShift
requirements:
* The severity is set to "warning" for all alerts.
* The "for" duration is increased to 1h for all alerts.
* The latency alerts are removed.

* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
