### PR TITLE
Bug 1943565: [4.7] jsonnet: fix ThanosSidecarUnhealthy alert

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -2393,6 +2393,6 @@ spec:
           {{ $value }} seconds.
         summary: Thanos Sidecar is unhealthy.
       expr: |
-        time() - max(thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}) by (job, pod) >= 600
+        time() - max(timestamp(thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"})) by (job,pod) >= 240
       labels:
         severity: critical


### PR DESCRIPTION
Backport of #1090 to release-4.7. Considering that the Thanos sidecar alerts doesn't need to be readjusted to fix the CI failures, I only backported the fix to the query.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
