### PR TITLE
jsonnet: replace external commit import

### DIFF
--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -64,7 +64,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "95b2fe908b29977a20f695afac33f6257bb2d3ea"
+      "version": "80e0257e25b59ff8113b9d21a155c785f69a4b95"
     }
   ],
   "legacyImports": true

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -203,7 +203,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "95b2fe908b29977a20f695afac33f6257bb2d3ea",
+      "version": "80e0257e25b59ff8113b9d21a155c785f69a4b95",
       "sum": "bE5eEPMulYMtz0lJSxDVnCXVTg/lqSSS5aEUUH3V19A="
     }
   ],


### PR DESCRIPTION
Replace external commit import for Thanos mixin by the commit that was
merged into the project.

/cc @simonpasquier 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
