### PR TITLE
Bug 1943667: increase for duration of KubeDaemonSetRolloutStuck

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -138,7 +138,7 @@ spec:
             ==
           0
         )
-      for: 15m
+      for: 30m
       labels:
         severity: warning
     - alert: KubeContainerWaiting

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -69,6 +69,16 @@ local excludedRules = [
 
 local patchedRules = [
   {
+    name: 'kubernetes-apps',
+    rules: [
+      // Stop-gap fix for https://bugzilla.redhat.com/show_bug.cgi?id=1943667
+      {
+        alert: 'KubeDaemonSetRolloutStuck',
+        'for': '30m',
+      },
+    ],
+  },
+  {
     name: 'prometheus',
     rules: [
       {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
