### PR TITLE
Remove kube-state-metrics flag temporary

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -32,7 +32,6 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        - --metric-blacklist=kube_secret_labels
         image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         resources:

--- a/jsonnet/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics.libsonnet
@@ -108,9 +108,6 @@ function(params)
                     }
                   else
                     c {
-                      args+: [
-                        '--metric-blacklist=kube_secret_labels',
-                      ],
                       securityContext: {},
                       resources: {
                         requests: {


### PR DESCRIPTION
To be able to merge the https://github.com/openshift/kube-state-metrics/pull/47 cleanly, we need to remove this flag first as it was changed in 2.0 release.

cc @simonpasquier please have a look. Thank you!