### PR TITLE
dashboards: change refresh var behavior to On Time Range Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1087](https://github.com/openshift/cluster-monitoring-operator/pull/1087) Remove ThanosQueryInstantLatencyHigh and ThanosQueryRangeLatencyHigh alerts.
 - [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Decrease alert severity to "warning" for all Thanos sidecar alerts.
 - [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Increase "for" duration to 1 hour for all Thanos sidecar alerts.
+- [#1097](https://github.com/openshift/cluster-monitoring-operator/pull/1097) Change the default variable refresh behavior from "On Dashboard Reload" to "On Time Range Change" on Grafana dashboards.
 
 ## 4.7
 

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -1815,7 +1815,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info, cluster)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 0,
                       "tagValuesQuery": "",
@@ -3054,7 +3054,7 @@ items:
 
                       ],
                       "query": "label_values(etcd_server_has_leader, job)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 2,
                       "tagValuesQuery": "",
@@ -7884,7 +7884,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info, cluster)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -7911,7 +7911,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -8856,7 +8856,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info, cluster)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -8883,7 +8883,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, node)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -10595,7 +10595,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info, cluster)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -12596,7 +12596,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info, cluster)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -12623,7 +12623,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -14811,7 +14811,7 @@ items:
 
                       ],
                       "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\"}, workload_type)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "skipUrlSync": false,
                       "sort": 0,
@@ -14839,7 +14839,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info, cluster)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -14866,7 +14866,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 1,
                       "tagValuesQuery": "",
@@ -16212,7 +16212,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info, cluster)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 0,
                       "tagValuesQuery": "",
@@ -16243,7 +16243,7 @@ items:
 
                       ],
                       "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "skipUrlSync": false,
                       "sort": 1,
@@ -18267,7 +18267,7 @@ items:
 
                       ],
                       "query": "label_values(up{job=\"node-exporter\"}, instance)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 2,
                       "tagValuesQuery": "",
@@ -19345,7 +19345,7 @@ items:
 
                       ],
                       "query": "label_values(kube_pod_info, cluster)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 0,
                       "tagValuesQuery": "",
@@ -19376,7 +19376,7 @@ items:
 
                       ],
                       "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "skipUrlSync": false,
                       "sort": 1,
@@ -19408,7 +19408,7 @@ items:
 
                       ],
                       "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}, pod)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "skipUrlSync": false,
                       "sort": 1,
@@ -20682,7 +20682,7 @@ items:
 
                       ],
                       "query": "label_values(prometheus_build_info, job)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 2,
                       "tagValuesQuery": "",
@@ -20710,7 +20710,7 @@ items:
 
                       ],
                       "query": "label_values(prometheus_build_info, instance)",
-                      "refresh": 1,
+                      "refresh": 2,
                       "regex": "",
                       "sort": 2,
                       "tagValuesQuery": "",


### PR DESCRIPTION
Change the default variable refresh behavior from "On Dashboard Reload" to "On Time Range Change" on Grafana dashboards variables.

That is quite useful when navigating to old data, avoiding refresh the dashboards every new time range change.

![Screenshot from 2021-03-31 00-28-38](https://user-images.githubusercontent.com/3216894/113088325-c0884500-91bb-11eb-82c9-ce894b68d3db.png)


* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.


## Changes on Upstream

- [x] https://github.com/etcd-io/etcd/pull/12823
- [x] https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/577
- [x] node_exporter : already updated / refresh=2 (time)
- [x] prometheus : already updated / refresh=2 (time)