### PR TITLE
Bug 1944974: remove KubeControllerManagerDown and KubeSchedulerDown alerts

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -573,29 +573,6 @@ spec:
       for: 15m
       labels:
         severity: critical
-  - name: kubernetes-system-scheduler
-    rules:
-    - alert: KubeSchedulerDown
-      annotations:
-        description: KubeScheduler has disappeared from Prometheus target discovery.
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="scheduler"} == 1)
-      for: 15m
-      labels:
-        severity: critical
-  - name: kubernetes-system-controller-manager
-    rules:
-    - alert: KubeControllerManagerDown
-      annotations:
-        description: KubeControllerManager has disappeared from Prometheus target
-          discovery.
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="kube-controller-manager"} == 1)
-      for: 15m
-      labels:
-        severity: critical
   - name: kube-apiserver.rules
     rules:
     - expr: |

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -1,5 +1,9 @@
 local excludedRuleGroups = [
   'kube-apiserver-availability.rules',
+  // rules managed by openshift/cluster-kube-controller-manager-operator.
+  'kubernetes-system-controller-manager',
+  // rules managed by openshift/cluster-kube-scheduler-operator.
+  'kubernetes-system-scheduler',
 ];
 
 local excludedRules = [

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1242,13 +1242,13 @@ func TestPrometheusK8sControlPlaneRulesFiltered(t *testing.T) {
 	tests := []struct {
 		name           string
 		infrastructure InfrastructureReader
-		verify         func(bool, bool, bool)
+		verify         func(bool)
 	}{
 		{
 			name:           "default config",
 			infrastructure: NewDefaultInfrastructureConfig(),
-			verify: func(api, cm, sched bool) {
-				if !api || !cm || !sched {
+			verify: func(api bool) {
+				if !api {
 					t.Fatal("did not get all expected kubernetes control plane rules")
 				}
 			},
@@ -1256,8 +1256,8 @@ func TestPrometheusK8sControlPlaneRulesFiltered(t *testing.T) {
 		{
 			name:           "hosted control plane",
 			infrastructure: &InfrastructureConfig{highlyAvailableInfrastructure: true, hostedControlPlane: true},
-			verify: func(api, cm, sched bool) {
-				if api || cm || sched {
+			verify: func(api bool) {
+				if api {
 					t.Fatalf("kubernetes control plane rules found, none expected")
 				}
 			},
@@ -1271,19 +1271,13 @@ func TestPrometheusK8sControlPlaneRulesFiltered(t *testing.T) {
 			t.Fatal(err)
 		}
 		apiServerRulesFound := false
-		controllerManagerRulesFound := false
-		schedulerRulesFound := false
 		for _, g := range r.Spec.Groups {
 			switch g.Name {
 			case "kubernetes-system-apiserver":
 				apiServerRulesFound = true
-			case "kubernetes-system-controller-manager":
-				controllerManagerRulesFound = true
-			case "kubernetes-system-scheduler":
-				schedulerRulesFound = true
 			}
 		}
-		tc.verify(apiServerRulesFound, controllerManagerRulesFound, schedulerRulesFound)
+		tc.verify(apiServerRulesFound)
 	}
 }
 


### PR DESCRIPTION
Kubernetes scheduler and Kubernetes controller rules are managed by their respective operators [1][2]:
* https://github.com/openshift/cluster-kube-scheduler-operator/pull/180
* https://github.com/openshift/cluster-kube-controller-manager-operator/pull/298

There was already a [pull request](https://github.com/openshift/cluster-monitoring-operator/pull/516) to remove these rules from CMO but it never merged because at the time, it wasn't easy to customize the CMO assets.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
