### PR TITLE
Bug 1945851: Backport Remove the "instance" and "pod" labels for kube-state-metrics metrics

### DIFF
--- a/assets/kube-state-metrics/service-monitor.yaml
+++ b/assets/kube-state-metrics/service-monitor.yaml
@@ -11,7 +11,13 @@ spec:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     honorLabels: true
     interval: 1m
+    metricRelabelings:
+    - action: labeldrop
+      regex: instance
     port: https-main
+    relabelings:
+    - action: labeldrop
+      regex: pod
     scheme: https
     scrapeTimeout: 1m
     tlsConfig:

--- a/jsonnet/kube-state-metrics.jsonnet
+++ b/jsonnet/kube-state-metrics.jsonnet
@@ -33,6 +33,26 @@ local tlsVolumeName = 'kube-state-metrics-tls';
                 caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
                 serverName: 'server-name-replaced-at-runtime',
               },
+              // Drop the "instance" and "pod" labels since we're runinng only
+              // one instance of kube-state-metrics. The "instance" label must be
+              // dropped at the metrics relabeling stage (instead of the service
+              // discovery stage) because otherwise Prometheus will default its
+              // value to the address being scraped.
+              // The net result is to avoid excessive series churn when
+              // kube-state-metrics is redeployed because of node reboot, pod
+              // rescheduling or cluster upgrade.
+              metricRelabelings: [
+                {
+                  action: 'labeldrop',
+                  regex: 'instance',
+                },
+              ],
+              relabelings: [
+                {
+                  action: 'labeldrop',
+                  regex: 'pod',
+                },
+              ],
             },
             {
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',


### PR DESCRIPTION
Backport of #1052 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
