### PR TITLE
Bug 1945856: Revert "Bug 1934516: [4.7]: jsonnet/prometheus.jsonnet: Apply system-cluster-critical class to cluster Prometheus "

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -165,7 +165,7 @@ spec:
     kubernetes.io/os: linux
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
-  priorityClassName: openshift-user-critical
+  priorityClassName: system-cluster-critical
   probeNamespaceSelector: {}
   probeSelector: {}
   replicas: 2

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -395,7 +395,7 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
           ruleSelector: {},
           ruleNamespaceSelector: {},
           listenLocal: true,
-          priorityClassName: 'openshift-user-critical',
+          priorityClassName: 'system-cluster-critical',
           containers: [
             {
               name: 'prometheus-proxy',


### PR DESCRIPTION
Reverts openshift/cluster-monitoring-operator#1062

Once https://github.com/openshift/kubernetes/pull/642 merges, `system-cluster-critical` pods will not have -997 OOM score making it easily killable by OOMKiller.