### PR TITLE
Update denied metrics for kube-state-metrics 

### DIFF
--- a/assets/kube-state-metrics/cluster-role.yaml
+++ b/assets/kube-state-metrics/cluster-role.yaml
@@ -109,10 +109,3 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - list
-  - watch

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
+        - --metric-denylist=kube_secret_labels
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-rc.1
         name: kube-state-metrics
         resources:

--- a/jsonnet/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics.libsonnet
@@ -108,6 +108,9 @@ function(params)
                     }
                   else
                     c {
+                      args+: [
+                        '--metric-denylist=kube_secret_labels',
+                      ],
                       securityContext: {},
                       resources: {
                         requests: {
@@ -140,18 +143,5 @@ function(params)
           },
         },
       },
-    },
-  } + {
-    // TODO(simonpasquier): remove this patch after https://github.com/openshift/kube-state-metrics/pull/47 merges.
-    clusterRole+: {
-      rules+: [
-        {
-          apiGroups: ['extensions'],
-          resources: [
-            'ingresses',
-          ],
-          verbs: ['list', 'watch'],
-        },
-      ],
     },
   }

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -216,13 +216,6 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - list
-  - watch
-- apiGroups:
   - apps
   resources:
   - daemonsets


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

Follow-up of #1099, requires https://github.com/openshift/kube-state-metrics/pull/47

/hold