### PR TITLE
Bug 1938465: increase CPU requests for Thanos querier

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -76,7 +76,7 @@ spec:
               http://localhost:9090/-/ready; else exit 1; fi
         resources:
           requests:
-            cpu: 5m
+            cpu: 10m
             memory: 12Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -334,7 +334,7 @@ function(params)
                 resources: {
                   requests: {
                     memory: '12Mi',
-                    cpu: '5m',
+                    cpu: '10m',
                   },
                 },
                 ports: [


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

Looking at a recent e2e test run, the p90 value of CPU usage is closer to 10m than 5m so increasing the value a bit.

![image](https://user-images.githubusercontent.com/2587585/113723649-d92fb800-96f1-11eb-9ee0-f81381d935e4.png)
