### PR TITLE
Add management workload annotations

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -109,6 +109,8 @@ spec:
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:
+    annotations:
+      workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: alert-router
       app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         checksum/grafana-config: 4edd2a7c41f827b93497c2d118a926e7
         checksum/grafana-datasources: 0fc2251d80a7fdcb28e58d9944addd91
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       app.kubernetes.io/part-of: openshift-monitoring
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/part-of: openshift-monitoring
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       k8s-app: openshift-state-metrics
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: openshift-state-metrics
     spec:

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -23,6 +23,8 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: metrics-adapter
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -170,6 +170,8 @@ spec:
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:
+    annotations:
+      workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       app.kubernetes.io/part-of: openshift-monitoring
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       app.kubernetes.io/part-of: openshift-monitoring
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -119,6 +119,8 @@ spec:
   overrideHonorLabels: true
   overrideHonorTimestamps: true
   podMetadata:
+    annotations:
+      workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       k8s-app: telemeter-client
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: telemeter-client
     spec:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/name: thanos-query
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-querier

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -69,6 +69,9 @@ spec:
     keyFile: /etc/tls/grpc/server.key
   image: quay.io/thanos/thanos:v0.17.2
   listenLocal: true
+  podMetadata:
+    annotations:
+      workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   priorityClassName: openshift-user-critical
   queryConfig:
     key: query.yaml

--- a/jsonnet/add-workload-annotation.libsonnet
+++ b/jsonnet/add-workload-annotation.libsonnet
@@ -1,0 +1,24 @@
+{
+  addWorkloadAnnotation(o): {
+    local annotation = {
+      'workload.openshift.io/management': '{"effect": "PreferredDuringScheduling"}',
+    },
+    local addAnnotation(o) = o {
+      [if std.setMember(o.kind, ['DaemonSet', 'Deployment', 'ReplicaSet']) then 'spec']+: {
+        template+: {
+          metadata+: {
+            annotations+: annotation,
+          },
+        },
+      },
+      [if std.setMember(o.kind, ['Alertmanager', 'Prometheus', 'ThanosRuler']) then 'spec']+:
+        {
+          podMetadata+: {
+            annotations+: annotation,
+          },
+        },
+    },
+    [k]: addAnnotation(o[k])
+    for k in std.objectFields(o)
+  },
+}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -1,5 +1,6 @@
 local removeLimits = (import 'remove-limits.libsonnet').removeLimits;
 local addReleaseAnnotation = (import 'add-release-annotation.libsonnet').addReleaseAnnotation;
+local addWorkloadAnnotation = (import 'add-workload-annotation.libsonnet').addWorkloadAnnotation;
 local excludeRules = (import 'patch-rules.libsonnet').excludeRules;
 local patchRules = (import 'patch-rules.libsonnet').patchRules;
 local removeRunbookUrl = (import 'remove-runbook-urls.libsonnet').removeRunbookUrl;
@@ -374,7 +375,7 @@ local userWorkload =
 
 // Manifestation
 // TODO(paulfantom): removeRunbookUrl, excludeRules, and patchRules should be converted into sanitizeRules() function
-removeRunbookUrl(patchRules(excludeRules(addReleaseAnnotation(removeLimits(
+removeRunbookUrl(patchRules(excludeRules(addWorkloadAnnotation(addReleaseAnnotation(removeLimits(
   { ['alertmanager/' + name]: inCluster.alertmanager[name] for name in std.objectFields(inCluster.alertmanager) } +
   { ['cluster-monitoring-operator/' + name]: inCluster.clusterMonitoringOperator[name] for name in std.objectFields(inCluster.clusterMonitoringOperator) } +
   { ['grafana/' + name]: inCluster.grafana[name] for name in std.objectFields(inCluster.grafana) } +
@@ -393,4 +394,4 @@ removeRunbookUrl(patchRules(excludeRules(addReleaseAnnotation(removeLimits(
   { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
   { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } + 
   {}
-)))))
+))))))

--- a/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
     include.release.openshift.io/single-node-developer: "true"
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
     name: openshift-monitoring
@@ -21,6 +22,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
     include.release.openshift.io/single-node-developer: "true"
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
     name: openshift-user-workload-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -14,6 +14,8 @@ spec:
       app: cluster-monitoring-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: cluster-monitoring-operator
     spec:

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels:
         app: cluster-monitoring-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: cluster-monitoring-operator
       nodeSelector:


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
