### PR TITLE
Bug 1934516: Change prometheus priority class to system-cluster-critical again

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -178,7 +178,7 @@ spec:
       app.kubernetes.io/version: 2.24.0
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
-  priorityClassName: openshift-user-critical
+  priorityClassName: system-cluster-critical
   probeNamespaceSelector: {}
   probeSelector: {}
   replicas: 2

--- a/jsonnet/prometheus.libsonnet
+++ b/jsonnet/prometheus.libsonnet
@@ -314,7 +314,7 @@ function(params)
         ruleSelector: {},
         ruleNamespaceSelector: {},
         listenLocal: true,
-        priorityClassName: 'openshift-user-critical',
+        priorityClassName: 'system-cluster-critical',
         containers: [
           {
             name: 'prometheus-proxy',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Switch the priorityclass to system-cluster-critical again

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

