### PR TITLE
Bug 1948082: Set unavailable message

### DIFF
--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -251,6 +251,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 					"Progressing", "False",
 					"Upgradeable", "True",
 				),
+				hasUnavailableMessage(),
 			},
 		},
 		{
@@ -278,6 +279,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 					"Progressing", "False",
 					"Upgradeable", "True",
 				),
+				hasUnavailableMessage(),
 			},
 		},
 	} {
@@ -355,6 +357,18 @@ func hasUpdatedStatusConditions(want ...string) checkFunc {
 		}
 		if !reflect.DeepEqual(got, want) {
 			return fmt.Errorf("want conditions to be equal, but they aren't: want %q got %q", want, got)
+		}
+		return nil
+	}
+}
+
+func hasUnavailableMessage() checkFunc {
+	return func(mock *clusterOperatorMock, _ error) error {
+		sort.Sort(byType(mock.statusUpdated.Status.Conditions))
+		for _, c := range mock.statusUpdated.Status.Conditions {
+			if c.Type == v1.OperatorAvailable && c.Status == v1.ConditionFalse && c.Message == "" {
+				return fmt.Errorf("want a message if available status is false, got %q", c.Message)
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
