### PR TITLE
Bug 1920700: Bump prometheus-adapter to v0.8.4

### DIFF
--- a/assets/prometheus-adapter/api-service.yaml
+++ b/assets/prometheus-adapter/api-service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io

--- a/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
+++ b/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/assets/prometheus-adapter/cluster-role-binding-delegator.yaml
+++ b/assets/prometheus-adapter/cluster-role-binding-delegator.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: resource-metrics:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-adapter/cluster-role-binding.yaml
+++ b/assets/prometheus-adapter/cluster-role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: prometheus-adapter
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-adapter/cluster-role-server-resources.yaml
+++ b/assets/prometheus-adapter/cluster-role-server-resources.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: resource-metrics-server-resources
 rules:
 - apiGroups:

--- a/assets/prometheus-adapter/cluster-role.yaml
+++ b/assets/prometheus-adapter/cluster-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: prometheus-adapter
 rules:
 - apiGroups:

--- a/assets/prometheus-adapter/config-map.yaml
+++ b/assets/prometheus-adapter/config-map.yaml
@@ -34,6 +34,6 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: adapter-config
   namespace: openshift-monitoring

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: prometheus-adapter
   namespace: openshift-monitoring
 spec:
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: prometheus-adapter
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 0.8.2
+        app.kubernetes.io/version: 0.8.4
     spec:
       containers:
       - args:
@@ -38,7 +38,7 @@ spec:
         - --metrics-relist-interval=1m
         - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc:9091
         - --secure-port=6443
-        image: directxman12/k8s-prometheus-adapter:v0.8.2
+        image: directxman12/k8s-prometheus-adapter:v0.8.4
         name: prometheus-adapter
         ports:
         - containerPort: 6443

--- a/assets/prometheus-adapter/role-binding-auth-reader.yaml
+++ b/assets/prometheus-adapter/role-binding-auth-reader.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: resource-metrics-auth-reader
   namespace: kube-system
 roleRef:

--- a/assets/prometheus-adapter/service-account.yaml
+++ b/assets/prometheus-adapter/service-account.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: prometheus-adapter
   namespace: openshift-monitoring

--- a/assets/prometheus-adapter/service-monitor.yaml
+++ b/assets/prometheus-adapter/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: prometheus-adapter
   namespace: openshift-monitoring
 spec:

--- a/assets/prometheus-adapter/service.yaml
+++ b/assets/prometheus-adapter/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.2
+    app.kubernetes.io/version: 0.8.4
   name: prometheus-adapter
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -45,7 +45,7 @@ local commonConfig = {
     grafana: '7.3.5',
     kubeStateMetrics: '2.0.0-rc.1',
     nodeExporter: '1.0.1',
-    prometheusAdapter: '0.8.2',
+    prometheusAdapter: '0.8.4',
     prometheusOperator: '0.45.0',
     promLabelProxy: '0.2.0',
     thanos: '0.17.2',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
