### PR TITLE
Provide an explicit list of allowed labels for the kube_node_labels metric

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         - --metric-denylist=kube_secret_labels
+        - --metric-labels-allowlist=nodes=[label_beta_kubernetes_io_instance_type,label_node_role_kubernetes_io,label_kubernetes_io_arch,label_node_openshift_io_os_id]
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-rc.1
         name: kube-state-metrics
         resources:

--- a/jsonnet/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics.libsonnet
@@ -110,6 +110,8 @@ function(params)
                     c {
                       args+: [
                         '--metric-denylist=kube_secret_labels',
+                        // Explictly allow the node labels that are required by Telemetry rules.
+                        '--metric-labels-allowlist=nodes=[label_beta_kubernetes_io_instance_type,label_node_role_kubernetes_io,label_kubernetes_io_arch,label_node_openshift_io_os_id]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
