### PR TITLE
Bug 1940933: jsonnet: make AggregatedAPIDown more resilient to OCP upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Decrease alert severity to "warning" for all Thanos sidecar alerts.
 - [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Increase "for" duration to 1 hour for all Thanos sidecar alerts.
 - [#1093](https://github.com/openshift/cluster-monitoring-operator/pull/1093) Bump kube-state-metrics to major new release v2.0.0-rc.1. This changes a lot of metrics and flags, see kube-state-metrics CHANGELOG for full changes. 
+- [#1117](https://github.com/openshift/cluster-monitoring-operator/pull/1117) Increase "for" duration to 15 minutes for AggregatedAPIDown.
 
 ## 4.7
 

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -452,7 +452,7 @@ spec:
         summary: An aggregated API is down.
       expr: |
         (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
-      for: 5m
+      for: 15m
       labels:
         severity: warning
     - alert: KubeAPIDown

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -86,6 +86,21 @@ local patchedRules = [
     ],
   },
   {
+    name: 'kubernetes-system-apiserver',
+    rules: [
+      {
+        // Make the alert more resilient to OCP upgrades: https://bugzilla.redhat.com/show_bug.cgi?id=1940933
+        // According to what we've seen in CI, it might take more time for the
+        // apiservice to claim the aggregated API during upgrades than what has
+        // been set in the upstream alert. It might take up to 15 minutes for
+        // the aggregated API to be claimed during upgrades. Thus, we need to
+        // increase the `for` clause to 15m to reflect that.
+        alert: 'AggregatedAPIDown',
+        'for': '15m',
+      },
+    ],
+  },
+  {
     name: 'prometheus',
     rules: [
       {


### PR DESCRIPTION
According to what we've seen in CI, it might take more time for the
apiservice to claim the aggregated API during upgrades than what has
been set in the upstream alert. It might take up to 15 minutes for the
aggregated API to be claimed during upgrades. Thus, we need to increase
the `for` clause to 15m to reflect that.

Note that from the CI failures, we might need to re-increase the duration to
30m for SNO clusters, but the alert might be firing for good reasons there.
The apiserver is heavily degraded and a lot more aggregated API than
usual are reported to be down. Even Prometheus seems to be degraded
as the following message is outputted:
```
Watchdog alert had missing intervals during the run, which may be a sign of a Prometheus outage in violation of the prometheus query SLO of 100% uptime during upgrade
``` 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
