### PR TITLE
Bug 1949123: [3.11]: rules: fix instance:node_filesystem_usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ $(JB_BIN):
 	chmod +x $(GOPATH)/bin/jb
 
 $(JSONNET_BIN):
-	go get -u github.com/google/go-jsonnet/cmd/jsonnet
+	wget -qO- "https://github.com/google/jsonnet/releases/download/v0.16.0/jsonnet-bin-v0.16.0-linux.tar.gz" | tar xvz -C $(GOPATH)/bin
+	chmod +x $(GOPATH)/bin/jsonnet
 
 test-unit:
 	go test $(PKGS)

--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -273,7 +273,7 @@ spec:
     rules:
     - expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[3m])) BY (instance)
       record: instance:node_cpu:rate:sum
-    - expr: sum((node_filesystem_size{mountpoint="/"} - node_filesystem_free{mountpoint="/"})) BY (instance)
+    - expr: sum(node_filesystem_size - node_filesystem_avail) BY (instance)
       record: instance:node_filesystem_usage:sum
     - expr: sum(rate(node_network_receive_bytes[3m])) BY (instance)
       record: instance:node_network_receive_bytes:rate:sum


### PR DESCRIPTION
The instance:node_filesystem_usage was only considering the `/`
mountpoint instead of accounting for all the filesystem.
Also replace node_filesystem_free_bytes by node_filesystem_avail_bytes
to take into account reserved blocks.

Previously, the version of the go-jsonnet package that we were
installing in the docker image used to generate manifests wasn't fixed
to a particular version. This resulted in golang errors with go-jsonnet
v0.17.0 as it required golang 1.10, but we are using a 1.9 image.

Also, this required to get the package from the jsonnet repository
instead of go-jsonnet as the assets weren't available for go-jsonnet.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
