### PR TITLE
Bug 1948711: jsonnet: apply HA conventions

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -19,8 +19,7 @@ spec:
       app.kubernetes.io/part-of: openshift-monitoring
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxUnavailable: 25%
   template:
     metadata:
       labels:
@@ -30,6 +29,16 @@ spec:
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 0.8.4
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: metrics-adapter
+                app.kubernetes.io/managed-by: cluster-monitoring-operator
+                app.kubernetes.io/name: prometheus-adapter
+                app.kubernetes.io/part-of: openshift-monitoring
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --prometheus-auth-config=/etc/prometheus-config/prometheus-config.yaml

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       app.kubernetes.io/component: query-layer
       app.kubernetes.io/instance: thanos-querier
       app.kubernetes.io/name: thanos-query
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 25%
   template:
     metadata:
       labels:
@@ -25,18 +28,13 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - thanos-query
-              namespaces:
-              - openshift-monitoring
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: query-layer
+                app.kubernetes.io/instance: thanos-querier
+                app.kubernetes.io/name: thanos-query
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - query

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -266,8 +266,27 @@ function(params)
 
     deployment+: {
       spec+: {
+        strategy+: {
+          // Apply HA conventions
+          rollingUpdate: {
+            maxUnavailable: '25%',
+          },
+        },
         template+: {
           spec+: {
+            affinity+: {
+              podAntiAffinity: {
+                // Apply HA conventons
+                requiredDuringSchedulingIgnoredDuringExecution: [
+                  {
+                    labelSelector: {
+                      matchLabels: tq.config.podLabelSelector,
+                    },
+                    topologyKey: 'kubernetes.io/hostname',
+                  },
+                ],
+              },
+            },
             volumes+: [
               {
                 name: 'secret-thanos-querier-tls',


### PR DESCRIPTION
Apply the following HA conventions to thanos-querier and
prometheus-adapter:
- 2 replicas
- Hard pod anti-affinity on hostname
- Set the maxUnavailable rollout strategy to 25%
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
