### PR TITLE
Bug 1950761: Revert: jsonnet: apply HA conventions

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -19,7 +19,8 @@ spec:
       app.kubernetes.io/part-of: openshift-monitoring
   strategy:
     rollingUpdate:
-      maxUnavailable: 25%
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       annotations:
@@ -31,16 +32,6 @@ spec:
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 0.8.4
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/component: metrics-adapter
-                app.kubernetes.io/managed-by: cluster-monitoring-operator
-                app.kubernetes.io/name: prometheus-adapter
-                app.kubernetes.io/part-of: openshift-monitoring
-            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --prometheus-auth-config=/etc/prometheus-config/prometheus-config.yaml

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -15,9 +15,6 @@ spec:
       app.kubernetes.io/component: query-layer
       app.kubernetes.io/instance: thanos-querier
       app.kubernetes.io/name: thanos-query
-  strategy:
-    rollingUpdate:
-      maxUnavailable: 25%
   template:
     metadata:
       annotations:
@@ -30,13 +27,18 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/component: query-layer
-                app.kubernetes.io/instance: thanos-querier
-                app.kubernetes.io/name: thanos-query
-            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-query
+              namespaces:
+              - openshift-monitoring
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - query

--- a/jsonnet/prometheus-adapter.libsonnet
+++ b/jsonnet/prometheus-adapter.libsonnet
@@ -15,9 +15,8 @@ local prometheusAdapter = (import 'github.com/prometheus-operator/kube-prometheu
 
 function(params)
   local cfg = params;
-  local pa = prometheusAdapter(cfg);
 
-  pa {
+  prometheusAdapter(cfg) + {
     clusterRoleAggregatedMetricsReader+:
       {
         metadata+: {
@@ -70,27 +69,8 @@ function(params)
       {
         spec+: {
           replicas: 2,
-          strategy+: {
-            // Apply HA conventions
-            rollingUpdate: {
-              maxUnavailable: '25%',
-            },
-          },
           template+: {
             spec+: {
-              affinity+: {
-                podAntiAffinity: {
-                  // Apply HA conventons
-                  requiredDuringSchedulingIgnoredDuringExecution: [
-                    {
-                      labelSelector: {
-                        matchLabels: pa.config.selectorLabels,
-                      },
-                      topologyKey: 'kubernetes.io/hostname',
-                    },
-                  ],
-                },
-              },
               containers:
                 std.map(
                   function(c)

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -266,27 +266,8 @@ function(params)
 
     deployment+: {
       spec+: {
-        strategy+: {
-          // Apply HA conventions
-          rollingUpdate: {
-            maxUnavailable: '25%',
-          },
-        },
         template+: {
           spec+: {
-            affinity+: {
-              podAntiAffinity: {
-                // Apply HA conventons
-                requiredDuringSchedulingIgnoredDuringExecution: [
-                  {
-                    labelSelector: {
-                      matchLabels: tq.config.podLabelSelector,
-                    },
-                    topologyKey: 'kubernetes.io/hostname',
-                  },
-                ],
-              },
-            },
             volumes+: [
               {
                 name: 'secret-thanos-querier-tls',


### PR DESCRIPTION
This reverts commit ade82fcbd3e4cf69ab0b62d5a21f496e66d7fbae.
This reverts commit 68f595a3f40829d1be19f0b0eaf87539849b96a4.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
