### PR TITLE
Rename workload annotations

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -110,7 +110,7 @@ spec:
     kubernetes.io/os: linux
   podMetadata:
     annotations:
-      workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: alert-router
       app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         checksum/grafana-config: 4edd2a7c41f827b93497c2d118a926e7
         checksum/grafana-datasources: 0fc2251d80a7fdcb28e58d9944addd91
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: openshift-state-metrics
     spec:

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: metrics-adapter
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -171,7 +171,7 @@ spec:
     kubernetes.io/os: linux
   podMetadata:
     annotations:
-      workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -120,7 +120,7 @@ spec:
   overrideHonorTimestamps: true
   podMetadata:
     annotations:
-      workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: telemeter-client
     spec:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-querier

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -71,7 +71,7 @@ spec:
   listenLocal: true
   podMetadata:
     annotations:
-      workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   priorityClassName: openshift-user-critical
   queryConfig:
     key: query.yaml

--- a/jsonnet/add-workload-annotation.libsonnet
+++ b/jsonnet/add-workload-annotation.libsonnet
@@ -1,7 +1,7 @@
 {
   addWorkloadAnnotation(o): {
     local annotation = {
-      'workload.openshift.io/management': '{"effect": "PreferredDuringScheduling"}',
+      'target.workload.openshift.io/management': '{"effect": "PreferredDuringScheduling"}',
     },
     local addAnnotation(o) = o {
       [if std.setMember(o.kind, ['DaemonSet', 'Deployment', 'ReplicaSet']) then 'spec']+: {

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: cluster-monitoring-operator
     spec:

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         app: cluster-monitoring-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: cluster-monitoring-operator
       nodeSelector:


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

/hold
Hold until after openshift/kubernetes#632 is merged please