### PR TITLE
Bug 1948711: Apply HA conventions to prometheus-adapter and thanos-ruler

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -19,8 +19,7 @@ spec:
       app.kubernetes.io/part-of: openshift-monitoring
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxUnavailable: 1
   template:
     metadata:
       annotations:
@@ -32,6 +31,16 @@ spec:
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 0.8.4
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: metrics-adapter
+                app.kubernetes.io/managed-by: cluster-monitoring-operator
+                app.kubernetes.io/name: prometheus-adapter
+                app.kubernetes.io/part-of: openshift-monitoring
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - --prometheus-auth-config=/etc/prometheus-config/prometheus-config.yaml

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       app.kubernetes.io/component: query-layer
       app.kubernetes.io/instance: thanos-querier
       app.kubernetes.io/name: thanos-query
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       annotations:
@@ -27,18 +30,13 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - thanos-query
-              namespaces:
-              - openshift-monitoring
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: query-layer
+                app.kubernetes.io/instance: thanos-querier
+                app.kubernetes.io/name: thanos-query
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - query

--- a/jsonnet/prometheus-adapter.libsonnet
+++ b/jsonnet/prometheus-adapter.libsonnet
@@ -15,8 +15,9 @@ local prometheusAdapter = (import 'github.com/prometheus-operator/kube-prometheu
 
 function(params)
   local cfg = params;
+  local pa = prometheusAdapter(cfg);
 
-  prometheusAdapter(cfg) + {
+  pa {
     clusterRoleAggregatedMetricsReader+:
       {
         metadata+: {
@@ -69,8 +70,27 @@ function(params)
       {
         spec+: {
           replicas: 2,
+          strategy+: {
+            // Apply HA conventions
+            rollingUpdate: {
+              maxUnavailable: 1,
+            },
+          },
           template+: {
             spec+: {
+              affinity+: {
+                podAntiAffinity: {
+                  // Apply HA conventions
+                  requiredDuringSchedulingIgnoredDuringExecution: [
+                    {
+                      labelSelector: {
+                        matchLabels: pa.config.selectorLabels,
+                      },
+                      topologyKey: 'kubernetes.io/hostname',
+                    },
+                  ],
+                },
+              },
               containers:
                 std.map(
                   function(c)

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -266,8 +266,27 @@ function(params)
 
     deployment+: {
       spec+: {
+        strategy+: {
+          // Apply HA conventions
+          rollingUpdate: {
+            maxUnavailable: 1,
+          },
+        },
         template+: {
           spec+: {
+            affinity+: {
+              podAntiAffinity: {
+                // Apply HA conventions
+                requiredDuringSchedulingIgnoredDuringExecution: [
+                  {
+                    labelSelector: {
+                      matchLabels: tq.config.podLabelSelector,
+                    },
+                    topologyKey: 'kubernetes.io/hostname',
+                  },
+                ],
+              },
+            },
             volumes+: [
               {
                 name: 'secret-thanos-querier-tls',

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2557,6 +2557,7 @@ func (f *Factory) NewPrometheus(manifest io.Reader) (*monv1.Prometheus, error) {
 
 	if !f.infrastructure.HighlyAvailableInfrastructure() {
 		p.Spec.Replicas = func(i int32) *int32 { return &i }(1)
+		p.Spec.Affinity = nil
 	}
 
 	return p, nil
@@ -2614,6 +2615,7 @@ func (f *Factory) NewAlertmanager(manifest io.Reader) (*monv1.Alertmanager, erro
 
 	if !f.infrastructure.HighlyAvailableInfrastructure() {
 		a.Spec.Replicas = func(i int32) *int32 { return &i }(1)
+		a.Spec.Affinity = nil
 	}
 
 	return a, nil
@@ -2631,6 +2633,7 @@ func (f *Factory) NewThanosRuler(manifest io.Reader) (*monv1.ThanosRuler, error)
 
 	if !f.infrastructure.HighlyAvailableInfrastructure() {
 		t.Spec.Replicas = func(i int32) *int32 { return &i }(1)
+		t.Spec.Affinity = nil
 	}
 
 	return t, nil
@@ -2661,6 +2664,7 @@ func (f *Factory) NewDeployment(manifest io.Reader) (*appsv1.Deployment, error) 
 
 	if !f.infrastructure.HighlyAvailableInfrastructure() {
 		d.Spec.Replicas = func(i int32) *int32 { return &i }(1)
+		d.Spec.Template.Spec.Affinity = nil
 	}
 
 	return d, nil


### PR DESCRIPTION
Apply the following HA conventions to thanos-querier and
prometheus-adapter:

- 2 replicas
- Hard pod anti-affinity on hostname
- ~~Set the maxUnavailable rollout strategy to 25%~~ Set maxUnavailable rollout strategy to 1

For non-HA topology, we remove the anti-affinity constraints as they are not needed with 1 replica.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
