### PR TITLE
Bug 1951052: drop CRI-O image metrics

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -86,6 +86,11 @@ spec:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
       insecureSkipVerify: false
   - interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: container_runtime_crio_image_pulls_by_digest|container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_by_name|container_runtime_crio_image_pulls_successes
+      sourceLabels:
+      - endpoint
     port: https-metrics
     relabelings:
     - action: replace

--- a/jsonnet/control-plane.libsonnet
+++ b/jsonnet/control-plane.libsonnet
@@ -87,6 +87,7 @@ function(params)
               },
             super.endpoints,
           ) +
+          // Collect metrics from CRI-O.
           [{
             interval: '30s',
             port: 'https-metrics',
@@ -108,6 +109,14 @@ function(params)
                 action: 'replace',
                 targetLabel: 'job',
                 replacement: 'crio',
+              },
+            ],
+            // Drop metrics with excessive label cardinality.
+            metricRelabelings: [
+              {
+                sourceLabels: ['endpoint'],
+                regex: 'container_runtime_crio_image_pulls_by_digest|container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_by_name|container_runtime_crio_image_pulls_successes',
+                action: 'drop',
               },
             ],
           }],


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
