### PR TITLE
Bug 1951505: Remove deprecated techPreviewUserWorkload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Increase "for" duration to 1 hour for all Thanos sidecar alerts.
 - [#1093](https://github.com/openshift/cluster-monitoring-operator/pull/1093) Bump kube-state-metrics to major new release v2.0.0-rc.1. This changes a lot of metrics and flags, see kube-state-metrics CHANGELOG for full changes. 
 - [#1117](https://github.com/openshift/cluster-monitoring-operator/pull/1117) Increase "for" duration to 15 minutes for AggregatedAPIDown.
+- [#1126](https://github.com/openshift/cluster-monitoring-operator/pull/1126) Remove deprecated techPreviewUserWorkload field from CMO's configmap.
 
 ## 4.7
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -24,7 +24,6 @@ import (
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "k8s.io/api/core/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -52,8 +51,6 @@ type ClusterMonitoringConfiguration struct {
 	K8sPrometheusAdapter     *K8sPrometheusAdapter        `json:"k8sPrometheusAdapter"`
 	ThanosQuerierConfig      *ThanosQuerierConfig         `json:"thanosQuerier"`
 	UserWorkloadEnabled      *bool                        `json:"enableUserWorkload"`
-	// TODO: remove in 4.8, this is here to ensure we warn users that their config will not work.
-	UserWorkloadConfig *UserWorkloadConfig `json:"techPreviewUserWorkload"`
 }
 
 type Images struct {
@@ -152,10 +149,6 @@ func (e *EtcdConfig) IsEnabled() bool {
 	return *e.Enabled
 }
 
-type UserWorkloadConfig struct {
-	Enabled *bool `json:"enabled"`
-}
-
 type TelemeterClientConfig struct {
 	ClusterID          string            `json:"clusterID"`
 	Enabled            *bool             `json:"enabled"`
@@ -242,9 +235,6 @@ func (c *Config) applyDefaults() {
 	}
 	if c.ClusterMonitoringConfiguration.EtcdConfig == nil {
 		c.ClusterMonitoringConfiguration.EtcdConfig = &EtcdConfig{}
-	}
-	if c.ClusterMonitoringConfiguration.UserWorkloadConfig == nil {
-		c.ClusterMonitoringConfiguration.UserWorkloadConfig = &UserWorkloadConfig{}
 	}
 }
 
@@ -401,24 +391,4 @@ func NewDefaultUserWorkloadMonitoringConfig() *UserWorkloadConfiguration {
 	u := &UserWorkloadConfiguration{}
 	u.applyDefaults()
 	return u
-}
-
-// IsUserWorkloadEnabled checks if user workload monitoring is
-// enabled. If old techPreview configuration exists, we warn user in logs.
-func (c *Config) IsUserWorkloadEnabled() bool {
-	if *c.ClusterMonitoringConfiguration.UserWorkloadEnabled == true {
-		return true
-	}
-
-	return c.ClusterMonitoringConfiguration.UserWorkloadConfig.isEnabled()
-}
-
-// return false, as this configuration is techPreview
-// and depracted from 4.7 onwards.
-// Instead warn user in the logs.
-func (c *UserWorkloadConfig) isEnabled() bool {
-	if c.Enabled != nil {
-		klog.Warning("DEPRECATED: Migrate to new user workload monitoring configuration, this tech preview was removed.")
-	}
-	return false
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -601,8 +601,6 @@ func (o *Operator) Config(key string) (*manifests.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if c.ClusterMonitoringConfiguration.UserWorkloadConfig != nil && c.ClusterMonitoringConfiguration.UserWorkloadConfig.Enabled != nil && *c.ClusterMonitoringConfiguration.UserWorkloadConfig.Enabled {
-		klog.Warningf("User Workload Monitoring enabled via the deprecated 'techPreviewUserWorkload' setting in %q configmap. Use the 'enableUserWorkload' setting instead.", key)
 	}
 
 	// Only fetch the token and cluster ID if they have not been specified in the config.

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -37,7 +37,7 @@ func NewPrometheusUserWorkloadTask(client *client.Client, factory *manifests.Fac
 }
 
 func (t *PrometheusUserWorkloadTask) Run() error {
-	if t.config.IsUserWorkloadEnabled() {
+	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		return t.create()
 	}
 

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -36,7 +36,7 @@ func NewPrometheusOperatorUserWorkloadTask(client *client.Client, factory *manif
 }
 
 func (t *PrometheusOperatorUserWorkloadTask) Run() error {
-	if t.config.IsUserWorkloadEnabled() {
+	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		return t.create()
 	}
 

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -203,7 +203,7 @@ func (t *ThanosQuerierTask) Run() error {
 			return errors.Wrap(err, "syncing Thanos Querier trusted CA bundle ConfigMap failed")
 		}
 
-		dep, err := t.factory.ThanosQuerierDeployment(s, t.config.IsUserWorkloadEnabled(), trustedCA)
+		dep, err := t.factory.ThanosQuerierDeployment(s, *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled, trustedCA)
 		if err != nil {
 			return errors.Wrap(err, "initializing Thanos Querier Deployment failed")
 		}

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -35,7 +35,7 @@ func NewThanosRulerUserWorkloadTask(client *client.Client, factory *manifests.Fa
 }
 
 func (t *ThanosRulerUserWorkloadTask) Run() error {
-	if t.config.IsUserWorkloadEnabled() {
+	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		return t.create()
 	}
 


### PR DESCRIPTION
Remove `techPreviewUserWorkload` from CMO's configmap as it is deprecated in 4.8.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
