### PR TITLE
Bug 1952032: jsonnet: add format changes made by make jsonnet-fmt

### DIFF
--- a/jsonnet/ibm-cloud-managed-profile.libsonnet
+++ b/jsonnet/ibm-cloud-managed-profile.libsonnet
@@ -8,27 +8,27 @@
   // Contact: cewong@redhat.com
 
   local removeMasterNodeSelector(sel) = {
-      [if x != "node-role.kubernetes.io/master" then x]: sel[x]
-      for x in std.objectFields(sel)
-    },
+    [if x != 'node-role.kubernetes.io/master' then x]: sel[x]
+    for x in std.objectFields(sel)
+  },
 
-  local setProfileAnnotation(metadata,profile) =
-    local annotations = if "annotations" in metadata then metadata.annotations else {};
+  local setProfileAnnotation(metadata, profile) =
+    local annotations = if 'annotations' in metadata then metadata.annotations else {};
     {
-      [if !std.startsWith(x, "include.release.openshift.io/") then x]: annotations[x]
+      [if !std.startsWith(x, 'include.release.openshift.io/') then x]: annotations[x]
       for x in std.objectFields(annotations)
     } +
     {
-      ["include.release.openshift.io/" + profile]: "true"
+      ['include.release.openshift.io/' + profile]: 'true',
     },
 
 
   manifests+:: {
     local operatorDeployment = import 'manifests/0000_50_cluster-monitoring-operator_05-deployment.json',
-    "0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed": operatorDeployment {
+    '0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed': operatorDeployment {
       local originalMetadata = super.metadata,
       metadata+: {
-        annotations: setProfileAnnotation(originalMetadata,"ibm-cloud-managed"),
+        annotations: setProfileAnnotation(originalMetadata, 'ibm-cloud-managed'),
       },
       spec+: {
         template+: {

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -392,6 +392,6 @@ removeRunbookUrl(patchRules(excludeRules(addWorkloadAnnotation(addReleaseAnnotat
   { ['thanos-querier/' + name]: inCluster.thanosQuerier[name] for name in std.objectFields(inCluster.thanosQuerier) } +
   { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
   { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
-  { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } + 
+  { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } +
   {}
 ))))))


### PR DESCRIPTION
This is partly preparation of the upcomming jsonnet-fmt ci job, partly
just maintanence.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
