### PR TITLE
Bug 1952149: oc adm top reporting unknown status for Windows node

### DIFF
--- a/assets/prometheus-adapter/config-map.yaml
+++ b/assets/prometheus-adapter/config-map.yaml
@@ -5,7 +5,7 @@ data:
       "cpu":
         "containerLabel": "container"
         "containerQuery": "sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!=\"POD\",container!=\"\",pod!=\"\"}[5m])) by (<<.GroupBy>>)"
-        "nodeQuery": "sum(1 - irate(node_cpu_seconds_total{mode=\"idle\"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)"
+        "nodeQuery": "sum(1 - irate(node_cpu_seconds_total{mode=\"idle\"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>) or sum(1- irate(windows_cpu_time_total{mode=\"idle\", job=\"windows-exporter\",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)"
         "resources":
           "overrides":
             "namespace":
@@ -17,7 +17,7 @@ data:
       "memory":
         "containerLabel": "container"
         "containerQuery": "sum(container_memory_working_set_bytes{<<.LabelMatchers>>,container!=\"POD\",container!=\"\",pod!=\"\"}) by (<<.GroupBy>>)"
-        "nodeQuery": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\",<<.LabelMatchers>>} - node_memory_MemAvailable_bytes{job=\"node-exporter\",<<.LabelMatchers>>}) by (<<.GroupBy>>)"
+        "nodeQuery": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\",<<.LabelMatchers>>} - node_memory_MemAvailable_bytes{job=\"node-exporter\",<<.LabelMatchers>>}) by (<<.GroupBy>>) or sum(windows_cs_physical_memory_bytes{job=\"windows-exporter\",<<.LabelMatchers>>} - windows_memory_available_bytes{job=\"windows-exporter\",<<.LabelMatchers>>}) by (<<.GroupBy>>)"
         "resources":
           "overrides":
             "instance":

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -96,6 +96,16 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
                },
                prometheusAdapter+:: {
                  prometheusURL: 'https://prometheus-k8s.openshift-monitoring.svc:9091',
+                 config+: {
+                   resourceRules+: {
+                     cpu+: {
+                       nodeQuery: 'sum(1 - irate(node_cpu_seconds_total{mode="idle"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>) or sum(1- irate(windows_cpu_time_total{mode=\"idle\", job=\"windows-exporter\",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)',
+                     },
+                     memory+: {
+                       nodeQuery: 'sum(node_memory_MemTotal_bytes{job="node-exporter",<<.LabelMatchers>>} - node_memory_MemAvailable_bytes{job="node-exporter",<<.LabelMatchers>>}) by (<<.GroupBy>>) or sum(windows_cs_physical_memory_bytes{job=\"windows-exporter\",<<.LabelMatchers>>} - windows_memory_available_bytes{job=\"windows-exporter\",<<.LabelMatchers>>}) by (<<.GroupBy>>)',
+                     },
+                   },
+                 },
                },
                etcd+:: {
                  ips: [],


### PR DESCRIPTION
This PR overrides the nodeQueries in the prometheus-adapter config-map to include windows_exporter queries in order to retrieve resource metrics: CPU and memory for Windows nodes. 
This fix has been merged upstream in [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus/pull/1058)
Ran commands:
`make generate`

This PR has been opened in an effort to merge this fix into release-4.7 since it is not included in release-0.7 of kube-prometheus.

* [ ] I added CHANGELOG entry for this change.
- [x] No user facing changes, so no entry in CHANGELOG was needed.
