### PR TITLE
Bug 1955445: fix dropped crio metrics

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -90,7 +90,7 @@ spec:
     - action: drop
       regex: container_runtime_crio_image_pulls_by_digest|container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_by_name|container_runtime_crio_image_pulls_successes
       sourceLabels:
-      - endpoint
+      - __name__
     port: https-metrics
     relabelings:
     - action: replace

--- a/jsonnet/control-plane.libsonnet
+++ b/jsonnet/control-plane.libsonnet
@@ -114,7 +114,7 @@ function(params)
             // Drop metrics with excessive label cardinality.
             metricRelabelings: [
               {
-                sourceLabels: ['endpoint'],
+                sourceLabels: ['__name__'],
                 regex: 'container_runtime_crio_image_pulls_by_digest|container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_by_name|container_runtime_crio_image_pulls_successes',
                 action: 'drop',
               },


### PR DESCRIPTION
There was a stupid typo in #1125 (the source label to match should be `__name__`).
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
