### PR TITLE
[4.7] Bug 1955449: drop crio image metrics

### DIFF
--- a/assets/prometheus-k8s/service-monitor-kubelet.yaml
+++ b/assets/prometheus-k8s/service-monitor-kubelet.yaml
@@ -85,6 +85,11 @@ spec:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
       insecureSkipVerify: false
   - interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_.+
+      sourceLabels:
+      - __name__
     port: https-metrics
     relabelings:
     - action: replace

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -236,6 +236,7 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
                 },
               super.endpoints,
             ) +
+            // Collect metrics from CRI-O.
             [{
               interval: '30s',
               port: 'https-metrics',
@@ -259,6 +260,15 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
                   replacement: 'crio',
                 },
               ],
+              // Drop metrics with excessive label cardinality.
+              metricRelabelings: [
+                {
+                  sourceLabels: ['__name__'],
+                  regex: 'container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_.+',
+                  action: 'drop',
+                },
+              ],
+
             }],
         },
       },


### PR DESCRIPTION
Backport of #1125, #1133 and #1148 (the automatic cherrypick isn't possible because the `jsonnet` layout has changed a lot).

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
