### PR TITLE
Bug 1949262: jsonnet: add hard anti-affinity to Prometheuses

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -13,18 +13,16 @@ metadata:
 spec:
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: prometheus
-              operator: In
-              values:
-              - k8s
-          namespaces:
-          - openshift-monitoring
-          topologyKey: kubernetes.io/hostname
-        weight: 100
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: prometheus
+            operator: In
+            values:
+            - k8s
+        namespaces:
+        - openshift-monitoring
+        topologyKey: kubernetes.io/hostname
   alerting:
     alertmanagers:
     - apiVersion: v2

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -13,18 +13,16 @@ metadata:
 spec:
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: prometheus
-              operator: In
-              values:
-              - user-workload
-          namespaces:
-          - openshift-user-workload-monitoring
-          topologyKey: kubernetes.io/hostname
-        weight: 100
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: prometheus
+            operator: In
+            values:
+            - user-workload
+        namespaces:
+        - openshift-user-workload-monitoring
+        topologyKey: kubernetes.io/hostname
   alerting:
     alertmanagers:
     - apiVersion: v2

--- a/jsonnet/anti-affinity.libsonnet
+++ b/jsonnet/anti-affinity.libsonnet
@@ -1,0 +1,9 @@
+local addon = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet';
+
+addon {
+  values+:: {
+    prometheus+: {
+      podAntiAffinity: 'hard',
+    },
+  },
+}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -321,7 +321,7 @@ local inCluster =
     telemeterClient: telemeterClient($.values.telemeterClient),
     openshiftStateMetrics: openshiftStateMetrics($.values.openshiftStateMetrics),
   } +
-  (import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet') +
+  (import './anti-affinity.libsonnet') +
   ibmCloudManagedProfile +
   {};
 
@@ -370,7 +370,7 @@ local userWorkload =
     prometheus: prometheusUserWorkload($.values.prometheus),
     prometheusOperator: prometheusOperatorUserWorkload($.values.prometheusOperator),
   } +
-  (import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet') +
+  (import './anti-affinity.libsonnet') +
   {};
 
 // Manifestation

--- a/jsonnet/prometheus-adapter.libsonnet
+++ b/jsonnet/prometheus-adapter.libsonnet
@@ -78,6 +78,8 @@ function(params)
           },
           template+: {
             spec+: {
+              // TODO(dgrisonnet): remove with kube-prometheus release-0.8
+              // sync.
               affinity+: {
                 podAntiAffinity: {
                   // Apply HA conventions

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -274,6 +274,8 @@ function(params)
         },
         template+: {
           spec+: {
+            // TODO(dgrisonnet): remove once the upstream anti-affinity addon
+            // can be extended.
             affinity+: {
               podAntiAffinity: {
                 // Apply HA conventions


### PR DESCRIPTION
Add hard anti-affinity constraints on hostname to the platform
and user-workload-monitoring Prometheuses to comply with the
high-availability conventions.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
