### PR TITLE
Makefile: drop test-rules from test-unit target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,11 +155,10 @@ test-rules: check-rules
 ###########
 
 .PHONY: test
-test: test-unit test-e2e
+test: test-unit test-rules test-e2e
 
-# TODO(simonpasquier): we should have a CI job specifically checking Prometheus rules.
 .PHONY: test-unit
-test-unit: test-rules
+test-unit:
 	go test -race -short $(PKGS) -count=1
 
 .PHONY: test-e2e


### PR DESCRIPTION
With https://github.com/openshift/release/pull/17927 the test-rule
target is now its own ci case. No need to run test-rules within the
test-unit target anymore.
This also adds the test-rules target to the test target for convenience.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
