### PR TITLE
Bug 1939412: remove managed-by label as it is conflicting with prometheus-operator

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     alertmanager: main
     app.kubernetes.io/component: alert-router
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.21.0
@@ -113,7 +112,6 @@ spec:
       workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: alert-router
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 0.21.0

--- a/assets/alertmanager/pod-disruption-budget.yaml
+++ b/assets/alertmanager/pod-disruption-budget.yaml
@@ -3,7 +3,6 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app.kubernetes.io/component: alert-router
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.21.0
@@ -15,6 +14,5 @@ spec:
     matchLabels:
       alertmanager: main
       app.kubernetes.io/component: alert-router
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -3,7 +3,6 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: alert-router
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.21.0

--- a/assets/alertmanager/secret.yaml
+++ b/assets/alertmanager/secret.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     alertmanager: main
     app.kubernetes.io/component: alert-router
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.21.0

--- a/assets/alertmanager/service-account.yaml
+++ b/assets/alertmanager/service-account.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     alertmanager: main
     app.kubernetes.io/component: alert-router
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.21.0

--- a/assets/alertmanager/service-monitor.yaml
+++ b/assets/alertmanager/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: alert-router
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.21.0
@@ -22,6 +21,5 @@ spec:
     matchLabels:
       alertmanager: main
       app.kubernetes.io/component: alert-router
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/alertmanager/service.yaml
+++ b/assets/alertmanager/service.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     alertmanager: main
     app.kubernetes.io/component: alert-router
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.21.0
@@ -24,7 +23,6 @@ spec:
     alertmanager: main
     app: alertmanager
     app.kubernetes.io/component: alert-router
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
   sessionAffinity: ClientIP

--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -3,7 +3,6 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: operator
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: cluster-monitoring-operator
     app.kubernetes.io/part-of: openshift-monitoring
     prometheus: k8s

--- a/assets/control-plane/etcd-prometheus-rule.yaml
+++ b/assets/control-plane/etcd-prometheus-rule.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/part-of: openshift-monitoring
     prometheus: k8s
     role: alert-rules

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     prometheus: k8s

--- a/assets/grafana/config.yaml
+++ b/assets/grafana/config.yaml
@@ -5,7 +5,6 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5

--- a/assets/grafana/dashboard-datasources.yaml
+++ b/assets/grafana/dashboard-datasources.yaml
@@ -5,7 +5,6 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -1870,7 +1870,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -3110,7 +3109,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -5638,7 +5636,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -7886,7 +7883,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -8858,7 +8854,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -10588,7 +10583,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -12568,7 +12562,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -14713,7 +14706,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -16171,7 +16163,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -17129,7 +17120,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -18114,7 +18104,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -19336,7 +19325,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5
@@ -20557,7 +20545,6 @@ items:
       include.release.openshift.io/single-node-developer: "true"
     labels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 7.3.5

--- a/assets/grafana/dashboard-sources.yaml
+++ b/assets/grafana/dashboard-sources.yaml
@@ -19,7 +19,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -14,18 +13,16 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: grafana
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
   template:
     metadata:
       annotations:
-        checksum/grafana-config: 4edd2a7c41f827b93497c2d118a926e7
-        checksum/grafana-datasources: 0fc2251d80a7fdcb28e58d9944addd91
+        checksum/grafana-config: 05b6f415e1e9ba492d7654d62d7e1543
+        checksum/grafana-datasources: 5112aea1c4230be98f4e95a8377242fd
         workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana
-        app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 7.3.5

--- a/assets/grafana/service-monitor.yaml
+++ b/assets/grafana/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5

--- a/assets/grafana/service.yaml
+++ b/assets/grafana/service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: grafana-tls
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -18,7 +17,6 @@ spec:
     targetPort: https
   selector:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
   type: ClusterIP

--- a/assets/kube-state-metrics/cluster-role-binding.yaml
+++ b/assets/kube-state-metrics/cluster-role-binding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.0.0-rc.1

--- a/assets/kube-state-metrics/cluster-role.yaml
+++ b/assets/kube-state-metrics/cluster-role.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.0.0-rc.1

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.0.0-rc.1
@@ -14,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: kube-state-metrics
       app.kubernetes.io/part-of: openshift-monitoring
   template:
@@ -23,7 +21,6 @@ spec:
         workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter
-        app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 2.0.0-rc.1

--- a/assets/kube-state-metrics/prometheus-rule.yaml
+++ b/assets/kube-state-metrics/prometheus-rule.yaml
@@ -3,7 +3,6 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.0.0-rc.1

--- a/assets/kube-state-metrics/service-account.yaml
+++ b/assets/kube-state-metrics/service-account.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.0.0-rc.1

--- a/assets/kube-state-metrics/service-monitor.yaml
+++ b/assets/kube-state-metrics/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.0.0-rc.1
@@ -38,6 +37,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: kube-state-metrics
       app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/kube-state-metrics/service.yaml
+++ b/assets/kube-state-metrics/service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: kube-state-metrics-tls
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.0.0-rc.1
@@ -22,6 +21,5 @@ spec:
     targetPort: https-self
   selector:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/node-exporter/cluster-role-binding.yaml
+++ b/assets/node-exporter/cluster-role-binding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.0.1

--- a/assets/node-exporter/cluster-role.yaml
+++ b/assets/node-exporter/cluster-role.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.0.1

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -3,7 +3,6 @@ kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.0.1
@@ -13,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: node-exporter
       app.kubernetes.io/part-of: openshift-monitoring
   template:
@@ -22,7 +20,6 @@ spec:
         workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter
-        app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: node-exporter
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 1.0.1

--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -3,7 +3,6 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.0.1

--- a/assets/node-exporter/service-account.yaml
+++ b/assets/node-exporter/service-account.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.0.1

--- a/assets/node-exporter/service-monitor.yaml
+++ b/assets/node-exporter/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.0.1
@@ -30,6 +29,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: node-exporter
       app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/node-exporter/service.yaml
+++ b/assets/node-exporter/service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: node-exporter-tls
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.0.1
@@ -19,6 +18,5 @@ spec:
     targetPort: https
   selector:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/prometheus-adapter/api-service.yaml
+++ b/assets/prometheus-adapter/api-service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.alpha.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
+++ b/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/cluster-role-binding-delegator.yaml
+++ b/assets/prometheus-adapter/cluster-role-binding-delegator.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/cluster-role-binding.yaml
+++ b/assets/prometheus-adapter/cluster-role-binding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/cluster-role-server-resources.yaml
+++ b/assets/prometheus-adapter/cluster-role-server-resources.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/cluster-role.yaml
+++ b/assets/prometheus-adapter/cluster-role.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/config-map.yaml
+++ b/assets/prometheus-adapter/config-map.yaml
@@ -31,7 +31,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4
@@ -14,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: metrics-adapter
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus-adapter
       app.kubernetes.io/part-of: openshift-monitoring
   strategy:
@@ -26,7 +24,6 @@ spec:
         workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: metrics-adapter
-        app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: prometheus-adapter
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 0.8.4
@@ -37,7 +34,6 @@ spec:
           - labelSelector:
               matchLabels:
                 app.kubernetes.io/component: metrics-adapter
-                app.kubernetes.io/managed-by: cluster-monitoring-operator
                 app.kubernetes.io/name: prometheus-adapter
                 app.kubernetes.io/part-of: openshift-monitoring
             topologyKey: kubernetes.io/hostname

--- a/assets/prometheus-adapter/role-binding-auth-reader.yaml
+++ b/assets/prometheus-adapter/role-binding-auth-reader.yaml
@@ -3,7 +3,6 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/service-account.yaml
+++ b/assets/prometheus-adapter/service-account.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4

--- a/assets/prometheus-adapter/service-monitor.yaml
+++ b/assets/prometheus-adapter/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4
@@ -22,6 +21,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: metrics-adapter
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus-adapter
       app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/prometheus-adapter/service.yaml
+++ b/assets/prometheus-adapter/service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-adapter-tls
   labels:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.8.4
@@ -18,7 +17,6 @@ spec:
     targetPort: 6443
   selector:
     app.kubernetes.io/component: metrics-adapter
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
   type: ClusterIP

--- a/assets/prometheus-k8s/cluster-role-binding.yaml
+++ b/assets/prometheus-k8s/cluster-role-binding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/cluster-role.yaml
+++ b/assets/prometheus-k8s/cluster-role.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/pod-disruption-budget.yaml
+++ b/assets/prometheus-k8s/pod-disruption-budget.yaml
@@ -3,7 +3,6 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -14,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       prometheus: k8s

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -3,7 +3,6 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -3,7 +3,6 @@ kind: Prometheus
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -174,7 +173,6 @@ spec:
       workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/role-binding-config.yaml
+++ b/assets/prometheus-k8s/role-binding-config.yaml
@@ -3,7 +3,6 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/role-binding-specific-namespaces.yaml
+++ b/assets/prometheus-k8s/role-binding-specific-namespaces.yaml
@@ -5,7 +5,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0
@@ -24,7 +23,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0
@@ -43,7 +41,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0
@@ -62,7 +59,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0
@@ -81,7 +77,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/role-config.yaml
+++ b/assets/prometheus-k8s/role-config.yaml
@@ -3,7 +3,6 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/role-specific-namespaces.yaml
+++ b/assets/prometheus-k8s/role-specific-namespaces.yaml
@@ -5,7 +5,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0
@@ -43,7 +42,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0
@@ -81,7 +79,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0
@@ -119,7 +116,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0
@@ -157,7 +153,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/service-account.yaml
+++ b/assets/prometheus-k8s/service-account.yaml
@@ -5,7 +5,6 @@ metadata:
     serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-k8s"}}'
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: thanos-sidecar
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-k8s/service-monitor.yaml
+++ b/assets/prometheus-k8s/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -21,7 +20,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       prometheus: k8s

--- a/assets/prometheus-k8s/service-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-thanos-sidecar.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-thanos-sidecar-tls
   labels:
     app.kubernetes.io/component: thanos-sidecar
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -20,7 +19,6 @@ spec:
     targetPort: thanos-proxy
   selector:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     prometheus: k8s

--- a/assets/prometheus-k8s/service.yaml
+++ b/assets/prometheus-k8s/service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -23,7 +22,6 @@ spec:
   selector:
     app: prometheus
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     prometheus: k8s

--- a/assets/prometheus-operator-user-workload/cluster-role-binding.yaml
+++ b/assets/prometheus-operator-user-workload/cluster-role-binding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator-user-workload/cluster-role.yaml
+++ b/assets/prometheus-operator-user-workload/cluster-role.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0
@@ -14,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: openshift-monitoring
   template:
@@ -23,7 +21,6 @@ spec:
         workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: controller
-        app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator-user-workload/service-account.yaml
+++ b/assets/prometheus-operator-user-workload/service-account.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator-user-workload/service-monitor.yaml
+++ b/assets/prometheus-operator-user-workload/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0
@@ -21,7 +20,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator-user-workload/service.yaml
+++ b/assets/prometheus-operator-user-workload/service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-user-workload-tls
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0
@@ -19,6 +18,5 @@ spec:
     targetPort: https
   selector:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/prometheus-operator/cluster-role-binding.yaml
+++ b/assets/prometheus-operator/cluster-role-binding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator/cluster-role.yaml
+++ b/assets/prometheus-operator/cluster-role.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0
@@ -14,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: openshift-monitoring
   template:
@@ -23,7 +21,6 @@ spec:
         workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: controller
-        app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator/prometheus-rule.yaml
+++ b/assets/prometheus-operator/prometheus-rule.yaml
@@ -3,7 +3,6 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator/service-account.yaml
+++ b/assets/prometheus-operator/service-account.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator/service-monitor.yaml
+++ b/assets/prometheus-operator/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0
@@ -21,7 +20,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 0.45.0

--- a/assets/prometheus-operator/service.yaml
+++ b/assets/prometheus-operator/service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-tls
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.45.0
@@ -22,6 +21,5 @@ spec:
     targetPort: 8080
   selector:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/prometheus-user-workload/cluster-role-binding.yaml
+++ b/assets/prometheus-user-workload/cluster-role-binding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/cluster-role.yaml
+++ b/assets/prometheus-user-workload/cluster-role.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/pod-disruption-budget.yaml
+++ b/assets/prometheus-user-workload/pod-disruption-budget.yaml
@@ -3,7 +3,6 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -14,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       prometheus: user-workload

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -3,7 +3,6 @@ kind: Prometheus
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -123,7 +122,6 @@ spec:
       workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/role-binding-config.yaml
+++ b/assets/prometheus-user-workload/role-binding-config.yaml
@@ -3,7 +3,6 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/role-binding-specific-namespaces.yaml
+++ b/assets/prometheus-user-workload/role-binding-specific-namespaces.yaml
@@ -5,7 +5,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/role-config.yaml
+++ b/assets/prometheus-user-workload/role-config.yaml
@@ -3,7 +3,6 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/role-specific-namespaces.yaml
+++ b/assets/prometheus-user-workload/role-specific-namespaces.yaml
@@ -5,7 +5,6 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/service-account.yaml
+++ b/assets/prometheus-user-workload/service-account.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: thanos-sidecar
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0

--- a/assets/prometheus-user-workload/service-monitor.yaml
+++ b/assets/prometheus-user-workload/service-monitor.yaml
@@ -3,7 +3,6 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -21,7 +20,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       prometheus: user-workload

--- a/assets/prometheus-user-workload/service-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-thanos-sidecar.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-user-workload-thanos-sidecar-tls
   labels:
     app.kubernetes.io/component: thanos-sidecar
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -20,7 +19,6 @@ spec:
     targetPort: thanos-proxy
   selector:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     prometheus: user-workload

--- a/assets/prometheus-user-workload/service.yaml
+++ b/assets/prometheus-user-workload/service.yaml
@@ -5,7 +5,6 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-user-workload-tls
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.24.0
@@ -23,7 +22,6 @@ spec:
   selector:
     app: prometheus
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
     prometheus: user-workload

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -71,7 +71,6 @@ local commonConfig = {
   // Labels applied to every object
   commonLabels: {
     'app.kubernetes.io/part-of': 'openshift-monitoring',
-    'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
   },
 };
 

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1869,7 +1869,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -3111,7 +3110,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -5641,7 +5639,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -7891,7 +7888,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -8865,7 +8861,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -10597,7 +10592,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -12579,7 +12573,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -14726,7 +14719,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -16186,7 +16178,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -17146,7 +17137,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -18133,7 +18123,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -19357,7 +19346,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5
@@ -20580,7 +20568,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/component: grafana
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.3.5


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
