### PR TITLE
Bug 1955467: remove node_mountstats_nfs_* metrics

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -36,7 +36,6 @@ spec:
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netclass.ignored-devices=^(veth.*)$
         - --collector.netdev.device-exclude=^(veth.*)$
-        - --collector.mountstats
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
         image: quay.io/prometheus/node-exporter:v1.0.1

--- a/jsonnet/node-exporter.libsonnet
+++ b/jsonnet/node-exporter.libsonnet
@@ -136,8 +136,9 @@ function(params)
                     c {
                       // Remove the flag to disable hwmon that is set upstream so we
                       // gather that data (especially for bare metal clusters), and
-                      // add flags to collect data not included by default.
-                      args: [a for a in c.args if a != '--no-collector.hwmon'] + ['--collector.mountstats', '--collector.cpu.info', '--collector.textfile.directory=' + textfileDir],
+                      // add flags to collect the node_cpu_info metric + metrics
+                      // from the text file.
+                      args: [a for a in c.args if a != '--no-collector.hwmon'] + ['--collector.cpu.info', '--collector.textfile.directory=' + textfileDir],
                       terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts+: [{
                         mountPath: textfileDir,


### PR DESCRIPTION
The node_exporter's mountstats collector gathers low-level metrics from
NFS mountstats (such as operation timings, transport and event
statistics). When available, these metrics can have high-cardinality
(for one cluster, we've seen that it can account for half of *all* the
series) though they aren't used by any rule or dashboard.

The mountstats collector had been enabled in #409 following a customer
request for enhancement. But looking at the history, the customer was
asking for the kubelet_volume_* metrics which weren't supported by their
storage provider at this time (it's been fixed since then NetApp/trident#134). The
mountstats metrics don't fill the same need and are superfluous.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
