### PR TITLE
Bug 1955051: Update kube node status capacity metric

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -91,7 +91,7 @@ spec:
             cluster:master_nodes
             * on(node) group_left() max by(node)
             (
-              kube_node_status_capacity_cpu_cores
+              kube_node_status_capacity{resource="cpu",unit="core"}
             )
           )
           or on(node) (
@@ -100,7 +100,7 @@ spec:
               kube_node_labels
             ) * on(node) group_left() max by(node)
             (
-              kube_node_status_capacity_cpu_cores
+              kube_node_status_capacity{resource="cpu",unit="core"}
             )
           )
         )
@@ -150,7 +150,7 @@ spec:
             cluster:master_nodes
             * on(node) group_left() max by(node)
             (
-              kube_node_status_capacity_memory_bytes
+              kube_node_status_capacity{resource="memory",unit="byte"}
             )
           )
           or on(node)
@@ -161,7 +161,7 @@ spec:
             )
             * on(node) group_left() max by(node)
             (
-              kube_node_status_capacity_memory_bytes
+              kube_node_status_capacity{resource="memory",unit="byte"}
             )
           )
         )

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -111,7 +111,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
                   cluster:master_nodes
                   * on(node) group_left() max by(node)
                   (
-                    kube_node_status_capacity_cpu_cores
+                    kube_node_status_capacity{resource="cpu",unit="core"}
                   )
                 )
                 or on(node) (
@@ -120,7 +120,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
                     kube_node_labels
                   ) * on(node) group_left() max by(node)
                   (
-                    kube_node_status_capacity_cpu_cores
+                    kube_node_status_capacity{resource="cpu",unit="core"}
                   )
                 )
               )
@@ -180,7 +180,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
                   cluster:master_nodes
                   * on(node) group_left() max by(node)
                   (
-                    kube_node_status_capacity_memory_bytes
+                    kube_node_status_capacity{resource="memory",unit="byte"}
                   )
                 )
                 or on(node)
@@ -191,7 +191,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
                   )
                   * on(node) group_left() max by(node)
                   (
-                    kube_node_status_capacity_memory_bytes
+                    kube_node_status_capacity{resource="memory",unit="byte"}
                   )
                 )
               )


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

`kube_node_status_capacity` is updated in [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md) 2.0. New change need us to use unit label to retrieve the metric

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
