### PR TITLE
[4.7] Bug 1955482: Drop high-cardinality metrics from kube-state-metrics which aren't used

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        - --metric-blacklist=kube_secret_labels
+        - --metric-blacklist=kube_secret_labels,kube_*_created,kube_*_metadata_resource_version,kube_replicaset_metadata_generation,kube_replicaset_status_observed_generation,kube_pod_restart_policy,kube_pod_init_container_status_terminated,kube_pod_init_container_status_running,kube_pod_container_status_terminated,kube_pod_container_status_running,kube_pod_completion_time,kube_pod_status_scheduled
         image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         resources:

--- a/jsonnet/kube-state-metrics.jsonnet
+++ b/jsonnet/kube-state-metrics.jsonnet
@@ -110,7 +110,21 @@ local tlsVolumeName = 'kube-state-metrics-tls';
                       c
                       {
                         args+: [
-                          '--metric-blacklist=kube_secret_labels',
+                          '--metric-blacklist=' +
+                          std.join(',', [
+                            'kube_secret_labels',
+                            'kube_*_created',
+                            'kube_*_metadata_resource_version',
+                            'kube_replicaset_metadata_generation',
+                            'kube_replicaset_status_observed_generation',
+                            'kube_pod_restart_policy',
+                            'kube_pod_init_container_status_terminated',
+                            'kube_pod_init_container_status_running',
+                            'kube_pod_container_status_terminated',
+                            'kube_pod_container_status_running',
+                            'kube_pod_completion_time',
+                            'kube_pod_status_scheduled',
+                          ]),
                         ],
                         securityContext: {},
                         resources: {


### PR DESCRIPTION
Manual backport of #1142 because the jsonnet directory has diverged a lot between 4.7 and 4.8.
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
