### PR TITLE
Bug 1955478: drop high-cardinality metrics from kube-state-metrics which aren't used

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -33,6 +33,19 @@ spec:
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         - --metric-denylist=kube_secret_labels
+        - |
+          --metric-denylist=
+          kube_*_created,
+          kube_*_metadata_resource_version,
+          kube_replicaset_metadata_generation,
+          kube_replicaset_status_observed_generation,
+          kube_pod_restart_policy,
+          kube_pod_init_container_status_terminated,
+          kube_pod_init_container_status_running,
+          kube_pod_container_status_terminated,
+          kube_pod_container_status_running,
+          kube_pod_completion_time,
+          kube_pod_status_scheduled
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
         name: kube-state-metrics
         resources:

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -321,6 +321,7 @@ local inCluster =
     openshiftStateMetrics: openshiftStateMetrics($.values.openshiftStateMetrics),
   } +
   (import './anti-affinity.libsonnet') +
+  (import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet') +
   ibmCloudManagedProfile +
   {};
 


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
