### PR TITLE
Bug 1957832: remove dependency of e2e tests on AWS

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -52,7 +52,6 @@ func TestAlertmanagerVolumeClaim(t *testing.T) {
 			"config.yaml": `alertmanagerMain:
   volumeClaimTemplate:
     spec:
-      storageClassName: gp2
       resources:
         requests:
           storage: 2Gi

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -76,7 +76,6 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 			"config.yaml": `prometheusK8s:
   volumeClaimTemplate:
     spec:
-      storageClassName: gp2
       resources:
         requests:
           storage: 2Gi

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -62,7 +62,6 @@ func TestUserWorkloadMonitoring(t *testing.T) {
 			"config.yaml": `prometheus:
   volumeClaimTemplate:
     spec:
-      storageClassName: gp2
       resources:
         requests:
           storage: 2Gi
@@ -154,7 +153,6 @@ func TestUserWorkloadMonitoringThanosRulerConfigurations(t *testing.T) {
       memory: 13Mi
   volumeClaimTemplate:
     spec:
-      storageClassName: gp2
       resources:
         requests:
           storage: 2Gi


### PR DESCRIPTION
The end-to-end tests validating persistent storage configuration
explicitly required the 'gp2' storage class which is AWS specific. By
removing any requirement on storage class, we ensure that the end-to-end
tests can be truly agnostic.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
