### PR TITLE
Bug 1950908: Allow all pod labels in metric labels

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         - --metric-denylist=kube_secret_labels
+        - --metric-labels-allowlist=pods=[*],node=[*]
         - |
           --metric-denylist=
           kube_*_created,

--- a/jsonnet/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics.libsonnet
@@ -110,6 +110,7 @@ function(params)
                     c {
                       args+: [
                         '--metric-denylist=kube_secret_labels',
+                        '--metric-labels-allowlist=pods=[*],node=[*]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

No changelog entry as this is a feature we already had, but it went away with KSM v2 update.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
