### PR TITLE
Bug 1955445: drop more CRI-O metrics

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -92,7 +92,7 @@ spec:
   - interval: 30s
     metricRelabelings:
     - action: drop
-      regex: container_runtime_crio_image_pulls_by_digest|container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_by_name|container_runtime_crio_image_pulls_successes
+      regex: container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_.+
       sourceLabels:
       - __name__
     port: https-metrics

--- a/jsonnet/control-plane.libsonnet
+++ b/jsonnet/control-plane.libsonnet
@@ -130,7 +130,7 @@ function(params)
             metricRelabelings: [
               {
                 sourceLabels: ['__name__'],
-                regex: 'container_runtime_crio_image_pulls_by_digest|container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_by_name|container_runtime_crio_image_pulls_successes',
+                regex: 'container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_.+',
                 action: 'drop',
               },
             ],


### PR DESCRIPTION
`container_runtime_crio_image_pulls_by_name_skipped` was still collected.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
