### PR TITLE
Bug 1953647: Add prometheus-adapter PodDisruptionBudget

### DIFF
--- a/assets/prometheus-adapter/pod-disruption-budget.yaml
+++ b/assets/prometheus-adapter/pod-disruption-budget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.8.4
+  name: prometheus-adapter
+  namespace: openshift-monitoring
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics-adapter
+      app.kubernetes.io/name: prometheus-adapter
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/hack/cluster-monitoring-operator-role.yaml.in
+++ b/hack/cluster-monitoring-operator-role.yaml.in
@@ -45,3 +45,6 @@ rules:
 - apiGroups: ["config.openshift.io"]
   resources: ["clusteroperators","clusteroperators/status"]
   verbs: ["get", "update", "create"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["create", "get", "update"]

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -131,8 +131,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "ba330fcd6a9eaacce5a85e3ec64f75d5eca75ea8",
-      "sum": "7/GK6yN2On+94UqhsixmDtuXCol6O12lBB/fz1D1ZdI="
+      "version": "bc9892e53e03506f0d26ff4497acaf8487a5f323",
+      "sum": "DjoZyKWXEcHZStbRuxhJqlPm3K/jvh/fbwjw/bJKqOk="
     },
     {
       "source": {

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -160,6 +160,14 @@ rules:
   - get
   - update
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews

--- a/pkg/tasks/prometheusadapter.go
+++ b/pkg/tasks/prometheusadapter.go
@@ -182,6 +182,19 @@ func (t *PrometheusAdapterTask) Run() error {
 		}
 	}
 	{
+		pdb, err := t.factory.PrometheusAdapterPodDisruptionBudget()
+		if err != nil {
+			return errors.Wrap(err, "initializing PrometheusAdapter PodDisruptionBudget failed")
+		}
+
+		if pdb != nil {
+			err = t.client.CreateOrUpdatePodDisruptionBudget(pdb)
+			if err != nil {
+				return errors.Wrap(err, "reconciling PrometheusAdapter PodDisruptionBudget failed")
+			}
+		}
+	}
+	{
 		sm, err := t.factory.PrometheusAdapterServiceMonitor()
 		if err != nil {
 			return errors.Wrap(err, "initializing PrometheusAdapter ServiceMonitor failed")


### PR DESCRIPTION
In high-availability topology, prometheus-adapter need to have a PodDisruptionBudget to align with OpenShift `Upgrades and Reconfiguration` conventions. https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#upgrade-and-reconfiguration

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
