### PR TITLE
Bug 1957703: [4.7]: Add hard anti-affinity constraints to Prometheuses

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -8,18 +8,16 @@ metadata:
 spec:
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: prometheus
-              operator: In
-              values:
-              - k8s
-          namespaces:
-          - openshift-monitoring
-          topologyKey: kubernetes.io/hostname
-        weight: 100
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: prometheus
+            operator: In
+            values:
+            - k8s
+        namespaces:
+        - openshift-monitoring
+        topologyKey: kubernetes.io/hostname
   alerting:
     alertmanagers:
     - apiVersion: v2

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -8,18 +8,16 @@ metadata:
 spec:
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: prometheus
-              operator: In
-              values:
-              - k8s
-          namespaces:
-          - openshift-monitoring
-          topologyKey: kubernetes.io/hostname
-        weight: 100
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: prometheus
+            operator: In
+            values:
+            - user-workload
+        namespaces:
+        - openshift-user-workload-monitoring
+        topologyKey: kubernetes.io/hostname
   alerting:
     alertmanagers:
     - apiVersion: v2

--- a/jsonnet/prometheus-user-workload.jsonnet
+++ b/jsonnet/prometheus-user-workload.jsonnet
@@ -189,6 +189,24 @@
           arbitraryFSAccessThroughSMs+: {
             deny: true,
           },
+          affinity+: {
+            podAntiAffinity: {
+              // Apply HA conventions
+              requiredDuringSchedulingIgnoredDuringExecution: [
+                {
+                  namespaces: [$._config.namespaceUserWorkload],
+                  labelSelector: {
+                    matchExpressions: [{
+                      key: 'prometheus',
+                      operator: 'In',
+                      values: ['user-workload'],
+                    }]
+                  },
+                  topologyKey: 'kubernetes.io/hostname',
+                },
+              ],
+            },
+          },
           thanos+: {
             image: $._config.imageRepos.openshiftThanos + ':' + $._config.versions.openshiftThanos,
             version: $._config.versions.openshiftThanos,

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -344,6 +344,24 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
     prometheus+:
       {
         spec+: {
+          affinity+: {
+            podAntiAffinity: {
+              // Apply HA conventions
+              requiredDuringSchedulingIgnoredDuringExecution: [
+                {
+                  namespaces: [$._config.namespace],
+                  labelSelector: {
+                    matchExpressions: [{
+                      key: 'prometheus',
+                      operator: 'In',
+                      values: [$._config.prometheus.name],
+                    }]
+                  },
+                  topologyKey: 'kubernetes.io/hostname',
+                },
+              ],
+            },
+          },
           thanos+: {
             image: $._config.imageRepos.openshiftThanos + ':' + $._config.versions.openshiftThanos,
             version: $._config.versions.openshiftThanos,


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-monitoring-operator/pull/1135 to release-4.7.

I couldn't cherry-pick the commit because of the changes made to kube-prometheus in 4.8.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
