### PR TITLE
Bug 1933847: Manage PodDisruptionBudget objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ vendor:
 	go mod verify
 
 .PHONY: generate
-generate: build-jsonnet manifests/0000_50_cluster-monitoring-operator_02-role.yaml docs
+generate: build-jsonnet manifests/0000_50_cluster-monitoring-operator_02-role.yaml docs check-assets
 
 .PHONY: generate-in-docker
 generate-in-docker:
@@ -149,6 +149,10 @@ check-rules: $(PROMTOOL_BIN) tmp/rules.yaml
 .PHONY: test-rules
 test-rules: check-rules
 	hack/test-rules.sh | tee "tmp/$@.out"
+
+.PHONY: check-assets
+check-assets:
+	hack/check-assets.sh
 
 ###########
 # Testing #

--- a/hack/check-assets.sh
+++ b/hack/check-assets.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+MANIFESTS_FILE="pkg/manifests/manifests.go"
+
+code=0
+for i in $(find assets/ -name '*.yaml' | sed 's/assets\///g'); do
+	if ! grep -cq "$i" "$MANIFESTS_FILE"; then
+		code=1
+		echo "File is not included in $MANIFESTS_FILE: $i"
+	fi
+done
+
+exit "$code"

--- a/hack/cluster-monitoring-operator-role.yaml.in
+++ b/hack/cluster-monitoring-operator-role.yaml.in
@@ -47,4 +47,4 @@ rules:
   verbs: ["get", "update", "create"]
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]
-  verbs: ["create", "get", "update"]
+  verbs: ["create", "get", "update", "delete"]

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -165,6 +165,7 @@ rules:
   - poddisruptionbudgets
   verbs:
   - create
+  - delete
   - get
   - update
 - apiGroups:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -446,6 +446,16 @@ func (c *Client) DeleteDeployment(d *appsv1.Deployment) error {
 	return err
 }
 
+func (c *Client) DeletePodDisruptionBudget(pdb *policyv1beta1.PodDisruptionBudget) error {
+	p := metav1.DeletePropagationForeground
+	err := c.kclient.PolicyV1beta1().PodDisruptionBudgets(pdb.GetNamespace()).Delete(context.TODO(), pdb.GetName(), metav1.DeleteOptions{PropagationPolicy: &p})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
+}
+
 func (c *Client) DeletePrometheus(p *monv1.Prometheus) error {
 	pclient := c.mclient.MonitoringV1().Prometheuses(p.GetNamespace())
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -51,18 +51,19 @@ const (
 )
 
 var (
-	AlertmanagerConfig             = "alertmanager/secret.yaml"
-	AlertmanagerService            = "alertmanager/service.yaml"
-	AlertmanagerProxySecret        = "alertmanager/proxy-secret.yaml"
-	AlertmanagerMain               = "alertmanager/alertmanager.yaml"
-	AlertmanagerServiceAccount     = "alertmanager/service-account.yaml"
-	AlertmanagerClusterRoleBinding = "alertmanager/cluster-role-binding.yaml"
-	AlertmanagerClusterRole        = "alertmanager/cluster-role.yaml"
-	AlertmanagerRBACProxySecret    = "alertmanager/kube-rbac-proxy-secret.yaml"
-	AlertmanagerRoute              = "alertmanager/route.yaml"
-	AlertmanagerServiceMonitor     = "alertmanager/service-monitor.yaml"
-	AlertmanagerTrustedCABundle    = "alertmanager/trusted-ca-bundle.yaml"
-	AlertmanagerPrometheusRule     = "alertmanager/prometheus-rule.yaml"
+	AlertmanagerConfig              = "alertmanager/secret.yaml"
+	AlertmanagerService             = "alertmanager/service.yaml"
+	AlertmanagerProxySecret         = "alertmanager/proxy-secret.yaml"
+	AlertmanagerMain                = "alertmanager/alertmanager.yaml"
+	AlertmanagerServiceAccount      = "alertmanager/service-account.yaml"
+	AlertmanagerClusterRoleBinding  = "alertmanager/cluster-role-binding.yaml"
+	AlertmanagerClusterRole         = "alertmanager/cluster-role.yaml"
+	AlertmanagerRBACProxySecret     = "alertmanager/kube-rbac-proxy-secret.yaml"
+	AlertmanagerRoute               = "alertmanager/route.yaml"
+	AlertmanagerServiceMonitor      = "alertmanager/service-monitor.yaml"
+	AlertmanagerTrustedCABundle     = "alertmanager/trusted-ca-bundle.yaml"
+	AlertmanagerPrometheusRule      = "alertmanager/prometheus-rule.yaml"
+	AlertmanagerPodDisruptionBudget = "alertmanager/pod-disruption-budget.yaml"
 
 	KubeStateMetricsClusterRoleBinding = "kube-state-metrics/cluster-role-binding.yaml"
 	KubeStateMetricsClusterRole        = "kube-state-metrics/cluster-role.yaml"
@@ -109,6 +110,7 @@ var (
 	PrometheusK8sGrpcTLSSecret               = "prometheus-k8s/grpc-tls-secret.yaml"
 	PrometheusK8sTrustedCABundle             = "prometheus-k8s/trusted-ca-bundle.yaml"
 	PrometheusK8sThanosSidecarServiceMonitor = "prometheus-k8s/service-monitor-thanos-sidecar.yaml"
+	PrometheusK8sPodDisruptionBudget         = "prometheus-k8s/pod-disruption-budget.yaml"
 
 	PrometheusUserWorkloadServingCertsCABundle        = "prometheus-user-workload/serving-certs-ca-bundle.yaml"
 	PrometheusUserWorkloadServiceAccount              = "prometheus-user-workload/service-account.yaml"
@@ -124,6 +126,7 @@ var (
 	PrometheusUserWorkloadPrometheusServiceMonitor    = "prometheus-user-workload/service-monitor.yaml"
 	PrometheusUserWorkloadGrpcTLSSecret               = "prometheus-user-workload/grpc-tls-secret.yaml"
 	PrometheusUserWorkloadThanosSidecarServiceMonitor = "prometheus-user-workload/service-monitor-thanos-sidecar.yaml"
+	PrometheusUserWorkloadPodDisruptionBudget         = "prometheus-user-workload/pod-disruption-budget.yaml"
 
 	PrometheusAdapterAPIService                         = "prometheus-adapter/api-service.yaml"
 	PrometheusAdapterClusterRole                        = "prometheus-adapter/cluster-role.yaml"
@@ -485,6 +488,10 @@ func (f *Factory) AlertmanagerRoute() (*routev1.Route, error) {
 
 func (f *Factory) AlertmanagerPrometheusRule() (*monv1.PrometheusRule, error) {
 	return f.NewPrometheusRule(f.assets.MustNewAssetReader(AlertmanagerPrometheusRule))
+}
+
+func (f *Factory) AlertmanagerPodDisruptionBudget() (*policyv1beta1.PodDisruptionBudget, error) {
+	return f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(AlertmanagerPodDisruptionBudget))
 }
 
 func (f *Factory) KubeStateMetricsClusterRoleBinding() (*rbacv1.ClusterRoleBinding, error) {
@@ -1449,6 +1456,14 @@ func (f *Factory) PrometheusUserWorkloadPrometheusServiceMonitor() (*monv1.Servi
 	sm.Namespace = f.namespaceUserWorkload
 
 	return sm, nil
+}
+
+func (f *Factory) PrometheusK8sPodDisruptionBudget() (*policyv1beta1.PodDisruptionBudget, error) {
+	return f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(PrometheusK8sPodDisruptionBudget))
+}
+
+func (f *Factory) PrometheusUserWorkloadPodDisruptionBudget() (*policyv1beta1.PodDisruptionBudget, error) {
+	return f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(PrometheusUserWorkloadPodDisruptionBudget))
 }
 
 func (f *Factory) PrometheusAdapterClusterRole() (*rbacv1.ClusterRole, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1700,6 +1700,48 @@ func TestPodDisruptionBudget(t *testing.T) {
 			},
 			ha: false,
 		},
+		{
+			name: "Prometheus HA",
+			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+				return f.PrometheusK8sPodDisruptionBudget()
+			},
+			ha: true,
+		},
+		{
+			name: "Prometheus non-HA",
+			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+				return f.PrometheusK8sPodDisruptionBudget()
+			},
+			ha: false,
+		},
+		{
+			name: "PrometheusUWM HA",
+			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+				return f.PrometheusUserWorkloadPodDisruptionBudget()
+			},
+			ha: true,
+		},
+		{
+			name: "PrometheusUWM non-HA",
+			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+				return f.PrometheusUserWorkloadPodDisruptionBudget()
+			},
+			ha: false,
+		},
+		{
+			name: "Alertmanager HA",
+			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+				return f.AlertmanagerPodDisruptionBudget()
+			},
+			ha: true,
+		},
+		{
+			name: "Alertmanager non-HA",
+			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+				return f.AlertmanagerPodDisruptionBudget()
+			},
+			ha: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -117,6 +117,20 @@ func (t *AlertmanagerTask) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "reconciling Alertmanager Service failed")
 	}
+
+	{
+		pdb, err := t.factory.PrometheusUserWorkloadPodDisruptionBudget()
+		if err != nil {
+			return errors.Wrap(err, "initializing Alertmanager PodDisruptionBudget object failed")
+		}
+
+		if pdb != nil {
+			err = t.client.CreateOrUpdatePodDisruptionBudget(pdb)
+			if err != nil {
+				return errors.Wrap(err, "reconciling Alertmanager PodDisruptionBudget object failed")
+			}
+		}
+	}
 	{
 		// Create trusted CA bundle ConfigMap.
 		trustedCA, err := t.factory.AlertmanagerTrustedCABundle()

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -270,6 +270,19 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "error creating Prometheus Client GRPC TLS secret")
 	}
 	{
+		pdb, err := t.factory.PrometheusK8sPodDisruptionBudget()
+		if err != nil {
+			return errors.Wrap(err, "initializing Prometheus PodDisruptionBudget object failed")
+		}
+
+		if pdb != nil {
+			err = t.client.CreateOrUpdatePodDisruptionBudget(pdb)
+			if err != nil {
+				return errors.Wrap(err, "reconciling Prometheus PodDisruptionBudget object failed")
+			}
+		}
+	}
+	{
 		// Create trusted CA bundle ConfigMap.
 		trustedCA, err := t.factory.PrometheusK8sTrustedCABundle()
 		if err != nil {

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -186,6 +186,19 @@ func (t *PrometheusUserWorkloadTask) create() error {
 	if err != nil {
 		return errors.Wrap(err, "error creating UserWorkload Prometheus Client GRPC TLS secret")
 	}
+	{
+		pdb, err := t.factory.PrometheusUserWorkloadPodDisruptionBudget()
+		if err != nil {
+			return errors.Wrap(err, "initializing UserWorkload Prometheus PodDisruptionBudget object failed")
+		}
+
+		if pdb != nil {
+			err = t.client.CreateOrUpdatePodDisruptionBudget(pdb)
+			if err != nil {
+				return errors.Wrap(err, "reconciling UserWorkload Prometheus PodDisruptionBudget object failed")
+			}
+		}
+	}
 
 	klog.V(4).Info("initializing UserWorkload Prometheus object")
 	p, err := t.factory.PrometheusUserWorkload(s)
@@ -288,6 +301,16 @@ func (t *PrometheusUserWorkloadTask) destroy() error {
 	err = t.client.DeletePrometheus(p)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus object failed")
+	}
+
+	pdb, err := t.factory.PrometheusUserWorkloadPodDisruptionBudget()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload Prometheus PodDisruptionBudget object failed")
+	}
+
+	err = t.client.DeletePodDisruptionBudget(pdb)
+	if err != nil {
+		return errors.Wrap(err, "deleting UserWorkload Prometheus PodDisruptionBudget object failed")
 	}
 
 	err = t.client.DeleteSecret(s)


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Added management of PodDisruptionBudget objects
Added a script to check if all objects in `assets/` are referenced in `pkg/manifests/manifests.go`.

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
