### PR TITLE
Bug 1958015: jsonnet: fix setting resource limits on config-reloader containers

### DIFF
--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -32,8 +32,8 @@ spec:
         - --prometheus-instance-namespaces=openshift-user-workload-monitoring
         - --alertmanager-instance-namespaces=openshift-user-workload-monitoring
         - --thanos-ruler-instance-namespaces=openshift-user-workload-monitoring
-        - --config-reloader-cpu=0
-        - --config-reloader-memory=0
+        - --config-reloader-cpu-limit=0
+        - --config-reloader-memory-limit=0
         image: quay.io/prometheus-operator/prometheus-operator:v0.47.0
         name: prometheus-operator
         ports:

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -33,8 +33,8 @@ spec:
         - --prometheus-instance-namespaces=openshift-monitoring
         - --thanos-ruler-instance-namespaces=openshift-monitoring
         - --alertmanager-instance-namespaces=openshift-monitoring
-        - --config-reloader-cpu=0
-        - --config-reloader-memory=0
+        - --config-reloader-cpu-limit=0
+        - --config-reloader-memory-limit=0
         - --web.enable-tls=true
         - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --web.tls-min-version=VersionTLS12

--- a/jsonnet/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/prometheus-operator-user-workload.libsonnet
@@ -61,8 +61,8 @@ function(params)
                         '--prometheus-instance-namespaces=' + cfg.namespace,
                         '--alertmanager-instance-namespaces=' + cfg.namespace,
                         '--thanos-ruler-instance-namespaces=' + cfg.namespace,
-                        '--config-reloader-cpu=0',
-                        '--config-reloader-memory=0',
+                        '--config-reloader-cpu-limit=0',
+                        '--config-reloader-memory-limit=0',
                       ],
                       securityContext: {},
                       resources: {

--- a/jsonnet/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator.libsonnet
@@ -31,8 +31,8 @@ function(params)
                         '--prometheus-instance-namespaces=' + cfg.namespace,
                         '--thanos-ruler-instance-namespaces=' + cfg.namespace,
                         '--alertmanager-instance-namespaces=' + cfg.namespace,
-                        '--config-reloader-cpu=0',
-                        '--config-reloader-memory=0',
+                        '--config-reloader-cpu-limit=0',
+                        '--config-reloader-memory-limit=0',
                         '--web.enable-tls=true',
                         '--web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
                         '--web.tls-min-version=VersionTLS12',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
