### PR TITLE
Bug 1955469: remove node_mountstats_nfs_* metrics

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -24,7 +24,6 @@ spec:
         - --path.rootfs=/host/root
         - --no-collector.wifi
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        - --collector.mountstats
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
         image: openshift/prometheus-node-exporter:v1.0.1

--- a/jsonnet/node-exporter.jsonnet
+++ b/jsonnet/node-exporter.jsonnet
@@ -138,7 +138,7 @@ local wtmpVolumeName = 'node-exporter-wtmp';
                         // Remove the flag to disable hwmon that is set upstream so we
                         // gather that data (especially for bare metal clusters), and
                         // add flags to collect data not included by default.
-                        args: [a for a in c.args if a != '--no-collector.hwmon'] + ['--collector.mountstats', '--collector.cpu.info', '--collector.textfile.directory=' + textfileDir],
+                        args: [a for a in c.args if a != '--no-collector.hwmon'] + ['--collector.cpu.info', '--collector.textfile.directory=' + textfileDir],
                         terminationMessagePolicy: 'FallbackToLogsOnError',
                         volumeMounts+: [{
                           mountPath: textfileDir,


### PR DESCRIPTION
The node_exporter's mountstats collector gathers low-level metrics from
NFS mountstats (such as operation timings, transport and event
statistics). When available, these metrics can have high-cardinality
(for one cluster, we've seen that it can account for half of all the
series) though they aren't used by any rule or dashboard.
    
The mountstats collector had been enabled in #409 following a customer
request for enhancement. But looking at the history, the customer was
asking for the kubelet_volume_* metrics which weren't supported by their
storage provider at this time (it's been fixed since then NetApp/trident#134). The
mountstats metrics don't fill the same need and are superfluous.

Backported from #1139

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
