### PR TITLE
[release-3.11]: Fix make generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,13 +82,19 @@ $(GOBINDATA_BIN):
 
 $(GOJSONTOYAML_BIN):
 	go get -u github.com/brancz/gojsontoyaml
+	# pin gojsontoyaml to prevent indentation changes caused by yaml.v2 conflicts
+	cd $(GOPATH)/src/github.com/brancz/gojsontoyaml && \
+		git reset --hard 3697ded27e8cfea8e547eb082ebfbde36f1b5ee6 && \
+		go build && \
+		mv gojsontoyaml $(GOJSONTOYAML_BIN)
 
 $(JB_BIN):
 	wget -O $(GOPATH)/bin/jb "https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/v0.1.0/jb-linux-amd64"
 	chmod +x $(GOPATH)/bin/jb
 
 $(JSONNET_BIN):
-	go get -u github.com/google/go-jsonnet/cmd/jsonnet
+	wget -qO- "https://github.com/google/go-jsonnet/releases/download/v0.17.0/go-jsonnet_0.17.0_Linux_x86_64.tar.gz" | tar xvz -C $(GOPATH)/bin
+	chmod +x $(GOPATH)/bin/jsonnet
 
 test-unit:
 	go test $(PKGS)


### PR DESCRIPTION
Download the bianry of go-jsonnet instead of building it as it requires
golang 1.10+ and we are only running golang 1.9 in CI.
Also pin gojsontoyaml to a particular commit to use yaml.v2 2.3.0
instead of yaml.v2 2.4.0 which provide a fix that changes the
indentation we had previously.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
