### PR TITLE
Bug 1955462: drop container_memory_failures_total metric backport

### DIFF
--- a/assets/prometheus-k8s/service-monitor-kubelet.yaml
+++ b/assets/prometheus-k8s/service-monitor-kubelet.yaml
@@ -61,6 +61,10 @@ spec:
       regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
       sourceLabels:
       - __name__
+    - action: drop
+      regex: container_memory_failures_total
+      sourceLabels:
+      - __name__
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -233,7 +233,22 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
                     caFile: '/etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt',
                     insecureSkipVerify: false,
                   },
-                },
+                }
+                +
+                if 'path' in e && e.path == '/metrics/cadvisor' then
+                // Drop cAdvisor metrics with excessive cardinality.
+                {
+                  metricRelabelings+: [
+                    {
+                      sourceLabels: ['__name__'],
+                      action: 'drop',
+                      regex: 'container_memory_failures_total',
+                    },
+                  ],
+                }
+              else
+                {}
+            ,
               super.endpoints,
             ) +
             // Collect metrics from CRI-O.

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -236,19 +236,19 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
                 }
                 +
                 if 'path' in e && e.path == '/metrics/cadvisor' then
-                // Drop cAdvisor metrics with excessive cardinality.
-                {
-                  metricRelabelings+: [
-                    {
-                      sourceLabels: ['__name__'],
-                      action: 'drop',
-                      regex: 'container_memory_failures_total',
-                    },
-                  ],
-                }
-              else
-                {}
-            ,
+                  // Drop cAdvisor metrics with excessive cardinality.
+                  {
+                    metricRelabelings+: [
+                      {
+                        sourceLabels: ['__name__'],
+                        action: 'drop',
+                        regex: 'container_memory_failures_total',
+                      },
+                    ],
+                  }
+                else
+                  {}
+              ,
               super.endpoints,
             ) +
             // Collect metrics from CRI-O.


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

The container_memory_failures_total metric isn't used anywhere and it generates at least 4 series per container.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
