### PR TITLE
Bug 1960767: Protect Grafana metrics endpoint

### DIFF
--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -107,7 +107,6 @@ spec:
         - -openshift-service-account=grafana
         - -openshift-ca=/etc/pki/tls/cert.pem
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        - -skip-auth-regex=^/metrics
         env:
         - name: HTTP_PROXY
           value: ""

--- a/jsonnet/grafana.libsonnet
+++ b/jsonnet/grafana.libsonnet
@@ -205,7 +205,6 @@ function(params)
                   '-openshift-service-account=grafana',
                   '-openshift-ca=/etc/pki/tls/cert.pem',
                   '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-                  '-skip-auth-regex=^/metrics',
                 ],
                 env: [
                   { name: 'HTTP_PROXY', value: '' },


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Before this PR, `/metrics` endpoint of Grafana deployment is not protected and anyone can see the live prometheus metrics. Though it is not a super critical security bug, it is good to protect it from unauthorised access.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
