### PR TITLE
Bug 1959278: Remove obsolete user-workload ServiceMonitor

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -140,6 +140,10 @@ func (c *Client) Namespace() string {
 	return c.namespace
 }
 
+func (c *Client) UserWorkloadNamespace() string {
+	return c.userWorkloadNamespace
+}
+
 func (c *Client) ConfigMapListWatchForNamespace(ns string) *cache.ListWatch {
 	return cache.NewListWatchFromClient(c.kclient.CoreV1().RESTClient(), "configmaps", ns, fields.Everything())
 }


### PR DESCRIPTION
The ServiceMonitor for the user-workload Prometheus instance was
renamed from `prometheus` to `prometheus-user-workload` in #1044.  The
old ServiceMonitor should be removed now.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1959278

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
