### PR TITLE
Bug 1957190: use NamespaceSelector instead of explicit allow/deny list

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -175,17 +175,23 @@ spec:
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.26.0
-  podMonitorNamespaceSelector: {}
+  podMonitorNamespaceSelector:
+    matchLabels:
+      openshift.io/cluster-monitoring: "true"
   podMonitorSelector: {}
   priorityClassName: system-cluster-critical
-  probeNamespaceSelector: {}
+  probeNamespaceSelector:
+    matchLabels:
+      openshift.io/cluster-monitoring: "true"
   probeSelector: {}
   replicas: 2
   resources:
     requests:
       cpu: 70m
       memory: 1Gi
-  ruleNamespaceSelector: {}
+  ruleNamespaceSelector:
+    matchLabels:
+      openshift.io/cluster-monitoring: "true"
   ruleSelector: {}
   secrets:
   - kube-etcd-client-certs
@@ -199,7 +205,9 @@ spec:
     runAsNonRoot: true
     runAsUser: 65534
   serviceAccountName: prometheus-k8s
-  serviceMonitorNamespaceSelector: {}
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      openshift.io/cluster-monitoring: "true"
   serviceMonitorSelector: {}
   thanos:
     image: quay.io/thanos/thanos:v0.19.0

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -28,7 +28,6 @@ spec:
       containers:
       - args:
         - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.47.1
-        - --deny-namespaces=openshift-monitoring
         - --prometheus-instance-namespaces=openshift-user-workload-monitoring
         - --alertmanager-instance-namespaces=openshift-user-workload-monitoring
         - --thanos-ruler-instance-namespaces=openshift-user-workload-monitoring

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -29,7 +29,6 @@ spec:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.47.1
-        - --namespaces=openshift-monitoring
         - --prometheus-instance-namespaces=openshift-monitoring
         - --thanos-ruler-instance-namespaces=openshift-monitoring
         - --alertmanager-instance-namespaces=openshift-monitoring

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -123,17 +123,32 @@ spec:
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.26.0
-  podMonitorNamespaceSelector: {}
+  podMonitorNamespaceSelector:
+    matchExpressions:
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values:
+      - "true"
   podMonitorSelector: {}
   priorityClassName: openshift-user-critical
-  probeNamespaceSelector: {}
+  probeNamespaceSelector:
+    matchExpressions:
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values:
+      - "true"
   probeSelector: {}
   replicas: 2
   resources:
     requests:
       cpu: 6m
       memory: 30Mi
-  ruleNamespaceSelector: {}
+  ruleNamespaceSelector:
+    matchExpressions:
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values:
+      - "true"
   ruleSelector:
     matchLabels:
       openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
@@ -145,7 +160,12 @@ spec:
     runAsNonRoot: true
     runAsUser: 65534
   serviceAccountName: prometheus-user-workload
-  serviceMonitorNamespaceSelector: {}
+  serviceMonitorNamespaceSelector:
+    matchExpressions:
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values:
+      - "true"
   serviceMonitorSelector: {}
   thanos:
     image: quay.io/thanos/thanos:v0.19.0

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -81,7 +81,12 @@ spec:
     requests:
       cpu: 1m
       memory: 21Mi
-  ruleNamespaceSelector: {}
+  ruleNamespaceSelector:
+    matchExpressions:
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values:
+      - "true"
   ruleSelector:
     matchExpressions:
     - key: openshift.io/prometheus-rule-evaluation-scope

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -88,7 +88,6 @@ func Main() int {
 	klog.InitFlags(flagset)
 	namespace := flagset.String("namespace", "openshift-monitoring", "Namespace to deploy and manage cluster monitoring stack in.")
 	namespaceUserWorkload := flagset.String("namespace-user-workload", "openshift-user-workload-monitoring", "Namespace to deploy and manage user workload monitoring stack in.")
-	namespaceSelector := flagset.String("namespace-selector", "openshift.io/cluster-monitoring=true", "Selector for namespaces to monitor.")
 	configMapName := flagset.String("configmap", "cluster-monitoring-config", "ConfigMap name to configure the cluster monitoring stack.")
 	kubeconfigPath := flagset.String("kubeconfig", "", "The path to the kubeconfig to connect to the apiserver with.")
 	apiserver := flagset.String("apiserver", "", "The address of the apiserver to talk to.")
@@ -177,7 +176,6 @@ func Main() int {
 		*releaseVersion,
 		*namespace,
 		*namespaceUserWorkload,
-		*namespaceSelector,
 		*configMapName,
 		userWorkloadConfigMapName,
 		*remoteWrite,

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -34,6 +34,20 @@ TODO(paulfantom):
 local commonConfig = {
   namespace: 'openshift-monitoring',
   namespaceUserWorkload: 'openshift-user-workload-monitoring',
+  clusterMonitoringNamespaceSelector: {
+    matchLabels: {
+      'openshift.io/cluster-monitoring': 'true',
+    },
+  },
+  userWorkloadMonitoringNamespaceSelector: {
+    matchExpressions: [
+      {
+        key: 'openshift.io/cluster-monitoring',
+        operator: 'NotIn',
+        values: ['true'],
+      },
+    ],
+  },
   prometheusName: 'k8s',
   ruleLabels: {
     role: 'alert-rules',
@@ -219,6 +233,7 @@ local inCluster =
           'openshift-etcd',
           $.values.common.namespaceUserWorkload,
         ],
+        namespaceSelector: $.values.common.clusterMonitoringNamespaceSelector,
         mixin+: {
           ruleLabels: $.values.common.ruleLabels,
           _config+: {
@@ -274,6 +289,7 @@ local inCluster =
           web: 9091,
           grpc: 10901,
         },
+        namespaceSelector: $.values.common.userWorkloadMonitoringNamespaceSelector,
       },
       thanosQuerier: $.values.thanos {
         name: 'thanos-querier',
@@ -343,6 +359,7 @@ local userWorkload =
           requests: { memory: '30Mi', cpu: '6m' },
         },
         namespaces: [$.values.common.namespaceUserWorkload],
+        namespaceSelector: $.values.common.userWorkloadMonitoringNamespaceSelector,
         mixin+: {
           ruleLabels: $.values.common.ruleLabels,
           _config+: {

--- a/jsonnet/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/prometheus-operator-user-workload.libsonnet
@@ -57,7 +57,6 @@ function(params)
                         function(arg) !std.startsWith(arg, '--kubelet-service'),
                         super.args,
                       ) + [
-                        '--deny-namespaces=' + cfg.denyNamespace,
                         '--prometheus-instance-namespaces=' + cfg.namespace,
                         '--alertmanager-instance-namespaces=' + cfg.namespace,
                         '--thanos-ruler-instance-namespaces=' + cfg.namespace,

--- a/jsonnet/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator.libsonnet
@@ -27,7 +27,6 @@ function(params)
                   if c.name == 'prometheus-operator' then
                     c {
                       args+: [
-                        '--namespaces=' + cfg.namespace,
                         '--prometheus-instance-namespaces=' + cfg.namespace,
                         '--thanos-ruler-instance-namespaces=' + cfg.namespace,
                         '--alertmanager-instance-namespaces=' + cfg.namespace,

--- a/jsonnet/prometheus-user-workload.libsonnet
+++ b/jsonnet/prometheus-user-workload.libsonnet
@@ -219,9 +219,11 @@ function(params)
           'prometheus-user-workload-thanos-sidecar-tls',
         ],
         configMaps: ['serving-certs-ca-bundle'],
+        probeNamespaceSelector: cfg.namespaceSelector,
+        podMonitorNamespaceSelector: cfg.namespaceSelector,
         serviceMonitorSelector: {},
-        serviceMonitorNamespaceSelector: {},
-        ruleNamespaceSelector: {},
+        serviceMonitorNamespaceSelector: cfg.namespaceSelector,
+        ruleNamespaceSelector: cfg.namespaceSelector,
         listenLocal: true,
         priorityClassName: 'openshift-user-critical',
         containers: [

--- a/jsonnet/prometheus.libsonnet
+++ b/jsonnet/prometheus.libsonnet
@@ -6,7 +6,6 @@ function(params)
   local cfg = params;
 
   prometheus(cfg) + {
-
     trustedCaBundle: {
       apiVersion: 'v1',
       kind: 'ConfigMap',
@@ -56,6 +55,7 @@ function(params)
         },
       },
     },
+
 
     // The ServiceAccount needs this annotation, to signify the identity
     // provider, that when a users it doing the oauth flow through the
@@ -309,10 +309,12 @@ function(params)
           'kube-rbac-proxy',
         ],
         configMaps: ['serving-certs-ca-bundle', 'kubelet-serving-ca-bundle'],
+        probeNamespaceSelector: cfg.namespaceSelector,
+        podMonitorNamespaceSelector: cfg.namespaceSelector,
         serviceMonitorSelector: {},
-        serviceMonitorNamespaceSelector: {},
+        serviceMonitorNamespaceSelector: cfg.namespaceSelector,
         ruleSelector: {},
-        ruleNamespaceSelector: {},
+        ruleNamespaceSelector: cfg.namespaceSelector,
         listenLocal: true,
         priorityClassName: 'system-cluster-critical',
         containers: [

--- a/jsonnet/thanos-ruler.libsonnet
+++ b/jsonnet/thanos-ruler.libsonnet
@@ -343,7 +343,7 @@ function(params) {
             },
           ],
       },
-      ruleNamespaceSelector: {},
+      ruleNamespaceSelector: cfg.namespaceSelector,
       volumes: [
         {
           name: 'serving-certs-ca-bundle',

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -66,7 +66,6 @@ type Client struct {
 	version               string
 	namespace             string
 	userWorkloadNamespace string
-	namespaceSelector     string
 	kclient               kubernetes.Interface
 	oscclient             openshiftconfigclientset.Interface
 	ossclient             openshiftsecurityclientset.Interface
@@ -76,7 +75,7 @@ type Client struct {
 	aggclient             aggregatorclient.Interface
 }
 
-func New(cfg *rest.Config, version string, namespace, userWorkloadNamespace string, namespaceSelector string) (*Client, error) {
+func New(cfg *rest.Config, version string, namespace, userWorkloadNamespace string) (*Client, error) {
 	mclient, err := monitoring.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -121,7 +120,6 @@ func New(cfg *rest.Config, version string, namespace, userWorkloadNamespace stri
 		version:               version,
 		namespace:             namespace,
 		userWorkloadNamespace: userWorkloadNamespace,
-		namespaceSelector:     namespaceSelector,
 		kclient:               kclient,
 		oscclient:             oscclient,
 		ossclient:             ossclient,
@@ -280,22 +278,6 @@ func (c *Client) GetConfigmap(namespace, name string) (*v1.ConfigMap, error) {
 
 func (c *Client) GetSecret(namespace, name string) (*v1.Secret, error) {
 	return c.kclient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-}
-
-func (c *Client) NamespacesToMonitor() ([]string, error) {
-	namespaces, err := c.kclient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: c.namespaceSelector,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "listing namespaces failed")
-	}
-
-	namespaceNames := make([]string, len(namespaces.Items))
-	for i, namespace := range namespaces.Items {
-		namespaceNames[i] = namespace.Name
-	}
-
-	return namespaceNames, nil
 }
 
 func (c *Client) CreateOrUpdatePrometheus(p *monv1.Prometheus) error {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -236,8 +236,6 @@ var (
 
 var (
 	PrometheusConfigReloaderFlag                         = "--prometheus-config-reloader="
-	PrometheusOperatorNamespaceFlag                      = "--namespaces="
-	PrometheusOperatorDenyNamespaceFlag                  = "--deny-namespaces="
 	PrometheusOperatorPrometheusInstanceNamespacesFlag   = "--prometheus-instance-namespaces="
 	PrometheusOperatorAlertmanagerInstanceNamespacesFlag = "--alertmanager-instance-namespaces="
 
@@ -1799,7 +1797,7 @@ func (f *Factory) PrometheusOperatorUserWorkloadServiceAccount() (*v1.ServiceAcc
 	return s, nil
 }
 
-func (f *Factory) PrometheusOperatorDeployment(namespaces []string) (*appsv1.Deployment, error) {
+func (f *Factory) PrometheusOperatorDeployment() (*appsv1.Deployment, error) {
 	d, err := f.NewDeployment(f.assets.MustNewAssetReader(PrometheusOperatorDeployment))
 	if err != nil {
 		return nil, err
@@ -1823,10 +1821,6 @@ func (f *Factory) PrometheusOperatorDeployment(namespaces []string) (*appsv1.Dep
 
 			args := d.Spec.Template.Spec.Containers[i].Args
 			for i := range args {
-				if strings.HasPrefix(args[i], PrometheusOperatorNamespaceFlag) && len(namespaces) > 0 {
-					args[i] = PrometheusOperatorNamespaceFlag + strings.Join(namespaces, ",")
-				}
-
 				if strings.HasPrefix(args[i], PrometheusConfigReloaderFlag) && f.config.Images.PrometheusConfigReloader != "" {
 					args[i] = PrometheusConfigReloaderFlag + f.config.Images.PrometheusConfigReloader
 				}
@@ -1850,7 +1844,7 @@ func (f *Factory) PrometheusOperatorDeployment(namespaces []string) (*appsv1.Dep
 	return d, nil
 }
 
-func (f *Factory) PrometheusOperatorUserWorkloadDeployment(denyNamespaces []string) (*appsv1.Deployment, error) {
+func (f *Factory) PrometheusOperatorUserWorkloadDeployment() (*appsv1.Deployment, error) {
 	d, err := f.NewDeployment(f.assets.MustNewAssetReader(PrometheusOperatorUserWorkloadDeployment))
 	if err != nil {
 		return nil, err
@@ -1873,10 +1867,6 @@ func (f *Factory) PrometheusOperatorUserWorkloadDeployment(denyNamespaces []stri
 
 			args := d.Spec.Template.Spec.Containers[i].Args
 			for i := range args {
-				if strings.HasPrefix(args[i], PrometheusOperatorDenyNamespaceFlag) {
-					args[i] = PrometheusOperatorDenyNamespaceFlag + strings.Join(denyNamespaces, ",")
-				}
-
 				if strings.HasPrefix(args[i], PrometheusConfigReloaderFlag) {
 					args[i] = PrometheusConfigReloaderFlag + f.config.Images.PrometheusConfigReloader
 				}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -566,7 +566,7 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.PrometheusOperatorDeployment([]string{"default", "openshift-monitoring"})
+	_, err = f.PrometheusOperatorDeployment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -740,7 +740,7 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 	}
 
 	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath))
-	d, err := f.PrometheusOperatorDeployment([]string{"default", "openshift-monitoring"})
+	d, err := f.PrometheusOperatorDeployment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -760,22 +760,14 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 	}
 
 	prometheusReloaderFound := false
-	namespacesFound := false
 	for i := range d.Spec.Template.Spec.Containers[0].Args {
 		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusConfigReloaderFlag+"docker.io/openshift/origin-prometheus-config-reloader:latest") {
 			prometheusReloaderFound = true
-		}
-		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusOperatorNamespaceFlag+"default,openshift-monitoring") {
-			namespacesFound = true
 		}
 	}
 
 	if !prometheusReloaderFound {
 		t.Fatal("Configuring the Prometheus Config reloader image failed")
-	}
-
-	if !namespacesFound {
-		t.Fatal("Configuring the namespaces to watch failed")
 	}
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -150,13 +150,13 @@ type Operator struct {
 
 func New(
 	config *rest.Config,
-	version, namespace, namespaceUserWorkload, namespaceSelector, configMapName, userWorkloadConfigMapName string,
+	version, namespace, namespaceUserWorkload, configMapName, userWorkloadConfigMapName string,
 	remoteWrite bool,
 	images map[string]string,
 	telemetryMatches []string,
 	a *manifests.Assets,
 ) (*Operator, error) {
-	c, err := client.New(config, version, namespace, namespaceUserWorkload, namespaceSelector)
+	c, err := client.New(config, version, namespace, namespaceUserWorkload)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tasks/prometheusoperator.go
+++ b/pkg/tasks/prometheusoperator.go
@@ -83,12 +83,7 @@ func (t *PrometheusOperatorTask) Run() error {
 		return errors.Wrap(err, "reconciling Prometheus Operator Service failed")
 	}
 
-	clusterNamespaces, err := t.client.NamespacesToMonitor()
-	if err != nil {
-		return errors.Wrap(err, "listing namespaces to monitor failed")
-	}
-
-	d, err := t.factory.PrometheusOperatorDeployment(clusterNamespaces)
+	d, err := t.factory.PrometheusOperatorDeployment()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus Operator Deployment failed")
 	}

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -84,12 +84,7 @@ func (t *PrometheusOperatorUserWorkloadTask) create() error {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator Service failed")
 	}
 
-	denyNamespaces, err := t.client.NamespacesToMonitor()
-	if err != nil {
-		return errors.Wrap(err, "initializing UserWorkload denied namespaces list failed")
-	}
-
-	d, err := t.factory.PrometheusOperatorUserWorkloadDeployment(denyNamespaces)
+	d, err := t.factory.PrometheusOperatorUserWorkloadDeployment()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator Deployment failed")
 	}
@@ -116,7 +111,7 @@ func (t *PrometheusOperatorUserWorkloadTask) create() error {
 }
 
 func (t *PrometheusOperatorUserWorkloadTask) destroy() error {
-	dep, err := t.factory.PrometheusOperatorUserWorkloadDeployment(nil)
+	dep, err := t.factory.PrometheusOperatorUserWorkloadDeployment()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator Deployment failed")
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -90,7 +90,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		return nil, nil, errors.Wrap(err, "creating monitoring client failed")
 	}
 
-	operatorClient, err := client.New(config, "", namespaceName, userWorkloadNamespaceName, "")
+	operatorClient, err := client.New(config, "", namespaceName, userWorkloadNamespaceName)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating operator client failed")
 	}


### PR DESCRIPTION
Instead of the `--namespaces` and `deny-namespaces` flags to specify
which namespaces the Prometheus operator should watch/not watch, we
configure the Prometheus resources with the proper namespace selectors.
In practice, the Prometheus `k8s` resource looks for all namespaces with
the `openshift.io/cluster-monitoring=true` label and The Prometheus
`user-workload` resource for all namespaces without the
`openshift.io/cluster-monitoring=true` label.
    
The goal is to decrease the number of listers/watchers that the operator
needs to maintain which should reduce the load on the API server.
Concretely with the `--namespaces` flag, the operator would create
40 listers/watchers (1 per namespace) per watched object type (secret,
prometheus, statefulset, ...). With namespace selectors, the
operator needs only 1 lister/watcher per object type.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
