### PR TITLE
Bug 1950290: remove KubeClientCertificateExpiration alert rule

### DIFF
--- a/assets/prometheus-k8s/rules.yaml
+++ b/assets/prometheus-k8s/rules.yaml
@@ -1823,24 +1823,6 @@ spec:
         short: 6h
   - name: kubernetes-system-apiserver
     rules:
-    - alert: KubeClientCertificateExpiration
-      annotations:
-        description: A client certificate used to authenticate to the apiserver is
-          expiring in less than 1.5 hours.
-        summary: Client certificate is about to expire.
-      expr: |
-        apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 5400
-      labels:
-        severity: warning
-    - alert: KubeClientCertificateExpiration
-      annotations:
-        description: A client certificate used to authenticate to the apiserver is
-          expiring in less than 1.0 hours.
-        summary: Client certificate is about to expire.
-      expr: |
-        apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 3600
-      labels:
-        severity: critical
     - alert: AggregatedAPIErrors
       annotations:
         description: An aggregated API {{ $labels.name }}/{{ $labels.namespace }}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -43,6 +43,11 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
                      // Removing CPUThrottlingHigh alert as per https://bugzilla.redhat.com/show_bug.cgi?id=1843346
                      else if ruleGroup.name == 'kubernetes-resources' then
                        ruleGroup { rules: std.filter(function(rule) !('alert' in rule && rule.alert == 'CPUThrottlingHigh'), ruleGroup.rules) }
+                     else if ruleGroup.name == 'kubernetes-system-apiserver' then
+                       // KubeClientCertificateExpiration alert isn't
+                       // actionable because the cluster admin has no way to
+                       // prevent a client from using an expird certificate.
+                       ruleGroup { rules: std.filter(function(rule) !('alert' in rule && (rule.alert == 'KubeClientCertificateExpiration')), ruleGroup.rules) }
                      else if ruleGroup.name == 'kubernetes-system-kubelet' then
                        ruleGroup { rules: std.filter(function(rule) !('alert' in rule && (rule.alert == 'KubeletClientCertificateExpiration' || rule.alert == 'KubeletServerCertificateExpiration')), ruleGroup.rules) }
                      else if ruleGroup.name == 'prometheus' then


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->
This PR is a partial backport of https://github.com/openshift/cluster-monitoring-operator/pull/1044 to remove unactionable KubeClientCertificateExpiration alert.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
