### PR TITLE
Bug 1962261: further adjust memory usage

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -79,7 +79,7 @@ spec:
     resources:
       requests:
         cpu: 1m
-        memory: 20Mi
+        memory: 15Mi
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /etc/kube-rbac-proxy
@@ -119,7 +119,7 @@ spec:
   resources:
     requests:
       cpu: 4m
-      memory: 48Mi
+      memory: 40Mi
   secrets:
   - alertmanager-main-tls
   - alertmanager-main-proxy

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           requests:
             cpu: 2m
-            memory: 40Mi
+            memory: 80Mi
         securityContext: {}
         volumeMounts:
         - mountPath: /tmp
@@ -73,7 +73,7 @@ spec:
         resources:
           requests:
             cpu: 1m
-            memory: 40Mi
+            memory: 15Mi
         securityContext: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -95,7 +95,7 @@ spec:
         resources:
           requests:
             cpu: 1m
-            memory: 40Mi
+            memory: 15Mi
         securityContext: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -76,7 +76,7 @@ spec:
         resources:
           requests:
             cpu: 1m
-            memory: 30Mi
+            memory: 15Mi
         securityContext:
           runAsGroup: 65532
           runAsNonRoot: true

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -54,7 +54,7 @@ spec:
         resources:
           requests:
             cpu: 1m
-            memory: 25Mi
+            memory: 40Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -95,7 +95,7 @@ spec:
     resources:
       requests:
         cpu: 1m
-        memory: 20Mi
+        memory: 15Mi
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /etc/tls/private
@@ -111,7 +111,7 @@ spec:
     resources:
       requests:
         cpu: 1m
-        memory: 20Mi
+        memory: 15Mi
     terminationMessagePolicy: FallbackToLogsOnError
   - args:
     - --secure-listen-address=[$(POD_IP)]:10902
@@ -152,6 +152,7 @@ spec:
     resources:
       requests:
         cpu: 1m
+        memory: 25Mi
     volumeMounts:
     - mountPath: /etc/tls/grpc
       name: secret-grpc-tls

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         resources:
           requests:
             cpu: 5m
-            memory: 60Mi
+            memory: 150Mi
         securityContext: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -69,7 +69,7 @@ spec:
         resources:
           requests:
             cpu: 1m
-            memory: 40Mi
+            memory: 15Mi
         securityContext: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -140,7 +140,7 @@ spec:
         resources:
           requests:
             cpu: 1m
-            memory: 20Mi
+            memory: 15Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
@@ -156,7 +156,7 @@ spec:
         resources:
           requests:
             cpu: 1m
-            memory: 20Mi
+            memory: 15Mi
         terminationMessagePolicy: FallbackToLogsOnError
       - args:
         - --secure-listen-address=0.0.0.0:9093
@@ -175,7 +175,7 @@ spec:
         resources:
           requests:
             cpu: 1m
-            memory: 20Mi
+            memory: 15Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private

--- a/jsonnet/alertmanager.libsonnet
+++ b/jsonnet/alertmanager.libsonnet
@@ -221,7 +221,7 @@ function(params)
         resources: {
           requests: {
             cpu: '4m',
-            memory: '48Mi',
+            memory: '40Mi',
           },
         },
         containers: [
@@ -289,7 +289,7 @@ function(params)
             resources: {
               requests: {
                 cpu: '1m',
-                memory: '20Mi',
+                memory: '15Mi',
               },
             },
             ports: [

--- a/jsonnet/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics.libsonnet
@@ -101,7 +101,7 @@ function(params)
                       securityContext: {},
                       resources: {
                         requests: {
-                          memory: '40Mi',
+                          memory: '15Mi',
                           cpu: '1m',
                         },
                       },
@@ -115,7 +115,7 @@ function(params)
                       securityContext: {},
                       resources: {
                         requests: {
-                          memory: '40Mi',
+                          memory: '80Mi',
                           cpu: '2m',
                         },
                       },

--- a/jsonnet/node-exporter.libsonnet
+++ b/jsonnet/node-exporter.libsonnet
@@ -127,7 +127,7 @@ function(params)
                       }],
                       resources: {
                         requests: {
-                          memory: '30Mi',
+                          memory: '15Mi',
                           cpu: '1m',
                         },
                       },

--- a/jsonnet/prometheus-adapter.libsonnet
+++ b/jsonnet/prometheus-adapter.libsonnet
@@ -120,7 +120,7 @@ function(params)
                         ],
                         resources: {
                           requests: {
-                            memory: '25Mi',
+                            memory: '40Mi',
                             cpu: '1m',
                           },
                         },

--- a/jsonnet/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator.libsonnet
@@ -40,7 +40,7 @@ function(params)
                       securityContext: {},
                       resources: {
                         requests: {
-                          memory: '60Mi',
+                          memory: '150Mi',
                           cpu: '5m',
                         },
                       },
@@ -78,7 +78,7 @@ function(params)
                       securityContext: {},
                       resources: {
                         requests: {
-                          memory: '40Mi',
+                          memory: '15Mi',
                           cpu: '1m',
                         },
                       },

--- a/jsonnet/prometheus.libsonnet
+++ b/jsonnet/prometheus.libsonnet
@@ -384,7 +384,7 @@ function(params)
             image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
             resources: {
               requests: {
-                memory: '20Mi',
+                memory: '15Mi',
                 cpu: '1m',
               },
             },
@@ -426,7 +426,7 @@ function(params)
             ],
             resources: {
               requests: {
-                memory: '20Mi',
+                memory: '15Mi',
                 cpu: '1m',
               },
             },
@@ -493,6 +493,7 @@ function(params)
             resources: {
               requests: {
                 cpu: '1m',
+                memory: '25Mi',
               },
             },
           },

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -428,7 +428,7 @@ function(params)
                 image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
                 resources: {
                   requests: {
-                    memory: '20Mi',
+                    memory: '15Mi',
                     cpu: '1m',
                   },
                 },
@@ -470,7 +470,7 @@ function(params)
                 ],
                 resources: {
                   requests: {
-                    memory: '20Mi',
+                    memory: '15Mi',
                     cpu: '1m',
                   },
                 },
@@ -481,7 +481,7 @@ function(params)
                 image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
                 resources: {
                   requests: {
-                    memory: '20Mi',
+                    memory: '15Mi',
                     cpu: '1m',
                   },
                 },

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -71,7 +71,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 50Mi
+            memory: 75Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cluster-monitoring-operator/telemetry

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -100,7 +100,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 50Mi
+            memory: 75Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cluster-monitoring-operator/telemetry


### PR DESCRIPTION
This PR is a follow up of https://github.com/openshift/cluster-monitoring-operator/pull/1158 and further adjusts memory requests for monitoring components.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.