### PR TITLE
Bug 1955478: fix regex patterns in kube-state-metrics deny list

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -36,8 +36,8 @@ spec:
         - --metric-labels-allowlist=pods=[*],node=[*]
         - |
           --metric-denylist=
-          kube_*_created,
-          kube_*_metadata_resource_version,
+          kube_.+_created,
+          kube_.+_metadata_resource_version,
           kube_replicaset_metadata_generation,
           kube_replicaset_status_observed_generation,
           kube_pod_restart_policy,

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -131,8 +131,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "bc9892e53e03506f0d26ff4497acaf8487a5f323",
-      "sum": "DjoZyKWXEcHZStbRuxhJqlPm3K/jvh/fbwjw/bJKqOk="
+      "version": "2c34d3dff64b7c9a4c158149d6554b0ad9a0e144",
+      "sum": "mG7Jfa33upviONZuXZsQqW3iegVP5CF+U3KFH/HqKUw="
     },
     {
       "source": {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
