### PR TITLE
Bug 1962172: increase scrape timeouts for kubelet endpoints

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -50,6 +50,7 @@ spec:
       - __metrics_path__
       targetLabel: metrics_path
     scheme: https
+    scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
       insecureSkipVerify: false
@@ -73,6 +74,7 @@ spec:
       - __metrics_path__
       targetLabel: metrics_path
     scheme: https
+    scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
       insecureSkipVerify: false
@@ -86,6 +88,7 @@ spec:
       - __metrics_path__
       targetLabel: metrics_path
     scheme: https
+    scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
       insecureSkipVerify: false

--- a/jsonnet/control-plane.libsonnet
+++ b/jsonnet/control-plane.libsonnet
@@ -84,6 +84,12 @@ function(params)
                   caFile: '/etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt',
                   insecureSkipVerify: false,
                 },
+              } +
+              {
+                // Increase the scrape timeout to match the scrape interval
+                // because the kubelet metric endpoints might take more than the default
+                // 10 seconds to reply.
+                scrapeTimeout: '30s',
               }
               +
               if 'path' in e && e.path == '/metrics/cadvisor' then


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
