### PR TITLE
Bug 1963833: don't attempt to delete nil PodDisruptionBudget object

### DIFF
--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -308,9 +308,11 @@ func (t *PrometheusUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus PodDisruptionBudget object failed")
 	}
 
-	err = t.client.DeletePodDisruptionBudget(pdb)
-	if err != nil {
-		return errors.Wrap(err, "deleting UserWorkload Prometheus PodDisruptionBudget object failed")
+	if pdb != nil {
+		err = t.client.DeletePodDisruptionBudget(pdb)
+		if err != nil {
+			return errors.Wrap(err, "deleting UserWorkload Prometheus PodDisruptionBudget object failed")
+		}
 	}
 
 	err = t.client.DeleteSecret(s)


### PR DESCRIPTION
`NewPodDisruptionBudget` may return nil PodDisruptionBudget when `!f.infrastructure.HighlyAvailableInfrastructure()`:

https://github.com/openshift/cluster-monitoring-operator/blob/cddf199b164c64b365867cdcc449e6c75825337a/pkg/manifests/manifests.go#L2430-L2432

this would cause a segfault later when `DeletePodDisruptionBudget` was
called with that nil `PodDisruptionBudget`, causing Single Node clusters
to fail to install.


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.