### PR TITLE
Bug 1961081: update PodDisruptionBudget api version to policy/v1

### DIFF
--- a/assets/alertmanager/pod-disruption-budget.yaml
+++ b/assets/alertmanager/pod-disruption-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/assets/prometheus-adapter/pod-disruption-budget.yaml
+++ b/assets/prometheus-adapter/pod-disruption-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/assets/prometheus-k8s/pod-disruption-budget.yaml
+++ b/assets/prometheus-k8s/pod-disruption-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/assets/prometheus-user-workload/pod-disruption-budget.yaml
+++ b/assets/prometheus-user-workload/pod-disruption-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/jsonnet/alertmanager.libsonnet
+++ b/jsonnet/alertmanager.libsonnet
@@ -348,4 +348,7 @@ function(params)
         ],
       },
     },
+    podDisruptionBudget+: {
+      apiVersion: 'policy/v1',
+    },
   }

--- a/jsonnet/prometheus-adapter.libsonnet
+++ b/jsonnet/prometheus-adapter.libsonnet
@@ -212,4 +212,7 @@ function(params)
         ],
       },
     },
+    podDisruptionBudget+: {
+      apiVersion: 'policy/v1',
+    },
   }

--- a/jsonnet/prometheus-user-workload.libsonnet
+++ b/jsonnet/prometheus-user-workload.libsonnet
@@ -333,4 +333,8 @@ function(params)
         ],
       },
     },
+    podDisruptionBudget+: {
+      apiVersion: 'policy/v1',
+    },
+
   }

--- a/jsonnet/prometheus.libsonnet
+++ b/jsonnet/prometheus.libsonnet
@@ -512,4 +512,7 @@ function(params)
         ],
       },
     },
+    podDisruptionBudget+: {
+      apiVersion: 'policy/v1',
+    },
   }


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
