### PR TITLE
Bug 1964334: guard monitoring related /metrics endpoint from unauthorised access

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -39,7 +39,6 @@ spec:
     - -openshift-service-account=alertmanager-main
     - -openshift-ca=/etc/pki/tls/cert.pem
     - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    - -skip-auth-regex=^/metrics
     env:
     - name: HTTP_PROXY
       value: ""

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -53,7 +53,6 @@ spec:
     - -cookie-secret-file=/etc/proxy/secrets/session_secret
     - -openshift-ca=/etc/pki/tls/cert.pem
     - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    - -skip-auth-regex=^/metrics
     env:
     - name: HTTP_PROXY
       value: ""

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -98,7 +98,6 @@ spec:
         - -cookie-secret-file=/etc/proxy/secrets/session_secret
         - -openshift-ca=/etc/pki/tls/cert.pem
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        - -skip-auth-regex=^/metrics
         env:
         - name: HTTP_PROXY
           value: ""

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -34,7 +34,6 @@ spec:
     - -openshift-service-account=thanos-ruler
     - -openshift-ca=/etc/pki/tls/cert.pem
     - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    - -skip-auth-regex=^/metrics
     env:
     - name: HTTP_PROXY
       value: ""

--- a/jsonnet/alertmanager.libsonnet
+++ b/jsonnet/alertmanager.libsonnet
@@ -263,7 +263,6 @@ function(params)
               '-openshift-service-account=alertmanager-main',
               '-openshift-ca=/etc/pki/tls/cert.pem',
               '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-              '-skip-auth-regex=^/metrics',
             ],
             terminationMessagePolicy: 'FallbackToLogsOnError',
             resources: {

--- a/jsonnet/prometheus.libsonnet
+++ b/jsonnet/prometheus.libsonnet
@@ -361,7 +361,6 @@ function(params)
               '-cookie-secret-file=/etc/proxy/secrets/session_secret',
               '-openshift-ca=/etc/pki/tls/cert.pem',
               '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-              '-skip-auth-regex=^/metrics',
             ],
             terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -405,7 +405,6 @@ function(params)
                   '-cookie-secret-file=/etc/proxy/secrets/session_secret',
                   '-openshift-ca=/etc/pki/tls/cert.pem',
                   '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-                  '-skip-auth-regex=^/metrics',
                 ],
                 terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [

--- a/jsonnet/thanos-ruler.libsonnet
+++ b/jsonnet/thanos-ruler.libsonnet
@@ -418,7 +418,6 @@ function(params) {
             '-openshift-service-account=thanos-ruler',
             '-openshift-ca=/etc/pki/tls/cert.pem',
             '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-            '-skip-auth-regex=^/metrics',
           ],
           terminationMessagePolicy: 'FallbackToLogsOnError',
           resources: {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Currently the /metrics endpoint of alertmanager/prometheus/thanos-querier are accessible without any authentication. This must be fixed to avoid any leakage of any sensitive metrics details.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
