### PR TITLE
Bug 1961081: update pdb apiversion to v1

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -39,7 +39,7 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extensionsobj "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -446,9 +446,9 @@ func (c *Client) DeleteDeployment(d *appsv1.Deployment) error {
 	return err
 }
 
-func (c *Client) DeletePodDisruptionBudget(pdb *policyv1beta1.PodDisruptionBudget) error {
+func (c *Client) DeletePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget) error {
 	p := metav1.DeletePropagationForeground
-	err := c.kclient.PolicyV1beta1().PodDisruptionBudgets(pdb.GetNamespace()).Delete(context.TODO(), pdb.GetName(), metav1.DeleteOptions{PropagationPolicy: &p})
+	err := c.kclient.PolicyV1().PodDisruptionBudgets(pdb.GetNamespace()).Delete(context.TODO(), pdb.GetName(), metav1.DeleteOptions{PropagationPolicy: &p})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -1062,8 +1062,8 @@ func (c *Client) CreateIfNotExistConfigMap(cm *v1.ConfigMap) (*v1.ConfigMap, err
 	return res, nil
 }
 
-func (c *Client) CreateOrUpdatePodDisruptionBudget(pdb *policyv1beta1.PodDisruptionBudget) error {
-	pdbClient := c.kclient.PolicyV1beta1().PodDisruptionBudgets(pdb.Namespace)
+func (c *Client) CreateOrUpdatePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget) error {
+	pdbClient := c.kclient.PolicyV1().PodDisruptionBudgets(pdb.Namespace)
 	existing, err := pdbClient.Get(context.TODO(), pdb.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err := pdbClient.Create(context.TODO(), pdb, metav1.CreateOptions{})

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -37,7 +37,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -490,7 +490,7 @@ func (f *Factory) AlertmanagerPrometheusRule() (*monv1.PrometheusRule, error) {
 	return f.NewPrometheusRule(f.assets.MustNewAssetReader(AlertmanagerPrometheusRule))
 }
 
-func (f *Factory) AlertmanagerPodDisruptionBudget() (*policyv1beta1.PodDisruptionBudget, error) {
+func (f *Factory) AlertmanagerPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {
 	return f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(AlertmanagerPodDisruptionBudget))
 }
 
@@ -1458,11 +1458,11 @@ func (f *Factory) PrometheusUserWorkloadPrometheusServiceMonitor() (*monv1.Servi
 	return sm, nil
 }
 
-func (f *Factory) PrometheusK8sPodDisruptionBudget() (*policyv1beta1.PodDisruptionBudget, error) {
+func (f *Factory) PrometheusK8sPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {
 	return f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(PrometheusK8sPodDisruptionBudget))
 }
 
-func (f *Factory) PrometheusUserWorkloadPodDisruptionBudget() (*policyv1beta1.PodDisruptionBudget, error) {
+func (f *Factory) PrometheusUserWorkloadPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {
 	return f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(PrometheusUserWorkloadPodDisruptionBudget))
 }
 
@@ -1621,7 +1621,7 @@ func (f *Factory) PrometheusAdapterDeployment(apiAuthSecretName string, requesth
 	return dep, nil
 }
 
-func (f *Factory) PrometheusAdapterPodDisruptionBudget() (*policyv1beta1.PodDisruptionBudget, error) {
+func (f *Factory) PrometheusAdapterPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {
 	pdb, err := f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(PrometheusAdapterPodDisruptionBudget))
 	if err != nil {
 		return nil, err
@@ -2426,7 +2426,7 @@ func (f *Factory) NewDaemonSet(manifest io.Reader) (*appsv1.DaemonSet, error) {
 	return ds, nil
 }
 
-func (f *Factory) NewPodDisruptionBudget(manifest io.Reader) (*policyv1beta1.PodDisruptionBudget, error) {
+func (f *Factory) NewPodDisruptionBudget(manifest io.Reader) (*policyv1.PodDisruptionBudget, error) {
 	if !f.infrastructure.HighlyAvailableInfrastructure() {
 		return nil, nil
 	}
@@ -3255,8 +3255,8 @@ func NewDaemonSet(manifest io.Reader) (*appsv1.DaemonSet, error) {
 	return &ds, nil
 }
 
-func NewPodDisruptionBudget(manifest io.Reader) (*policyv1beta1.PodDisruptionBudget, error) {
-	pdb := policyv1beta1.PodDisruptionBudget{}
+func NewPodDisruptionBudget(manifest io.Reader) (*policyv1.PodDisruptionBudget, error) {
+	pdb := policyv1.PodDisruptionBudget{}
 	err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&pdb)
 	if err != nil {
 		return nil, err

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -24,7 +24,7 @@ import (
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -1683,61 +1683,61 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 func TestPodDisruptionBudget(t *testing.T) {
 	tests := []struct {
 		name   string
-		getPDB func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error)
+		getPDB func(f *Factory) (*policyv1.PodDisruptionBudget, error)
 		ha     bool
 	}{
 		{
 			name: "PrometheusAdapter HA",
-			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.PrometheusAdapterPodDisruptionBudget()
 			},
 			ha: true,
 		},
 		{
 			name: "PrometheusAdapter non-HA",
-			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.PrometheusAdapterPodDisruptionBudget()
 			},
 			ha: false,
 		},
 		{
 			name: "Prometheus HA",
-			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.PrometheusK8sPodDisruptionBudget()
 			},
 			ha: true,
 		},
 		{
 			name: "Prometheus non-HA",
-			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.PrometheusK8sPodDisruptionBudget()
 			},
 			ha: false,
 		},
 		{
 			name: "PrometheusUWM HA",
-			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.PrometheusUserWorkloadPodDisruptionBudget()
 			},
 			ha: true,
 		},
 		{
 			name: "PrometheusUWM non-HA",
-			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.PrometheusUserWorkloadPodDisruptionBudget()
 			},
 			ha: false,
 		},
 		{
 			name: "Alertmanager HA",
-			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.AlertmanagerPodDisruptionBudget()
 			},
 			ha: true,
 		},
 		{
 			name: "Alertmanager non-HA",
-			getPDB: func(f *Factory) (*policyv1beta1.PodDisruptionBudget, error) {
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.AlertmanagerPodDisruptionBudget()
 			},
 			ha: false,


### PR DESCRIPTION
Pull request #1176 updated the assets managed by the operator
to use the policy/v1 version for all pod disruption budgets.
This was not sufficient to make the operator use the v1 version.

This commit updates the operator code to use the v1 client-go APIs
to make sure no deprecation warnings show in the logs.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.