### PR TITLE
Bug 1965367: pkg/operator: Fix typo in etcd-metric-serving-ca resource name

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -114,7 +114,7 @@ const (
 	apiAuthenticationConfigMap    = "kube-system/extension-apiserver-authentication"
 	kubeletServingCAConfigMap     = "openshift-config-managed/kubelet-serving-ca"
 	prometheusAdapterTLSSecret    = "openshift-monitoring/prometheus-adapter-tls"
-	etcdClientCAConfigMap         = "openshift-config/etcd-metrics-serving-ca"
+	etcdClientCAConfigMap         = "openshift-config/etcd-metric-serving-ca"
 	telemeterCABundleConfigMap    = "openshift-monitoring/telemeter-trusted-ca-bundle"
 	alertmanagerCABundleConfigMap = "openshift-monitoring/alertmanager-trusted-ca-bundle"
 	grpcTLS                       = "openshift-monitoring/grpc-tls"


### PR DESCRIPTION
It looks like when the watch for the etcd-metric-serving-ca ConfigMap
was added in 632cddad, there was a typo in the name used for the
watch, but not elsewhere, e.g. when actually retrieving the object.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
