### PR TITLE
hack,test: Use new ghcr.io images for prometheus-example-app

### DIFF
--- a/hack/uwm_setup_files/prometheus-example-app.yaml
+++ b/hack/uwm_setup_files/prometheus-example-app.yaml
@@ -21,7 +21,7 @@ spec:
         app: prometheus-example-app
     spec:
       containers:
-      - image: quay.io/brancz/prometheus-example-app:v0.2.0
+      - image: ghcr.io/rhobs/prometheus-example-app:0.3.0
         imagePullPolicy: IfNotPresent
         name: prometheus-example-app
 ---

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -398,7 +398,7 @@ func deployUserApplication(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "prometheus-example-app",
-							Image: "quay.io/brancz/prometheus-example-app:v0.2.0",
+							Image: "ghcr.io/rhobs/prometheus-example-app:0.3.0",
 						},
 					},
 				},


### PR DESCRIPTION
We've started publishing images to GitHub's containers registry under
the RHOBS organization for the prometheus-example-app.  This uses the
new images in place of the previous ones from a personal account.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
