### PR TITLE
Bug 1955490: Thanos ruler Statefulsets should have 2 replicas and hard affinity set

### DIFF
--- a/assets/thanos-ruler/alertmanagers-config-secret.yaml
+++ b/assets/thanos-ruler/alertmanagers-config-secret.yaml
@@ -3,7 +3,10 @@ data: {}
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/name: thanos-ruler
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler-alertmanagers-config
   namespace: openshift-user-workload-monitoring
 stringData:

--- a/assets/thanos-ruler/cluster-role-binding-monitoring.yaml
+++ b/assets/thanos-ruler/cluster-role-binding-monitoring.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/thanos-ruler/cluster-role-binding.yaml
+++ b/assets/thanos-ruler/cluster-role-binding.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/thanos-ruler/cluster-role.yaml
+++ b/assets/thanos-ruler/cluster-role.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler
 rules:
 - apiGroups:

--- a/assets/thanos-ruler/grpc-tls-secret.yaml
+++ b/assets/thanos-ruler/grpc-tls-secret.yaml
@@ -3,7 +3,10 @@ data: {}
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/name: thanos-ruler
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler-grpc-tls
   namespace: openshift-user-workload-monitoring
 type: Opaque

--- a/assets/thanos-ruler/oauth-cookie-secret.yaml
+++ b/assets/thanos-ruler/oauth-cookie-secret.yaml
@@ -3,7 +3,10 @@ data: {}
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/name: thanos-ruler
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler-oauth-cookie
   namespace: openshift-user-workload-monitoring
 type: Opaque

--- a/assets/thanos-ruler/oauth-htpasswd-secret.yaml
+++ b/assets/thanos-ruler/oauth-htpasswd-secret.yaml
@@ -3,7 +3,10 @@ data: {}
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/name: thanos-ruler
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler-oauth-htpasswd
   namespace: openshift-user-workload-monitoring
 type: Opaque

--- a/assets/thanos-ruler/query-config-secret.yaml
+++ b/assets/thanos-ruler/query-config-secret.yaml
@@ -3,7 +3,10 @@ data: {}
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/name: thanos-ruler
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler-query-config
   namespace: openshift-user-workload-monitoring
 stringData:

--- a/assets/thanos-ruler/route.yaml
+++ b/assets/thanos-ruler/route.yaml
@@ -1,6 +1,11 @@
 apiVersion: v1
 kind: Route
 metadata:
+  labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/thanos-ruler/service-account.yaml
+++ b/assets/thanos-ruler/service-account.yaml
@@ -3,5 +3,10 @@ kind: ServiceAccount
 metadata:
   annotations:
     serviceaccounts.openshift.io/oauth-redirectreference.thanos-ruler: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"thanos-ruler"}}'
+  labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring

--- a/assets/thanos-ruler/service-monitor.yaml
+++ b/assets/thanos-ruler/service-monitor.yaml
@@ -2,7 +2,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/name: thanos-ruler
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:
@@ -16,4 +19,6 @@ spec:
       serverName: server-name-replaced-at-runtime
   selector:
     matchLabels:
-      app.kubernetes.io/name: user-workload
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: user-workload
+      app.kubernetes.io/name: thanos-rule

--- a/assets/thanos-ruler/service.yaml
+++ b/assets/thanos-ruler/service.yaml
@@ -4,19 +4,24 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: thanos-ruler-tls
   labels:
-    app.kubernetes.io/name: user-workload
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:
+  clusterIP: None
   ports:
-  - name: web
-    port: 9091
-    targetPort: web
   - name: grpc
     port: 10901
-    targetPort: grpc
+    targetPort: 10901
+  - name: web
+    port: 9091
+    targetPort: 9091
   selector:
-    app: thanos-ruler
-    thanos-ruler: user-workload
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
   sessionAffinity: ClientIP
   type: ClusterIP

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -2,6 +2,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ThanosRuler
 metadata:
   labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
     thanosRulerName: user-workload
   name: user-workload
   namespace: openshift-user-workload-monitoring

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -10,6 +10,15 @@ metadata:
   name: user-workload
   namespace: openshift-user-workload-monitoring
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: rule-evaluation-engine
+            app.kubernetes.io/instance: user-workload
+            app.kubernetes.io/name: thanos-rule
+        topologyKey: kubernetes.io/hostname
   alertmanagersConfig:
     key: alertmanagers.yaml
     name: thanos-ruler-alertmanagers-config

--- a/assets/thanos-ruler/trusted-ca-bundle.yaml
+++ b/assets/thanos-ruler/trusted-ca-bundle.yaml
@@ -4,6 +4,10 @@ data:
 kind: ConfigMap
 metadata:
   labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: user-workload
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: 0.19.0
     config.openshift.io/inject-trusted-cabundle: "true"
   name: thanos-ruler-trusted-ca-bundle
   namespace: openshift-user-workload-monitoring

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -278,18 +278,14 @@ local inCluster =
       thanosRuler: $.values.thanos {
         name: 'user-workload',
         namespace: $.values.common.namespaceUserWorkload,
-        labels: {
-          'app.kubernetes.io/name': 'user-workload',
-        },
-        selectorLabels: {
-          app: 'thanos-ruler',
-          'thanos-ruler': 'user-workload',
-        },
         ports: {
           web: 9091,
           grpc: 10901,
         },
         namespaceSelector: $.values.common.userWorkloadMonitoringNamespaceSelector,
+        replicas: 2,
+        serviceMonitor: true,
+        volumeClaimTemplate: {},
       },
       thanosQuerier: $.values.thanos {
         name: 'thanos-querier',

--- a/jsonnet/thanos-ruler.libsonnet
+++ b/jsonnet/thanos-ruler.libsonnet
@@ -290,6 +290,19 @@ function(params)
           runAsUser: 65534,
         },
         replicas: 2,
+        affinity+: {
+          podAntiAffinity: {
+            // Apply HA conventions
+            requiredDuringSchedulingIgnoredDuringExecution: [
+              {
+                labelSelector: {
+                  matchLabels: cfg.podLabelSelector,
+                },
+                topologyKey: 'kubernetes.io/hostname',
+              },
+            ],
+          },
+        },
         resources: {
           requests: {
             memory: '21Mi',

--- a/jsonnet/thanos-ruler.libsonnet
+++ b/jsonnet/thanos-ruler.libsonnet
@@ -1,457 +1,435 @@
-// TODO(paulfantom): This should use upstream kube-thanos project.
+local thanosRule = import 'kube-thanos/kube-thanos-rule.libsonnet';
 
-function(params) {
-  local cfg = params,
-
-  mixin:: (import 'github.com/thanos-io/thanos/mixin/alerts/rule.libsonnet') {
-    rule+:: {
-      selector: 'job="thanos-ruler"',
-    },
-  },
-
-  thanosRulerPrometheusRule: {
-    apiVersion: 'monitoring.coreos.com/v1',
-    kind: 'PrometheusRule',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: 'openshift-user-workload-monitoring',
-    },
-    spec: $.mixin.prometheusAlerts,
-  },
-
-  trustedCaBundle: {
-    apiVersion: 'v1',
-    kind: 'ConfigMap',
-    metadata: {
-      name: 'thanos-ruler-trusted-ca-bundle',
-      namespace: cfg.namespace,
-      labels: {
-        'config.openshift.io/inject-trusted-cabundle': 'true',
+function(params)
+  local tr = thanosRule(params);
+  local cfg = tr.config;
+  tr {
+    mixin:: (import 'github.com/thanos-io/thanos/mixin/alerts/rule.libsonnet') {
+      rule+:: {
+        selector: 'job="thanos-ruler"',
       },
     },
-    data: {
-      'ca-bundle.crt': '',
-    },
-  },
 
-  route: {
-    apiVersion: 'v1',
-    kind: 'Route',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
+    thanosRulerPrometheusRule: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'PrometheusRule',
+      metadata: {
+        name: 'thanos-ruler',
+        namespace: cfg.namespace,
+      },
+      spec: $.mixin.prometheusAlerts,
     },
-    spec: {
-      to: {
-        kind: 'Service',
+
+    trustedCaBundle: {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'thanos-ruler-trusted-ca-bundle',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels {
+          'config.openshift.io/inject-trusted-cabundle': 'true',
+        },
+      },
+      data: {
+        'ca-bundle.crt': '',
+      },
+    },
+
+    route: {
+      apiVersion: 'v1',
+      kind: 'Route',
+      metadata: {
+        name: 'thanos-ruler',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
+      },
+      spec: {
+        to: {
+          kind: 'Service',
+          name: 'thanos-ruler',
+        },
+        port: {
+          targetPort: 'web',
+        },
+        tls: {
+          termination: 'Reencrypt',
+          insecureEdgeTerminationPolicy: 'Redirect',
+        },
+      },
+    },
+
+    clusterRole: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: {
+        name: 'thanos-ruler',
+        labels: cfg.commonLabels,
+      },
+      rules: [
+        {
+          apiGroups: ['authentication.k8s.io'],
+          resources: ['tokenreviews'],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['authorization.k8s.io'],
+          resources: ['subjectaccessreviews'],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['security.openshift.io'],
+          resourceNames: ['nonroot'],
+          resources: ['securitycontextconstraints'],
+          verbs: ['use'],
+        },
+      ],
+    },
+
+    clusterRoleBinding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: 'thanos-ruler',
+        labels: cfg.commonLabels,
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
         name: 'thanos-ruler',
       },
-      port: {
-        targetPort: 'web',
-      },
-      tls: {
-        termination: 'Reencrypt',
-        insecureEdgeTerminationPolicy: 'Redirect',
-      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: 'thanos-ruler',
+        namespace: cfg.namespace,
+      }],
     },
-  },
 
-  clusterRole: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'ClusterRole',
-    metadata: {
-      name: 'thanos-ruler',
+    clusterRoleBindingMonitoring: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: 'thanos-ruler-monitoring',
+        labels: cfg.commonLabels,
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'cluster-monitoring-view',
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: 'thanos-ruler',
+        namespace: cfg.namespace,
+      }],
     },
-    rules: [
-      {
-        apiGroups: ['authentication.k8s.io'],
-        resources: ['tokenreviews'],
-        verbs: ['create'],
-      },
-      {
-        apiGroups: ['authorization.k8s.io'],
-        resources: ['subjectaccessreviews'],
-        verbs: ['create'],
-      },
-      {
-        apiGroups: ['security.openshift.io'],
-        resourceNames: ['nonroot'],
-        resources: ['securitycontextconstraints'],
-        verbs: ['use'],
-      },
-    ],
-  },
 
-  clusterRoleBinding: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'ClusterRoleBinding',
-    metadata: {
-      name: 'thanos-ruler',
+    grpcTlsSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-grpc-tls',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
+      },
+      type: 'Opaque',
+      data: {},
     },
-    roleRef: {
-      apiGroup: 'rbac.authorization.k8s.io',
-      kind: 'ClusterRole',
-      name: 'thanos-ruler',
-    },
-    subjects: [{
-      kind: 'ServiceAccount',
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-    }],
-  },
 
-  clusterRoleBindingMonitoring: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'ClusterRoleBinding',
-    metadata: {
-      name: 'thanos-ruler-monitoring',
+    // holds the secret which is used encrypt/decrypt cookies
+    // issued by the oauth proxy.
+    oauthCookieSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-oauth-cookie',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
+      },
+      type: 'Opaque',
+      data: {},
     },
-    roleRef: {
-      apiGroup: 'rbac.authorization.k8s.io',
-      kind: 'ClusterRole',
-      name: 'cluster-monitoring-view',
-    },
-    subjects: [{
-      kind: 'ServiceAccount',
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-    }],
-  },
 
-  grpcTlsSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-grpc-tls',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
+    // holds the htpasswd configuration
+    // which includes a static secret used to authenticate/authorize
+    // requests originating from grafana.
+    oauthHtpasswdSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-oauth-htpasswd',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
+      },
+      type: 'Opaque',
+      data: {},
+    },
+
+    // alertmanager config holds the http configuration
+    // for communication between thanos ruler and alertmanager.
+    alertmanagersConfigSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-alertmanagers-config',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
+      },
+      type: 'Opaque',
+      data: {},
+      stringData: {
+        'alertmanagers.yaml': std.manifestYamlDoc({
+          alertmanagers: [{
+            http_config: {
+              bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+              tls_config: {
+                ca_file: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+                server_name: 'alertmanager-main.openshift-monitoring.svc',
+              },
+            },
+            static_configs: ['dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc'],
+            scheme: 'https',
+            api_version: 'v2',
+          }],
+        }),
       },
     },
-    type: 'Opaque',
-    data: {},
-  },
 
-  // holds the secret which is used encrypt/decrypt cookies
-  // issued by the oauth proxy.
-  oauthCookieSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-oauth-cookie',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
+    // query config which holds http configuration
+    // for communication between thanos ruler and thanos querier.
+    queryConfigSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-query-config',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
       },
-    },
-    type: 'Opaque',
-    data: {},
-  },
-
-  // holds the htpasswd configuration
-  // which includes a static secret used to authenticate/authorize
-  // requests originating from grafana.
-  oauthHtpasswdSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-oauth-htpasswd',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
-      },
-    },
-    type: 'Opaque',
-    data: {},
-  },
-
-  // alertmanager config holds the http configuration
-  // for communication between thanos ruler and alertmanager.
-  alertmanagersConfigSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-alertmanagers-config',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
-      },
-    },
-    type: 'Opaque',
-    data: {},
-    stringData: {
-      'alertmanagers.yaml': std.manifestYamlDoc({
-        alertmanagers: [{
+      type: 'Opaque',
+      data: {},
+      stringData: {
+        'query.yaml': std.manifestYamlDoc([{
           http_config: {
             bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
             tls_config: {
               ca_file: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-              server_name: 'alertmanager-main.openshift-monitoring.svc',
+              server_name: 'thanos-querier.openshift-monitoring.svc',
             },
           },
-          static_configs: ['dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc'],
+          static_configs: ['thanos-querier.openshift-monitoring.svc:9091'],
           scheme: 'https',
-          api_version: 'v2',
-        }],
-      }),
-    },
-  },
-
-  // query config which holds http configuration
-  // for communication between thanos ruler and thanos querier.
-  queryConfigSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-query-config',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
+        }]),
       },
     },
-    type: 'Opaque',
-    data: {},
-    stringData: {
-      'query.yaml': std.manifestYamlDoc([{
-        http_config: {
-          bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-          tls_config: {
-            ca_file: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-            server_name: 'thanos-querier.openshift-monitoring.svc',
-          },
+
+    serviceAccount: {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        name: 'thanos-ruler',
+        namespace: cfg.namespace,
+        annotations: {
+          'serviceaccounts.openshift.io/oauth-redirectreference.thanos-ruler': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"thanos-ruler"}}',
         },
-        static_configs: ['thanos-querier.openshift-monitoring.svc:9091'],
-        scheme: 'https',
-      }]),
+        labels: cfg.commonLabels,
+      },
     },
-  },
 
-  serviceAccount: {
-    apiVersion: 'v1',
-    kind: 'ServiceAccount',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-      annotations: {
-        'serviceaccounts.openshift.io/oauth-redirectreference.thanos-ruler': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"thanos-ruler"}}',
-      },
-    },
-  },
-
-  service: {
-    apiVersion: 'v1',
-    kind: 'Service',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-      annotations: {
-        'service.beta.openshift.io/serving-cert-secret-name': 'thanos-ruler-tls',
-      },
-      labels: cfg.labels,
-    },
-    spec: {
-      ports: [{
-        name: 'web',
-        port: cfg.ports.web,
-        targetPort: 'web',
-      }, {
-        name: 'grpc',
-        port: cfg.ports.grpc,
-        targetPort: 'grpc',
-      }],
-      selector: cfg.selectorLabels,
-      sessionAffinity: 'ClientIP',
-      type: 'ClusterIP',
-    },
-  },
-
-  serviceMonitor: {
-    apiVersion: 'monitoring.coreos.com/v1',
-    kind: 'ServiceMonitor',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
-      },
-    },
-    spec: {
-      selector: {
-        matchLabels: cfg.labels,
-      },
-      endpoints: [
-        {
-          port: 'web',
-          interval: '30s',
-          scheme: 'https',
-          tlsConfig: {
-            caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-            serverName: 'server-name-replaced-at-runtime',
-          },
-          bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+    service+: {
+      metadata+: {
+        name: 'thanos-ruler',
+        annotations: {
+          'service.beta.openshift.io/serving-cert-secret-name': 'thanos-ruler-tls',
         },
-      ],
+        labels: cfg.commonLabels,
+      },
+      spec+: {
+        sessionAffinity: 'ClientIP',
+        type: 'ClusterIP',
+      },
     },
-  },
 
-  thanosRuler: {
-    apiVersion: 'monitoring.coreos.com/v1',
-    kind: 'ThanosRuler',
-    metadata: {
-      name: cfg.name,
-      namespace: cfg.namespace,
-      labels: {
-        thanosRulerName: cfg.name,
+    serviceMonitor+: {
+      metadata+: {
+        name: 'thanos-ruler',
+        labels: cfg.commonLabels,
       },
-    },
-    spec: {
-      securityContext: {
-        fsGroup: 65534,
-        runAsNonRoot: true,
-        runAsUser: 65534,
-      },
-      replicas: 2,
-      resources: {
-        requests: {
-          memory: '21Mi',
-          cpu: '1m',
+      spec+: {
+        selector+: {
+          matchLabels: cfg.podLabelSelector,
         },
-      },
-      image: cfg.image,
-      grpcServerTlsConfig: {
-        certFile: '/etc/tls/grpc/server.crt',
-        keyFile: '/etc/tls/grpc/server.key',
-        caFile: '/etc/tls/grpc/ca.crt',
-      },
-      alertmanagersConfig: {
-        key: 'alertmanagers.yaml',
-        name: 'thanos-ruler-alertmanagers-config',
-      },
-      queryConfig: {
-        key: 'query.yaml',
-        name: 'thanos-ruler-query-config',
-      },
-      enforcedNamespaceLabel: 'namespace',
-      listenLocal: true,
-      ruleSelector: {
-        matchExpressions:
-          [
-            {
-              key: 'openshift.io/prometheus-rule-evaluation-scope',
-              operator: 'NotIn',
-              values: ['leaf-prometheus'],
+        endpoints: [
+          {
+            port: 'web',
+            interval: '30s',
+            scheme: 'https',
+            tlsConfig: {
+              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+              serverName: 'server-name-replaced-at-runtime',
             },
-          ],
+            bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+          },
+        ],
       },
-      ruleNamespaceSelector: cfg.namespaceSelector,
-      volumes: [
-        {
-          name: 'serving-certs-ca-bundle',
-          configmap: {
+    },
+
+
+    thanosRuler: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ThanosRuler',
+      metadata: {
+        name: cfg.name,
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels {
+          thanosRulerName: cfg.name,
+        },
+      },
+      spec: {
+        securityContext: {
+          fsGroup: 65534,
+          runAsNonRoot: true,
+          runAsUser: 65534,
+        },
+        replicas: 2,
+        resources: {
+          requests: {
+            memory: '21Mi',
+            cpu: '1m',
+          },
+        },
+        image: cfg.image,
+        grpcServerTlsConfig: {
+          certFile: '/etc/tls/grpc/server.crt',
+          keyFile: '/etc/tls/grpc/server.key',
+          caFile: '/etc/tls/grpc/ca.crt',
+        },
+        alertmanagersConfig: {
+          key: 'alertmanagers.yaml',
+          name: 'thanos-ruler-alertmanagers-config',
+        },
+        queryConfig: {
+          key: 'query.yaml',
+          name: 'thanos-ruler-query-config',
+        },
+        enforcedNamespaceLabel: 'namespace',
+        listenLocal: true,
+        ruleSelector: {
+          matchExpressions:
+            [
+              {
+                key: 'openshift.io/prometheus-rule-evaluation-scope',
+                operator: 'NotIn',
+                values: ['leaf-prometheus'],
+              },
+            ],
+        },
+        ruleNamespaceSelector: cfg.namespaceSelector,
+        volumes: [
+          {
             name: 'serving-certs-ca-bundle',
-          },
-        },
-        {
-          name: 'secret-thanos-ruler-tls',
-          secret: {
-            secretName: 'thanos-ruler-tls',
-          },
-        },
-        {
-          name: 'secret-thanos-ruler-oauth-cookie',
-          secret: {
-            secretName: 'thanos-ruler-oauth-cookie',
-          },
-        },
-        {
-          name: 'secret-thanos-ruler-oauth-htpasswd',
-          secret: {
-            secretName: 'thanos-ruler-oauth-htpasswd',
-          },
-        },
-      ],
-      serviceAccountName: 'thanos-ruler',
-      priorityClassName: 'openshift-user-critical',
-      containers: [
-        {
-          name: 'thanos-ruler',
-          terminationMessagePolicy: 'FallbackToLogsOnError',
-          volumeMounts: [
-            {
-              mountPath: '/etc/tls/private',
-              name: 'secret-thanos-ruler-tls',
-            },
-            {
-              mountPath: '/etc/tls/grpc',
-              name: 'secret-grpc-tls',
-            },
-            {
-              mountPath: '/etc/prometheus/configmaps/serving-certs-ca-bundle',
+            configmap: {
               name: 'serving-certs-ca-bundle',
             },
-          ],
-        },
-        {
-          name: 'thanos-ruler-proxy',
-          image: 'quay.io/openshift/oauth-proxy:latest',  //FIXME(paulfantom)
-          ports: [{
-            containerPort: cfg.ports.web,
-            name: 'web',
-          }],
-          env: [
-            { name: 'HTTP_PROXY', value: '' },
-            { name: 'HTTPS_PROXY', value: '' },
-            { name: 'NO_PROXY', value: '' },
-          ],
-          args: [
-            '-provider=openshift',
-            '-https-address=:9091',
-            '-http-address=',
-            '-email-domain=*',
-            '-upstream=http://localhost:10902',
-            '-openshift-sar={"resource": "namespaces", "verb": "get"}',
-            '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}',
-            '-tls-cert=/etc/tls/private/tls.crt',
-            '-tls-key=/etc/tls/private/tls.key',
-            '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token',
-            '-cookie-secret-file=/etc/proxy/secrets/session_secret',
-            '-openshift-service-account=thanos-ruler',
-            '-openshift-ca=/etc/pki/tls/cert.pem',
-            '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-          ],
-          terminationMessagePolicy: 'FallbackToLogsOnError',
-          resources: {
-            requests: {
-              cpu: '1m',
-              memory: '12Mi',
+          },
+          {
+            name: 'secret-thanos-ruler-tls',
+            secret: {
+              secretName: 'thanos-ruler-tls',
             },
           },
-          volumeMounts: [
-            {
-              mountPath: '/etc/tls/private',
-              name: 'secret-thanos-ruler-tls',
-            },
-            {
-              mountPath: '/etc/proxy/secrets',
-              name: 'secret-thanos-ruler-oauth-cookie',
-            },
-          ],
-        },
-        {
-          name: 'config-reloader',
-          resources: {
-            requests: {
-              cpu: '1m',
-              memory: '10Mi',
+          {
+            name: 'secret-thanos-ruler-oauth-cookie',
+            secret: {
+              secretName: 'thanos-ruler-oauth-cookie',
             },
           },
-        },
-      ],
+          {
+            name: 'secret-thanos-ruler-oauth-htpasswd',
+            secret: {
+              secretName: 'thanos-ruler-oauth-htpasswd',
+            },
+          },
+        ],
+        serviceAccountName: 'thanos-ruler',
+        priorityClassName: 'openshift-user-critical',
+        containers: [
+          {
+            name: 'thanos-ruler',
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+            volumeMounts: [
+              {
+                mountPath: '/etc/tls/private',
+                name: 'secret-thanos-ruler-tls',
+              },
+              {
+                mountPath: '/etc/tls/grpc',
+                name: 'secret-grpc-tls',
+              },
+              {
+                mountPath: '/etc/prometheus/configmaps/serving-certs-ca-bundle',
+                name: 'serving-certs-ca-bundle',
+              },
+            ],
+          },
+          {
+            name: 'thanos-ruler-proxy',
+            image: 'quay.io/openshift/oauth-proxy:latest',  //FIXME(paulfantom)
+            ports: [{
+              containerPort: cfg.ports.web,
+              name: 'web',
+            }],
+            env: [
+              { name: 'HTTP_PROXY', value: '' },
+              { name: 'HTTPS_PROXY', value: '' },
+              { name: 'NO_PROXY', value: '' },
+            ],
+            args: [
+              '-provider=openshift',
+              '-https-address=:9091',
+              '-http-address=',
+              '-email-domain=*',
+              '-upstream=http://localhost:10902',
+              '-openshift-sar={"resource": "namespaces", "verb": "get"}',
+              '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}',
+              '-tls-cert=/etc/tls/private/tls.crt',
+              '-tls-key=/etc/tls/private/tls.key',
+              '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token',
+              '-cookie-secret-file=/etc/proxy/secrets/session_secret',
+              '-openshift-service-account=thanos-ruler',
+              '-openshift-ca=/etc/pki/tls/cert.pem',
+              '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+            ],
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+            resources: {
+              requests: {
+                cpu: '1m',
+                memory: '12Mi',
+              },
+            },
+            volumeMounts: [
+              {
+                mountPath: '/etc/tls/private',
+                name: 'secret-thanos-ruler-tls',
+              },
+              {
+                mountPath: '/etc/proxy/secrets',
+                name: 'secret-thanos-ruler-oauth-cookie',
+              },
+            ],
+          },
+          {
+            name: 'config-reloader',
+            resources: {
+              requests: {
+                cpu: '1m',
+                memory: '10Mi',
+              },
+            },
+          },
+        ],
+      },
     },
-  },
 
-  // statefulSet from kube-thanos is not needed because thanosruler custom resource
-  // is used instead.
-  //statefulSet:: {},
-
-}
+    // statefulSet from kube-thanos is not needed because thanosruler custom resource
+    // is used instead.
+    statefulSet:: {},
+  }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

Changes:
1. Add hard pod anti-affinity to thanos-ruler.
2. Thanos-ruler configuration uses ``kube-thanos-rule.libsonnet`` from upstream kube-thanos project

2 replica is not guaranteed due to [lack of MaxUnavailable Rolling Update  in Stateful Set](https://github.com/kubernetes/kubernetes/issues/68397). There is already [a PR on Kubernetes](https://github.com/kubernetes/kubernetes/pull/82162), once it is merged we can come back to this issue.
