### PR TITLE
Bug 1933708: Add deployment config in recording rule

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -381,6 +381,15 @@ spec:
     - expr: sum by(exported_service) (rate(haproxy_server_http_responses_total{exported_namespace="openshift-monitoring",
         exported_service=~"alertmanager-main|grafana|prometheus-k8s"}[5m]))
       record: monitoring:haproxy_server_http_responses_total:sum
+    - expr: max by (cluster, namespace, workload, pod) (label_replace(label_replace(kube_pod_owner{job="kube-state-metrics",
+        owner_kind="ReplicationController"},"replicationcontroller", "$1", "owner_name",
+        "(.*)") * on(replicationcontroller, namespace) group_left(owner_name) topk
+        by(replicationcontroller, namespace) (1, max by (replicationcontroller, namespace,
+        owner_name) (kube_replicationcontroller_owner{job="kube-state-metrics"})),"workload",
+        "$1", "owner_name", "(.*)"))
+      labels:
+        workload_type: deploymentconfig
+      record: namespace_workload_pod:kube_pod_owner:relabel
   - name: openshift-sre.rules
     rules:
     - expr: sum(rate(apiserver_request_total{job="apiserver"}[10m])) BY (code)

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -510,6 +510,11 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
             expr: 'sum by(exported_service) (rate(haproxy_server_http_responses_total{exported_namespace="openshift-monitoring", exported_service=~"alertmanager-main|grafana|prometheus-k8s"}[5m]))',
             record: 'monitoring:haproxy_server_http_responses_total:sum',
           },
+          {
+            expr: 'max by (cluster, namespace, workload, pod) (label_replace(label_replace(kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicationController"},"replicationcontroller", "$1", "owner_name", "(.*)") * on(replicationcontroller, namespace) group_left(owner_name) topk by(replicationcontroller, namespace) (1, max by (replicationcontroller, namespace, owner_name) (kube_replicationcontroller_owner{job="kube-state-metrics"})),"workload", "$1", "owner_name", "(.*)"))',
+            labels: { workload_type: 'deploymentconfig' },
+            record: 'namespace_workload_pod:kube_pod_owner:relabel',
+          },
         ],
       },
       {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
