### PR TITLE
Bug 1949840: Improve update and status reporting

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -443,24 +443,29 @@ func (o *Operator) sync(key string) error {
 
 	tl := tasks.NewTaskRunner(
 		o.client,
-		[]*tasks.TaskSpec{
-			tasks.NewTaskSpec("Updating Prometheus Operator", tasks.NewPrometheusOperatorTask(o.client, factory)),
-			tasks.NewTaskSpec("Updating user workload Prometheus Operator", tasks.NewPrometheusOperatorUserWorkloadTask(o.client, factory, config)),
-			tasks.NewTaskSpec("Updating Cluster Monitoring Operator", tasks.NewClusterMonitoringOperatorTask(o.client, factory)),
-			tasks.NewTaskSpec("Updating Grafana", tasks.NewGrafanaTask(o.client, factory, config)),
-			tasks.NewTaskSpec("Updating Prometheus-k8s", tasks.NewPrometheusTask(o.client, factory, config)),
-			tasks.NewTaskSpec("Updating Prometheus-user-workload", tasks.NewPrometheusUserWorkloadTask(o.client, factory, config)),
-			tasks.NewTaskSpec("Updating Alertmanager", tasks.NewAlertmanagerTask(o.client, factory)),
-			tasks.NewTaskSpec("Updating node-exporter", tasks.NewNodeExporterTask(o.client, factory)),
-			tasks.NewTaskSpec("Updating kube-state-metrics", tasks.NewKubeStateMetricsTask(o.client, factory)),
-			tasks.NewTaskSpec("Updating openshift-state-metrics", tasks.NewOpenShiftStateMetricsTask(o.client, factory)),
-			tasks.NewTaskSpec("Updating prometheus-adapter", tasks.NewPrometheusAdapterTaks(o.namespace, o.client, factory)),
-			tasks.NewTaskSpec("Updating Telemeter client", tasks.NewTelemeterClientTask(o.client, factory, config)),
-			tasks.NewTaskSpec("Updating configuration sharing", tasks.NewConfigSharingTask(o.client, factory, config)),
-			tasks.NewTaskSpec("Updating Thanos Querier", tasks.NewThanosQuerierTask(o.client, factory, config)),
-			tasks.NewTaskSpec("Updating User Workload Thanos Ruler", tasks.NewThanosRulerUserWorkloadTask(o.client, factory, config)),
-			tasks.NewTaskSpec("Updating Control Plane components", tasks.NewControlPlaneTask(o.client, factory, config)),
-		},
+		// update prometheus-operator before anything else because it is responsible for managing many other resources (e.g. Prometheus, Alertmanager, Thanos Ruler, ...).
+		tasks.NewTaskGroup(
+			[]*tasks.TaskSpec{
+				tasks.NewTaskSpec("Updating Prometheus Operator", tasks.NewPrometheusOperatorTask(o.client, factory)),
+			}),
+		tasks.NewTaskGroup(
+			[]*tasks.TaskSpec{
+				tasks.NewTaskSpec("Updating user workload Prometheus Operator", tasks.NewPrometheusOperatorUserWorkloadTask(o.client, factory, config)),
+				tasks.NewTaskSpec("Updating Cluster Monitoring Operator", tasks.NewClusterMonitoringOperatorTask(o.client, factory)),
+				tasks.NewTaskSpec("Updating Grafana", tasks.NewGrafanaTask(o.client, factory, config)),
+				tasks.NewTaskSpec("Updating Prometheus-k8s", tasks.NewPrometheusTask(o.client, factory, config)),
+				tasks.NewTaskSpec("Updating Prometheus-user-workload", tasks.NewPrometheusUserWorkloadTask(o.client, factory, config)),
+				tasks.NewTaskSpec("Updating Alertmanager", tasks.NewAlertmanagerTask(o.client, factory)),
+				tasks.NewTaskSpec("Updating node-exporter", tasks.NewNodeExporterTask(o.client, factory)),
+				tasks.NewTaskSpec("Updating kube-state-metrics", tasks.NewKubeStateMetricsTask(o.client, factory)),
+				tasks.NewTaskSpec("Updating openshift-state-metrics", tasks.NewOpenShiftStateMetricsTask(o.client, factory)),
+				tasks.NewTaskSpec("Updating prometheus-adapter", tasks.NewPrometheusAdapterTaks(o.namespace, o.client, factory)),
+				tasks.NewTaskSpec("Updating Telemeter client", tasks.NewTelemeterClientTask(o.client, factory, config)),
+				tasks.NewTaskSpec("Updating configuration sharing", tasks.NewConfigSharingTask(o.client, factory, config)),
+				tasks.NewTaskSpec("Updating Thanos Querier", tasks.NewThanosQuerierTask(o.client, factory, config)),
+				tasks.NewTaskSpec("Updating User Workload Thanos Ruler", tasks.NewThanosRulerUserWorkloadTask(o.client, factory, config)),
+				tasks.NewTaskSpec("Updating Control Plane components", tasks.NewControlPlaneTask(o.client, factory, config)),
+			}),
 	)
 
 	klog.Info("Updating ClusterOperator status to in progress.")
@@ -471,9 +476,7 @@ func (o *Operator) sync(key string) error {
 
 	taskName, err := tl.RunAll()
 	if err != nil {
-		klog.Infof("Updating ClusterOperator status to failed. Err: %v", err)
-		failedTaskReason := strings.Join(strings.Fields(taskName+"Failed"), "")
-		reportErr := o.client.StatusReporter().SetFailed(err, failedTaskReason)
+		reportErr := o.reportError(err, taskName)
 		if reportErr != nil {
 			klog.Errorf("error occurred while setting status to failed: %v", reportErr)
 		}
@@ -487,6 +490,12 @@ func (o *Operator) sync(key string) error {
 	}
 
 	return nil
+}
+
+func (o *Operator) reportError(err error, taskName string) error {
+	klog.Infof("Updating ClusterOperator status to failed. Err: %v", err)
+	failedTaskReason := strings.Join(strings.Fields(taskName+"Failed"), "")
+	return o.client.StatusReporter().SetFailed(err, failedTaskReason)
 }
 
 func (o *Operator) loadInfrastructureConfig() *InfrastructureConfig {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -145,6 +145,8 @@ type Operator struct {
 	reconcileAttempts prometheus.Counter
 	reconcileStatus   prometheus.Gauge
 
+	failedReconcileAttempts int
+
 	assets *manifests.Assets
 }
 
@@ -422,11 +424,7 @@ func (o *Operator) enqueue(obj interface{}) {
 func (o *Operator) sync(key string) error {
 	config, err := o.Config(key)
 	if err != nil {
-		klog.Infof("Updating ClusterOperator status to failed: %v", err)
-		reportErr := o.client.StatusReporter().SetFailed(err, "InvalidConfiguration")
-		if reportErr != nil {
-			klog.Errorf("error occurred while setting status to failed: %v", reportErr)
-		}
+		o.reportError(err, "InvalidConfiguration")
 		return err
 	}
 	config.SetImages(o.images)
@@ -476,14 +474,12 @@ func (o *Operator) sync(key string) error {
 
 	taskName, err := tl.RunAll()
 	if err != nil {
-		reportErr := o.reportError(err, taskName)
-		if reportErr != nil {
-			klog.Errorf("error occurred while setting status to failed: %v", reportErr)
-		}
+		o.reportError(err, taskName)
 		return err
 	}
 
 	klog.Info("Updating ClusterOperator status to done.")
+	o.failedReconcileAttempts = 0
 	err = o.client.StatusReporter().SetDone()
 	if err != nil {
 		klog.Errorf("error occurred while setting status to done: %v", err)
@@ -492,10 +488,18 @@ func (o *Operator) sync(key string) error {
 	return nil
 }
 
-func (o *Operator) reportError(err error, taskName string) error {
-	klog.Infof("Updating ClusterOperator status to failed. Err: %v", err)
-	failedTaskReason := strings.Join(strings.Fields(taskName+"Failed"), "")
-	return o.client.StatusReporter().SetFailed(err, failedTaskReason)
+func (o *Operator) reportError(err error, taskName string) {
+	klog.Infof("ClusterOperator reconciliation failed (attempt %d), retrying. Err: %v", o.failedReconcileAttempts+1, err)
+	if o.failedReconcileAttempts == 2 {
+		// Only update the ClusterOperator status after 3 retries have been attempted to avoid flapping status.
+		klog.Infof("Updating ClusterOperator status to failed after %d attempts. Err: %v", o.failedReconcileAttempts+1, err)
+		failedTaskReason := strings.Join(strings.Fields(taskName+"Failed"), "")
+		reportErr := o.client.StatusReporter().SetFailed(err, failedTaskReason)
+		if reportErr != nil {
+			klog.Errorf("error occurred while setting status to failed: %v", reportErr)
+		}
+	}
+	o.failedReconcileAttempts++
 }
 
 func (o *Operator) loadInfrastructureConfig() *InfrastructureConfig {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -172,7 +172,7 @@ func New(
 		namespace:                 namespace,
 		namespaceUserWorkload:     namespaceUserWorkload,
 		client:                    c,
-		queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cluster-monitoring"),
+		queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(50*time.Millisecond, 3*time.Minute), "cluster-monitoring"),
 		informers:                 make([]cache.SharedIndexInformer, 0),
 		assets:                    a,
 	}


### PR DESCRIPTION
This PR adds Three commits, that aim to improve our reconcile loop:

1. Update `prometheus-operator` first and wait for it to finish before updating the other operands concurrently.
2. Allow the reconcile loop three attempts before calling `SetFailed` and thus reporting `available=false`.
3. Back-off more aggressively in case of failures. The `DefaultControllerRateLimiter`s default back-off is a bit slow and it also adds per bucket back-off tracking, which we don't use due to only ever queuing one event. Instead this introduces an instance of `ItemExponentialFailureRateLimiter`, which is also used by `DefaultControllerRateLimiter`, but with more aggressive rate limiting settings.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
