### PR TITLE
*: improve discovery of currently used component versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -31,6 +31,7 @@ about: Create release checklist
 - [ ] update and pin jsonnet dependencies in [jsonnet/jsonnetfile.json](https://github.com/openshift/cluster-monitoring-operator/blob/master/jsonnet/jsonnetfile.json).
   - example: https://github.com/openshift/cluster-monitoring-operator/blob/release-4.3/jsonnet/jsonnetfile.json
   - dependencies should be pinned to branches released in previous paragraph
+  - ensure `jsonnet/version.json` file is tracking up-to-date component versions by running `make versions` and regenerating `assets/` if necessary
 - [ ] update golang dependencies in [go.mod](https://github.com/openshift/cluster-monitoring-operator/blob/master/go.mod) and [hack/tools/go.mod](https://github.com/openshift/cluster-monitoring-operator/blob/master/hack/tools/go.mod) files.
   - most important are dependencies on prometheus-operator and kubernetes components
   - update the tooling prometheus dependency to be in sync with the main one

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ json-manifests: $(JSON_MANIFESTS_DIR) $(JSON_MANIFESTS)
 manifests/0000_50_cluster-monitoring-operator_02-role.yaml: hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in $(ASSETS)
 	python2 hack/merge_cluster_roles.py hack/cluster-monitoring-operator-role.yaml.in `find assets | grep role | grep -v "role-binding"` > $@
 
+.PHONY: versions
+versions:
+	./hack/generate-versions.sh > jsonnet/versions.json
+
 .PHONY: docs
 docs: $(EMBEDMD_BIN) Documentation/telemeter_query
 	$(EMBEDMD_BIN) -w `find Documentation -name "*.md"`

--- a/hack/generate-versions.sh
+++ b/hack/generate-versions.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# A naive way to generate `jsonnet/versions.json` file from downstream forks
+# It uses `VERSION` file located in each repository or a special function to figure out correct version
+# 
+# Script is based on https://github.com/prometheus-operator/kube-prometheus/blob/main/scripts/generate-versions.sh
+#
+
+get_version_from_file() {
+  curl --retry 5 --silent --fail "https://raw.githubusercontent.com/${1}/master/VERSION"
+}
+
+# Fallback mechanism when VERSION file is empty or not found
+get_version_from_user() {
+    ver=""
+    echo >&2 -n "Cannot determine version of ${1}. Please provide version manually (without alphabetical prefixes) and press ENTER: "
+    read -r ver
+    echo "$ver"
+}
+
+get_version() {
+  component="${1}"
+  v="$(get_version_from_file "${component}")"
+
+  if [[ "$v" == "" ]]; then
+     v="$(get_version_from_user "${component}")"
+  fi
+  echo "$v"
+}
+
+
+cat <<-EOF
+{ 
+  "alertmanager": "$(get_version "openshift/prometheus-alertmanager")",
+  "prometheus": "$(get_version "openshift/prometheus")",
+  "grafana": "$(get_version "openshift/grafana")",
+  "kubeStateMetrics": "$(get_version "openshift/kube-state-metrics")",
+  "nodeExporter": "$(get_version "openshift/node_exporter")",
+  "prometheusAdapter": "$(get_version "openshift/k8s-prometheus-adapter")",
+  "prometheusOperator": "$(get_version "openshift/prometheus-operator")",
+  "promLabelProxy": "$(get_version "openshift/prom-label-proxy")",
+  "kubeRbacProxy": "$(get_version "openshift/kube-rbac-proxy")",
+  "thanos": "$(get_version "openshift/thanos")"
+}
+EOF

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -54,18 +54,7 @@ local commonConfig = {
     prometheus: $.prometheusName,
   },
   // versions are used by some CRs and reflected in labels.
-  versions: {
-    alertmanager: '0.21.0',
-    prometheus: '2.26.1',
-    grafana: '7.5.5',
-    kubeStateMetrics: '2.0.0',
-    nodeExporter: '1.1.2',
-    prometheusAdapter: '0.8.4',
-    prometheusOperator: '0.48.1',
-    promLabelProxy: '0.2.0',
-    thanos: '0.20.2',
-    kubeRbacProxy: '0.10.0',
-  },
+  versions: (import './versions.json'),
   // In OSE images are overridden
   images: {
     alertmanager: 'quay.io/prometheus/alertmanager:v' + $.versions.alertmanager,

--- a/jsonnet/versions.json
+++ b/jsonnet/versions.json
@@ -1,0 +1,12 @@
+{ 
+  "alertmanager": "0.21.0",
+  "prometheus": "2.26.1",
+  "grafana": "7.5.5",
+  "kubeStateMetrics": "2.0.0",
+  "nodeExporter": "1.1.2",
+  "prometheusAdapter": "0.8.4",
+  "prometheusOperator": "0.48.1",
+  "promLabelProxy": "0.3.0",
+  "kubeRbacProxy": "0.10.0",
+  "thanos": "0.20.2"
+}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

During a release process, we need to pin version numbers of operands to ensure correct metadata is assigned to k8s objects managed by CMO. To improve this process and make it error-prone I created a simple bash script to poll every downstream fork for `VERSION` file and use the content of those files to create a simple JSON map put into `versions.json`. This JSON file is then imported into the jsonnet codebase and used to generate correct metadata.

Since the `versions.json` file can be treated as a source of truth (to some degree) it should improve our ability to discover which operand version is shipped with which OpenShift release. Additionally, in the future, it opens an easy path to use the file in some sort of documentation generator. 

Waiting for https://github.com/openshift/cluster-monitoring-operator/pull/1187 to merge and then to rebase onto `master`

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
