### PR TITLE
operator: log queue length for debug

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -417,6 +417,7 @@ func (o *Operator) enqueue(obj interface{}) {
 	}
 
 	o.queue.Add(key)
+	klog.Infof("add key %v, now have %v items in the queue", key, o.queue.Len())
 }
 
 func (o *Operator) sync(key string) error {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -170,7 +170,7 @@ func New(
 		namespace:                 namespace,
 		namespaceUserWorkload:     namespaceUserWorkload,
 		client:                    c,
-		queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cluster-monitoring"),
+		queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second, 5*time.Minute), "cluster-monitoring"),
 		informers:                 make([]cache.SharedIndexInformer, 0),
 		assets:                    a,
 	}


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
