### PR TITLE
Bug 1967614: Revert anti-affinity to soft

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -12,16 +12,18 @@ metadata:
 spec:
   affinity:
     podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/component: prometheus
-            app.kubernetes.io/name: prometheus
-            app.kubernetes.io/part-of: openshift-monitoring
-            prometheus: k8s
-        namespaces:
-        - openshift-monitoring
-        topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: prometheus
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/part-of: openshift-monitoring
+              prometheus: k8s
+          namespaces:
+          - openshift-monitoring
+          topologyKey: kubernetes.io/hostname
+        weight: 100
   alerting:
     alertmanagers:
     - apiVersion: v2

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -12,16 +12,18 @@ metadata:
 spec:
   affinity:
     podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/component: prometheus
-            app.kubernetes.io/name: prometheus
-            app.kubernetes.io/part-of: openshift-monitoring
-            prometheus: user-workload
-        namespaces:
-        - openshift-user-workload-monitoring
-        topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: prometheus
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/part-of: openshift-monitoring
+              prometheus: user-workload
+          namespaces:
+          - openshift-user-workload-monitoring
+          topologyKey: kubernetes.io/hostname
+        weight: 100
   alerting:
     alertmanagers:
     - apiVersion: v2

--- a/jsonnet/anti-affinity.libsonnet
+++ b/jsonnet/anti-affinity.libsonnet
@@ -3,7 +3,7 @@ local addon = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kub
 addon {
   values+:: {
     prometheus+: {
-      podAntiAffinity: 'hard',
+      podAntiAffinity: 'soft',
     },
     prometheusAdapter+: {
       podAntiAffinity: 'hard',

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -136,10 +136,10 @@ func TestPrometheusAlertmanagerAntiAffinity(t *testing.T) {
 
 		if strings.Contains(p.Namespace, testNameSpace) &&
 			strings.Contains(p.Name, testPod2) {
-			if p.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			if p.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
 				k8sOk = true
 			} else {
-				t.Fatal("Failed to find requiredDuringSchedulingIgnoredDuringExecution in prometheus pod spec")
+				t.Fatal("Failed to find preferredDuringSchedulingIgnoredDuringExecution in prometheus pod spec")
 			}
 		}
 	}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.


Reverts https://github.com/openshift/cluster-monitoring-operator/pull/1135/files

**Why revert?**

CMO fails repeatedly because the prometheus-k8s statefulset never converges to the desired state
https://bugzilla.redhat.com/show_bug.cgi?id=1967614#c0