### PR TITLE
[DO NOT MERGE] Use zone as topology key for upgrades to go smoothly

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -17,7 +17,7 @@ spec:
             - k8s
         namespaces:
         - openshift-monitoring
-        topologyKey: kubernetes.io/hostname
+        topologyKey: topology.kubernetes.io/zone
   alerting:
     alertmanagers:
     - apiVersion: v2

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -17,7 +17,7 @@ spec:
             - user-workload
         namespaces:
         - openshift-user-workload-monitoring
-        topologyKey: kubernetes.io/hostname
+        topologyKey: topology.kubernetes.io/zone
   alerting:
     alertmanagers:
     - apiVersion: v2

--- a/jsonnet/prometheus-user-workload.jsonnet
+++ b/jsonnet/prometheus-user-workload.jsonnet
@@ -202,7 +202,7 @@
                       values: ['user-workload'],
                     }]
                   },
-                  topologyKey: 'kubernetes.io/hostname',
+                  topologyKey: 'topology.kubernetes.io/zone',
                 },
               ],
             },

--- a/jsonnet/prometheus.jsonnet
+++ b/jsonnet/prometheus.jsonnet
@@ -382,7 +382,7 @@ local metrics = import 'telemeter-client/metrics.jsonnet';
                       values: [$._config.prometheus.name],
                     }]
                   },
-                  topologyKey: 'kubernetes.io/hostname',
+                  topologyKey: 'topology.kubernetes.io/zone',
                 },
               ],
             },


### PR DESCRIPTION
This may help in scheduler allocating the pod to a new zone and there by creation of new PV.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
