### PR TITLE
Bug 1955589: add PodDisruptionBudget to ThanosQuerier to meet HA requ…

### DIFF
--- a/assets/thanos-querier/pod-disruption-budget.yaml
+++ b/assets/thanos-querier/pod-disruption-budget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-querier
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: 0.20.2
+  name: thanos-querier-pdb
+  namespace: openshift-monitoring
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: thanos-querier
+      app.kubernetes.io/name: thanos-query

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -517,4 +517,21 @@ function(params)
         },
       },
     },
+
+    podDisruptionBudget: {
+      apiVersion: 'policy/v1',
+      kind: 'PodDisruptionBudget',
+      metadata: {
+        name: 'thanos-querier-pdb',
+        namespace: cfg.namespace,
+        labels: tq.config.commonLabels,
+      },
+      spec: {
+        minAvailable: 1,
+        selector: {
+          matchLabels: tq.config.podLabelSelector,
+        },
+
+      },
+    },
   }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -193,6 +193,7 @@ var (
 	TelemeterClientServingCertsCABundle   = "telemeter-client/serving-certs-ca-bundle.yaml"
 
 	ThanosQuerierDeployment           = "thanos-querier/deployment.yaml"
+	ThanosQuerierPodDisruptionBudget  = "thanos-querier/pod-disruption-budget.yaml"
 	ThanosQuerierService              = "thanos-querier/service.yaml"
 	ThanosQuerierServiceMonitor       = "thanos-querier/service-monitor.yaml"
 	ThanosQuerierPrometheusRule       = "thanos-querier/prometheus-rule.yaml"
@@ -2723,6 +2724,19 @@ func (f *Factory) NewClusterRole(manifest io.Reader) (*rbacv1.ClusterRole, error
 
 func (f *Factory) NewValidatingWebhook(manifest io.Reader) (*admissionv1.ValidatingWebhookConfiguration, error) {
 	return NewValidatingWebhook(manifest)
+}
+
+func (f *Factory) ThanosQuerierPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {
+	pdb, err := f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(ThanosQuerierPodDisruptionBudget))
+	if err != nil {
+		return nil, err
+	}
+
+	if pdb != nil {
+		pdb.Namespace = f.namespace
+	}
+
+	return pdb, nil
 }
 
 func (f *Factory) ThanosQuerierDeployment(grpcTLS *v1.Secret, enableUserWorkloadMonitoring bool, trustedCA *v1.ConfigMap) (*appsv1.Deployment, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1692,6 +1692,20 @@ func TestPodDisruptionBudget(t *testing.T) {
 			},
 			ha: false,
 		},
+		{
+			name: "ThanosQuerier HA",
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
+				return f.ThanosQuerierPodDisruptionBudget()
+			},
+			ha: true,
+		},
+		{
+			name: "ThanosQuerier non-HA",
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
+				return f.ThanosQuerierPodDisruptionBudget()
+			},
+			ha: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -214,6 +214,20 @@ func (t *ThanosQuerierTask) Run() error {
 		}
 	}
 
+	{
+		pdb, err := t.factory.ThanosQuerierPodDisruptionBudget()
+		if err != nil {
+			return errors.Wrap(err, "initializing ThanosQuerier PodDisruptionBudget failed")
+		}
+
+		if pdb != nil {
+			err = t.client.CreateOrUpdatePodDisruptionBudget(pdb)
+			if err != nil {
+				return errors.Wrap(err, "reconciling ThanosQuerier PodDisruptionBudget failed")
+			}
+		}
+	}
+
 	tqsm, err := t.factory.ThanosQuerierServiceMonitor()
 	if err != nil {
 		return errors.Wrap(err, "initializing Thanos Querier ServiceMonitor failed")


### PR DESCRIPTION
…irements

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

To guarantee high availability during upgrade of ThanosQuerier, we set a PodDisruptionBudget to prevent all its pods go offline at the same time.