### PR TITLE
Bug 1949711: Ignore failures from prometheusrules.openshift.io webhook

### DIFF
--- a/assets/prometheus-operator/prometheus-rule-validating-webhook.yaml
+++ b/assets/prometheus-operator/prometheus-rule-validating-webhook.yaml
@@ -16,6 +16,7 @@ webhooks:
       namespace: openshift-monitoring
       path: /admission-prometheusrules/validate
       port: 8080
+  failurePolicy: Ignore
   name: prometheusrules.openshift.io
   rules:
   - apiGroups:

--- a/jsonnet/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator.libsonnet
@@ -186,6 +186,7 @@ function(params)
           admissionReviewVersions: ['v1'],
           sideEffects: 'None',
           timeoutSeconds: 5,
+          failurePolicy: 'Ignore',
         },
       ],
     },


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

The default failurePolicy(fail) prevents the CVO from reconciling the deletion of openshift-monitoring namespace.

* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
