### PR TITLE
Bug 1939401: [4.9] Add Labels to telemeter, openshift-state-metrics, thanos-querier

### DIFF
--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: grafana
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.5.5

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.0.0

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -3,6 +3,7 @@ kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.1.2

--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -2,20 +2,25 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    k8s-app: openshift-state-metrics
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: openshift-state-metrics
+    app.kubernetes.io/part-of: openshift-monitoring
   name: openshift-state-metrics
   namespace: openshift-monitoring
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: openshift-state-metrics
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: openshift-state-metrics
   template:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
-        k8s-app: openshift-state-metrics
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: openshift-state-metrics
     spec:
       containers:
       - args:

--- a/assets/openshift-state-metrics/service.yaml
+++ b/assets/openshift-state-metrics/service.yaml
@@ -17,4 +17,5 @@ spec:
     port: 9443
     targetPort: https-self
   selector:
-    k8s-app: openshift-state-metrics
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: openshift-state-metrics

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.9.0

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.50.0

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -2,20 +2,25 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    k8s-app: telemeter-client
+    app.kubernetes.io/component: telemetry-metrics-collector
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: telemeter-client
+    app.kubernetes.io/part-of: openshift-monitoring
   name: telemeter-client
   namespace: openshift-monitoring
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: telemeter-client
+      app.kubernetes.io/component: telemetry-metrics-collector
+      app.kubernetes.io/name: telemeter-client
   template:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
-        k8s-app: telemeter-client
+        app.kubernetes.io/component: telemetry-metrics-collector
+        app.kubernetes.io/name: telemeter-client
     spec:
       containers:
       - command:

--- a/assets/telemeter-client/service.yaml
+++ b/assets/telemeter-client/service.yaml
@@ -14,4 +14,5 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    k8s-app: telemeter-client
+    app.kubernetes.io/component: telemetry-metrics-collector
+    app.kubernetes.io/name: telemeter-client

--- a/assets/thanos-querier/cluster-role-binding.yaml
+++ b/assets/thanos-querier/cluster-role-binding.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier
 roleRef:

--- a/assets/thanos-querier/cluster-role.yaml
+++ b/assets/thanos-querier/cluster-role.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier
 rules:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -4,7 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring
@@ -15,6 +17,7 @@ spec:
       app.kubernetes.io/component: query-layer
       app.kubernetes.io/instance: thanos-querier
       app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: openshift-monitoring
   strategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -26,6 +29,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-querier
         app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: openshift-monitoring
         app.kubernetes.io/version: 0.22.0
     spec:
       affinity:
@@ -36,6 +40,7 @@ spec:
                 app.kubernetes.io/component: query-layer
                 app.kubernetes.io/instance: thanos-querier
                 app.kubernetes.io/name: thanos-query
+                app.kubernetes.io/part-of: openshift-monitoring
             topologyKey: kubernetes.io/hostname
       containers:
       - args:

--- a/assets/thanos-querier/grpc-tls-secret.yaml
+++ b/assets/thanos-querier/grpc-tls-secret.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier-grpc-tls
   namespace: openshift-monitoring

--- a/assets/thanos-querier/kube-rbac-proxy-rules-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-rules-secret.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier-kube-rbac-proxy-rules
   namespace: openshift-monitoring

--- a/assets/thanos-querier/kube-rbac-proxy-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-secret.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier-kube-rbac-proxy
   namespace: openshift-monitoring

--- a/assets/thanos-querier/oauth-cookie-secret.yaml
+++ b/assets/thanos-querier/oauth-cookie-secret.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier-oauth-cookie
   namespace: openshift-monitoring

--- a/assets/thanos-querier/oauth-htpasswd-secret.yaml
+++ b/assets/thanos-querier/oauth-htpasswd-secret.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier-oauth-htpasswd
   namespace: openshift-monitoring

--- a/assets/thanos-querier/pod-disruption-budget.yaml
+++ b/assets/thanos-querier/pod-disruption-budget.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier-pdb
   namespace: openshift-monitoring
@@ -15,3 +16,4 @@ spec:
       app.kubernetes.io/component: query-layer
       app.kubernetes.io/instance: thanos-querier
       app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring

--- a/assets/thanos-querier/route.yaml
+++ b/assets/thanos-querier/route.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring

--- a/assets/thanos-querier/service-account.yaml
+++ b/assets/thanos-querier/service-account.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring

--- a/assets/thanos-querier/service-monitor.yaml
+++ b/assets/thanos-querier/service-monitor.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring
@@ -24,3 +25,4 @@ spec:
       app.kubernetes.io/component: query-layer
       app.kubernetes.io/instance: thanos-querier
       app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/thanos-querier/service.yaml
+++ b/assets/thanos-querier/service.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring
@@ -25,4 +26,5 @@ spec:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/part-of: openshift-monitoring
   type: ClusterIP

--- a/jsonnet/components/grafana.libsonnet
+++ b/jsonnet/components/grafana.libsonnet
@@ -185,6 +185,11 @@ function(params)
     // TLS.
 
     deployment+: {
+      metadata+: {
+        labels+: {
+          'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+        },
+      },
       spec+: {
         template+: {
           spec+: {

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -81,6 +81,11 @@ function(params)
     // released, which is why it is shadowed here for the time being.
 
     deployment+: {
+      metadata+: {
+        labels+: {
+          'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+        },
+      },
       spec+: {
         template+: {
           spec+: {

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -77,6 +77,11 @@ function(params)
     // configured on the `Service` above and adds the default init text
     // collectors to the process.
     daemonset+: {
+      metadata+: {
+        labels+: {
+          'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+        },
+      },
       spec+: {
         template+: {
           spec+: {

--- a/jsonnet/components/openshift-state-metrics.libsonnet
+++ b/jsonnet/components/openshift-state-metrics.libsonnet
@@ -18,6 +18,11 @@ function(params) {
   clusterRoleBinding: osm.openshiftStateMetrics.clusterRoleBinding,
   clusterRole: osm.openshiftStateMetrics.clusterRole,
   deployment: osm.openshiftStateMetrics.deployment {
+    metadata+: {
+      labels+: {
+        'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+      } + cfg.commonLabels + osm._config.commonLabels,
+    },
     spec+: {
       template+: {
         spec+: {

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -70,6 +70,11 @@ function(params)
 
     deployment+:
       {
+        metadata+: {
+          labels+: {
+            'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+          },
+        },
         spec+: {
           replicas: 2,
           strategy+: {

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -8,6 +8,11 @@ function(params)
   operator(cfg) + {
 
     deployment+: {
+      metadata+: {
+        labels+: {
+          'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+        },
+      },
       spec+: {
         template+: {
           spec+: {

--- a/jsonnet/components/telemeter-client.libsonnet
+++ b/jsonnet/components/telemeter-client.libsonnet
@@ -28,6 +28,11 @@ function(params) {
   secret: tc.telemeterClient.secret,
   servingCertsCABundle: tc.telemeterClient.servingCertsCABundle,
   deployment: tc.telemeterClient.deployment {
+    metadata+: {
+      labels+: {
+        'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+      } + cfg.commonLabels + tc._config.commonLabels,
+    },
     spec+: {
       template+: {
         spec+: {

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -277,6 +277,11 @@ function(params)
     // proxy container pointing to the mounted htpasswd file.  If Grafana is
     // disabled, these things are not injected.
     deployment+: {
+      metadata+: {
+        labels+: {
+          'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+        },
+      },
       spec+: {
         strategy+: {
           // Apply HA conventions

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -99,8 +99,8 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "689af8b8dcb57484dc0c6428a3e8c9d73ef294a2",
-      "sum": "xoF0ibl74QrQ1DWbmoZ3JY83dEVeU0EQCvom96KGEuA=",
+      "version": "a6c557f455f56e2e406f19f471a49ffc066af610",
+      "sum": "YbabTSgCAw6v0rzfxU59vWkoJy2RNDC5WQdbDGuZo0U=",
       "name": "openshift-state-metrics"
     },
     {
@@ -110,8 +110,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "03842e05c3530786315e436522471667af86627e",
-      "sum": "6V/mbT+FzC90aukHKfM2CtkBCeyeWzHdkif9WMVakrA=",
+      "version": "1e97dddbde49e13867733cbf3219f6505d3b083a",
+      "sum": "Sm209vnPf0l7otdQvWS2rX376AqnhaIrlWqCpopMPCM=",
       "name": "telemeter-client"
     },
     {

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -221,6 +221,7 @@ local inCluster =
       openshiftStateMetrics: {
         namespace: $.values.common.namespace,
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
+        commonLabels+: $.values.common.commonLabels,
       },
       prometheus: {
         namespace: $.values.common.namespace,
@@ -303,10 +304,12 @@ local inCluster =
         tlsCipherSuites: $.values.common.tlsCipherSuites,
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
         promLabelProxyImage: $.values.common.images.promLabelProxy,
+        commonLabels+: $.values.common.commonLabels,
       },
       telemeterClient: {
         namespace: $.values.common.namespace,
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
+        commonLabels+: $.values.common.commonLabels,
       },
       controlPlane: {
         namespace: $.values.common.namespace,


### PR DESCRIPTION
This PR fixes this [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1939401)  .
Added missing pod-labels as per the [Kube recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
