### PR TITLE
Bug 1970624: jsonnet: reduce threshold of AggregatedAPIDown

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -398,7 +398,7 @@ spec:
           has been only {{ $value | humanize }}% available over the last 10m.
         summary: An aggregated API is down.
       expr: |
-        (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
+        (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 70
       for: 5m
       labels:
         severity: warning

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -89,6 +89,19 @@ local patchedRules = [
     ],
   },
   {
+    name: 'kubernetes-system-apiserver',
+    rules: [
+      {
+        // Lower treshold to be resilient to DNS rollouts and CA rotations.
+        // https://bugzilla.redhat.com/show_bug.cgi?id=1970624
+        alert: 'AggregatedAPIDown',
+        expr: |||
+          (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 70
+        |||,
+      },
+    ],
+  },
+  {
     name: 'prometheus',
     rules: [
       {


### PR DESCRIPTION
Reduce threshold of AggregatedAPIDown alert from 85 to 70 to be more
resilient to DNS rollouts and CA rotations. A time window of 1m30 was
too tight when facing these, so we want to increase the window to 3m.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
