### PR TITLE
manifests: Add openshift-partners-metrics namespace

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
@@ -27,3 +27,18 @@ metadata:
     openshift.io/cluster-monitoring: "true"
     name: openshift-user-workload-monitoring
     network.openshift.io/policy-group: monitoring
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-partners-metrics
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-developer: "true"
+    workload.openshift.io/allowed: "management"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    name: openshift-partners-metrics
+    network.openshift.io/policy-group: monitoring


### PR DESCRIPTION
This PR add a new namespace called openshift-partners-metrics namespace
to the manifest directory.

This namespace will be used by the partners who could define special
metrics to be sent by telemeter.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
