### PR TITLE
WIP: Add CRI-O metrics as own ServiceMonitor

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -92,28 +92,6 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
       insecureSkipVerify: false
-  - interval: 30s
-    metricRelabelings:
-    - action: drop
-      regex: container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_.+
-      sourceLabels:
-      - __name__
-    port: https-metrics
-    relabelings:
-    - action: replace
-      regex: (.+)(?::\d+)
-      replacement: $1:9537
-      sourceLabels:
-      - __address__
-      targetLabel: __address__
-    - action: replace
-      replacement: crio
-      sourceLabels:
-      - endpoint
-      targetLabel: endpoint
-    - action: replace
-      replacement: crio
-      targetLabel: job
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:

--- a/assets/cri-o/cluster-role-binding.yaml
+++ b/assets/cri-o/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crio-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crio-metrics
+subjects:
+- kind: ServiceAccount
+  name: crio-metrics
+  namespace: openshift-monitoring

--- a/assets/cri-o/cluster-role.yaml
+++ b/assets/cri-o/cluster-role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crio-metrics
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - crio-metrics
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/assets/cri-o/daemonset.yaml
+++ b/assets/cri-o/daemonset.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: crio-metrics-proxy
+  namespace: openshift-monitoring
+spec:
+  selector:
+    matchLabels:
+      name: crio-metrics-proxy
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        name: crio-metrics-proxy
+    spec:
+      containers:
+      - args:
+        - --upstream=http://127.0.0.1:9537
+        - --secure-listen-address=0.0.0.0:9538
+        - --v=10
+        - --tls-cert-file=/tls/crio-metrics-server.crt
+        - --tls-private-key-file=/tls/crio-metrics-server.key
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
+        name: proxy
+        ports:
+        - containerPort: 9538
+          name: https
+        volumeMounts:
+        - mountPath: /tls
+          name: crio-metrics
+      - args:
+        - bash
+        - -c
+        - while true; do echo "Copying certs" && cp /tls/* /crio && sleep 86400; done
+        image: registry.fedoraproject.org/fedora-minimal:34
+        name: sidecar
+        volumeMounts:
+        - mountPath: /tls
+          name: crio-metrics
+        - mountPath: /crio
+          name: etc-crio-certs
+      hostNetwork: true
+      serviceAccountName: crio-metrics
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      volumes:
+      - name: crio-metrics
+        secret:
+          secretName: crio-metrics
+      - hostPath:
+          path: /etc/crio/certs
+          type: DirectoryOrCreate
+        name: etc-crio-certs

--- a/assets/cri-o/secret.yaml
+++ b/assets/cri-o/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  name: crio-metrics
+  namespace: openshift-monitoring
+type: Opaque

--- a/assets/cri-o/security-context-constraints.yaml
+++ b/assets/cri-o/security-context-constraints.yaml
@@ -1,0 +1,20 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: Used for CRI-O metrics
+  name: crio-metrics
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:openshift-monitoring:crio-metrics

--- a/assets/cri-o/service-account.yaml
+++ b/assets/cri-o/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crio-metrics
+  namespace: openshift-monitoring

--- a/assets/cri-o/service-monitor.yaml
+++ b/assets/cri-o/service-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: crio-metrics
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 10s
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      ca:
+        secret:
+          key: crio-metrics-server.crt
+          name: crio-metrics
+      serverName: crio-metrics
+  selector:
+    matchLabels:
+      name: crio-metrics

--- a/assets/cri-o/service.yaml
+++ b/assets/cri-o/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: crio-metrics
+  name: crio-metrics
+  namespace: openshift-monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    name: crio-metrics-proxy

--- a/jsonnet/control-plane.libsonnet
+++ b/jsonnet/control-plane.libsonnet
@@ -107,40 +107,7 @@ function(params)
                 {}
             ,
             super.endpoints,
-          ) +
-          // Collect metrics from CRI-O.
-          [{
-            interval: '30s',
-            port: 'https-metrics',
-            relabelings: [
-              {
-                sourceLabels: ['__address__'],
-                action: 'replace',
-                targetLabel: '__address__',
-                regex: '(.+)(?::\\d+)',
-                replacement: '$1:9537',
-              },
-              {
-                sourceLabels: ['endpoint'],
-                action: 'replace',
-                targetLabel: 'endpoint',
-                replacement: 'crio',
-              },
-              {
-                action: 'replace',
-                targetLabel: 'job',
-                replacement: 'crio',
-              },
-            ],
-            // Drop metrics with excessive label cardinality.
-            metricRelabelings: [
-              {
-                sourceLabels: ['__name__'],
-                regex: 'container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_.+',
-                action: 'drop',
-              },
-            ],
-          }],
+          ),
       },
     },
 

--- a/jsonnet/cri-o.libsonnet
+++ b/jsonnet/cri-o.libsonnet
@@ -1,0 +1,253 @@
+local defaults = {
+  local defaults = self,
+  namespace: error 'must provide namespace',
+  name: 'crio-metrics',
+  proxyName: self.name + '-proxy',
+  servingPort: 9538,
+};
+
+local crio = function(params) {
+  local g = self,
+  _config:: defaults + params,
+
+  securityContextConstraints: {
+    apiVersion: 'security.openshift.io/v1',
+    kind: 'SecurityContextConstraints',
+    metadata: {
+      annotations: {
+        'kubernetes.io/description': 'Used for CRI-O metrics',
+      },
+      name: g._config.name,
+    },
+    allowHostDirVolumePlugin: true,
+    allowHostIPC: false,
+    allowHostNetwork: true,
+    allowHostPID: false,
+    allowHostPorts: true,
+    allowPrivilegeEscalation: false,
+    allowPrivilegedContainer: false,
+    readOnlyRootFilesystem: false,
+    runAsUser: {
+      type: 'RunAsAny',
+    },
+    seLinuxContext: {
+      type: 'RunAsAny',
+    },
+    users: [
+      'system:serviceaccount:' + g._config.namespace + ':' + g._config.name,
+    ],
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: g._config.name,
+      namespace: g._config.namespace,
+    },
+  },
+
+  clusterRole: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'ClusterRole',
+    metadata: {
+      name: g._config.name,
+    },
+    rules: [
+      {
+        apiGroups: ['authentication.k8s.io'],
+        resources: ['tokenreviews'],
+        verbs: ['create'],
+      },
+      {
+        apiGroups: ['authorization.k8s.io'],
+        resources: ['subjectaccessreviews'],
+        verbs: ['create'],
+      },
+      {
+        apiGroups: ['security.openshift.io'],
+        resources: ['securitycontextconstraints'],
+        resourceNames: [g._config.name],
+        verbs: ['use'],
+      },
+    ],
+  },
+
+  clusterRoleBinding: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'ClusterRoleBinding',
+    metadata: {
+      name: g._config.name,
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: g._config.name,
+    },
+    subjects: [
+      {
+        kind: 'ServiceAccount',
+        name: g._config.name,
+        namespace: g._config.namespace,
+      },
+    ],
+  },
+
+  secret: {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    type: 'Opaque',
+    metadata: {
+      name: g._config.name,
+      namespace: g._config.namespace,
+    },
+    data: {},
+  },
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: g._config.name,
+      namespace: g._config.namespace,
+      labels: {
+        name: g._config.name,
+      },
+    },
+    spec: {
+      clusterIP: 'None',
+      ports: [{
+        name: 'https',
+        port: 443,
+        targetPort: 'https',
+      }],
+      selector: {
+        name: g._config.proxyName,
+      },
+    },
+  },
+
+  serviceMonitor: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata: {
+      name: g._config.name,
+      namespace: g._config.namespace,
+    },
+    spec: {
+      endpoints: [{
+        bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+        interval: '10s',
+        path: '/metrics',
+        port: 'https',
+        scheme: 'https',
+        tlsConfig: {
+          serverName: g._config.name,
+          ca: {
+            secret: {
+              key: g._config.name + '-server.crt',
+              name: g._config.name,
+            },
+          },
+        },
+      }],
+      selector: {
+        matchLabels: {
+          name: g._config.name,
+        },
+      },
+    },
+  },
+
+  daemonset: {
+    apiVersion: 'apps/v1',
+    kind: 'DaemonSet',
+    metadata: {
+      name: g._config.proxyName,
+      namespace: g._config.namespace,
+    },
+    spec: {
+      selector: {
+        matchLabels: {
+          name: g._config.proxyName,
+        },
+      },
+      template: {
+        metadata: {
+          labels: {
+            name: g._config.proxyName,
+          },
+        },
+        spec: {
+          hostNetwork: true,
+          serviceAccountName: g._config.name,
+          tolerations: [{
+            effect: 'NoSchedule',
+            key: 'node-role.kubernetes.io/master',
+          }],
+          containers: [
+            {
+              name: 'proxy',
+              image: 'quay.io/brancz/kube-rbac-proxy:v0.9.0',
+              args: [
+                // TODO: use https if CRI-O supports it
+                '--upstream=http://127.0.0.1:9537',
+                '--secure-listen-address=0.0.0.0:' + g._config.servingPort,
+                '--v=10',
+                '--tls-cert-file=/tls/' + g._config.name + '-server.crt',
+                '--tls-private-key-file=/tls/' + g._config.name + '-server.key',
+              ],
+              ports: [{
+                name: 'https',
+                containerPort: g._config.servingPort,
+              }],
+              volumeMounts: [{
+                mountPath: '/tls',
+                name: g._config.name,
+              }],
+            },
+            {
+              name: 'sidecar',
+              image: 'registry.fedoraproject.org/fedora-minimal:34',
+              args: [
+                'bash',
+                '-c',
+                'while true; do echo "Copying certs" && cp /tls/* /crio && sleep 86400; done',
+              ],
+              volumeMounts: [
+                {
+                  name: g._config.name,
+                  mountPath: '/tls',
+                },
+                {
+                  name: 'etc-crio-certs',
+                  mountPath: '/crio',
+                },
+              ],
+            },
+          ],
+          volumes: [
+            {
+              name: g._config.name,
+              secret: {
+                secretName: g._config.name,
+              },
+            },
+            {
+              name: 'etc-crio-certs',
+              hostPath: {
+                path: '/etc/crio/certs',
+                type: 'DirectoryOrCreate',
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+
+};
+
+function(params)
+  local cfg = params;
+  crio(cfg) {}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -23,6 +23,7 @@ local thanosQuerier = import './thanos-querier.libsonnet';
 
 local openshiftStateMetrics = import './openshift-state-metrics.libsonnet';
 local telemeterClient = import './telemeter-client.libsonnet';
+local crio = import './cri-o.libsonnet';
 
 /*
 TODO(paulfantom):
@@ -317,6 +318,9 @@ local inCluster =
           },
         },
       },
+      crio: {
+        namespace: $.values.common.namespace,
+      },
     },
 
     // Objects
@@ -335,6 +339,7 @@ local inCluster =
 
     telemeterClient: telemeterClient($.values.telemeterClient),
     openshiftStateMetrics: openshiftStateMetrics($.values.openshiftStateMetrics),
+    crio: crio($.values.crio),
   } +
   (import './anti-affinity.libsonnet') +
   (import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet') +
@@ -410,5 +415,6 @@ removeRunbookUrl(patchRules(excludeRules(addWorkloadAnnotation(addReleaseAnnotat
   { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
   { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
   { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } +
+  { ['cri-o/' + name]: inCluster.crio[name] for name in std.objectFields(inCluster.crio) } +
   {}
 ))))))

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -9,6 +9,7 @@
 # 	assets/cluster-monitoring-operator/monitoring-rules-edit-cluster-role.yaml
 # 	assets/cluster-monitoring-operator/monitoring-rules-view-cluster-role.yaml
 # 	assets/cluster-monitoring-operator/user-workload-config-edit-role.yaml
+# 	assets/cri-o/cluster-role.yaml
 # 	assets/grafana/cluster-role.yaml
 # 	assets/kube-state-metrics/cluster-role.yaml
 # 	assets/node-exporter/cluster-role.yaml
@@ -224,6 +225,14 @@ rules:
   - configmaps
   verbs:
   - '*'
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - crio-metrics
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 - apiGroups:
   - apps
   resources:

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -231,6 +231,15 @@ var (
 	ControlPlaneEtcdPrometheusRule    = "control-plane/etcd-prometheus-rule.yaml"
 	ControlPlaneKubeletServiceMonitor = "control-plane/service-monitor-kubelet.yaml"
 	ControlPlaneEtcdServiceMonitor    = "control-plane/service-monitor-etcd.yaml"
+
+	CrioClusterRole                = "cri-o/cluster-role.yaml"
+	CrioClusterRoleBinding         = "cri-o/cluster-role-binding.yaml"
+	CrioDaemonSet                  = "cri-o/daemonset.yaml"
+	CrioSecret                     = "cri-o/secret.yaml"
+	CrioSecurityContextConstraints = "cri-o/security-context-constraints.yaml"
+	CrioService                    = "cri-o/service.yaml"
+	CrioServiceAccount             = "cri-o/service-account.yaml"
+	CrioServiceMonitor             = "cri-o/service-monitor.yaml"
 )
 
 var (
@@ -3772,4 +3781,72 @@ func removeEmptyDuplicates(elements []string) []string {
 
 func (f *Factory) GetAdditionalAlertmanagerConfigSecretName() string {
 	return AdditionalAlertmanagerConfigSecretName
+}
+
+func (f *Factory) CrioSecurityContextConstraints() (*securityv1.SecurityContextConstraints, error) {
+	scc, err := f.NewSecurityContextConstraints(f.assets.MustNewAssetReader(CrioSecurityContextConstraints))
+	if err != nil {
+		return nil, err
+	}
+	return scc, nil
+}
+
+func (f *Factory) CrioServiceAccount() (*v1.ServiceAccount, error) {
+	s, err := f.NewServiceAccount(f.assets.MustNewAssetReader(CrioServiceAccount))
+	if err != nil {
+		return nil, err
+	}
+	s.Namespace = f.namespace
+	return s, nil
+}
+
+func (f *Factory) CrioClusterRole() (*rbacv1.ClusterRole, error) {
+	return f.NewClusterRole(f.assets.MustNewAssetReader(CrioClusterRole))
+}
+
+func (f *Factory) CrioClusterRoleBinding() (*rbacv1.ClusterRoleBinding, error) {
+	crb, err := f.NewClusterRoleBinding(f.assets.MustNewAssetReader(CrioClusterRoleBinding))
+	if err != nil {
+		return nil, err
+	}
+	crb.Subjects[0].Namespace = f.namespace
+	return crb, nil
+}
+
+func (f *Factory) CrioSecret() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetReader(CrioSecret))
+	if err != nil {
+		return nil, err
+	}
+	s.Namespace = f.namespace
+	s.Data = make(map[string][]byte)
+	s.Annotations = make(map[string]string)
+	return s, nil
+}
+
+func (f *Factory) CrioService() (*v1.Service, error) {
+	s, err := f.NewService(f.assets.MustNewAssetReader(CrioService))
+	if err != nil {
+		return nil, err
+	}
+	s.Namespace = f.namespace
+	return s, nil
+}
+
+func (f *Factory) CrioServiceMonitor() (*monv1.ServiceMonitor, error) {
+	sm, err := f.NewServiceMonitor(f.assets.MustNewAssetReader(CrioServiceMonitor))
+	if err != nil {
+		return nil, err
+	}
+	sm.Namespace = f.namespace
+	return sm, nil
+}
+
+func (f *Factory) CrioDaemonSet() (*appsv1.DaemonSet, error) {
+	ds, err := f.NewDaemonSet(f.assets.MustNewAssetReader(CrioDaemonSet))
+	if err != nil {
+		return nil, err
+	}
+	ds.Namespace = f.namespace
+	return ds, nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -460,6 +460,7 @@ func (o *Operator) sync(key string) error {
 			tasks.NewTaskSpec("Updating Thanos Querier", tasks.NewThanosQuerierTask(o.client, factory, config)),
 			tasks.NewTaskSpec("Updating User Workload Thanos Ruler", tasks.NewThanosRulerUserWorkloadTask(o.client, factory, config)),
 			tasks.NewTaskSpec("Updating Control Plane components", tasks.NewControlPlaneTask(o.client, factory, config)),
+			tasks.NewTaskSpec("Updating CRI-O", tasks.NewCrioTask(o.client, factory)),
 		},
 	)
 

--- a/pkg/tasks/crio.go
+++ b/pkg/tasks/crio.go
@@ -1,0 +1,121 @@
+package tasks
+
+import (
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+)
+
+type CrioTask struct {
+	client  *client.Client
+	factory *manifests.Factory
+}
+
+func NewCrioTask(client *client.Client, factory *manifests.Factory) *CrioTask {
+	return &CrioTask{
+		client:  client,
+		factory: factory,
+	}
+}
+
+func (t *CrioTask) Run() error {
+	scc, err := t.factory.CrioSecurityContextConstraints()
+	if err != nil {
+		return errors.Wrap(err, "initializing CRI-O SecurityContextConstraints failed")
+	}
+
+	err = t.client.CreateOrUpdateSecurityContextConstraints(scc)
+	if err != nil {
+		return errors.Wrap(err, "reconciling CRI-O SecurityContextConstraints failed")
+	}
+
+	sa, err := t.factory.CrioServiceAccount()
+	if err != nil {
+		return errors.Wrap(err, "initializing CRI-O Service failed")
+	}
+
+	err = t.client.CreateOrUpdateServiceAccount(sa)
+	if err != nil {
+		return errors.Wrap(err, "reconciling CRI-O ServiceAccount failed")
+	}
+
+	cr, err := t.factory.CrioClusterRole()
+	if err != nil {
+		return errors.Wrap(err, "initializing CRI-O ClusterRole failed")
+	}
+
+	err = t.client.CreateOrUpdateClusterRole(cr)
+	if err != nil {
+		return errors.Wrap(err, "reconciling CRI-O ClusterRole failed")
+	}
+
+	crb, err := t.factory.CrioClusterRoleBinding()
+	if err != nil {
+		return errors.Wrap(err, "initializing CRI-O ClusterRoleBinding failed")
+	}
+
+	err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+	if err != nil {
+		return errors.Wrap(err, "reconciling CRI-O ClusterRoleBinding failed")
+	}
+
+	s, err := t.factory.CrioSecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing CRI-O secret failed")
+	}
+
+	loaded, err := t.client.GetSecret(s.Namespace, s.Name)
+	switch {
+	case apierrors.IsNotFound(err):
+		klog.V(5).Info("creating new CRI-O secret")
+	case err == nil:
+		s = loaded
+		klog.V(5).Info("found existing CRI-O secret")
+	default:
+		return errors.Wrap(err, "reading CRI-O secret")
+	}
+
+	err = manifests.RotateCrioSecret(s)
+	if err != nil {
+		return errors.Wrap(err, "rotating CRI-O secret")
+	}
+
+	err = t.client.CreateOrUpdateSecret(s)
+	if err != nil {
+		return errors.Wrap(err, "reconciling CRI-O secret failed")
+	}
+
+	srv, err := t.factory.CrioService()
+	if err != nil {
+		return errors.Wrap(err, "initializing CRI-O service failed")
+	}
+
+	err = t.client.CreateOrUpdateService(srv)
+	if err != nil {
+		return errors.Wrap(err, "reconciling CRI-O service failed")
+	}
+
+	sm, err := t.factory.CrioServiceMonitor()
+	if err != nil {
+		return errors.Wrap(err, "initializing CRI-O service monitor failed")
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(sm)
+	if err != nil {
+		return errors.Wrap(err, "reconciling CRI-O service monitor failed")
+	}
+
+	ds, err := t.factory.CrioDaemonSet()
+	if err != nil {
+		return errors.Wrap(err, "initializing CRI-O DaemonSet failed")
+	}
+
+	err = t.client.CreateOrUpdateDaemonSet(ds)
+	if err != nil {
+		return errors.Wrap(err, "reconciling CRI-O DaemonSet failed")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adding CRI-O metrics in dedicated namespace rather than a kubelet mapping.

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
