### PR TITLE
Correct serverName json tag

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -93,7 +93,7 @@ type PrometheusK8sConfig struct {
 	RemoteWrite         []monv1.RemoteWriteSpec              `json:"remoteWrite"`
 	TelemetryMatches    []string                             `json:"-"`
 	// EXPERIMENTAL: this configuration field may change in future releases.
-	AlertmanagerConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertManagerConfigs"`
+	AlertmanagerConfigs []AdditionalAlertmanagerConfig `json:"additionalAlertManagerConfigs"`
 }
 
 type AdditionalAlertmanagerConfig struct {
@@ -122,7 +122,7 @@ type TLSConfig struct {
 	// The client key in the Prometheus container to use for the targets.
 	Key *v1.SecretKeySelector `json:"key,omitempty"`
 	// Used to verify the hostname for the targets.
-	ServerName string `yaml:"server_name,omitempty"`
+	ServerName string `json:"serverName,omitempty"`
 	// Disable target certificate validation.
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1081,6 +1081,7 @@ func TestAdditionalAlertManagerConfigsSecret(t *testing.T) {
       key:
         name: alertmanager2-cert
         key: key.crt
+      serverName: alertmanager2-remote.com
     pathPrefix: /
     staticConfigs:
     - alertmanager2-remote.com
@@ -1097,6 +1098,7 @@ func TestAdditionalAlertManagerConfigsSecret(t *testing.T) {
       key:
         name: alertmanager3-key
         key: key.crt
+      serverName: alertmanager3-remote.com
     pathPrefix: /
     staticConfigs:
     - alertmanager3-remote.com
@@ -1121,6 +1123,7 @@ func TestAdditionalAlertManagerConfigsSecret(t *testing.T) {
     ca_file: /etc/prometheus/secrets/alertmanager2-cert/root-ca.crt
     cert_file: /etc/prometheus/secrets/alertmanager2-cert/cert.crt
     key_file: /etc/prometheus/secrets/alertmanager2-cert/key.crt
+    server_name: alertmanager2-remote.com
     insecure_skip_verify: false
   static_configs:
   - targets:
@@ -1133,6 +1136,7 @@ func TestAdditionalAlertManagerConfigsSecret(t *testing.T) {
     ca_file: /etc/prometheus/secrets/alertmanager3-ca/root-ca.crt
     cert_file: /etc/prometheus/secrets/alertmanager3-cert/cert.crt
     key_file: /etc/prometheus/secrets/alertmanager3-key/key.crt
+    server_name: alertmanager3-remote.com
     insecure_skip_verify: false
   static_configs:
   - targets:


### PR DESCRIPTION
Correct the serverName for json tag.

Signed-off-by: clyang82 <chuyang@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
