### PR TITLE
Improve monitoring telemetry rules

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -353,12 +353,12 @@ spec:
       record: openshift:build_by_strategy:sum
   - name: openshift-monitoring.rules
     rules:
-    - expr: sum by (job,namespace) (prometheus_tsdb_head_series{namespace=~"openshift-monitoring|openshift-user-workload-monitoring"})
+    - expr: sum by (job,namespace) (max without(instance) (prometheus_tsdb_head_series{namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}))
       record: openshift:prometheus_tsdb_head_series:sum
-    - expr: sum by(job,namespace) (rate(prometheus_tsdb_head_samples_appended_total{namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[2m]))
+    - expr: sum by(job,namespace) (max without(instance) (rate(prometheus_tsdb_head_samples_appended_total{namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[2m])))
       record: openshift:prometheus_tsdb_head_samples_appended_total:sum
-    - expr: sum by (namespace) (container_memory_working_set_bytes{namespace=~"openshift-monitoring|openshift-user-workload-monitoring",
-        container=""})
+    - expr: sum by (namespace) (max without(instance) (container_memory_working_set_bytes{namespace=~"openshift-monitoring|openshift-user-workload-monitoring",
+        container=""}))
       record: monitoring:container_memory_working_set_bytes:sum
     - expr: sum by(exported_service) (rate(haproxy_server_http_responses_total{exported_namespace="openshift-monitoring",
         exported_service=~"alertmanager-main|grafana|prometheus-k8s"}[5m]))


### PR DESCRIPTION
When the Prometheus pods are redeployed and persistent storage is used,
the recording rules used to report telemetry about monitoring would
double count for 5 minutes (at most). It happens because of how
Prometheus handles staleness: the individual metrics would be present
for both the old and new pods if their `instance` labels have changed
(e.g. their IP addresses are different). To avoid this artifact, the
rules aggregate away the `instance` label.

Original `openshift:prometheus_tsdb_head_series:sum` recording rule
![image](https://user-images.githubusercontent.com/2587585/122366883-423a7400-cf5c-11eb-82a0-7ad403c6aa15.png)

The modified query on the same dataset
![image](https://user-images.githubusercontent.com/2587585/122367042-6302c980-cf5c-11eb-9e19-a75a1954d118.png)

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
