### PR TITLE
Bug 1972076: jsonnet: Disable cpufreq collector in node_exporter

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -35,6 +35,7 @@ spec:
         - --collector.netdev.device-exclude=^(veth.*)$
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
+        - --no-collector.cpufreq
         image: quay.io/prometheus/node-exporter:v1.1.2
         name: node-exporter
         resources:

--- a/jsonnet/node-exporter.libsonnet
+++ b/jsonnet/node-exporter.libsonnet
@@ -138,7 +138,19 @@ function(params)
                       // gather that data (especially for bare metal clusters), and
                       // add flags to collect the node_cpu_info metric + metrics
                       // from the text file.
-                      args: [a for a in c.args if a != '--no-collector.hwmon'] + ['--collector.cpu.info', '--collector.textfile.directory=' + textfileDir],
+                      args: [a for a in c.args if a != '--no-collector.hwmon'] +
+                            [
+                              '--collector.cpu.info',
+                              '--collector.textfile.directory=' + textfileDir,
+
+                              // The cpufreq collector seems to be causing high
+                              // load on some nodes with lots of cores.  Disable
+                              // it temporarily as a workaround.
+                              //
+                              // https://bugzilla.redhat.com/show_bug.cgi?id=1972076
+                              // https://github.com/prometheus/node_exporter/issues/1880
+                              '--no-collector.cpufreq',
+                            ],
                       terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts+: [{
                         mountPath: textfileDir,


### PR DESCRIPTION
The node_exporter cpufreq collector seems to be causing high load on
some machines with lots of cores.  This disables it temporarily as a
workaround until the issue can be addressed upstream.  We don't seem
to rely on these metrics anywhere.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1972076

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
