### PR TITLE
test/e2e: make tests more resilient to hiccups

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -378,17 +378,17 @@ func TestAlertmanagerOAuthProxy(t *testing.T) {
 			"active", "true",
 		)
 		if err != nil {
-			t.Fatal(err)
+			return errors.Wrap(err, "error getting alerts from Alertmanager")
 		}
 
 		res, err := gabs.ParseJSON(body)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "error parsing Alertmanager response: %s", string(body))
 		}
 
 		count, err := res.ArrayCount()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "error getting count of items")
 		}
 
 		if count == 1 {

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -305,7 +305,7 @@ func (c *PrometheusClient) WaitForQueryReturn(t *testing.T, timeout time.Duratio
 	err := Poll(5*time.Second, timeout, func() error {
 		body, err := c.PrometheusQuery(query)
 		if err != nil {
-			t.Fatal(err)
+			return errors.Wrapf(err, "error getting response for query %q", query)
 		}
 
 		v, err := GetFirstValueFromPromQuery(body)
@@ -333,7 +333,7 @@ func (c *PrometheusClient) WaitForRulesReturn(t *testing.T, timeout time.Duratio
 	err := Poll(5*time.Second, timeout, func() error {
 		body, err := c.PrometheusRules()
 		if err != nil {
-			t.Fatal(err)
+			return errors.Wrap(err, "error getting rules")
 		}
 
 		if err := validate(body); err != nil {

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -630,17 +630,17 @@ func assertUserWorkloadMetrics(t *testing.T) {
 			"active", "true",
 		)
 		if err != nil {
-			t.Fatal(err)
+			return errors.Wrap(err, "error getting alerts from Alertmanager")
 		}
 
 		res, err := gabs.ParseJSON(body)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "error parsing Alertmanager response: %s", string(body))
 		}
 
 		count, err := res.ArrayCount()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "error getting count of items")
 		}
 
 		if count == 1 {


### PR DESCRIPTION
Follow-up of #1194

@bison I knew that other places were still looking for improvements and https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-monitoring-operator/1227/pull-ci-openshift-cluster-monitoring-operator-master-e2e-agnostic-operator/1405453185732055040 reminded me which ones :smiley: 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
