### PR TITLE
Bug 1970147: jsonnet: disable insecure cypher suites for prometheus-adapter

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -47,6 +47,7 @@ spec:
         - --metrics-relist-interval=1m
         - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc:9091
         - --secure-port=6443
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         image: directxman12/k8s-prometheus-adapter:v0.8.4
         name: prometheus-adapter
         ports:

--- a/jsonnet/alertmanager.libsonnet
+++ b/jsonnet/alertmanager.libsonnet
@@ -303,7 +303,7 @@ function(params)
               '--config-file=/etc/kube-rbac-proxy/config.yaml',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',
-              '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+              '--tls-cipher-suites=' + cfg.tlsCipherSuites,
               '--logtostderr=true',
               '--v=10',
             ],

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -86,6 +86,8 @@ local commonConfig = {
   commonLabels: {
     'app.kubernetes.io/part-of': 'openshift-monitoring',
   },
+  // TLS Cipher suite applied to every component serving HTTPS traffic
+  tlsCipherSuites: 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
 };
 
 // objects deployed in openshift-monitoring namespace
@@ -112,6 +114,7 @@ local inCluster =
         version: $.values.common.versions.alertmanager,
         image: $.values.common.images.alertmanager,
         commonLabels+: $.values.common.commonLabels,
+        tlsCipherSuites: $.values.common.tlsCipherSuites,
         mixin+: { ruleLabels: $.values.common.ruleLabels },
       },
       grafana: {
@@ -242,6 +245,7 @@ local inCluster =
           },
         },
         thanos: $.values.thanosSidecar,
+        tlsCipherSuites: $.values.common.tlsCipherSuites,
       },
       prometheusAdapter: {
         namespace: $.values.common.namespace,
@@ -249,6 +253,7 @@ local inCluster =
         image: $.values.common.images.prometheusAdapter,
         prometheusURL: 'https://prometheus-' + $.values.prometheus.name + '.' + $.values.common.namespace + '.svc:9091',
         commonLabels+: $.values.common.commonLabels,
+        tlsCipherSuites: $.values.common.tlsCipherSuites,
       },
       prometheusOperator: {
         namespace: $.values.common.namespace,
@@ -262,6 +267,7 @@ local inCluster =
             prometheusSelector: 'job=~"prometheus-k8s|prometheus-user-workload"',
           },
         },
+        tlsCipherSuites: $.values.common.tlsCipherSuites,
       },
       thanos: {
         image: $.values.common.images.thanos,
@@ -298,6 +304,7 @@ local inCluster =
         replicaLabels: ['prometheus_replica', 'thanos_ruler_replica'],
         stores: ['dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local'],
         serviceMonitor: true,
+        tlsCipherSuites: $.values.common.tlsCipherSuites,
       },
       telemeterClient: {
         namespace: $.values.common.namespace,
@@ -367,6 +374,7 @@ local userWorkload =
           },
         },
         thanos: inCluster.values.thanosSidecar,
+        tlsCipherSuites: $.values.common.tlsCipherSuites,
       },
       prometheusOperator: {
         namespace: $.values.common.namespace,

--- a/jsonnet/prometheus-adapter.libsonnet
+++ b/jsonnet/prometheus-adapter.libsonnet
@@ -94,6 +94,7 @@ function(params)
                           '--metrics-relist-interval=1m',
                           '--prometheus-url=' + cfg.prometheusURL,
                           '--secure-port=6443',
+                          '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                         ],
                         terminationMessagePolicy: 'FallbackToLogsOnError',
                         volumeMounts: [

--- a/jsonnet/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator.libsonnet
@@ -33,7 +33,7 @@ function(params)
                         '--config-reloader-cpu-limit=0',
                         '--config-reloader-memory-limit=0',
                         '--web.enable-tls=true',
-                        '--web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+                        '--web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
                         '--web.tls-min-version=VersionTLS12',
                       ],
                       securityContext: {},
@@ -55,7 +55,7 @@ function(params)
                       args: [
                         '--logtostderr',
                         '--secure-listen-address=:8443',
-                        '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+                        '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                         '--upstream=https://prometheus-operator.openshift-monitoring.svc:8080/',
                         '--tls-cert-file=/etc/tls/private/tls.crt',
                         '--tls-private-key-file=/etc/tls/private/tls.key',

--- a/jsonnet/prometheus-user-workload.libsonnet
+++ b/jsonnet/prometheus-user-workload.libsonnet
@@ -247,7 +247,7 @@ function(params)
               '--upstream=http://127.0.0.1:9090',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',
-              '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+              '--tls-cipher-suites=' + cfg.tlsCipherSuites,
               '--allow-paths=/metrics',
             ],
             terminationMessagePolicy: 'FallbackToLogsOnError',
@@ -286,7 +286,7 @@ function(params)
               '--upstream=http://127.0.0.1:10902',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',
-              '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+              '--tls-cipher-suites=' + cfg.tlsCipherSuites,
               '--allow-paths=/metrics',
               '--logtostderr=true',
             ],

--- a/jsonnet/prometheus.libsonnet
+++ b/jsonnet/prometheus.libsonnet
@@ -401,7 +401,7 @@ function(params)
               '--config-file=/etc/kube-rbac-proxy/config.yaml',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',
-              '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+              '--tls-cipher-suites=' + cfg.tlsCipherSuites,
               '--logtostderr=true',
               '--v=10',
             ],
@@ -461,7 +461,7 @@ function(params)
               '--upstream=http://127.0.0.1:10902',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',
-              '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+              '--tls-cipher-suites=' + cfg.tlsCipherSuites,
               '--allow-paths=/metrics',
               '--logtostderr=true',
             ],

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -443,7 +443,7 @@ function(params)
                   '--config-file=/etc/kube-rbac-proxy/config.yaml',
                   '--tls-cert-file=/etc/tls/private/tls.crt',
                   '--tls-private-key-file=/etc/tls/private/tls.key',
-                  '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+                  '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                   '--logtostderr=true',
                   '--allow-paths=/api/v1/query,/api/v1/query_range',
                 ],
@@ -496,7 +496,7 @@ function(params)
                   '--config-file=/etc/kube-rbac-proxy/config.yaml',
                   '--tls-cert-file=/etc/tls/private/tls.crt',
                   '--tls-private-key-file=/etc/tls/private/tls.key',
-                  '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  //FIXME(paulfantom)
+                  '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                   '--logtostderr=true',
                   '--allow-paths=/api/v1/rules',
                 ],


### PR DESCRIPTION
Running sslscan against the prometheus adapter secure port reports two
insecure SSL ciphers, ECDHE-RSA-DES-CBC3-SHA and DES-CBC3-SHA.

This commit removes those ciphers from the list.

It is not enough to pull in changes from the [kube-prometheus PR](https://github.com/prometheus-operator/kube-prometheus/pull/1216) since we override the prometheus-adapter args completely:  

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
