### PR TITLE
*: improve discovery of currently used component versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -31,6 +31,7 @@ about: Create release checklist
 - [ ] update and pin jsonnet dependencies in [jsonnet/jsonnetfile.json](https://github.com/openshift/cluster-monitoring-operator/blob/master/jsonnet/jsonnetfile.json).
   - example: https://github.com/openshift/cluster-monitoring-operator/blob/release-4.3/jsonnet/jsonnetfile.json
   - dependencies should be pinned to branches released in previous paragraph
+  - ensure `jsonnet/version.json` file is tracking up-to-date component versions by running `make versions` and regenerating `assets/` if necessary
 - [ ] update golang dependencies in [go.mod](https://github.com/openshift/cluster-monitoring-operator/blob/master/go.mod) and [hack/tools/go.mod](https://github.com/openshift/cluster-monitoring-operator/blob/master/hack/tools/go.mod) files.
   - most important are dependencies on prometheus-operator and kubernetes components
   - update the tooling prometheus dependency to be in sync with the main one

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ $(JSON_MANIFESTS): $(MANIFESTS)
 .PHONY: json-manifests
 json-manifests: $(JSON_MANIFESTS_DIR) $(JSON_MANIFESTS)
 
+.PHONY: versions
+versions:
+	./hack/generate-versions.sh > jsonnet/versions.json
+
 .PHONY: docs
 docs: $(EMBEDMD_BIN) Documentation/telemeter_query
 	$(EMBEDMD_BIN) -w `find Documentation -name "*.md"`

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -70,7 +70,7 @@ spec:
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --logtostderr=true
     - --v=10
-    image: quay.io/coreos/kube-rbac-proxy:v0.8.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.9.0
     name: kube-rbac-proxy
     ports:
     - containerPort: 9092
@@ -89,7 +89,7 @@ spec:
     - --insecure-listen-address=127.0.0.1:9096
     - --upstream=http://127.0.0.1:9093
     - --label=namespace
-    image: quay.io/coreos/prom-label-proxy:v0.2.0
+    image: quay.io/prometheuscommunity/prom-label-proxy:v0.3.0
     name: prom-label-proxy
     resources:
       requests:

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         - --upstream=http://127.0.0.1:8081/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -87,7 +87,7 @@ spec:
         - --upstream=http://127.0.0.1:8082/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100

--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - --upstream=http://127.0.0.1:8081/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -45,7 +45,7 @@ spec:
         - --upstream=http://127.0.0.1:8082/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -88,7 +88,7 @@ spec:
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --logtostderr=true
     - --v=10
-    image: quay.io/coreos/kube-rbac-proxy:v0.8.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.9.0
     name: kube-rbac-proxy
     ports:
     - containerPort: 9092
@@ -107,7 +107,7 @@ spec:
     - --insecure-listen-address=127.0.0.1:9095
     - --upstream=http://127.0.0.1:9090
     - --label=namespace
-    image: quay.io/coreos/prom-label-proxy:v0.2.0
+    image: quay.io/prometheuscommunity/prom-label-proxy:v0.3.0
     name: prom-label-proxy
     resources:
       requests:
@@ -127,7 +127,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: quay.io/coreos/kube-rbac-proxy:v0.8.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.9.0
     name: kube-rbac-proxy-thanos
     ports:
     - containerPort: 10902

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --upstream-ca-file=/etc/configmaps/operator-cert-ca-bundle/service-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -47,7 +47,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --allow-paths=/metrics
-    image: quay.io/coreos/kube-rbac-proxy:v0.8.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.9.0
     name: kube-rbac-proxy
     ports:
     - containerPort: 9091
@@ -73,7 +73,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: quay.io/coreos/kube-rbac-proxy:v0.8.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.9.0
     name: kube-rbac-proxy-thanos
     ports:
     - containerPort: 10902

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        image: quay.io/coreos/kube-rbac-proxy:latest
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -137,7 +137,7 @@ spec:
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
         - --allow-paths=/api/v1/query,/api/v1/query_range
-        image: quay.io/coreos/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9092
@@ -156,7 +156,7 @@ spec:
         - --insecure-listen-address=127.0.0.1:9095
         - --upstream=http://127.0.0.1:9090
         - --label=namespace
-        image: quay.io/coreos/prom-label-proxy:v0.2.0
+        image: quay.io/prometheuscommunity/prom-label-proxy:v0.3.0
         name: prom-label-proxy
         resources:
           requests:
@@ -172,7 +172,7 @@ spec:
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
         - --allow-paths=/api/v1/rules
-        image: quay.io/coreos/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy-rules
         ports:
         - containerPort: 9093

--- a/hack/generate-versions.sh
+++ b/hack/generate-versions.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# A naive way to generate `jsonnet/versions.json` file from downstream forks
+# It uses `VERSION` file located in each repository or a special function to figure out correct version
+# 
+# Script is based on https://github.com/prometheus-operator/kube-prometheus/blob/main/scripts/generate-versions.sh
+#
+
+get_version_from_file() {
+  curl --retry 5 --silent --fail "https://raw.githubusercontent.com/${1}/master/VERSION"
+}
+
+# Fallback mechanism when VERSION file is empty or not found
+get_version_from_user() {
+    ver=""
+    echo >&2 -n "Cannot determine version of ${1}. Please provide version manually (without alphabetical prefixes) and press ENTER: "
+    read -r ver
+    echo "$ver"
+}
+
+get_version() {
+  component="${1}"
+  v="$(get_version_from_file "${component}")"
+
+  if [[ "$v" == "" ]]; then
+     v="$(get_version_from_user "${component}")"
+  fi
+  echo "$v" | sed 's/v//g'
+}
+
+
+cat <<-EOF
+{ 
+  "alertmanager": "$(get_version "openshift/prometheus-alertmanager")",
+  "prometheus": "$(get_version "openshift/prometheus")",
+  "grafana": "$(get_version "openshift/grafana")",
+  "kubeStateMetrics": "$(get_version "openshift/kube-state-metrics")",
+  "nodeExporter": "$(get_version "openshift/node_exporter")",
+  "prometheusAdapter": "$(get_version "openshift/k8s-prometheus-adapter")",
+  "prometheusOperator": "$(get_version "openshift/prometheus-operator")",
+  "promLabelProxy": "$(get_version "openshift/prom-label-proxy")",
+  "kubeRbacProxy": "$(get_version "openshift/kube-rbac-proxy")",
+  "thanos": "$(get_version "openshift/thanos")"
+}
+EOF

--- a/jsonnet/alertmanager.libsonnet
+++ b/jsonnet/alertmanager.libsonnet
@@ -284,7 +284,7 @@ function(params)
           },
           {
             name: 'kube-rbac-proxy',
-            image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
+            image: cfg.kubeRbacProxyImage,
             resources: {
               requests: {
                 cpu: '1m',
@@ -321,7 +321,7 @@ function(params)
           },
           {
             name: 'prom-label-proxy',
-            image: 'quay.io/coreos/prom-label-proxy:v0.2.0',  // FIXME(paulfantom)
+            image: cfg.promLabelProxyImage,
             args: [
               '--insecure-listen-address=127.0.0.1:9096',
               '--upstream=http://127.0.0.1:9093',

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -54,18 +54,7 @@ local commonConfig = {
     prometheus: $.prometheusName,
   },
   // versions are used by some CRs and reflected in labels.
-  versions: {
-    alertmanager: '0.21.0',
-    prometheus: '2.26.1',
-    grafana: '7.5.5',
-    kubeStateMetrics: '2.0.0',
-    nodeExporter: '1.1.2',
-    prometheusAdapter: '0.8.4',
-    prometheusOperator: '0.48.1',
-    promLabelProxy: '0.2.0',
-    thanos: '0.20.2',
-    kubeRbacProxy: '0.10.0',
-  },
+  versions: (import './versions.json'),
   // In OSE images are overridden
   images: {
     alertmanager: 'quay.io/prometheus/alertmanager:v' + $.versions.alertmanager,
@@ -76,7 +65,7 @@ local commonConfig = {
     prometheusAdapter: 'directxman12/k8s-prometheus-adapter:v' + $.versions.prometheusAdapter,
     prometheusOperator: 'quay.io/prometheus-operator/prometheus-operator:v' + $.versions.prometheusOperator,
     prometheusOperatorReloader: 'quay.io/prometheus-operator/prometheus-config-reloader:v' + $.versions.prometheusOperator,
-    promLabelProxy: 'quay.io/prometheuscommunity/prom-label-proxy:v' + $.versions.thanos,
+    promLabelProxy: 'quay.io/prometheuscommunity/prom-label-proxy:v' + $.versions.promLabelProxy,
     telemeter: '',
     thanos: 'quay.io/thanos/thanos:v' + $.versions.thanos,
     kubeRbacProxy: 'quay.io/brancz/kube-rbac-proxy:v' + $.versions.kubeRbacProxy,

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -107,6 +107,8 @@ local inCluster =
         commonLabels+: $.values.common.commonLabels,
         tlsCipherSuites: $.values.common.tlsCipherSuites,
         mixin+: { ruleLabels: $.values.common.ruleLabels },
+        kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
+        promLabelProxyImage: $.values.common.images.promLabelProxy,
       },
       grafana: {
         namespace: $.values.common.namespace,
@@ -217,6 +219,7 @@ local inCluster =
       },
       openshiftStateMetrics: {
         namespace: $.values.common.namespace,
+        kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
       },
       prometheus: {
         namespace: $.values.common.namespace,
@@ -239,6 +242,8 @@ local inCluster =
         },
         thanos: $.values.thanosSidecar,
         tlsCipherSuites: $.values.common.tlsCipherSuites,
+        kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
+        promLabelProxyImage: $.values.common.images.promLabelProxy,
       },
       prometheusAdapter: {
         namespace: $.values.common.namespace,
@@ -299,9 +304,12 @@ local inCluster =
         stores: ['dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local'],
         serviceMonitor: true,
         tlsCipherSuites: $.values.common.tlsCipherSuites,
+        kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
+        promLabelProxyImage: $.values.common.images.promLabelProxy,
       },
       telemeterClient: {
         namespace: $.values.common.namespace,
+        kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
       },
       controlPlane: {
         namespace: $.values.common.namespace,
@@ -393,6 +401,7 @@ local userWorkload =
         },
         thanos: inCluster.values.thanosSidecar,
         tlsCipherSuites: $.values.common.tlsCipherSuites,
+        kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
       },
       prometheusOperator: {
         namespace: $.values.common.namespace,

--- a/jsonnet/openshift-state-metrics.libsonnet
+++ b/jsonnet/openshift-state-metrics.libsonnet
@@ -17,7 +17,25 @@ function(params) {
   // This shouldn't make much difference as openshift-state-metrics project is scheduled for deprecation
   clusterRoleBinding: osm.openshiftStateMetrics.clusterRoleBinding,
   clusterRole: osm.openshiftStateMetrics.clusterRole,
-  deployment: osm.openshiftStateMetrics.deployment,
+  deployment: osm.openshiftStateMetrics.deployment {
+    spec+: {
+      template+: {
+        spec+: {
+          containers:
+            std.map(
+              function(c)
+                if c.name == 'kube-rbac-proxy-main' || c.name == 'kube-rbac-proxy-self' then
+                  c {
+                    image: cfg.kubeRbacProxyImage,
+                  }
+                else
+                  c,
+              super.containers,
+            ),
+        },
+      },
+    },
+  },
   serviceAccount: osm.openshiftStateMetrics.serviceAccount,
   service: osm.openshiftStateMetrics.service,
   serviceMonitor: osm.openshiftStateMetrics.serviceMonitor,

--- a/jsonnet/prometheus-user-workload.libsonnet
+++ b/jsonnet/prometheus-user-workload.libsonnet
@@ -229,7 +229,7 @@ function(params)
         containers: [
           {
             name: 'kube-rbac-proxy',
-            image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
+            image: cfg.kubeRbacProxyImage,
             resources: {
               requests: {
                 memory: '10Mi',
@@ -260,7 +260,7 @@ function(params)
           },
           {
             name: 'kube-rbac-proxy-thanos',
-            image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
+            image: cfg.kubeRbacProxyImage,
             resources: {
               requests: {
                 memory: '10Mi',

--- a/jsonnet/prometheus.libsonnet
+++ b/jsonnet/prometheus.libsonnet
@@ -382,7 +382,7 @@ function(params)
           },
           {
             name: 'kube-rbac-proxy',
-            image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
+            image: cfg.kubeRbacProxyImage,
             resources: {
               requests: {
                 memory: '15Mi',
@@ -419,7 +419,7 @@ function(params)
           },
           {
             name: 'prom-label-proxy',
-            image: 'quay.io/coreos/prom-label-proxy:v0.2.0',  // FIXME(paulfantom)
+            image: cfg.promLabelProxyImage,
             args: [
               '--insecure-listen-address=127.0.0.1:9095',
               '--upstream=http://127.0.0.1:9090',
@@ -435,7 +435,7 @@ function(params)
           },
           {
             name: 'kube-rbac-proxy-thanos',
-            image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
+            image: cfg.kubeRbacProxyImage,
             resources: {
               requests: {
                 memory: '10Mi',

--- a/jsonnet/telemeter-client.libsonnet
+++ b/jsonnet/telemeter-client.libsonnet
@@ -15,9 +15,6 @@ function(params) {
         'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305',
         'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
       ],
-      versions+: {
-        kubeRbacProxy: 'latest',
-      },
     },
   },
 
@@ -45,6 +42,10 @@ function(params) {
                       ,
                       c.args,
                     ),
+                  }
+                else if c.name == 'kube-rbac-proxy' then
+                  c {
+                    image: cfg.kubeRbacProxyImage,
                   }
                 else
                   c,

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -428,7 +428,7 @@ function(params)
               },
               {
                 name: 'kube-rbac-proxy',
-                image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
+                image: cfg.kubeRbacProxyImage,
                 resources: {
                   requests: {
                     memory: '15Mi',
@@ -465,7 +465,7 @@ function(params)
               },
               {
                 name: 'prom-label-proxy',
-                image: 'quay.io/coreos/prom-label-proxy:v0.2.0',  // FIXME(paulfantom)
+                image: cfg.promLabelProxyImage,
                 args: [
                   '--insecure-listen-address=127.0.0.1:9095',
                   '--upstream=http://127.0.0.1:9090',
@@ -481,7 +481,7 @@ function(params)
               },
               {
                 name: 'kube-rbac-proxy-rules',
-                image: 'quay.io/coreos/kube-rbac-proxy:v0.8.0',  //FIXME(paulfantom)
+                image: cfg.kubeRbacProxyImage,
                 resources: {
                   requests: {
                     memory: '15Mi',

--- a/jsonnet/versions.json
+++ b/jsonnet/versions.json
@@ -1,0 +1,12 @@
+{ 
+  "alertmanager": "0.21.0",
+  "prometheus": "2.26.1",
+  "grafana": "7.5.5",
+  "kubeStateMetrics": "2.0.0",
+  "nodeExporter": "1.1.2",
+  "prometheusAdapter": "0.8.4",
+  "prometheusOperator": "0.48.1",
+  "promLabelProxy": "0.3.0",
+  "kubeRbacProxy": "0.9.0",
+  "thanos": "0.20.2"
+}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

During a release process, we need to pin version numbers of operands to ensure correct metadata is assigned to k8s objects managed by CMO. To improve this process and make it error-prone I created a simple bash script to poll every downstream fork for `VERSION` file and use the content of those files to create a simple JSON map put into `versions.json`. This JSON file is then imported into the jsonnet codebase and used to generate correct metadata.

Since the `versions.json` file can be treated as a source of truth (to some degree) it should improve our ability to discover which operand version is shipped with which OpenShift release. Additionally, in the future, it opens an easy path to use the file in some sort of documentation generator. 

Waiting for https://github.com/openshift/cluster-monitoring-operator/pull/1187 to merge and then to rebase onto `master`

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
