### PR TITLE
AggregatedAPIDown alert threshold set back to 85%

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -398,7 +398,7 @@ spec:
           has been only {{ $value | humanize }}% available over the last 10m.
         summary: An aggregated API is down.
       expr: |
-        (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 70
+        (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
       for: 5m
       labels:
         severity: warning

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -89,19 +89,6 @@ local patchedRules = [
     ],
   },
   {
-    name: 'kubernetes-system-apiserver',
-    rules: [
-      {
-        // Lower treshold to be resilient to DNS rollouts and CA rotations.
-        // https://bugzilla.redhat.com/show_bug.cgi?id=1970624
-        alert: 'AggregatedAPIDown',
-        expr: |||
-          (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 70
-        |||,
-      },
-    ],
-  },
-  {
     name: 'prometheus',
     rules: [
       {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This pull request reverts [a patch](https://github.com/openshift/cluster-monitoring-operator/pull/1211) to version 4.8 that mitigates a problem when upgrading monitoring components from 4.7 to 4.8: AggregatedAPIDown is triggered due to a long period of unavailability of prometheus adapter. Both deployments are offline at the same time during the upgrade.

After integrating these 2 PRs([PR1](https://github.com/openshift/cluster-monitoring-operator/pull/1149), [PR2](https://github.com/openshift/cluster-monitoring-operator/pull/1124)) into 4.8 release, Prometheus Adapter is able to keep itself always available during the upgrade process. We can set back the alert threshold to its default value 85%.





