### PR TITLE
Remove context.TODO() from client_go method calls

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -65,7 +64,7 @@ func TestAlertmanagerVolumeClaim(t *testing.T) {
 
 	// Wait for persistent volume claim
 	err = framework.Poll(time.Second, 5*time.Minute, func() error {
-		_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.Ns).Get(context.TODO(), "alertmanager-main-db-alertmanager-main-0", metav1.GetOptions{})
+		_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.Ns).Get(f.Ctx, "alertmanager-main-db-alertmanager-main-0", metav1.GetOptions{})
 		if err != nil {
 			return errors.Wrap(err, "getting alertmanager persistent volume claim failed")
 		}
@@ -95,7 +94,7 @@ func TestAlertmanagerTrustedCA(t *testing.T) {
 
 	// Wait for the new ConfigMap to be created
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		cm, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(context.TODO(), "alertmanager-trusted-ca-bundle", metav1.GetOptions{})
+		cm, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(f.Ctx, "alertmanager-trusted-ca-bundle", metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting new trusted CA ConfigMap failed")
 		if err != nil {
 			return false, nil
@@ -118,7 +117,7 @@ func TestAlertmanagerTrustedCA(t *testing.T) {
 
 	// Wait for the new hashed trusted CA bundle ConfigMap to be created
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(context.TODO(), newCM.Name, metav1.GetOptions{})
+		_, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(f.Ctx, newCM.Name, metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting new CA ConfigMap failed")
 		if err != nil {
 			return false, nil
@@ -134,7 +133,7 @@ func TestAlertmanagerTrustedCA(t *testing.T) {
 
 	// Get Alertmanager StatefulSet and make sure it has a volume mounted.
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		ss, err := f.KubeClient.AppsV1().StatefulSets(f.Ns).Get(context.TODO(), "alertmanager-main", metav1.GetOptions{})
+		ss, err := f.KubeClient.AppsV1().StatefulSets(f.Ns).Get(f.Ctx, "alertmanager-main", metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting Alertmanager StatefulSet failed")
 		if err != nil {
 			return false, nil
@@ -179,12 +178,12 @@ func TestAlertmanagerKubeRbacProxy(t *testing.T) {
 			Name: testNs,
 		},
 	}
-	ns, err = f.KubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	ns, err = f.KubeClient.CoreV1().Namespaces().Create(f.Ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := f.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), testNs, metav1.DeleteOptions{})
+		err := f.KubeClient.CoreV1().Namespaces().Delete(f.Ctx, testNs, metav1.DeleteOptions{})
 		t.Logf("deleting namespace %s: %v", testNs, err)
 	}()
 

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -46,7 +45,7 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 	}
 
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
-		_, err := f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(context.TODO(), "prometheus-user-workload", metav1.GetOptions{})
+		_, err := f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(f.Ctx, "prometheus-user-workload", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -80,7 +79,7 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 	assertOperatorCondition(t, configv1.OperatorDegraded, configv1.ConditionTrue)
 	assertOperatorCondition(t, configv1.OperatorAvailable, configv1.ConditionFalse)
 	// Check that the previous setup hasn't been reverted
-	_, err = f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(context.TODO(), "prometheus-user-workload", metav1.GetOptions{})
+	_, err = f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(f.Ctx, "prometheus-user-workload", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -47,8 +47,9 @@ func NewPrometheusClientFromRoute(
 	routeClient routev1.RouteV1Interface,
 	namespace, name string,
 	token string,
+	ctx context.Context,
 ) (*PrometheusClient, error) {
-	route, err := routeClient.Routes(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	route, err := routeClient.Routes(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -45,9 +45,9 @@ type PrometheusClient struct {
 // NewPrometheusClientFromRoute creates and returns a new PrometheusClient from the given OpenShift route.
 func NewPrometheusClientFromRoute(
 	routeClient routev1.RouteV1Interface,
+	ctx context.Context,
 	namespace, name string,
 	token string,
-	ctx context.Context,
 ) (*PrometheusClient, error) {
 	route, err := routeClient.Routes(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -61,6 +61,7 @@ type Framework struct {
 	MetricsClient       *metricsclient.Clientset
 	SchedulingClient    *schedulingv1client.SchedulingV1Client
 	kubeConfigPath      string
+	Ctx                 context.Context
 
 	MonitoringClient             *monClient.MonitoringV1Client
 	Ns, UserWorkloadMonitoringNs string
@@ -125,6 +126,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		Ns:                       namespaceName,
 		UserWorkloadMonitoringNs: userWorkloadNamespaceName,
 		kubeConfigPath:           kubeConfigPath,
+		Ctx:                      context.Background(),
 		SchedulingClient:         schedulingClient,
 	}
 
@@ -218,20 +220,20 @@ func (f *Framework) CreateServiceAccount(namespace, serviceAccount string) (clea
 		},
 	}
 
-	sa, err := f.KubeClient.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), sa, metav1.CreateOptions{})
+	sa, err := f.KubeClient.CoreV1().ServiceAccounts(namespace).Create(f.Ctx, sa, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	return func() error {
-		return f.KubeClient.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), sa.Name, metav1.DeleteOptions{})
+		return f.KubeClient.CoreV1().ServiceAccounts(namespace).Delete(f.Ctx, sa.Name, metav1.DeleteOptions{})
 	}, nil
 }
 
 func (f *Framework) GetServiceAccountToken(namespace, name string) (string, error) {
 	var token string
 	err := Poll(5*time.Second, time.Minute, func() error {
-		secrets, err := f.KubeClient.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{})
+		secrets, err := f.KubeClient.CoreV1().Secrets(namespace).List(f.Ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -270,13 +272,13 @@ func (f *Framework) CreateClusterRoleBinding(namespace, serviceAccount, clusterR
 		},
 	}
 
-	clusterRoleBinding, err := f.KubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
+	clusterRoleBinding, err := f.KubeClient.RbacV1().ClusterRoleBindings().Create(f.Ctx, clusterRoleBinding, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	return func() error {
-		return f.KubeClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), clusterRoleBinding.Name, metav1.DeleteOptions{})
+		return f.KubeClient.RbacV1().ClusterRoleBindings().Delete(f.Ctx, clusterRoleBinding.Name, metav1.DeleteOptions{})
 	}, nil
 }
 
@@ -299,13 +301,13 @@ func (f *Framework) CreateRoleBindingFromClusterRole(namespace, serviceAccount, 
 		},
 	}
 
-	roleBinding, err := f.KubeClient.RbacV1().RoleBindings(namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{})
+	roleBinding, err := f.KubeClient.RbacV1().RoleBindings(namespace).Create(f.Ctx, roleBinding, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	return func() error {
-		return f.KubeClient.RbacV1().RoleBindings(namespace).Delete(context.TODO(), roleBinding.Name, metav1.DeleteOptions{})
+		return f.KubeClient.RbacV1().RoleBindings(namespace).Delete(f.Ctx, roleBinding.Name, metav1.DeleteOptions{})
 	}, nil
 }
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -143,9 +143,9 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 	// Prometheus client depends on setup above.
 	f.ThanosQuerierClient, err = NewPrometheusClientFromRoute(
 		openshiftRouteClient,
+		f.Ctx,
 		namespaceName, "thanos-querier",
 		token,
-		f.Ctx,
 	)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating ThanosQuerierClient failed")
@@ -153,9 +153,9 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 
 	f.PrometheusK8sClient, err = NewPrometheusClientFromRoute(
 		openshiftRouteClient,
+		f.Ctx,
 		namespaceName, "prometheus-k8s",
 		token,
-		f.Ctx,
 	)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating PrometheusK8sClient failed")
@@ -163,9 +163,9 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 
 	f.AlertmanagerClient, err = NewPrometheusClientFromRoute(
 		openshiftRouteClient,
+		f.Ctx,
 		namespaceName, "alertmanager-main",
 		token,
-		f.Ctx,
 	)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating AlertmanagerClient failed")

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -145,6 +145,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		openshiftRouteClient,
 		namespaceName, "thanos-querier",
 		token,
+		f.Ctx,
 	)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating ThanosQuerierClient failed")
@@ -154,6 +155,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		openshiftRouteClient,
 		namespaceName, "prometheus-k8s",
 		token,
+		f.Ctx,
 	)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating PrometheusK8sClient failed")
@@ -163,6 +165,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		openshiftRouteClient,
 		namespaceName, "alertmanager-main",
 		token,
+		f.Ctx,
 	)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating AlertmanagerClient failed")

--- a/test/e2e/framework/secret.go
+++ b/test/e2e/framework/secret.go
@@ -26,13 +26,13 @@ import (
 	poTestFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
 
-func CreateSecret(kubeClient kubernetes.Interface, namespace string, relativePath string) error {
+func CreateSecret(kubeClient kubernetes.Interface, ctx context.Context, namespace string, relativePath string) error {
 	secret, err := parseSecretYaml(relativePath)
 	if err != nil {
 		return errors.Wrap(err, "parsing secret failed")
 	}
 
-	if _, err := kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+	if _, err := kubeClient.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		return errors.Wrap(err, "creating secret failed")
 	}
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -66,7 +65,7 @@ func testMain(m *testing.M) error {
 
 	// Wait for Prometheus operator.
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(context.TODO(), "prometheus-operator", metav1.GetOptions{})
+		_, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(f.Ctx, "prometheus-operator", metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -40,7 +39,7 @@ func TestMultinamespacePrometheusRule(t *testing.T) {
 			},
 		},
 	}
-	_, err := f.KubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, err := f.KubeClient.CoreV1().Namespaces().Create(f.Ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/priority_class_test.go
+++ b/test/e2e/priority_class_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,16 +27,16 @@ import (
 // system-node-critical      2000001000   false            114m
 func TestToEnsureUserPriorityClassIsPresentAndLower(t *testing.T) {
 	// Get system priority class values.
-	systemClusterPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(context.TODO(), "system-cluster-critical", v1.GetOptions{})
+	systemClusterPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(f.Ctx, "system-cluster-critical", v1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	systemNodePriorityClass, err := f.SchedulingClient.PriorityClasses().Get(context.TODO(), "system-node-critical", v1.GetOptions{})
+	systemNodePriorityClass, err := f.SchedulingClient.PriorityClasses().Get(f.Ctx, "system-node-critical", v1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Get our user priority class value.
-	userPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(context.TODO(), "openshift-user-critical", v1.GetOptions{})
+	userPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(f.Ctx, "openshift-user-critical", v1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -88,7 +87,7 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 	}
 
 	err = framework.Poll(time.Second, 5*time.Minute, func() error {
-		_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.Ns).Get(context.TODO(), "prometheus-k8s-db-prometheus-k8s-0", metav1.GetOptions{})
+		_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.Ns).Get(f.Ctx, "prometheus-k8s-db-prometheus-k8s-0", metav1.GetOptions{})
 		if err != nil {
 			return errors.Wrap(err, "getting prometheus persistent volume claim failed")
 		}
@@ -110,7 +109,7 @@ func TestPrometheusVolumeClaim(t *testing.T) {
 }
 
 func TestPrometheusAlertmanagerAntiAffinity(t *testing.T) {
-	pods, err := f.KubeClient.CoreV1().Pods(f.Ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase=Running"})
+	pods, err := f.KubeClient.CoreV1().Pods(f.Ns).List(f.Ctx, metav1.ListOptions{FieldSelector: "status.phase=Running"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/prometheusadapter_test.go
+++ b/test/e2e/prometheusadapter_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -61,7 +60,7 @@ func isAPIServiceAvailable(conditions []apiservicesv1.APIServiceCondition) bool 
 func TestMetricsAPIAvailability(t *testing.T) {
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		metricsService, err := f.APIServicesClient.ApiregistrationV1().APIServices().Get(context.TODO(), "v1beta1.metrics.k8s.io", metav1.GetOptions{})
+		metricsService, err := f.APIServicesClient.ApiregistrationV1().APIServices().Get(f.Ctx, "v1beta1.metrics.k8s.io", metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting metrics APIService failed")
 		if err != nil {
 			return false, nil
@@ -83,12 +82,12 @@ func TestMetricsAPIAvailability(t *testing.T) {
 func TestNodeMetricsPresence(t *testing.T) {
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		nodes, err := f.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodes, err := f.KubeClient.CoreV1().Nodes().List(f.Ctx, metav1.ListOptions{})
 		lastErr = errors.Wrap(err, "getting nodes list failed")
 		if err != nil {
 			return false, nil
 		}
-		nodeMetrics, err := f.MetricsClient.MetricsV1beta1().NodeMetricses().List(context.TODO(), metav1.ListOptions{})
+		nodeMetrics, err := f.MetricsClient.MetricsV1beta1().NodeMetricses().List(f.Ctx, metav1.ListOptions{})
 		lastErr = errors.Wrap(err, "getting metrics list failed")
 		if err != nil {
 			return false, nil
@@ -120,12 +119,12 @@ func TestNodeMetricsPresence(t *testing.T) {
 func TestPodMetricsPresence(t *testing.T) {
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		pods, err := f.KubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase=Running"})
+		pods, err := f.KubeClient.CoreV1().Pods("").List(f.Ctx, metav1.ListOptions{FieldSelector: "status.phase=Running"})
 		lastErr = errors.Wrap(err, "getting pods list failed")
 		if err != nil {
 			return false, nil
 		}
-		podMetrics, err := f.MetricsClient.MetricsV1beta1().PodMetricses("").List(context.TODO(), metav1.ListOptions{})
+		podMetrics, err := f.MetricsClient.MetricsV1beta1().PodMetricses("").List(f.Ctx, metav1.ListOptions{})
 		lastErr = errors.Wrap(err, "getting metrics list failed")
 		if err != nil {
 			return false, nil
@@ -169,7 +168,7 @@ func TestAggregatedMetricPermissions(t *testing.T) {
 	hasRule := func(apiGroup, resource, verb string) checkFunc {
 		return func(clusterRole string) error {
 			return framework.Poll(time.Second, 5*time.Minute, func() error {
-				viewRole, err := f.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), clusterRole, metav1.GetOptions{})
+				viewRole, err := f.KubeClient.RbacV1().ClusterRoles().Get(f.Ctx, clusterRole, metav1.GetOptions{})
 				if err != nil {
 					return errors.Wrapf(err, "getting %s cluster role failed", clusterRole)
 				}
@@ -225,7 +224,7 @@ func TestAggregatedMetricPermissions(t *testing.T) {
 func TestPrometheusAdapterCARotation(t *testing.T) {
 	// Wait for prometheus-adapter deployment
 	err := framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		_, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(context.TODO(), "prometheus-adapter", metav1.GetOptions{})
+		_, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(f.Ctx, "prometheus-adapter", metav1.GetOptions{})
 		if err != nil {
 			return errors.Wrap(err, "getting prometheus-adapter deployment failed")
 		}
@@ -235,12 +234,12 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tls, err := f.KubeClient.CoreV1().Secrets("openshift-monitoring").Get(context.TODO(), "prometheus-adapter-tls", metav1.GetOptions{})
+	tls, err := f.KubeClient.CoreV1().Secrets("openshift-monitoring").Get(f.Ctx, "prometheus-adapter-tls", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	apiAuth, err := f.KubeClient.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "extension-apiserver-authentication", metav1.GetOptions{})
+	apiAuth, err := f.KubeClient.CoreV1().ConfigMaps("kube-system").Get(f.Ctx, "extension-apiserver-authentication", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +252,7 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 
 	// the secret might not have been created yet, so wait for it
 	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		_, err = f.KubeClient.CoreV1().Secrets("openshift-monitoring").Get(context.TODO(), adapterSecret.GetName(), metav1.GetOptions{})
+		_, err = f.KubeClient.CoreV1().Secrets("openshift-monitoring").Get(f.Ctx, adapterSecret.GetName(), metav1.GetOptions{})
 		return err
 	})
 	if err != nil {
@@ -262,12 +261,12 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 
 	// Delete the signer secrets. This causes kube-system/extension-apiserver-authentication
 	// to be reissued.
-	err = f.KubeClient.CoreV1().Secrets("openshift-kube-controller-manager-operator").Delete(context.TODO(), "csr-signer-signer", metav1.DeleteOptions{})
+	err = f.KubeClient.CoreV1().Secrets("openshift-kube-controller-manager-operator").Delete(f.Ctx, "csr-signer-signer", metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = f.KubeClient.CoreV1().Secrets("openshift-kube-controller-manager-operator").Delete(context.TODO(), "csr-signer", metav1.DeleteOptions{})
+	err = f.KubeClient.CoreV1().Secrets("openshift-kube-controller-manager-operator").Delete(f.Ctx, "csr-signer", metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +274,7 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 	// Wait for the new secret to be deployed
 	var newSecret corev1.Secret
 	err = framework.Poll(5*time.Second, 15*time.Minute, func() error {
-		secrets, err := f.KubeClient.CoreV1().Secrets("openshift-monitoring").List(context.TODO(), metav1.ListOptions{
+		secrets, err := f.KubeClient.CoreV1().Secrets("openshift-monitoring").List(f.Ctx, metav1.ListOptions{
 			LabelSelector: "monitoring.openshift.io/name=prometheus-adapter,monitoring.openshift.io/hash!=" + adapterSecret.Labels["monitoring.openshift.io/hash"],
 		})
 
@@ -300,7 +299,7 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 
 	// Wait for prometheus-adapter deployment to reference new secret
 	err = framework.Poll(time.Second, 5*time.Minute, func() error {
-		d, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(context.TODO(), "prometheus-adapter", metav1.GetOptions{})
+		d, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(f.Ctx, "prometheus-adapter", metav1.GetOptions{})
 		if err != nil {
 			return errors.Wrap(err, "getting prometheus-adapter deployment failed")
 		}
@@ -325,7 +324,7 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 
 	// Wait for new Prometheus adapter to roll out
 	err = framework.Poll(time.Second, 5*time.Minute, func() error {
-		d, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(context.TODO(), "prometheus-adapter", metav1.GetOptions{})
+		d, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(f.Ctx, "prometheus-adapter", metav1.GetOptions{})
 		if err != nil {
 			return errors.Wrap(err, "getting prometheus-adapter deployment failed")
 		}

--- a/test/e2e/thanos_querier_test.go
+++ b/test/e2e/thanos_querier_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 
 	// Wait for the new ConfigMap to be created
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		cm, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(context.TODO(), "thanos-querier-trusted-ca-bundle", metav1.GetOptions{})
+		cm, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(f.Ctx, "thanos-querier-trusted-ca-bundle", metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting new trusted CA ConfigMap failed")
 		if err != nil {
 			return false, nil
@@ -59,7 +58,7 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 
 	// Wait for the new hashed trusted CA bundle ConfigMap to be created
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(context.TODO(), newCM.Name, metav1.GetOptions{})
+		_, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(f.Ctx, newCM.Name, metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting new CA ConfigMap failed")
 		if err != nil {
 			return false, nil
@@ -75,7 +74,7 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 
 	// Get Thanos Querier Deployment and make sure it has a volume mounted.
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		ss, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(context.TODO(), "thanos-querier", metav1.GetOptions{})
+		ss, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(f.Ctx, "thanos-querier", metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting Thanos Querier deployment failed")
 		if err != nil {
 			return false, nil

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -106,7 +105,7 @@ func assertPrometheusVCConfig(cm *v1.ConfigMap) func(*testing.T) {
 
 		// Wait for persistent volume claim
 		err := framework.Poll(time.Second, 5*time.Minute, func() error {
-			_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.UserWorkloadMonitoringNs).Get(context.TODO(), "prometheus-user-workload-db-prometheus-user-workload-0", metav1.GetOptions{})
+			_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.UserWorkloadMonitoringNs).Get(f.Ctx, "prometheus-user-workload-db-prometheus-user-workload-0", metav1.GetOptions{})
 			if err != nil {
 				return errors.Wrap(err, "getting prometheus persistent volume claim failed")
 			}
@@ -184,7 +183,7 @@ func assertThanosRulerVCConfig(cm *v1.ConfigMap) func(*testing.T) {
 
 		// Wait for persistent volume claim
 		err := framework.Poll(time.Second, 5*time.Minute, func() error {
-			_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.UserWorkloadMonitoringNs).Get(context.TODO(), "thanos-ruler-user-workload-data-thanos-ruler-user-workload-0", metav1.GetOptions{})
+			_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(f.UserWorkloadMonitoringNs).Get(f.Ctx, "thanos-ruler-user-workload-data-thanos-ruler-user-workload-0", metav1.GetOptions{})
 			if err != nil {
 				return errors.Wrap(err, "getting thanos ruler persistent volume claim failed")
 			}
@@ -210,7 +209,7 @@ func assertThanosRulerVCConfig(cm *v1.ConfigMap) func(*testing.T) {
 func assertThanosRulerResourcesConfigured(cpu, memory string) func(*testing.T) {
 	return func(t *testing.T) {
 		err := framework.Poll(time.Second, 5*time.Minute, func() error {
-			pods, err := f.KubeClient.CoreV1().Pods(f.UserWorkloadMonitoringNs).List(context.TODO(), metav1.ListOptions{
+			pods, err := f.KubeClient.CoreV1().Pods(f.UserWorkloadMonitoringNs).List(f.Ctx, metav1.ListOptions{
 				LabelSelector: "thanos-ruler=user-workload",
 				FieldSelector: "status.phase=Running"})
 			if err != nil {
@@ -258,7 +257,7 @@ func createUserWorkloadAssets(cm *v1.ConfigMap) func(*testing.T) {
 		}
 
 		err := framework.Poll(time.Second, 5*time.Minute, func() error {
-			_, err := f.KubeClient.AppsV1().Deployments(f.UserWorkloadMonitoringNs).Get(context.TODO(), "prometheus-operator", metav1.GetOptions{})
+			_, err := f.KubeClient.AppsV1().Deployments(f.UserWorkloadMonitoringNs).Get(f.Ctx, "prometheus-operator", metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -270,7 +269,7 @@ func createUserWorkloadAssets(cm *v1.ConfigMap) func(*testing.T) {
 		}
 
 		err = framework.Poll(time.Second, 5*time.Minute, func() error {
-			_, err := f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(context.TODO(), "prometheus-user-workload", metav1.GetOptions{})
+			_, err := f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(f.Ctx, "prometheus-user-workload", metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -307,7 +306,7 @@ func createUserWorkloadAssets(cm *v1.ConfigMap) func(*testing.T) {
 
 func assertThanosRulerDeployment(t *testing.T) {
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
-		_, err := f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(context.TODO(), "thanos-ruler-user-workload", metav1.GetOptions{})
+		_, err := f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(f.Ctx, "thanos-ruler-user-workload", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -363,7 +362,7 @@ func assertMetricsForMonitoringComponents(t *testing.T) {
 }
 
 func deployUserApplication(t *testing.T) {
-	_, err := f.KubeClient.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+	_, err := f.KubeClient.CoreV1().Namespaces().Create(f.Ctx, &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: userWorkloadTestNs,
 		},
@@ -373,7 +372,7 @@ func deployUserApplication(t *testing.T) {
 	}
 
 	err = framework.Poll(time.Second, 5*time.Minute, func() error {
-		_, err := f.KubeClient.CoreV1().Namespaces().Get(context.TODO(), userWorkloadTestNs, metav1.GetOptions{})
+		_, err := f.KubeClient.CoreV1().Namespaces().Get(f.Ctx, userWorkloadTestNs, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -383,7 +382,7 @@ func deployUserApplication(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := f.KubeClient.AppsV1().Deployments(userWorkloadTestNs).Create(context.TODO(), &appsv1.Deployment{
+	app, err := f.KubeClient.AppsV1().Deployments(userWorkloadTestNs).Create(f.Ctx, &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-app",
 		},
@@ -415,7 +414,7 @@ func deployUserApplication(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.KubeClient.CoreV1().Services(userWorkloadTestNs).Create(context.TODO(), &v1.Service{
+	_, err = f.KubeClient.CoreV1().Services(userWorkloadTestNs).Create(f.Ctx, &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-app",
 			Labels: map[string]string{
@@ -438,7 +437,7 @@ func deployUserApplication(t *testing.T) {
 		},
 	}, metav1.CreateOptions{})
 
-	_, err = f.MonitoringClient.ServiceMonitors(userWorkloadTestNs).Create(context.TODO(), &monitoringv1.ServiceMonitor{
+	_, err = f.MonitoringClient.ServiceMonitors(userWorkloadTestNs).Create(f.Ctx, &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-monitor",
 			Labels: map[string]string{
@@ -464,7 +463,7 @@ func deployUserApplication(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.MonitoringClient.PrometheusRules(userWorkloadTestNs).Create(context.TODO(), &monitoringv1.PrometheusRule{
+	_, err = f.MonitoringClient.PrometheusRules(userWorkloadTestNs).Create(f.Ctx, &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-rule",
 			Labels: map[string]string{
@@ -494,7 +493,7 @@ func deployUserApplication(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.MonitoringClient.PrometheusRules(userWorkloadTestNs).Create(context.TODO(), &monitoringv1.PrometheusRule{
+	_, err = f.MonitoringClient.PrometheusRules(userWorkloadTestNs).Create(f.Ctx, &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-rule-leaf",
 			Labels: map[string]string{
@@ -527,7 +526,7 @@ func deployUserApplication(t *testing.T) {
 }
 
 func createPrometheusAlertmanagerInUserNamespace(t *testing.T) {
-	_, err := f.MonitoringClient.Alertmanagers(userWorkloadTestNs).Create(context.TODO(), &monitoringv1.Alertmanager{
+	_, err := f.MonitoringClient.Alertmanagers(userWorkloadTestNs).Create(f.Ctx, &monitoringv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "not-to-be-reconciled",
 		},
@@ -539,7 +538,7 @@ func createPrometheusAlertmanagerInUserNamespace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.MonitoringClient.Prometheuses(userWorkloadTestNs).Create(context.TODO(), &monitoringv1.Prometheus{
+	_, err = f.MonitoringClient.Prometheuses(userWorkloadTestNs).Create(f.Ctx, &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "not-to-be-reconciled",
 		},
@@ -1005,12 +1004,12 @@ func assertTenancyForRules(t *testing.T) {
 }
 
 func assertPrometheusAlertmanagerInUserNamespace(t *testing.T) {
-	_, err := f.KubeClient.AppsV1().StatefulSets(userWorkloadTestNs).Get(context.TODO(), "prometheus-not-to-be-reconciled", metav1.GetOptions{})
+	_, err := f.KubeClient.AppsV1().StatefulSets(userWorkloadTestNs).Get(f.Ctx, "prometheus-not-to-be-reconciled", metav1.GetOptions{})
 	if err == nil {
 		t.Fatal("expected no Prometheus statefulset to be deployed, but found one")
 	}
 
-	_, err = f.KubeClient.AppsV1().StatefulSets(userWorkloadTestNs).Get(context.TODO(), "alertmanager-not-to-be-reconciled", metav1.GetOptions{})
+	_, err = f.KubeClient.AppsV1().StatefulSets(userWorkloadTestNs).Get(f.Ctx, "alertmanager-not-to-be-reconciled", metav1.GetOptions{})
 	if err == nil {
 		t.Fatal("expected no Alertmanager statefulset to be deployed, but found one")
 	}
@@ -1021,7 +1020,7 @@ func assertGRPCTLSRotation(t *testing.T) {
 		t.Helper()
 		var result int
 		err := framework.Poll(5*time.Second, time.Minute, func() error {
-			s, err := f.KubeClient.CoreV1().Secrets(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: "monitoring.openshift.io/hash"})
+			s, err := f.KubeClient.CoreV1().Secrets(ns).List(f.Ctx, metav1.ListOptions{LabelSelector: "monitoring.openshift.io/hash"})
 			if err != nil {
 				return err
 			}
@@ -1073,7 +1072,7 @@ func assertGRPCTLSRotation(t *testing.T) {
 	const expectedGRPCSecretCount = 4
 
 	err = framework.Poll(time.Second, 5*time.Minute, func() error {
-		s, err := f.KubeClient.CoreV1().Secrets(f.Ns).Get(context.TODO(), "grpc-tls", metav1.GetOptions{})
+		s, err := f.KubeClient.CoreV1().Secrets(f.Ns).Get(f.Ctx, "grpc-tls", metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("error loading grpc-tls secret: %v", err)
 		}
@@ -1102,7 +1101,7 @@ func assertDeletedUserWorkloadAssets(cm *v1.ConfigMap) func(*testing.T) {
 		}
 
 		err = framework.Poll(time.Second, 5*time.Minute, func() error {
-			_, err := f.KubeClient.AppsV1().Deployments(f.UserWorkloadMonitoringNs).Get(context.TODO(), "prometheus-operator", metav1.GetOptions{})
+			_, err := f.KubeClient.AppsV1().Deployments(f.UserWorkloadMonitoringNs).Get(f.Ctx, "prometheus-operator", metav1.GetOptions{})
 			if err == nil {
 				return errors.New("prometheus-operator deployment not deleted")
 			}
@@ -1116,7 +1115,7 @@ func assertDeletedUserWorkloadAssets(cm *v1.ConfigMap) func(*testing.T) {
 		}
 
 		err = framework.Poll(time.Second, 5*time.Minute, func() error {
-			_, err := f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(context.TODO(), "prometheus-user-workload", metav1.GetOptions{})
+			_, err := f.KubeClient.AppsV1().StatefulSets(f.UserWorkloadMonitoringNs).Get(f.Ctx, "prometheus-user-workload", metav1.GetOptions{})
 			if err == nil {
 				return errors.New("prometheus statefulset not deleted")
 			}

--- a/test/e2e/validatingwebhook_test.go
+++ b/test/e2e/validatingwebhook_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
 	yaml "github.com/ghodss/yaml"
@@ -56,7 +55,7 @@ spec:
 )
 
 func TestPrometheusRuleValidatingWebhook(t *testing.T) {
-	_, err := f.AdmissionClient.ValidatingWebhookConfigurations().Get(context.TODO(), webhookName, metav1.GetOptions{})
+	_, err := f.AdmissionClient.ValidatingWebhookConfigurations().Get(f.Ctx, webhookName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("unable to get prometheus rules validating webhook", err)
 	}
@@ -66,7 +65,7 @@ func TestPrometheusRuleValidatingWebhook(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to unmarshal prometheus rule", err)
 	}
-	_, err = f.MonitoringClient.PrometheusRules(f.Ns).Create(context.TODO(), &validPromRule, metav1.CreateOptions{})
+	_, err = f.MonitoringClient.PrometheusRules(f.Ns).Create(f.Ctx, &validPromRule, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("unable to create prometheus rule", err)
 	}
@@ -76,7 +75,7 @@ func TestPrometheusRuleValidatingWebhook(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to unmarshal prometheus rule", err)
 	}
-	_, err = f.MonitoringClient.PrometheusRules(f.Ns).Create(context.TODO(), &invalidPromRule, metav1.CreateOptions{})
+	_, err = f.MonitoringClient.PrometheusRules(f.Ns).Create(f.Ctx, &invalidPromRule, metav1.CreateOptions{})
 	if err == nil {
 		t.Fatal("invalid rule was accepted by validatingwebhook")
 	}


### PR DESCRIPTION
As in title [MON-1251](https://issues.redhat.com/browse/MON-1251)

This is first PR to remove context.TODO() and replace with real context in tests

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
