### PR TITLE
alert:KubeDeploymentReplicasMismatch: only fire if cluster is in read…

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -275,7 +275,7 @@ spec:
           healthy nodes and then contact support.
         summary: Deployment has not matched the expected number of replicas
       expr: |
-        (
+        (((
           kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
             !=
           kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
@@ -283,7 +283,7 @@ spec:
           changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
             ==
           0
-        ) and cluster:control_plane:all_nodes_ready
+        )) * scalar(cluster:control_plane:all_nodes_ready)) != 0
       for: 15m
       labels:
         severity: warning

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -343,7 +343,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
           },
           {
             expr: |||
-              (
+              (((
                 kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
                   !=
                 kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
@@ -351,7 +351,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
                 changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
                   ==
                 0
-              ) and cluster:control_plane:all_nodes_ready
+              )) * scalar(cluster:control_plane:all_nodes_ready)) != 0
             |||,
             alert: 'KubeDeploymentReplicasMismatch',
             'for': '15m',


### PR DESCRIPTION
…y state

The original change as per https://github.com/openshift/cluster-monitoring-operator/pull/1065
meant that this alert would never fire since there was no commonality between label sets.

This change uses a scalar to ensure the alert will fire if and only if the
'cluster:control_plane:all_nodes_ready' record evaluates as 1.

See linked PR for context on why this alert differs from upstream.

Thanks @paulfantom for help with the query

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
