### PR TITLE
Makefile: add check to verify runbook urls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ vendor:
 	go mod verify
 
 .PHONY: generate
-generate: build-jsonnet docs check-assets
+generate: build-jsonnet docs check-assets check-runbooks
 
 .PHONY: generate-in-docker
 generate-in-docker:
@@ -155,6 +155,12 @@ test-rules: check-rules
 .PHONY: check-assets
 check-assets:
 	hack/check-assets.sh
+
+.PHONY: check-runbooks
+check-runbooks:
+	# Get runbook urls from the alerts annotations and test if a link is broken
+	# with wget. It also make sure that the command succeed when there are no urls.
+	@grep -rho 'runbook_url.*' assets || true | cut -f2- -d: | wget --spider -nv -i -
 
 ###########
 # Testing #


### PR DESCRIPTION
Add a Makefile rule called `check-runbooks` to verify that the links
specified in the runbook_url annotation of alerts shipped in OpenShift
aren't broken.

/cc @paulfantom 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
