### PR TITLE
Makefile: update $(JSONNET_VENDOR) dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ generate-in-docker:
 		cmo-tooling make generate
 
 
-$(JSONNET_VENDOR): $(JB_BIN) jsonnet/jsonnetfile.json
+$(JSONNET_VENDOR): $(JB_BIN) jsonnet/jsonnetfile.json jsonnet/jsonnetfile.lock.json
 	cd jsonnet && $(JB_BIN) install
 
 $(ASSETS): build-jsonnet


### PR DESCRIPTION
Upstream sha version for jsonnet code are kept in the
`jsonnet/jsonnetfile.lock.json`. This file is not a dependency for
generating assets and running make generate can lead to generating assets
from stale jsonnet code.

This commit adds the `jsonnet/jsonnetfile.lock.json` as a dependency of the
`$(JSONNET_VENDOR)` Makefile target. With this we ensure the
`jsonnet/vendor` folder is refetched every time a new version of an
upstream jsonnet dependency has been commited.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
