### PR TITLE
Revert "alert:KubeDeploymentReplicasMismatch: only fire if cluster is in ready state"

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -275,7 +275,7 @@ spec:
           healthy nodes and then contact support.
         summary: Deployment has not matched the expected number of replicas
       expr: |
-        (((
+        (
           kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
             !=
           kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
@@ -283,7 +283,7 @@ spec:
           changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
             ==
           0
-        )) * scalar(cluster:control_plane:all_nodes_ready)) != 0
+        ) and cluster:control_plane:all_nodes_ready
       for: 15m
       labels:
         severity: warning

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -343,7 +343,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
           },
           {
             expr: |||
-              (((
+              (
                 kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
                   !=
                 kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
@@ -351,7 +351,7 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
                 changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
                   ==
                 0
-              )) * scalar(cluster:control_plane:all_nodes_ready)) != 0
+              ) and cluster:control_plane:all_nodes_ready
             |||,
             alert: 'KubeDeploymentReplicasMismatch',
             'for': '15m',


### PR DESCRIPTION
Reverts openshift/cluster-monitoring-operator#1245

We're not entirely sure this PR is related, but we're seeing a bunch of `KubeDeploymentReplicasMismatch` firing in CI (e.g. [here][1]), so rolling this back to see if it helps.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oc/843/pull-ci-openshift-oc-master-e2e-aws-upgrade/1408423006006415360