### PR TITLE
Bug 1974830: Update KubeDeploymentReplicasMismatch alert

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -240,9 +240,12 @@ spec:
       record: cluster:vsphere_esxi_version_total:sum
     - expr: sum by(hw_version)(vsphere_node_hw_version_total)
       record: cluster:vsphere_node_hw_version_total:sum
-    - expr: absent(count(max by (node) (kube_node_role{role="master"}) and (min by
-        (node) (kube_node_status_condition{condition="Ready",status="true"} == 0)))
-        > 0)
+    - expr: |
+        sum(
+          min by (node) (kube_node_status_condition{condition="Ready",status="true"})
+            and
+          max by (node) (kube_node_role{role="master"})
+        ) == bool sum(kube_node_role{role="master"})
       record: cluster:control_plane:all_nodes_ready
     - alert: ClusterMonitoringOperatorReconciliationErrors
       annotations:
@@ -275,15 +278,15 @@ spec:
           healthy nodes and then contact support.
         summary: Deployment has not matched the expected number of replicas
       expr: |
-        (
+        (((
           kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
-            !=
+            >
           kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
         ) and (
           changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
             ==
           0
-        ) and cluster:control_plane:all_nodes_ready
+        ))) * scalar(cluster:control_plane:all_nodes_ready == 1)
       for: 15m
       labels:
         severity: warning


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
