### PR TITLE
Remove context.TODO() and propagate real context

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -174,6 +174,7 @@ func Main() int {
 
 	userWorkloadConfigMapName := "user-workload-monitoring-config"
 	o, err := cmo.New(
+		ctx,
 		config,
 		*releaseVersion,
 		*namespace,
@@ -184,7 +185,6 @@ func Main() int {
 		images.asMap(),
 		telemetryConfig.Matches,
 		assets,
-		ctx,
 	)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -170,6 +170,8 @@ func Main() int {
 	config.QPS = 100
 	config.Burst = 200
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	userWorkloadConfigMapName := "user-workload-monitoring-config"
 	o, err := cmo.New(
 		config,
@@ -182,6 +184,7 @@ func Main() int {
 		images.asMap(),
 		telemetryConfig.Matches,
 		assets,
+		ctx,
 	)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
@@ -198,7 +201,6 @@ func Main() int {
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	go http.ListenAndServe("127.0.0.1:8080", mux)
 
-	ctx, cancel := context.WithCancel(context.Background())
 	wg, ctx := errgroup.WithContext(ctx)
 
 	wg.Go(func() error { return o.Run(ctx.Done()) })

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1323,7 +1323,7 @@ func (c *Client) CRDReady(crd *extensionsobj.CustomResourceDefinition) (bool, er
 }
 
 func (c *Client) StatusReporter() *StatusReporter {
-	return NewStatusReporter(c.oscclient.ConfigV1().ClusterOperators(), "monitoring", c.namespace, c.userWorkloadNamespace, c.version)
+	return NewStatusReporter(c.oscclient.ConfigV1().ClusterOperators(), "monitoring", c.ctx, c.namespace, c.userWorkloadNamespace, c.version)
 }
 
 func (c *Client) DeleteRoleBinding(binding *rbacv1.RoleBinding) error {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -77,7 +77,7 @@ type Client struct {
 	ctx                   context.Context
 }
 
-func New(cfg *rest.Config, version string, namespace, userWorkloadNamespace string, ctx context.Context) (*Client, error) {
+func New(ctx context.Context, cfg *rest.Config, version string, namespace, userWorkloadNamespace string) (*Client, error) {
 	mclient, err := monitoring.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -1323,7 +1323,7 @@ func (c *Client) CRDReady(crd *extensionsobj.CustomResourceDefinition) (bool, er
 }
 
 func (c *Client) StatusReporter() *StatusReporter {
-	return NewStatusReporter(c.oscclient.ConfigV1().ClusterOperators(), "monitoring", c.ctx, c.namespace, c.userWorkloadNamespace, c.version)
+	return NewStatusReporter(c.ctx, c.oscclient.ConfigV1().ClusterOperators(), "monitoring",  c.namespace, c.userWorkloadNamespace, c.version)
 }
 
 func (c *Client) DeleteRoleBinding(binding *rbacv1.RoleBinding) error {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1279,7 +1279,7 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(serviceMonitor.DeepCopy()),
-				ctx: context.Background(),
+				ctx:     context.Background(),
 			}
 			if _, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(c.ctx, serviceMonitor.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
@@ -1371,7 +1371,7 @@ func TestCreateOrUpdatePrometheusRule(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(rule.DeepCopy()),
-				ctx: context.Background(),
+				ctx:     context.Background(),
 			}
 			if _, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(c.ctx, rule.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
@@ -1463,7 +1463,7 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(prometheus.DeepCopy()),
-				ctx: context.Background(),
+				ctx:     context.Background(),
 			}
 			if _, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(c.ctx, prometheus.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
@@ -1556,7 +1556,7 @@ func TestCreateOrUpdateAlertmanager(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(alertmanager.DeepCopy()),
-				ctx: context.Background(),
+				ctx:     context.Background(),
 			}
 			if _, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(c.ctx, alertmanager.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -192,9 +192,10 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(dep.DeepCopy()),
+				ctx:     context.Background(),
 			}
 
-			if _, err := c.kclient.AppsV1().Deployments(ns).Get(context.TODO(), dep.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.AppsV1().Deployments(ns).Get(c.ctx, dep.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -205,7 +206,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			after, err := c.kclient.AppsV1().Deployments(ns).Get(context.TODO(), dep.Name, metav1.GetOptions{})
+			after, err := c.kclient.AppsV1().Deployments(ns).Get(c.ctx, dep.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -287,8 +288,9 @@ func TestCreateOrUpdateDaemonSet(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(ds.DeepCopy()),
+				ctx:     context.Background(),
 			}
-			if _, err := c.kclient.AppsV1().DaemonSets(ns).Get(context.TODO(), ds.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.AppsV1().DaemonSets(ns).Get(c.ctx, ds.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -297,7 +299,7 @@ func TestCreateOrUpdateDaemonSet(t *testing.T) {
 			if err := c.CreateOrUpdateDaemonSet(ds); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.AppsV1().DaemonSets(ns).Get(context.TODO(), ds.Name, metav1.GetOptions{})
+			after, err := c.kclient.AppsV1().DaemonSets(ns).Get(c.ctx, ds.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -378,9 +380,10 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(s.DeepCopy()),
+				ctx:     context.Background(),
 			}
 
-			if _, err := c.kclient.CoreV1().Secrets(ns).Get(context.TODO(), s.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.CoreV1().Secrets(ns).Get(c.ctx, s.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -389,7 +392,7 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 			if err := c.CreateOrUpdateSecret(s); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.CoreV1().Secrets(ns).Get(context.TODO(), s.Name, metav1.GetOptions{})
+			after, err := c.kclient.CoreV1().Secrets(ns).Get(c.ctx, s.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -470,9 +473,10 @@ func TestCreateOrUpdateConfigMap(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(cm),
+				ctx:     context.Background(),
 			}
 
-			if _, err := c.kclient.CoreV1().ConfigMaps(ns).Get(context.TODO(), cm.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.CoreV1().ConfigMaps(ns).Get(c.ctx, cm.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -482,7 +486,7 @@ func TestCreateOrUpdateConfigMap(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			after, err := c.kclient.CoreV1().ConfigMaps(ns).Get(context.TODO(), cm.Name, metav1.GetOptions{})
+			after, err := c.kclient.CoreV1().ConfigMaps(ns).Get(c.ctx, cm.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -611,9 +615,10 @@ func TestCreateOrUpdateService(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(svc.DeepCopy()),
+				ctx:     context.Background(),
 			}
 
-			before, err := c.kclient.CoreV1().Services(ns).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+			before, err := c.kclient.CoreV1().Services(ns).Get(c.ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -625,7 +630,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			after, err := c.kclient.CoreV1().Services(ns).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+			after, err := c.kclient.CoreV1().Services(ns).Get(c.ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -709,8 +714,9 @@ func TestCreateOrUpdateRole(t *testing.T) {
 			}
 			c := Client{
 				kclient: fake.NewSimpleClientset(role.DeepCopy()),
+				ctx:     context.Background(),
 			}
-			if _, err := c.kclient.RbacV1().Roles(ns).Get(context.TODO(), role.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.RbacV1().Roles(ns).Get(c.ctx, role.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -719,7 +725,7 @@ func TestCreateOrUpdateRole(t *testing.T) {
 			if err := c.CreateOrUpdateRole(role); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.RbacV1().Roles(ns).Get(context.TODO(), role.Name, metav1.GetOptions{})
+			after, err := c.kclient.RbacV1().Roles(ns).Get(c.ctx, role.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -845,8 +851,9 @@ func TestCreateOrUpdateRoleBinding(t *testing.T) {
 			}
 			c := Client{
 				kclient: fake.NewSimpleClientset(roleBinding.DeepCopy()),
+				ctx:     context.Background(),
 			}
-			before, err := c.kclient.RbacV1().RoleBindings(ns).Get(context.TODO(), roleBinding.Name, metav1.GetOptions{})
+			before, err := c.kclient.RbacV1().RoleBindings(ns).Get(c.ctx, roleBinding.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -859,7 +866,7 @@ func TestCreateOrUpdateRoleBinding(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.RbacV1().RoleBindings(ns).Get(context.TODO(), roleBinding.Name, metav1.GetOptions{})
+			after, err := c.kclient.RbacV1().RoleBindings(ns).Get(c.ctx, roleBinding.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -942,8 +949,9 @@ func TestCreateOrUpdateClusterRole(t *testing.T) {
 			}
 			c := Client{
 				kclient: fake.NewSimpleClientset(clusterRole.DeepCopy()),
+				ctx:     context.Background(),
 			}
-			if _, err := c.kclient.RbacV1().ClusterRoles().Get(context.TODO(), clusterRole.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.RbacV1().ClusterRoles().Get(c.ctx, clusterRole.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -952,7 +960,7 @@ func TestCreateOrUpdateClusterRole(t *testing.T) {
 			if err := c.CreateOrUpdateClusterRole(clusterRole); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.RbacV1().ClusterRoles().Get(context.TODO(), clusterRole.Name, metav1.GetOptions{})
+			after, err := c.kclient.RbacV1().ClusterRoles().Get(c.ctx, clusterRole.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1078,8 +1086,9 @@ func TestCreateOrUpdateClusterRoleBinding(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(clusterRoleBinding.DeepCopy()),
+				ctx:     context.Background(),
 			}
-			before, err := c.kclient.RbacV1().ClusterRoleBindings().Get(context.TODO(), clusterRoleBinding.Name, metav1.GetOptions{})
+			before, err := c.kclient.RbacV1().ClusterRoleBindings().Get(c.ctx, clusterRoleBinding.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1091,7 +1100,7 @@ func TestCreateOrUpdateClusterRoleBinding(t *testing.T) {
 			if err := c.CreateOrUpdateClusterRoleBinding(clusterRoleBinding); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.RbacV1().ClusterRoleBindings().Get(context.TODO(), clusterRoleBinding.Name, metav1.GetOptions{})
+			after, err := c.kclient.RbacV1().ClusterRoleBindings().Get(c.ctx, clusterRoleBinding.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1175,10 +1184,11 @@ func TestCreateOrUpdateSecurityContextConstraints(t *testing.T) {
 
 			c := Client{
 				ossclient: ossfake.NewSimpleClientset(),
+				ctx:       context.Background(),
 			}
-			c.ossclient.SecurityV1().SecurityContextConstraints().Create(context.TODO(), scc.DeepCopy(), metav1.CreateOptions{})
+			c.ossclient.SecurityV1().SecurityContextConstraints().Create(c.ctx, scc.DeepCopy(), metav1.CreateOptions{})
 
-			if _, err := c.ossclient.SecurityV1().SecurityContextConstraints().Get(context.TODO(), scc.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.ossclient.SecurityV1().SecurityContextConstraints().Get(c.ctx, scc.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1188,7 +1198,7 @@ func TestCreateOrUpdateSecurityContextConstraints(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			after, err := c.ossclient.SecurityV1().SecurityContextConstraints().Get(context.TODO(), scc.GetName(), metav1.GetOptions{})
+			after, err := c.ossclient.SecurityV1().SecurityContextConstraints().Get(c.ctx, scc.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1269,8 +1279,9 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(serviceMonitor.DeepCopy()),
+				ctx: context.Background(),
 			}
-			if _, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(context.TODO(), serviceMonitor.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(c.ctx, serviceMonitor.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1279,7 +1290,7 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 			if err := c.CreateOrUpdateServiceMonitor(serviceMonitor); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(context.TODO(), serviceMonitor.GetName(), metav1.GetOptions{})
+			after, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(c.ctx, serviceMonitor.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1360,8 +1371,9 @@ func TestCreateOrUpdatePrometheusRule(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(rule.DeepCopy()),
+				ctx: context.Background(),
 			}
-			if _, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(context.TODO(), rule.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(c.ctx, rule.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1370,7 +1382,7 @@ func TestCreateOrUpdatePrometheusRule(t *testing.T) {
 			if err := c.CreateOrUpdatePrometheusRule(rule); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(context.TODO(), rule.GetName(), metav1.GetOptions{})
+			after, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(c.ctx, rule.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1451,8 +1463,9 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(prometheus.DeepCopy()),
+				ctx: context.Background(),
 			}
-			if _, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(context.TODO(), prometheus.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(c.ctx, prometheus.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1462,7 +1475,7 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			after, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(context.TODO(), prometheus.GetName(), metav1.GetOptions{})
+			after, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(c.ctx, prometheus.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1543,8 +1556,9 @@ func TestCreateOrUpdateAlertmanager(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(alertmanager.DeepCopy()),
+				ctx: context.Background(),
 			}
-			if _, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(context.TODO(), alertmanager.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(c.ctx, alertmanager.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1554,7 +1568,7 @@ func TestCreateOrUpdateAlertmanager(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			after, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(context.TODO(), alertmanager.GetName(), metav1.GetOptions{})
+			after, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(c.ctx, alertmanager.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -34,6 +34,7 @@ const (
 type StatusReporter struct {
 	client                clientv1.ClusterOperatorInterface
 	clusterOperatorName   string
+	ctx                   context.Context
 	namespace             string
 	userWorkloadNamespace string
 	version               string
@@ -43,6 +44,7 @@ func NewStatusReporter(client clientv1.ClusterOperatorInterface, name, namespace
 	return &StatusReporter{
 		client:                client,
 		clusterOperatorName:   name,
+		ctx:                   context.Background(),
 		namespace:             namespace,
 		userWorkloadNamespace: userWorkloadNamespace,
 		version:               version,
@@ -66,10 +68,10 @@ func (r *StatusReporter) relatedObjects() []v1.ObjectReference {
 }
 
 func (r *StatusReporter) SetDone() error {
-	co, err := r.client.Get(context.TODO(), r.clusterOperatorName, metav1.GetOptions{})
+	co, err := r.client.Get(r.ctx, r.clusterOperatorName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		co = r.newClusterOperator()
-		co, err = r.client.Create(context.TODO(), co, metav1.CreateOptions{})
+		co, err = r.client.Create(r.ctx, co, metav1.CreateOptions{})
 	}
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
@@ -98,7 +100,7 @@ func (r *StatusReporter) SetDone() error {
 		co.Status.Versions = nil
 	}
 
-	_, err = r.client.UpdateStatus(context.TODO(), co, metav1.UpdateOptions{})
+	_, err = r.client.UpdateStatus(r.ctx, co, metav1.UpdateOptions{})
 	return err
 }
 
@@ -110,10 +112,10 @@ func (r *StatusReporter) SetDone() error {
 // Once controller operator versions are available, an additional check will be introduced that toggles
 // the OperatorProgressing state in case of version upgrades.
 func (r *StatusReporter) SetInProgress() error {
-	co, err := r.client.Get(context.TODO(), r.clusterOperatorName, metav1.GetOptions{})
+	co, err := r.client.Get(r.ctx, r.clusterOperatorName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		co = r.newClusterOperator()
-		co, err = r.client.Create(context.TODO(), co, metav1.CreateOptions{})
+		co, err = r.client.Create(r.ctx, co, metav1.CreateOptions{})
 	}
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
@@ -127,19 +129,19 @@ func (r *StatusReporter) SetInProgress() error {
 	co.Status.Conditions = conditions.entries()
 	co.Status.RelatedObjects = r.relatedObjects()
 
-	_, err = r.client.UpdateStatus(context.TODO(), co, metav1.UpdateOptions{})
+	_, err = r.client.UpdateStatus(r.ctx, co, metav1.UpdateOptions{})
 	return err
 }
 
 func (r *StatusReporter) Get() (*v1.ClusterOperator, error) {
-	return r.client.Get(context.TODO(), r.clusterOperatorName, metav1.GetOptions{})
+	return r.client.Get(r.ctx, r.clusterOperatorName, metav1.GetOptions{})
 }
 
 func (r *StatusReporter) SetFailed(statusErr error, reason string) error {
-	co, err := r.client.Get(context.TODO(), r.clusterOperatorName, metav1.GetOptions{})
+	co, err := r.client.Get(r.ctx, r.clusterOperatorName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		co = r.newClusterOperator()
-		co, err = r.client.Create(context.TODO(), co, metav1.CreateOptions{})
+		co, err = r.client.Create(r.ctx, co, metav1.CreateOptions{})
 	}
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
@@ -156,7 +158,7 @@ func (r *StatusReporter) SetFailed(statusErr error, reason string) error {
 	conditions.setCondition(v1.OperatorUpgradeable, v1.ConditionTrue, "", asExpectedReason, time)
 	co.Status.Conditions = conditions.entries()
 
-	_, err = r.client.UpdateStatus(context.TODO(), co, metav1.UpdateOptions{})
+	_, err = r.client.UpdateStatus(r.ctx, co, metav1.UpdateOptions{})
 	return err
 }
 

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -40,11 +40,11 @@ type StatusReporter struct {
 	version               string
 }
 
-func NewStatusReporter(client clientv1.ClusterOperatorInterface, name, namespace, userWorkloadNamespace, version string) *StatusReporter {
+func NewStatusReporter(client clientv1.ClusterOperatorInterface, name string, ctx context.Context, namespace, userWorkloadNamespace, version string) *StatusReporter {
 	return &StatusReporter{
 		client:                client,
 		clusterOperatorName:   name,
-		ctx:                   context.Background(),
+		ctx:                   ctx,
 		namespace:             namespace,
 		userWorkloadNamespace: userWorkloadNamespace,
 		version:               version,

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -40,11 +40,11 @@ type StatusReporter struct {
 	version               string
 }
 
-func NewStatusReporter(client clientv1.ClusterOperatorInterface, name string, ctx context.Context, namespace, userWorkloadNamespace, version string) *StatusReporter {
+func NewStatusReporter(ctx context.Context, client clientv1.ClusterOperatorInterface, name string, namespace, userWorkloadNamespace, version string) *StatusReporter {
 	return &StatusReporter{
+		ctx:                   ctx,
 		client:                client,
 		clusterOperatorName:   name,
-		ctx:                   ctx,
 		namespace:             namespace,
 		userWorkloadNamespace: userWorkloadNamespace,
 		version:               version,

--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestStatusReporterSetDone(t *testing.T) {
+	ctx := context.Background()
 	for _, tc := range []struct {
 		name  string
 		given givenStatusReporter
@@ -102,6 +103,7 @@ func TestStatusReporterSetDone(t *testing.T) {
 			sr := NewStatusReporter(
 				mock,
 				tc.given.operatorName,
+				ctx,
 				tc.given.namespace,
 				tc.given.userWorkloadNamespace,
 				tc.given.version,
@@ -123,6 +125,7 @@ func TestStatusReporterSetDone(t *testing.T) {
 }
 
 func TestStatusReporterSetInProgress(t *testing.T) {
+	ctx := context.Background()
 	for _, tc := range []struct {
 		name  string
 		given givenStatusReporter
@@ -193,6 +196,7 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 			sr := NewStatusReporter(
 				mock,
 				tc.given.operatorName,
+				ctx,
 				tc.given.namespace,
 				tc.given.userWorkloadNamespace,
 				tc.given.version,
@@ -214,6 +218,7 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 }
 
 func TestStatusReporterSetFailed(t *testing.T) {
+	ctx := context.Background()
 	failedErr := errors.New("foo")
 
 	for _, tc := range []struct {
@@ -289,6 +294,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 			sr := NewStatusReporter(
 				mock,
 				tc.given.operatorName,
+				ctx,
 				tc.given.namespace,
 				tc.given.userWorkloadNamespace,
 				tc.given.version,

--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -101,9 +101,9 @@ func TestStatusReporterSetDone(t *testing.T) {
 			mock := &clusterOperatorMock{}
 
 			sr := NewStatusReporter(
+				ctx,
 				mock,
 				tc.given.operatorName,
-				ctx,
 				tc.given.namespace,
 				tc.given.userWorkloadNamespace,
 				tc.given.version,
@@ -194,9 +194,9 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 			mock := &clusterOperatorMock{}
 
 			sr := NewStatusReporter(
+				ctx,
 				mock,
 				tc.given.operatorName,
-				ctx,
 				tc.given.namespace,
 				tc.given.userWorkloadNamespace,
 				tc.given.version,
@@ -292,9 +292,9 @@ func TestStatusReporterSetFailed(t *testing.T) {
 			mock := &clusterOperatorMock{}
 
 			sr := NewStatusReporter(
+				ctx,
 				mock,
 				tc.given.operatorName,
-				ctx,
 				tc.given.namespace,
 				tc.given.userWorkloadNamespace,
 				tc.given.version,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -460,7 +460,7 @@ func (o *Operator) sync(key string) error {
 				tasks.NewTaskSpec("Updating node-exporter", tasks.NewNodeExporterTask(o.client, factory)),
 				tasks.NewTaskSpec("Updating kube-state-metrics", tasks.NewKubeStateMetricsTask(o.client, factory)),
 				tasks.NewTaskSpec("Updating openshift-state-metrics", tasks.NewOpenShiftStateMetricsTask(o.client, factory)),
-				tasks.NewTaskSpec("Updating prometheus-adapter", tasks.NewPrometheusAdapterTaks(o.namespace, o.client, factory)),
+				tasks.NewTaskSpec("Updating prometheus-adapter", tasks.NewPrometheusAdapterTask(o.ctx, o.namespace, o.client, factory)),
 				tasks.NewTaskSpec("Updating Telemeter client", tasks.NewTelemeterClientTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating configuration sharing", tasks.NewConfigSharingTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Thanos Querier", tasks.NewThanosQuerierTask(o.client, factory, config)),
@@ -468,7 +468,6 @@ func (o *Operator) sync(key string) error {
 				tasks.NewTaskSpec("Updating Control Plane components", tasks.NewControlPlaneTask(o.client, factory, config)),
 			}),
 	)
-
 	klog.Info("Updating ClusterOperator status to in progress.")
 	err = o.client.StatusReporter().SetInProgress()
 	if err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -124,6 +124,8 @@ const (
 )
 
 type Operator struct {
+	ctx context.Context
+
 	namespace, namespaceUserWorkload string
 
 	configMapName             string
@@ -148,25 +150,24 @@ type Operator struct {
 	failedReconcileAttempts int
 
 	assets *manifests.Assets
-
-	ctx context.Context
 }
 
 func New(
+	ctx context.Context,
 	config *rest.Config,
 	version, namespace, namespaceUserWorkload, configMapName, userWorkloadConfigMapName string,
 	remoteWrite bool,
 	images map[string]string,
 	telemetryMatches []string,
 	a *manifests.Assets,
-	ctx context.Context,
 ) (*Operator, error) {
-	c, err := client.New(config, version, namespace, namespaceUserWorkload, ctx)
+	c, err := client.New(ctx, config, version, namespace, namespaceUserWorkload)
 	if err != nil {
 		return nil, err
 	}
 
 	o := &Operator{
+		ctx:                       ctx,
 		images:                    images,
 		telemetryMatches:          telemetryMatches,
 		configMapName:             configMapName,

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -91,7 +91,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		return nil, nil, errors.Wrap(err, "creating monitoring client failed")
 	}
 
-	operatorClient, err := client.New(config, "", namespaceName, userWorkloadNamespaceName)
+	operatorClient, err := client.New(context.Background(), config, "", namespaceName, userWorkloadNamespaceName)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating operator client failed")
 	}


### PR DESCRIPTION
As in title [MON-1251](https://issues.redhat.com/browse/MON-1251)

This is second PR after https://github.com/openshift/cluster-monitoring-operator/pull/1240 to remove context.TODO() calls
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
