### PR TITLE
Allow configuration of the log level for Alertmanager in the CMO configmap

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -128,6 +128,7 @@ type TLSConfig struct {
 }
 
 type AlertmanagerMainConfig struct {
+	LogLevel            string                               `json:"logLevel"`
 	NodeSelector        map[string]string                    `json:"nodeSelector"`
 	Tolerations         []v1.Toleration                      `json:"tolerations"`
 	Resources           *v1.ResourceRequirements             `json:"resources"`

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -412,6 +412,10 @@ func (f *Factory) AlertmanagerMain(host string, trustedCABundleCM *v1.ConfigMap)
 
 	a.Spec.ExternalURL = f.AlertmanagerExternalURL(host).String()
 
+	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.LogLevel != "" {
+		a.Spec.LogLevel = f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.LogLevel
+	}
+
 	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Resources != nil {
 		a.Spec.Resources = *f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Resources
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1210,6 +1210,7 @@ k8sPrometheusAdapter:
 
 func TestAlertmanagerMainConfiguration(t *testing.T) {
 	c, err := NewConfigFromString(`alertmanagerMain:
+  logLevel: debug
   baseImage: quay.io/test/alertmanager
   nodeSelector:
     type: worker
@@ -1245,6 +1246,10 @@ ingress:
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if a.Spec.LogLevel != "debug" {
+		t.Fatalf("Alertmanager logLevel is not configured correctly, want: 'debug', got: '%s'", a.Spec.LogLevel)
 	}
 
 	if *a.Spec.Image != "docker.io/openshift/origin-prometheus-alertmanager:latest" {


### PR DESCRIPTION
Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

This PR provides a way to the user to set alertmanager logLevel as described in the [openshift doc](https://docs.openshift.com/container-platform/4.7/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components_configuring-the-monitoring-stack).

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
