### PR TITLE
Revert "Bug 1974830: Update KubeDeploymentReplicasMismatch alert"

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -240,12 +240,9 @@ spec:
       record: cluster:vsphere_esxi_version_total:sum
     - expr: sum by(hw_version)(vsphere_node_hw_version_total)
       record: cluster:vsphere_node_hw_version_total:sum
-    - expr: |
-        sum(
-          min by (node) (kube_node_status_condition{condition="Ready",status="true"})
-            and
-          max by (node) (kube_node_role{role="master"})
-        ) == bool sum(kube_node_role{role="master"})
+    - expr: absent(count(max by (node) (kube_node_role{role="master"}) and (min by
+        (node) (kube_node_status_condition{condition="Ready",status="true"} == 0)))
+        > 0)
       record: cluster:control_plane:all_nodes_ready
     - alert: ClusterMonitoringOperatorReconciliationErrors
       annotations:
@@ -278,15 +275,15 @@ spec:
           healthy nodes and then contact support.
         summary: Deployment has not matched the expected number of replicas
       expr: |
-        (((
+        (
           kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
-            >
+            !=
           kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
         ) and (
           changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
             ==
           0
-        ))) * scalar(cluster:control_plane:all_nodes_ready == 1)
+        ) and cluster:control_plane:all_nodes_ready
       for: 15m
       labels:
         severity: warning

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -316,16 +316,9 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
             record: 'cluster:vsphere_node_hw_version_total:sum',
           },
           {
-            expr: |||
-              sum(
-                min by (node) (kube_node_status_condition{condition="Ready",status="true"})
-                  and
-                max by (node) (kube_node_role{role="master"})
-              ) == bool sum(kube_node_role{role="master"})
-            |||,
+            expr: 'absent(count(max by (node) (kube_node_role{role="master"}) and (min by (node) (kube_node_status_condition{condition="Ready",status="true"} == 0))) > 0)',
             record: 'cluster:control_plane:all_nodes_ready',
-            // Returns 1 if all control plane nodes are ready or 0 otherwise.
-            // Should be used to suppress alerts during control plane upgrades or disruption.
+            // Returns 1 if all control plane nodes are ready and is absent otherwise. Should be used to suppress alerts during control plane upgrades or disruption.
           },
           {
             expr: 'max(max_over_time(cluster_monitoring_operator_last_reconciliation_successful[1h])) == 0',
@@ -350,15 +343,15 @@ local droppedKsmLabels = 'endpoint, instance, job, pod, service';
           },
           {
             expr: |||
-              (((
+              (
                 kube_deployment_spec_replicas{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
-                  >
+                  !=
                 kube_deployment_status_replicas_available{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}
               ) and (
                 changes(kube_deployment_status_replicas_updated{namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"}[5m])
                   ==
                 0
-              ))) * scalar(cluster:control_plane:all_nodes_ready == 1)
+              ) and cluster:control_plane:all_nodes_ready
             |||,
             alert: 'KubeDeploymentReplicasMismatch',
             'for': '15m',


### PR DESCRIPTION
Reverts openshift/cluster-monitoring-operator#1253

Seems to have broken again:

```console
$ w3m -dump -cols 200 'https://search.ci.openshift.org/?search=alert+KubeDeploymentReplicasMismatch+fired&maxAge=336h&type=junit' | grep -o '[0-9]* days ago' | sort -n | uniq -c
      2 3 days ago
    171 4 days ago
    211 5 days ago
    185 6 days ago
     25 7 days ago
      1 9 days ago
      4 11 days ago
      2 12 days ago
      4 13 days ago
```

shows us recovering after the previous alert.  And:

```console
$ w3m -dump -cols 200 'https://search.ci.openshift.org/?search=alert+KubeDeploymentReplicasMismatch+fired&maxAge=336h&type=junit' | grep -o '[0-9]* hours ago' | wc -l
264
```

shows us breaking again after #1253 landed.