### PR TITLE
Bug 1974832: Improve HighlyAvailableWorkloadIncorrectlySpread to detect single point of failure

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -32,15 +32,16 @@ spec:
       annotations:
         description: Workload {{ $labels.namespace }}/{{ $labels.workload }} is incorrectly
           spread across multiple nodes which breaks high-availability requirements.
-          There are {{ $value }} pods on node {{ $labels.node }}, where there should
-          only be one. Since the workload is using persistent volumes, manual intervention
-          is needed. Please follow the guidelines provided in the runbook of this
-          alert to fix this issue.
+          Since the workload is using persistent volumes, manual intervention is needed.
+          Please follow the guidelines provided in the runbook of this alert to fix
+          this issue.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/HighlyAvailableWorkloadIncorrectlySpread.md
         summary: Highly-available workload is incorrectly spread across multiple nodes
           and manual intervention is needed.
       expr: |
-        count by(node,workload,namespace)
+        count without (node)
+        (
+          group by (node, workload, namespace)
           (
             kube_pod_info{node!=""}
             * on(namespace,pod) group_left(workload)
@@ -52,11 +53,11 @@ spec:
                 * on(namespace,workload,workload_type) group_left()
                 (
                   count without(pod) (namespace_workload_pod:kube_pod_owner:relabel{namespace=~"(openshift-.*|kube-.*|default)"}) > 1
-                  <= on() group_left count(kube_node_role{role="worker"})
                 )
               )
             )
-          ) > 1
+          )
+        ) == 1
       for: 1h
       labels:
         severity: warning

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -24,7 +24,9 @@ function(params) {
         },
         {
           expr: |||
-            count by(node,workload,namespace)
+            count without (node)
+            (
+              group by (node, workload, namespace)
               (
                 kube_pod_info{node!=""}
                 * on(namespace,pod) group_left(workload)
@@ -36,16 +38,16 @@ function(params) {
                     * on(namespace,workload,workload_type) group_left()
                     (
                       count without(pod) (namespace_workload_pod:kube_pod_owner:relabel{%(namespaceSelector)s}) > 1
-                      <= on() group_left count(kube_node_role{role="worker"})
                     )
                   )
                 )
-              ) > 1
+              )
+            ) == 1
           ||| % cfg,
           alert: 'HighlyAvailableWorkloadIncorrectlySpread',
           'for': '1h',
           annotations: {
-            description: 'Workload {{ $labels.namespace }}/{{ $labels.workload }} is incorrectly spread across multiple nodes which breaks high-availability requirements. There are {{ $value }} pods on node {{ $labels.node }}, where there should only be one. Since the workload is using persistent volumes, manual intervention is needed. Please follow the guidelines provided in the runbook of this alert to fix this issue.',
+            description: 'Workload {{ $labels.namespace }}/{{ $labels.workload }} is incorrectly spread across multiple nodes which breaks high-availability requirements. Since the workload is using persistent volumes, manual intervention is needed. Please follow the guidelines provided in the runbook of this alert to fix this issue.',
             summary: 'Highly-available workload is incorrectly spread across multiple nodes and manual intervention is needed.',
             runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/HighlyAvailableWorkloadIncorrectlySpread.md',
           },

--- a/test/rules/workload_incorrectly_spread.yaml
+++ b/test/rules/workload_incorrectly_spread.yaml
@@ -1,0 +1,139 @@
+# Tests HighlyAvailableWorkloadIncorrectlySpread
+
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Prometheus and Alertmanager instances are incorrectly spread.
+  - interval: 1m
+    input_series:
+      # Workload
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="prometheus-k8s-0", workload="prometheus-k8s", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="prometheus-k8s-1", workload="prometheus-k8s", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-0", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-1", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-2", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      # PVC
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="prometheus-k8s-db-prometheus-k8s-0", pod="prometheus-k8s-0", volumes="prometheus-k8s-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="prometheus-k8s-db-prometheus-k8s-1", pod="prometheus-k8s-1", volumes="prometheus-k8s-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-0", pod="alertmanager-main-0", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-1", pod="alertmanager-main-1", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-2", pod="alertmanager-main-2", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      # Node info
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="prometheus-k8s-0"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="prometheus-k8s-1"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="alertmanager-main-0"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="alertmanager-main-1"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="alertmanager-main-2"}'
+        values: '1+0x60'
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: "HighlyAvailableWorkloadIncorrectlySpread"
+      - eval_time: 60m
+        alertname: "HighlyAvailableWorkloadIncorrectlySpread"
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: openshift-monitoring
+              workload: prometheus-k8s
+            exp_annotations:
+              description: 'Workload openshift-monitoring/prometheus-k8s is incorrectly spread across multiple nodes which breaks high-availability requirements. Since the workload is using persistent volumes, manual intervention is needed. Please follow the guidelines provided in the runbook of this alert to fix this issue.'
+              summary: 'Highly-available workload is incorrectly spread across multiple nodes and manual intervention is needed.'
+              runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/HighlyAvailableWorkloadIncorrectlySpread.md'
+          - exp_labels:
+              severity: warning
+              namespace: openshift-monitoring
+              workload: alertmanager-main
+            exp_annotations:
+              description: 'Workload openshift-monitoring/alertmanager-main is incorrectly spread across multiple nodes which breaks high-availability requirements. Since the workload is using persistent volumes, manual intervention is needed. Please follow the guidelines provided in the runbook of this alert to fix this issue.'
+              summary: 'Highly-available workload is incorrectly spread across multiple nodes and manual intervention is needed.'
+              runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/HighlyAvailableWorkloadIncorrectlySpread.md'
+
+  # Prometheus and Alertmanager instances are correctly spread.
+  - interval: 1m
+    input_series:
+      # Workload
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="prometheus-k8s-0", workload="prometheus-k8s", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="prometheus-k8s-1", workload="prometheus-k8s", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-0", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-1", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-2", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      # PVC
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="prometheus-k8s-db-prometheus-k8s-0", pod="prometheus-k8s-0", volumes="prometheus-k8s-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="prometheus-k8s-db-prometheus-k8s-1", pod="prometheus-k8s-1", volumes="prometheus-k8s-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-0", pod="alertmanager-main-0", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-1", pod="alertmanager-main-1", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-2", pod="alertmanager-main-2", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      # Node info
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="prometheus-k8s-0"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-2.compute.internal", pod="prometheus-k8s-1"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="alertmanager-main-0"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-2.compute.internal", pod="alertmanager-main-1"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-3.compute.internal", pod="alertmanager-main-2"}'
+        values: '1+0x60'
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: "HighlyAvailableWorkloadIncorrectlySpread"
+      - eval_time: 60m
+        alertname: "HighlyAvailableWorkloadIncorrectlySpread"
+
+  # Alertmanager instances are spread across only 2 nodes.
+  - interval: 1m
+    input_series:
+      # Alertmanager workload
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-0", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-1", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      - series: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="openshift-monitoring", pod="alertmanager-main-2", workload="alertmanager-main", workload_type="statefulset"}'
+        values: '1+0x60'
+      # PVC
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-0", pod="alertmanager-main-0", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-1", pod="alertmanager-main-1", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      - series: 'kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="openshift-monitoring", persistentvolumeclaim="alertmanager-main-db-alertmanager-main-2", pod="alertmanager-main-2", volumes="alertmanager-main-db"}'
+        values: '1+0x60'
+      # Node info
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="alertmanager-main-0"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-1.compute.internal", pod="alertmanager-main-1"}'
+        values: '1+0x60'
+      - series: 'kube_pod_info{namespace="openshift-monitoring", node="ip-10-0-173-86.sa-east-2.compute.internal", pod="alertmanager-main-2"}'
+        values: '1+0x60'
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: "HighlyAvailableWorkloadIncorrectlySpread"
+      - eval_time: 60m
+        alertname: "HighlyAvailableWorkloadIncorrectlySpread"


### PR DESCRIPTION
Improve HighlyAvailableWorkloadIncorrectlySpread alert to only fire when
all instances of a workload are on the same node. Ultimately what we
want to catch with this alert are single points of failures and even if
multiple instances end up on the same node, if one of them is correctly
spread, then the workload is highly available.

/cc @simonpasquier 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
