### PR TITLE
Bug 1943565: ThanosSidecarUnhealthy will never fire if the sidecar is never healthy

### DIFF
--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -266,7 +266,7 @@ spec:
           more than {{ $value }} seconds.
         summary: Thanos Sidecar is unhealthy.
       expr: |
-        time() - max(timestamp(thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"})) by (job,pod) >= 240
+        time() - max(thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}) by (job,pod) >= 240
       for: 1h
       labels:
         severity: warning

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -118,8 +118,25 @@ local patchedRules = [
     name: 'thanos-sidecar',
     rules: [
       {
-        alert: '',
+        alert: 'ThanosSidecarPrometheusDown',
         'for': '1h',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'ThanosSidecarBucketOperationsFailed',
+        'for': '1h',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'ThanosSidecarUnhealthy',
+        'for': '1h',
+        expr: |||
+          time() - max(thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}) by (job,pod) >= 240
+        |||,
         labels: {
           severity: 'warning',
         },


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

This is a back port of https://github.com/thanos-io/thanos/pull/4342. Originally got into 4.9 as part of https://github.com/openshift/cluster-monitoring-operator/pull/1244/files#diff-9f32475601d9c279cd63600ea04308adf63ac5809e2b483526ae4105e8c3670cL289

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
