### PR TITLE
Bug 1977435: jsonnet: bump prometheus-operator to v0.49.0

### DIFF
--- a/assets/prometheus-operator-user-workload/cluster-role-binding.yaml
+++ b/assets/prometheus-operator-user-workload/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-user-workload-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-operator-user-workload/cluster-role.yaml
+++ b/assets/prometheus-operator-user-workload/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-user-workload-operator
 rules:
 - apiGroups:

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:
@@ -24,17 +24,17 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 0.48.1
+        app.kubernetes.io/version: 0.49.0
     spec:
       containers:
       - args:
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.48.1
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.49.0
         - --prometheus-instance-namespaces=openshift-user-workload-monitoring
         - --alertmanager-instance-namespaces=openshift-user-workload-monitoring
         - --thanos-ruler-instance-namespaces=openshift-user-workload-monitoring
         - --config-reloader-cpu-limit=0
         - --config-reloader-memory-limit=0
-        image: quay.io/prometheus-operator/prometheus-operator:v0.48.1
+        image: quay.io/prometheus-operator/prometheus-operator:v0.49.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/assets/prometheus-operator-user-workload/service-account.yaml
+++ b/assets/prometheus-operator-user-workload/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-operator-user-workload/service-monitor.yaml
+++ b/assets/prometheus-operator-user-workload/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:
@@ -22,4 +22,4 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 0.48.1
+      app.kubernetes.io/version: 0.49.0

--- a/assets/prometheus-operator-user-workload/service.yaml
+++ b/assets/prometheus-operator-user-workload/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/prometheus-operator/cluster-role-binding.yaml
+++ b/assets/prometheus-operator/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-operator/cluster-role.yaml
+++ b/assets/prometheus-operator/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
 rules:
 - apiGroups:

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:
@@ -24,12 +24,12 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 0.48.1
+        app.kubernetes.io/version: 0.49.0
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.48.1
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.49.0
         - --prometheus-instance-namespaces=openshift-monitoring
         - --thanos-ruler-instance-namespaces=openshift-monitoring
         - --alertmanager-instance-namespaces=openshift-monitoring
@@ -38,7 +38,7 @@ spec:
         - --web.enable-tls=true
         - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --web.tls-min-version=VersionTLS12
-        image: quay.io/prometheus-operator/prometheus-operator:v0.48.1
+        image: quay.io/prometheus-operator/prometheus-operator:v0.49.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/assets/prometheus-operator/prometheus-rule.yaml
+++ b/assets/prometheus-operator/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
     prometheus: k8s
     role: alert-rules
   name: prometheus-operator-rules

--- a/assets/prometheus-operator/service-account.yaml
+++ b/assets/prometheus-operator/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
   namespace: openshift-monitoring

--- a/assets/prometheus-operator/service-monitor.yaml
+++ b/assets/prometheus-operator/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:
@@ -22,4 +22,4 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 0.48.1
+      app.kubernetes.io/version: 0.49.0

--- a/assets/prometheus-operator/service.yaml
+++ b/assets/prometheus-operator/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.48.1
+    app.kubernetes.io/version: 0.49.0
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/versions.json
+++ b/jsonnet/versions.json
@@ -5,7 +5,7 @@
   "kubeStateMetrics": "2.0.0",
   "nodeExporter": "1.1.2",
   "prometheusAdapter": "0.8.4",
-  "prometheusOperator": "0.48.1",
+  "prometheusOperator": "0.49.0",
   "promLabelProxy": "0.3.0",
   "kubeRbacProxy": "0.9.0",
   "thanos": "0.20.2"


### PR DESCRIPTION
Follow-up PR to https://github.com/openshift/prometheus-operator/pull/131

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
