### PR TITLE
Bug 1978829: alert: ClusterMonitoringOperatorReconciliationErrors: reduce range du…

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -283,8 +283,9 @@ spec:
       annotations:
         message: Cluster Monitoring Operator is experiencing unexpected reconciliation
           errors. Inspect the cluster-monitoring-operator log for potential root causes.
-      expr: max(max_over_time(cluster_monitoring_operator_last_reconciliation_successful[1h]))
+      expr: max_over_time(cluster_monitoring_operator_last_reconciliation_successful[5m])
         == 0
+      for: 1h
       labels:
         severity: warning
     - alert: AlertmanagerReceiversNotConfigured

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -360,8 +360,9 @@ function(params) {
           // Should be used to suppress alerts during control plane upgrades or disruption.
         },
         {
-          expr: 'max(max_over_time(cluster_monitoring_operator_last_reconciliation_successful[1h])) == 0',
+          expr: 'max_over_time(cluster_monitoring_operator_last_reconciliation_successful[5m]) == 0',
           alert: 'ClusterMonitoringOperatorReconciliationErrors',
+          'for': '1h',
           annotations: {
             message: 'Cluster Monitoring Operator is experiencing unexpected reconciliation errors. Inspect the cluster-monitoring-operator log for potential root causes.',
           },


### PR DESCRIPTION
…ration and add for clause

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
