### PR TITLE
Bug 1978662: Set a degraded message when persistent storage is not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Add config option to disable Grafana deployment.
 - [#1278](https://github.com/openshift/cluster-monitoring-operator/pull/1278) Add EnforcedTargetLimit option for user-workload Prometheus.
+- [#1270](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Show a message in the degraded condition when Platform Monitoring Prometheus runs without persistent storage. 
 
 ## 4.8
 

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -29,7 +29,7 @@ import (
 const (
 	unavailableMessage string = "Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error."
 	asExpectedReason   string = "AsExpected"
-	StorageNotConfiguredMessage = "Prometheus is running without persistent storage and upgrades and cluster disruptions can lead to data loss. Please refer to the official documentation to see how to configure storage for Prometheus: https://docs.openshift.com/container-platform/4.7/monitoring/configuring-the-monitoring-stack.html"
+	StorageNotConfiguredMessage = "Prometheus is running without persistent storage which can lead to data loss during upgrades and cluster disruptions. Please refer to the official documentation to see how to configure storage for Prometheus: https://docs.openshift.com/container-platform/4.8/monitoring/configuring-the-monitoring-stack.html"
 	StorageNotConfiguredReason  = "PrometheusDataPersistenceNotConfigured"
 )
 

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -29,6 +29,8 @@ import (
 const (
 	unavailableMessage string = "Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error."
 	asExpectedReason   string = "AsExpected"
+	StorageNotConfiguredMessage = "Prometheus is running without persistent storage and upgrades and cluster disruptions can lead to data loss. Please refer to the official documentation to see how to configure storage for Prometheus: https://docs.openshift.com/container-platform/4.7/monitoring/configuring-the-monitoring-stack.html"
+	StorageNotConfiguredReason  = "PrometheusDataPersistenceNotConfigured"
 )
 
 type StatusReporter struct {
@@ -67,7 +69,7 @@ func (r *StatusReporter) relatedObjects() []v1.ObjectReference {
 	}
 }
 
-func (r *StatusReporter) SetDone() error {
+func (r *StatusReporter) SetDone(degradedConditionMessage string, degradedConditionReason string) error {
 	co, err := r.client.Get(r.ctx, r.clusterOperatorName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		co = r.newClusterOperator()
@@ -82,7 +84,7 @@ func (r *StatusReporter) SetDone() error {
 	conditions := newConditions(co.Status, r.version, time)
 	conditions.setCondition(v1.OperatorAvailable, v1.ConditionTrue, "Successfully rolled out the stack.", "RollOutDone", time)
 	conditions.setCondition(v1.OperatorProgressing, v1.ConditionFalse, "", "", time)
-	conditions.setCondition(v1.OperatorDegraded, v1.ConditionFalse, "", "", time)
+	conditions.setCondition(v1.OperatorDegraded, v1.ConditionFalse, degradedConditionMessage, degradedConditionReason, time)
 	conditions.setCondition(v1.OperatorUpgradeable, v1.ConditionTrue, "", asExpectedReason, time)
 	co.Status.Conditions = conditions.entries()
 

--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -113,7 +113,7 @@ func TestStatusReporterSetDone(t *testing.T) {
 				w(mock)
 			}
 
-			got := sr.SetDone()
+			got := sr.SetDone("", "")
 
 			for _, check := range tc.check {
 				if err := check(mock, got); err != nil {

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -38,6 +38,19 @@ type Config struct {
 	UserWorkloadConfiguration      *UserWorkloadConfiguration      `json:"-"`
 }
 
+func (c Config) IsStorageConfigured() bool {
+	if c.ClusterMonitoringConfiguration == nil {
+		return false
+	}
+
+	prometheusK8sConfig := c.ClusterMonitoringConfiguration.PrometheusK8sConfig
+	if prometheusK8sConfig == nil {
+		return false
+	}
+
+	return prometheusK8sConfig.VolumeClaimTemplate != nil
+}
+
 type ClusterMonitoringConfiguration struct {
 	PrometheusOperatorConfig *PrometheusOperatorConfig    `json:"prometheusOperator"`
 	PrometheusK8sConfig      *PrometheusK8sConfig         `json:"prometheusK8s"`

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -481,9 +481,14 @@ func (o *Operator) sync(key string) error {
 		return err
 	}
 
+	var degradedConditionMessage, degradedConditionReason string
+	if !config.IsStorageConfigured() {
+		degradedConditionMessage = client.StorageNotConfiguredMessage
+		degradedConditionReason = client.StorageNotConfiguredReason
+	}
 	klog.Info("Updating ClusterOperator status to done.")
 	o.failedReconcileAttempts = 0
-	err = o.client.StatusReporter().SetDone()
+	err = o.client.StatusReporter().SetDone(degradedConditionMessage, degradedConditionReason)
 	if err != nil {
 		klog.Errorf("error occurred while setting status to done: %v", err)
 	}


### PR DESCRIPTION
When persistent storage is not configured for prometheus, upgrades and cluster disruptions can lead to data loss. 
In order to make cluster admins aware of this problem, this PR adds a message to the degraded condition indicating this problem. The value of the condition is kept as `degraded=false` since there is no real degradation with the cluster monitoring.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
