### PR TITLE
Allow configuring additional alertmanagers for UWM Prometheus and Thanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#1278](https://github.com/openshift/cluster-monitoring-operator/pull/1278) Add EnforcedTargetLimit option for user-workload Prometheus.
 - [#1291](https://github.com/openshift/cluster-monitoring-operator/pull/1291) Drop high caredinality cAdvisor metrics via [kube-prometheus #1250](https://github.com/prometheus-operator/kube-prometheus/pull/1250)
 - [#1270](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Show a message in the degraded condition when Platform Monitoring Prometheus runs without persistent storage. 
+- [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Allow configuring additional Alertmanagers in User Workload Prometheus.
 
 ## 4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [#1278](https://github.com/openshift/cluster-monitoring-operator/pull/1278) Add EnforcedTargetLimit option for user-workload Prometheus.
 - [#1291](https://github.com/openshift/cluster-monitoring-operator/pull/1291) Drop high caredinality cAdvisor metrics via [kube-prometheus #1250](https://github.com/prometheus-operator/kube-prometheus/pull/1250)
 - [#1270](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Show a message in the degraded condition when Platform Monitoring Prometheus runs without persistent storage. 
-- [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Allow configuring additional Alertmanagers in User Workload Prometheus.
+- [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Allow configuring additional Alertmanagers in User Workload Prometheus and Thanos Ruler.
 
 ## 4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Add config option to disable Grafana deployment.
 - [#1278](https://github.com/openshift/cluster-monitoring-operator/pull/1278) Add EnforcedTargetLimit option for user-workload Prometheus.
 - [#1291](https://github.com/openshift/cluster-monitoring-operator/pull/1291) Drop high caredinality cAdvisor metrics via [kube-prometheus #1250](https://github.com/prometheus-operator/kube-prometheus/pull/1250)
-- [#1270](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Show a message in the degraded condition when Platform Monitoring Prometheus runs without persistent storage. 
+- [#1270](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Show a message in the degraded condition when Platform Monitoring Prometheus runs without persistent storage.
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Allow configuring additional Alertmanagers in User Workload Prometheus and Thanos Ruler.
 
 ## 4.8

--- a/pkg/manifests/amcfg.go
+++ b/pkg/manifests/amcfg.go
@@ -1,0 +1,209 @@
+package manifests
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+)
+
+// PrometheusAdditionalAlertmanagerConfigs is a AdditionalAlertmanagerConfig slice
+type PrometheusAdditionalAlertmanagerConfigs []AdditionalAlertmanagerConfig
+
+// PrometheusAdditionalAlertmanagerConfig is an AdditionalAlertmanagerConfig
+// which can be marshaled into a yaml string,
+// compatible with the Prometheus configuration format
+type PrometheusAdditionalAlertmanagerConfig AdditionalAlertmanagerConfig
+
+func (a PrometheusAdditionalAlertmanagerConfigs) MarshalYAML() (interface{}, error) {
+	result := make([]interface{}, len(a))
+	for i, item := range a {
+		promAmCfg := PrometheusAdditionalAlertmanagerConfig(item)
+		if y, err := promAmCfg.MarshalYAML(); err != nil {
+			return nil, err
+		} else {
+			result[i] = y
+		}
+	}
+
+	return result, nil
+}
+
+type amConfigPrometheus struct {
+	Scheme        string                  `yaml:"scheme,omitempty"`
+	PathPrefix    string                  `yaml:"path_prefix,omitempty"`
+	Timeout       *string                 `yaml:"timeout,omitempty"`
+	APIVersion    string                  `yaml:"api_version,omitempty"`
+	Authorization amConfigAuthorization   `yaml:"authorization,omitempty"`
+	TLSConfig     amConfigTLS             `yaml:"tls_config,omitempty"`
+	StaticConfigs []amConfigStaticConfigs `yaml:"static_configs,omitempty"`
+}
+
+type amConfigAuthorization struct {
+	CredentialsFile string `yaml:"credentials_file"`
+}
+
+type amConfigTLS struct {
+	CA                 string `yaml:"ca_file,omitempty"`
+	Cert               string `yaml:"cert_file,omitempty"`
+	Key                string `yaml:"key_file,omitempty"`
+	ServerName         string `yaml:"server_name,omitempty"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify,omitempty"`
+}
+
+type amConfigStaticConfigs struct {
+	Targets []string `yaml:"targets"`
+}
+
+// MarshalYAML marshals a PrometheusAdditionalAlertmanagerConfig into
+// a format compatible with the Prometheus configuration.
+func (a PrometheusAdditionalAlertmanagerConfig) MarshalYAML() (interface{}, error) {
+	cfg := amConfigPrometheus{
+		Scheme:     a.Scheme,
+		PathPrefix: a.PathPrefix,
+		Timeout:    a.Timeout,
+		APIVersion: a.APIVersion,
+		TLSConfig: amConfigTLS{
+			CA:                 "",
+			Cert:               "",
+			Key:                "",
+			ServerName:         a.TLSConfig.ServerName,
+			InsecureSkipVerify: a.TLSConfig.InsecureSkipVerify,
+		},
+		Authorization: amConfigAuthorization{
+			CredentialsFile: "",
+		},
+	}
+	if caPath, err := secretPath(a.TLSConfig.CA); err != nil {
+		return nil, err
+	} else {
+		cfg.TLSConfig.CA = caPath
+	}
+	if keyPath, err := secretPath(a.TLSConfig.Key); err != nil {
+		return nil, err
+	} else {
+		cfg.TLSConfig.Key = keyPath
+	}
+	if certPath, err := secretPath(a.TLSConfig.Cert); err != nil {
+		return nil, err
+	} else {
+		cfg.TLSConfig.Cert = certPath
+	}
+	if bearerTokenPath, err := secretPath(a.BearerToken); err != nil {
+		return nil, err
+	} else {
+		cfg.Authorization.CredentialsFile = bearerTokenPath
+	}
+
+	cfg.StaticConfigs = []amConfigStaticConfigs{
+		{
+			Targets: a.StaticConfigs,
+		},
+	}
+
+	return cfg, nil
+}
+
+// ThanosAlertmanagerAdditionalConfigs is a AdditionalAlertmanagerConfig slice
+type ThanosAlertmanagerAdditionalConfigs []AdditionalAlertmanagerConfig
+
+// ThanosAlertmanagerAdditionalConfig is an AdditionalAlertmanagerConfig
+// which can be marshaled into a yaml string,
+// compatible with the Prometheus configuration format
+type ThanosAlertmanagerAdditionalConfig AdditionalAlertmanagerConfig
+
+func (a ThanosAlertmanagerAdditionalConfigs) MarshalYAML() (interface{}, error) {
+	result := make([]interface{}, len(a))
+	for i, item := range a {
+		promAmCfg := ThanosAlertmanagerAdditionalConfig(item)
+		if y, err := promAmCfg.MarshalYAML(); err != nil {
+			return nil, err
+		} else {
+			result[i] = y
+		}
+	}
+
+	return result, nil
+}
+
+type amConfigThanos struct {
+	Scheme        string       `yaml:"scheme,omitempty"`
+	PathPrefix    string       `yaml:"path_prefix,omitempty"`
+	Timeout       *string      `yaml:"timeout,omitempty"`
+	APIVersion    string       `yaml:"api_version,omitempty"`
+	HTTPConfig    amHTTPConfig `yaml:"http_config,omitempty"`
+	StaticConfigs []string     `yaml:"static_configs,omitempty"`
+}
+
+type amHTTPConfig struct {
+	BearerTokenFile string      `yaml:"bearer_token_file,omitempty"`
+	TLSConfig       amConfigTLS `yaml:"tls_config,omitempty"`
+}
+
+// MarshalYAML marshals a ThanosAlertmanagerAdditionalConfig into
+// a format compatible with the Prometheus configuration.
+func (a ThanosAlertmanagerAdditionalConfig) MarshalYAML() (interface{}, error) {
+	cfg := amConfigThanos{
+		Scheme:     a.Scheme,
+		PathPrefix: a.PathPrefix,
+		Timeout:    a.Timeout,
+		APIVersion: a.APIVersion,
+		HTTPConfig: amHTTPConfig{
+			BearerTokenFile: "",
+			TLSConfig: amConfigTLS{
+				CA:                 "",
+				Cert:               "",
+				Key:                "",
+				ServerName:         a.TLSConfig.ServerName,
+				InsecureSkipVerify: a.TLSConfig.InsecureSkipVerify,
+			},
+		},
+	}
+	if caPath, err := secretPath(a.TLSConfig.CA); err != nil {
+		return nil, err
+	} else {
+		cfg.HTTPConfig.TLSConfig.CA = caPath
+	}
+	if keyPath, err := secretPath(a.TLSConfig.Key); err != nil {
+		return nil, err
+	} else {
+		cfg.HTTPConfig.TLSConfig.Key = keyPath
+	}
+	if certPath, err := secretPath(a.TLSConfig.Cert); err != nil {
+		return nil, err
+	} else {
+		cfg.HTTPConfig.TLSConfig.Cert = certPath
+	}
+	if bearerTokenPath, err := secretPath(a.BearerToken); err != nil {
+		return nil, err
+	} else {
+		cfg.HTTPConfig.BearerTokenFile = bearerTokenPath
+	}
+
+	cfg.StaticConfigs = a.StaticConfigs
+
+	return cfg, nil
+}
+
+func secretPath(s *v1.SecretKeySelector) (string, error) {
+	if s == nil {
+		return "", nil
+	}
+
+	if err := validateSecret(s); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("/etc/prometheus/secrets/%s/%s", s.Name, s.Key), nil
+}
+
+func validateSecret(s *v1.SecretKeySelector) error {
+	if s != nil {
+		if s.Name == "" {
+			return errors.Errorf("secret %q for ca not found", s.Name)
+		}
+		if s.Key == "" {
+			return errors.Errorf("secret key %q for ca not found", s.Key)
+		}
+	}
+	return nil
+}

--- a/pkg/manifests/amcfg.go
+++ b/pkg/manifests/amcfg.go
@@ -19,7 +19,7 @@ func (a PrometheusAdditionalAlertmanagerConfigs) MarshalYAML() (interface{}, err
 	for i, item := range a {
 		promAmCfg := PrometheusAdditionalAlertmanagerConfig(item)
 		if y, err := promAmCfg.MarshalYAML(); err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "additional Alertmanager configuration[%d]", i)
 		} else {
 			result[i] = y
 		}
@@ -108,7 +108,7 @@ type ThanosAlertmanagerAdditionalConfigs []AdditionalAlertmanagerConfig
 
 // ThanosAlertmanagerAdditionalConfig is an AdditionalAlertmanagerConfig
 // which can be marshaled into a yaml string,
-// compatible with the Prometheus configuration format
+// compatible with the Thanos configuration format
 type ThanosAlertmanagerAdditionalConfig AdditionalAlertmanagerConfig
 
 func (a ThanosAlertmanagerAdditionalConfigs) MarshalYAML() (interface{}, error) {
@@ -116,7 +116,7 @@ func (a ThanosAlertmanagerAdditionalConfigs) MarshalYAML() (interface{}, error) 
 	for i, item := range a {
 		promAmCfg := ThanosAlertmanagerAdditionalConfig(item)
 		if y, err := promAmCfg.MarshalYAML(); err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "additional Alertmanager configuration[%d]", i)
 		} else {
 			result[i] = y
 		}
@@ -197,13 +197,16 @@ func secretPath(s *v1.SecretKeySelector) (string, error) {
 }
 
 func validateSecret(s *v1.SecretKeySelector) error {
-	if s != nil {
-		if s.Name == "" {
-			return errors.Errorf("secret %q for ca not found", s.Name)
-		}
-		if s.Key == "" {
-			return errors.Errorf("secret key %q for ca not found", s.Key)
-		}
+	if s == nil {
+		return nil
 	}
+
+	if s.Name == "" {
+		return errors.Errorf("secret %q for ca not found", s.Name)
+	}
+	if s.Key == "" {
+		return errors.Errorf("secret key %q for ca not found", s.Key)
+	}
+
 	return nil
 }

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -83,7 +83,7 @@ func (c Config) GetThanosRulerAlertmanagerConfigs() []AdditionalAlertmanagerConf
 		return nil
 	}
 
-	alertmanagerConfigs := c.UserWorkloadConfiguration.ThanosRuler.AlertManagersConfigs
+	alertmanagerConfigs := c.UserWorkloadConfiguration.ThanosRuler.AlertmanagersConfigs
 	if len(alertmanagerConfigs) == 0 {
 		return nil
 	}
@@ -193,7 +193,7 @@ type ThanosRulerConfig struct {
 	Tolerations          []v1.Toleration                      `json:"tolerations"`
 	Resources            *v1.ResourceRequirements             `json:"resources"`
 	VolumeClaimTemplate  *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
-	AlertManagersConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
+	AlertmanagersConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
 }
 
 type ThanosQuerierConfig struct {

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -145,8 +145,7 @@ type PrometheusK8sConfig struct {
 	VolumeClaimTemplate *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
 	RemoteWrite         []monv1.RemoteWriteSpec              `json:"remoteWrite"`
 	TelemetryMatches    []string                             `json:"-"`
-	// EXPERIMENTAL: this configuration field may change in future releases.
-	AlertmanagerConfigs []AdditionalAlertmanagerConfig `json:"additionalAlertmanagerConfigs"`
+	AlertmanagerConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
 }
 
 type AdditionalAlertmanagerConfig struct {

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -53,19 +53,39 @@ func (c Config) IsStorageConfigured() bool {
 
 // GetPrometheusUWAdditionalAlertmanagerConfigs returns the alertmanager configurations for
 // the User Workload Monitoring Prometheus instance.
-// If no additional configurations are specified, GetPrometheusUWAdditionalAlertmanagerConfigs returns an empty array.
+// If no additional configurations are specified, GetPrometheusUWAdditionalAlertmanagerConfigs returns nil.
 func (c Config) GetPrometheusUWAdditionalAlertmanagerConfigs() []AdditionalAlertmanagerConfig {
 	if c.UserWorkloadConfiguration == nil {
-		return []AdditionalAlertmanagerConfig{}
+		return nil
 	}
 
 	if c.UserWorkloadConfiguration.Prometheus == nil {
-		return []AdditionalAlertmanagerConfig{}
+		return nil
 	}
 
 	alertmanagerConfigs := c.UserWorkloadConfiguration.Prometheus.AlertmanagerConfigs
-	if alertmanagerConfigs == nil {
-		return []AdditionalAlertmanagerConfig{}
+	if len(alertmanagerConfigs) == 0 {
+		return nil
+	}
+
+	return alertmanagerConfigs
+}
+
+// GetThanosRulerAlertmanagerConfigs returns the alertmanager configurations for
+// the User Workload Monitoring Thanos Ruler instance.
+// If no additional configurations are specified, GetThanosRulerAlertmanagerConfigs returns nil.
+func (c Config) GetThanosRulerAlertmanagerConfigs() []AdditionalAlertmanagerConfig {
+	if c.UserWorkloadConfiguration == nil {
+		return nil
+	}
+
+	if c.UserWorkloadConfiguration.ThanosRuler == nil {
+		return nil
+	}
+
+	alertmanagerConfigs := c.UserWorkloadConfiguration.ThanosRuler.AlertManagersConfigs
+	if len(alertmanagerConfigs) == 0 {
+		return nil
 	}
 
 	return alertmanagerConfigs
@@ -169,11 +189,12 @@ type AlertmanagerMainConfig struct {
 }
 
 type ThanosRulerConfig struct {
-	LogLevel            string                               `json:"logLevel"`
-	NodeSelector        map[string]string                    `json:"nodeSelector"`
-	Tolerations         []v1.Toleration                      `json:"tolerations"`
-	Resources           *v1.ResourceRequirements             `json:"resources"`
-	VolumeClaimTemplate *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+	LogLevel             string                               `json:"logLevel"`
+	NodeSelector         map[string]string                    `json:"nodeSelector"`
+	Tolerations          []v1.Toleration                      `json:"tolerations"`
+	Resources            *v1.ResourceRequirements             `json:"resources"`
+	VolumeClaimTemplate  *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+	AlertManagersConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertManagerConfigs"`
 }
 
 type ThanosQuerierConfig struct {

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -51,6 +51,26 @@ func (c Config) IsStorageConfigured() bool {
 	return prometheusK8sConfig.VolumeClaimTemplate != nil
 }
 
+// GetPrometheusUWAdditionalAlertmanagerConfigs returns the alertmanager configurations for
+// the User Workload Monitoring Prometheus instance.
+// If no additional configurations are specified, GetPrometheusUWAdditionalAlertmanagerConfigs returns an empty array.
+func (c Config) GetPrometheusUWAdditionalAlertmanagerConfigs() []AdditionalAlertmanagerConfig {
+	if c.UserWorkloadConfiguration == nil {
+		return []AdditionalAlertmanagerConfig{}
+	}
+
+	if c.UserWorkloadConfiguration.Prometheus == nil {
+		return []AdditionalAlertmanagerConfig{}
+	}
+
+	alertmanagerConfigs := c.UserWorkloadConfiguration.Prometheus.AlertmanagerConfigs
+	if alertmanagerConfigs == nil {
+		return []AdditionalAlertmanagerConfig{}
+	}
+
+	return alertmanagerConfigs
+}
+
 type ClusterMonitoringConfiguration struct {
 	PrometheusOperatorConfig *PrometheusOperatorConfig    `json:"prometheusOperator"`
 	PrometheusK8sConfig      *PrometheusK8sConfig         `json:"prometheusK8s"`
@@ -417,6 +437,7 @@ type PrometheusRestrictedConfig struct {
 	RemoteWrite         []monv1.RemoteWriteSpec              `json:"remoteWrite"`
 	EnforcedSampleLimit *uint64                              `json:"enforcedSampleLimit"`
 	EnforcedTargetLimit *uint64                              `json:"enforcedTargetLimit"`
+	AlertmanagerConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertManagerConfigs"`
 }
 
 func (u *UserWorkloadConfiguration) applyDefaults() {

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -146,7 +146,7 @@ type PrometheusK8sConfig struct {
 	RemoteWrite         []monv1.RemoteWriteSpec              `json:"remoteWrite"`
 	TelemetryMatches    []string                             `json:"-"`
 	// EXPERIMENTAL: this configuration field may change in future releases.
-	AlertmanagerConfigs []AdditionalAlertmanagerConfig `json:"additionalAlertManagerConfigs"`
+	AlertmanagerConfigs []AdditionalAlertmanagerConfig `json:"additionalAlertmanagerConfigs"`
 }
 
 type AdditionalAlertmanagerConfig struct {
@@ -194,7 +194,7 @@ type ThanosRulerConfig struct {
 	Tolerations          []v1.Toleration                      `json:"tolerations"`
 	Resources            *v1.ResourceRequirements             `json:"resources"`
 	VolumeClaimTemplate  *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
-	AlertManagersConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertManagerConfigs"`
+	AlertManagersConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
 }
 
 type ThanosQuerierConfig struct {
@@ -458,7 +458,7 @@ type PrometheusRestrictedConfig struct {
 	RemoteWrite         []monv1.RemoteWriteSpec              `json:"remoteWrite"`
 	EnforcedSampleLimit *uint64                              `json:"enforcedSampleLimit"`
 	EnforcedTargetLimit *uint64                              `json:"enforcedTargetLimit"`
-	AlertmanagerConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertManagerConfigs"`
+	AlertmanagerConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
 }
 
 func (u *UserWorkloadConfiguration) applyDefaults() {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3459,6 +3459,9 @@ func (f *Factory) injectThanosRulerAlertmanagerDigest(t *monv1.ThanosRuler, aler
 	for i, _ := range t.Spec.Containers {
 		containerName := t.Spec.Containers[i].Name
 		if containerName == "thanos-ruler" {
+			// Thanos ruler does not refresh its config when the alertmanagers secret changes.
+			// Because of this, we need to redeploy the statefulset
+			// whenever there is a change in the data of the secret.
 			t.Spec.Containers[i].Env = append(t.Spec.Containers[i].Env, v1.EnvVar{
 				Name:  "ALERTMANAGER_CONFIG_SECRET_VERSION",
 				Value: digest,

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1066,7 +1066,7 @@ func (f *Factory) ThanosRulerAlertmanagerConfigSecret() (*v1.Secret, error) {
 		return s, nil
 	}
 
-	additionalConfig, err := f.additionalAlertManagerConfigs(amConfigs, alertmanagerHttpConfigFormatThanos)
+	additionalConfig, err := f.additionalAlertmanagerConfigs(amConfigs, alertmanagerHttpConfigFormatThanos)
 	if err != nil {
 		return nil, err
 	}
@@ -1468,7 +1468,7 @@ func (f *Factory) PrometheusK8s(host string, grpcTLS *v1.Secret, trustedCABundle
 func (f *Factory) PrometheusK8sAdditionalAlertManagerConfigsSecret() (*v1.Secret, error) {
 	amConfigs := f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs
 
-	config, err := f.additionalAlertManagerConfigs(amConfigs, alertmanagerHttpConfigFormatPrometheus)
+	config, err := f.additionalAlertmanagerConfigs(amConfigs, alertmanagerHttpConfigFormatPrometheus)
 	if err != nil {
 		return nil, err
 	}
@@ -1486,7 +1486,7 @@ func (f *Factory) PrometheusK8sAdditionalAlertManagerConfigsSecret() (*v1.Secret
 
 func (f *Factory) PrometheusUserWorkloadAdditionalAlertManagerConfigsSecret() (*v1.Secret, error) {
 	amConfigs := f.config.GetPrometheusUWAdditionalAlertmanagerConfigs()
-	config, err := f.additionalAlertManagerConfigs(amConfigs, alertmanagerHttpConfigFormatPrometheus)
+	config, err := f.additionalAlertmanagerConfigs(amConfigs, alertmanagerHttpConfigFormatPrometheus)
 	if err != nil {
 		return nil, err
 	}
@@ -1654,7 +1654,7 @@ func (f *Factory) thanosAlertmanagerConfigHttpSection(alertmanagerConfig Additio
 	return cfg, nil
 }
 
-func (f *Factory) additionalAlertManagerConfigs(
+func (f *Factory) additionalAlertmanagerConfigs(
 	alertmanagerConfigs []AdditionalAlertmanagerConfig,
 	format alertmanagerHttpConfigFormat,
 ) ([]byte, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1038,7 +1038,7 @@ ingress:
 	}
 
 	if p.Spec.AdditionalAlertManagerConfigs != nil {
-		t.Fatal("additionalAlertManagerConfigs should not be set")
+		t.Fatal("additionalAlertmanagerConfigs should not be set")
 	}
 
 	storageRequest := p.Spec.Storage.VolumeClaimTemplate.Spec.Resources.Requests[v1.ResourceStorage]
@@ -1062,7 +1062,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "basic config",
 			config: `prometheusK8s:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - staticConfigs:
     - alertmanager1-remote.com
     - alertmanager1-remotex.com
@@ -1079,7 +1079,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "version, path and scheme override",
 			config: `prometheusK8s:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - apiVersion: v1
     pathPrefix: /path
     scheme: ftp
@@ -1102,7 +1102,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "bearer token",
 			config: `prometheusK8s:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - apiVersion: v2
     scheme: https    
     bearerToken:
@@ -1127,7 +1127,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "tls configuration token",
 			config: `prometheusK8s:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - apiVersion: v2
     scheme: https    
     tlsConfig:
@@ -1162,7 +1162,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "tls configuration token",
 			config: `prometheusK8s:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - apiVersion: v2
     scheme: https    
     tlsConfig:
@@ -1197,7 +1197,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "full configuration",
 			config: `prometheusK8s:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - apiVersion: v2
     scheme: https
     bearerToken:
@@ -1276,7 +1276,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(string(s.Data[AdditionalAlertmanagerConfigSecretKey]), tt.expected) {
-				t.Fatalf("additionalAlertManagerConfigs is not configured correctly\n\ngot:\n\n%#+v\n\nexpected:\n\n%#+v\n", string(s.Data[AdditionalAlertmanagerConfigSecretKey]), tt.expected)
+				t.Fatalf("additionalAlertmanagerConfigs is not configured correctly\n\ngot:\n\n%#+v\n\nexpected:\n\n%#+v\n", string(s.Data[AdditionalAlertmanagerConfigSecretKey]), tt.expected)
 			}
 		})
 	}
@@ -1305,7 +1305,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "basic config",
 			config: `thanosRuler:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - staticConfigs:
     - alertmanager1-remote.com
     - alertmanager1-remotex.com
@@ -1331,7 +1331,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "version, path and scheme override",
 			config: `thanosRuler:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - version: v1
     pathPrefix: /path-prefix
     scheme: ftp
@@ -1362,7 +1362,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "bearer token",
 			config: `thanosRuler:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - bearerToken:
       key: key
       name: bearer-token
@@ -1392,7 +1392,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "tls configuration token",
 			config: `thanosRuler:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - tlsConfig:
       ca:
         name: alertmanager-tls
@@ -1432,7 +1432,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "tls configuration token",
 			config: `thanosRuler:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - tlsConfig:
       ca:
         name: alertmanager-ca-tls
@@ -1472,7 +1472,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		{
 			name: "full configuration",
 			config: `thanosRuler:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - apiVersion: v2
     scheme: https
     bearerToken:
@@ -1544,7 +1544,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(s.StringData["alertmanagers.yaml"], tt.expected) {
-				t.Fatalf("additionalAlertManagerConfigs is not configured correctly\n\ngot:\n\n%#+v\n\nexpected:\n\n%#+v\n", s.StringData["alertmanagers.yaml"], tt.expected)
+				t.Fatalf("additionalAlertmanagerConfigs is not configured correctly\n\ngot:\n\n%#+v\n\nexpected:\n\n%#+v\n", s.StringData["alertmanagers.yaml"], tt.expected)
 			}
 		})
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1165,7 +1165,8 @@ func TestAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		t.Fatalf("Prometheus secrets are not generated correctly, expected to have %s but got none", exp)
 	}
 
-	s, err := f.AdditionalAlertManagerConfigsSecret()
+	alertManagerConfigs := f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs
+	s, err := f.AdditionalAlertManagerConfigsSecret("secret-name", "secret-namespace", alertManagerConfigs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1060,6 +1060,12 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		mountedSecrets []string
 	}{
 		{
+			name:           "empty config",
+			config:         "",
+			expected:       "[]\n",
+			mountedSecrets: []string{},
+		},
+		{
 			name: "basic config",
 			config: `prometheusK8s:
   additionalAlertmanagerConfigs:

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1052,127 +1052,501 @@ ingress:
 	}
 }
 
-func TestAdditionalAlertManagerConfigsSecret(t *testing.T) {
-	c, err := NewConfigFromString(`prometheusK8s:
+func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
+	testCases := []struct {
+		name           string
+		config         string
+		expected       string
+		mountedSecrets []string
+	}{
+		{
+			name: "basic config",
+			config: `prometheusK8s:
   additionalAlertManagerConfigs:
-  - apiVersion: v2
-    bearerToken:
-      name: alertmanager1-bearer-token
-      key: token
-    scheme: https
-    tlsConfig:
-      ca: 
-        name: alertmanager1-ca
-        key: root-ca.crt
-    pathPrefix: /
+  - staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			expected: `- tls_config:
+    insecure_skip_verify: false
+  static_configs:
+  - targets:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			mountedSecrets: []string{},
+		},
+		{
+			name: "version, path and scheme override",
+			config: `prometheusK8s:
+  additionalAlertManagerConfigs:
+  - apiVersion: v1
+    pathPrefix: /path
+    scheme: ftp
     staticConfigs:
     - alertmanager1-remote.com
     - alertmanager1-remotex.com
+`,
+			expected: `- scheme: ftp
+  path_prefix: /path
+  api_version: v1
+  tls_config:
+    insecure_skip_verify: false
+  static_configs:
+  - targets:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			mountedSecrets: []string{},
+		},
+		{
+			name: "bearer token",
+			config: `prometheusK8s:
+  additionalAlertManagerConfigs:
   - apiVersion: v2
-    scheme: https
-    timeout: 60s
-    tlsConfig:
-      ca: 
-        name: alertmanager2-cert
-        key: root-ca.crt
-      cert:
-        name: alertmanager2-cert
-        key: cert.crt
-      key:
-        name: alertmanager2-cert
-        key: key.crt
-      serverName: alertmanager2-remote.com
-    pathPrefix: /
+    scheme: https    
+    bearerToken:
+      name: alertmanager1-bearer-token
+      key: token
     staticConfigs:
-    - alertmanager2-remote.com
-  - apiVersion: v2
-    scheme: https
-    timeout: 60s
-    tlsConfig:
-      ca:
-        name: alertmanager3-ca
-        key: root-ca.crt
-      cert:
-        name: alertmanager3-cert
-        key: cert.crt
-      key:
-        name: alertmanager3-key
-        key: key.crt
-      serverName: alertmanager3-remote.com
-    pathPrefix: /
-    staticConfigs:
-    - alertmanager3-remote.com
-`)
-	expected := `- scheme: https
-  path_prefix: /
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com`,
+			expected: `- scheme: https
   api_version: v2
   authorization:
     credentials_file: /etc/prometheus/secrets/alertmanager1-bearer-token/token
   tls_config:
-    ca_file: /etc/prometheus/secrets/alertmanager1-ca/root-ca.crt
     insecure_skip_verify: false
   static_configs:
   - targets:
     - alertmanager1-remote.com
     - alertmanager1-remotex.com
-- scheme: https
-  path_prefix: /
+`,
+			mountedSecrets: []string{"alertmanager1-bearer-token"},
+		},
+		{
+			name: "tls configuration token",
+			config: `prometheusK8s:
+  additionalAlertManagerConfigs:
+  - apiVersion: v2
+    scheme: https    
+    tlsConfig:
+      ca:
+        name: alertmanager-tls
+        key: tls.ca
+      cert:
+        name: alertmanager-tls
+        key: tls.ca
+      key:
+        name: alertmanager-tls
+        key: tls.ca
+      serverName: alertmanager-remote.com
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com`,
+			expected: `- scheme: https
   api_version: v2
-  timeout: 60s
   tls_config:
-    ca_file: /etc/prometheus/secrets/alertmanager2-cert/root-ca.crt
-    cert_file: /etc/prometheus/secrets/alertmanager2-cert/cert.crt
-    key_file: /etc/prometheus/secrets/alertmanager2-cert/key.crt
-    server_name: alertmanager2-remote.com
+    ca_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
+    cert_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
+    key_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
+    server_name: alertmanager-remote.com
     insecure_skip_verify: false
   static_configs:
   - targets:
-    - alertmanager2-remote.com
-- scheme: https
-  path_prefix: /
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			mountedSecrets: []string{"alertmanager-tls"},
+		},
+		{
+			name: "tls configuration token",
+			config: `prometheusK8s:
+  additionalAlertManagerConfigs:
+  - apiVersion: v2
+    scheme: https    
+    tlsConfig:
+      ca:
+        name: alertmanager-ca-tls
+        key: tls.ca
+      cert:
+        name: alertmanager-cert-tls
+        key: tls.ca
+      key:
+        name: alertmanager-key-tls
+        key: tls.ca
+      serverName: alertmanager-remote.com
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com`,
+			expected: `- scheme: https
   api_version: v2
-  timeout: 60s
   tls_config:
-    ca_file: /etc/prometheus/secrets/alertmanager3-ca/root-ca.crt
-    cert_file: /etc/prometheus/secrets/alertmanager3-cert/cert.crt
-    key_file: /etc/prometheus/secrets/alertmanager3-key/key.crt
-    server_name: alertmanager3-remote.com
+    ca_file: /etc/prometheus/secrets/alertmanager-ca-tls/tls.ca
+    cert_file: /etc/prometheus/secrets/alertmanager-cert-tls/tls.ca
+    key_file: /etc/prometheus/secrets/alertmanager-key-tls/tls.ca
+    server_name: alertmanager-remote.com
     insecure_skip_verify: false
   static_configs:
   - targets:
-    - alertmanager3-remote.com
-`
-	if err != nil {
-		t.Fatal(err)
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			mountedSecrets: []string{"alertmanager-ca-tls", "alertmanager-cert-tls", "alertmanager-key-tls"},
+		},
+		{
+			name: "full configuration",
+			config: `prometheusK8s:
+  additionalAlertManagerConfigs:
+  - apiVersion: v2
+    scheme: https
+    bearerToken:
+      name: alertmanager-bearer-token
+      key: token
+    tlsConfig:
+      ca:
+        name: alertmanager-ca-tls
+        key: tls.ca
+      cert:
+        name: alertmanager-cert-tls
+        key: tls.ca
+      key:
+        name: alertmanager-key-tls
+        key: tls.ca
+      serverName: alertmanager-remote.com
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com`,
+			expected: `- scheme: https
+  api_version: v2
+  authorization:
+    credentials_file: /etc/prometheus/secrets/alertmanager-bearer-token/token
+  tls_config:
+    ca_file: /etc/prometheus/secrets/alertmanager-ca-tls/tls.ca
+    cert_file: /etc/prometheus/secrets/alertmanager-cert-tls/tls.ca
+    key_file: /etc/prometheus/secrets/alertmanager-key-tls/tls.ca
+    server_name: alertmanager-remote.com
+    insecure_skip_verify: false
+  static_configs:
+  - targets:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			mountedSecrets: []string{"alertmanager-bearer-token", "alertmanager-ca-tls", "alertmanager-cert-tls", "alertmanager-key-tls"},
+		},
 	}
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath))
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewConfigFromString(tt.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath))
 
-	p, err := f.PrometheusK8s(
-		"prometheus-k8s.openshift-monitoring.svc",
-		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-	)
+			p, err := f.PrometheusK8s(
+				"prometheus-k8s.openshift-monitoring.svc",
+				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			)
 
-	secrets := make(map[string]struct{})
-	for _, s := range p.Spec.Secrets {
-		secrets[s] = struct{}{}
+			secrets := make(map[string]struct{})
+			for _, s := range p.Spec.Secrets {
+				secrets[s] = struct{}{}
+			}
+			for _, exp := range tt.mountedSecrets {
+				if _, found := secrets[exp]; found {
+					continue
+				}
+				t.Fatalf("Prometheus secrets are not generated correctly, expected to have %s but got none", exp)
+			}
+
+			s, err := f.PrometheusK8sAdditionalAlertManagerConfigsSecret()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if s.Name != PrometheusK8sAdditionalAlertmanagerConfigSecretName {
+				t.Fatalf("invalid secret name, got %s, want %s", s.Name, PrometheusK8sAdditionalAlertmanagerConfigSecretName)
+			}
+
+			if s.Namespace != "openshift-monitoring" {
+				t.Fatalf("invalid secret namespace, got %s, want %s", s.Namespace, "openshift-monitoring")
+			}
+
+			if !reflect.DeepEqual(string(s.Data[AdditionalAlertmanagerConfigSecretKey]), tt.expected) {
+				t.Fatalf("additionalAlertManagerConfigs is not configured correctly\n\ngot:\n\n%#+v\n\nexpected:\n\n%#+v\n", string(s.Data[AdditionalAlertmanagerConfigSecretKey]), tt.expected)
+			}
+		})
 	}
-	for _, exp := range []string{"alertmanager2-cert", "alertmanager1-ca", "alertmanager1-bearer-token", "alertmanager3-ca", "alertmanager3-cert", "alertmanager3-key"} {
-		if _, found := secrets[exp]; found {
-			continue
-		}
-		t.Fatalf("Prometheus secrets are not generated correctly, expected to have %s but got none", exp)
+}
+
+func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   string
+		expected string
+	}{
+		{
+			name:   "no config",
+			config: ``,
+			expected: `"alertmanagers":
+- "api_version": "v2"
+  "http_config":
+    "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    "tls_config":
+      "ca_file": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+      "server_name": "alertmanager-main.openshift-monitoring.svc"
+  "scheme": "https"
+  "static_configs":
+  - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"`,
+		},
+		{
+			name: "basic config",
+			config: `thanosRuler:
+  additionalAlertManagerConfigs:
+  - staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			expected: `"alertmanagers":
+- "api_version": "v2"
+  "http_config":
+    "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    "tls_config":
+      "ca_file": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+      "server_name": "alertmanager-main.openshift-monitoring.svc"
+  "scheme": "https"
+  "static_configs":
+  - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
+- http_config:
+    tls_config:
+      insecure_skip_verify: false
+  static_configs:
+  - alertmanager1-remote.com
+  - alertmanager1-remotex.com
+`,
+		},
+		{
+			name: "version, path and scheme override",
+			config: `thanosRuler:
+  additionalAlertManagerConfigs:
+  - version: v1
+    pathPrefix: /path-prefix
+    scheme: ftp
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			expected: `"alertmanagers":
+- "api_version": "v2"
+  "http_config":
+    "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    "tls_config":
+      "ca_file": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+      "server_name": "alertmanager-main.openshift-monitoring.svc"
+  "scheme": "https"
+  "static_configs":
+  - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
+- scheme: ftp
+  path_prefix: /path-prefix
+  http_config:
+    tls_config:
+      insecure_skip_verify: false
+  static_configs:
+  - alertmanager1-remote.com
+  - alertmanager1-remotex.com
+`,
+		},
+		{
+			name: "bearer token",
+			config: `thanosRuler:
+  additionalAlertManagerConfigs:
+  - bearerToken:
+      key: key
+      name: bearer-token
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			expected: `"alertmanagers":
+- "api_version": "v2"
+  "http_config":
+    "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    "tls_config":
+      "ca_file": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+      "server_name": "alertmanager-main.openshift-monitoring.svc"
+  "scheme": "https"
+  "static_configs":
+  - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
+- http_config:
+    bearer_token_file: /etc/prometheus/secrets/bearer-token/key
+    tls_config:
+      insecure_skip_verify: false
+  static_configs:
+  - alertmanager1-remote.com
+  - alertmanager1-remotex.com
+`,
+		},
+		{
+			name: "tls configuration token",
+			config: `thanosRuler:
+  additionalAlertManagerConfigs:
+  - tlsConfig:
+      ca:
+        name: alertmanager-tls
+        key: tls.ca
+      cert:
+        name: alertmanager-tls
+        key: tls.ca
+      key:
+        name: alertmanager-tls
+        key: tls.ca
+      serverName: alertmanager-remote.com
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com`,
+			expected: `"alertmanagers":
+- "api_version": "v2"
+  "http_config":
+    "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    "tls_config":
+      "ca_file": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+      "server_name": "alertmanager-main.openshift-monitoring.svc"
+  "scheme": "https"
+  "static_configs":
+  - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
+- http_config:
+    tls_config:
+      ca_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
+      cert_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
+      key_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
+      server_name: alertmanager-remote.com
+      insecure_skip_verify: false
+  static_configs:
+  - alertmanager1-remote.com
+  - alertmanager1-remotex.com
+`,
+		},
+		{
+			name: "tls configuration token",
+			config: `thanosRuler:
+  additionalAlertManagerConfigs:
+  - tlsConfig:
+      ca:
+        name: alertmanager-ca-tls
+        key: tls.ca
+      cert:
+        name: alertmanager-cert-tls
+        key: tls.ca
+      key:
+        name: alertmanager-key-tls
+        key: tls.ca
+      serverName: alertmanager-remote.com
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com`,
+			expected: `"alertmanagers":
+- "api_version": "v2"
+  "http_config":
+    "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    "tls_config":
+      "ca_file": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+      "server_name": "alertmanager-main.openshift-monitoring.svc"
+  "scheme": "https"
+  "static_configs":
+  - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
+- http_config:
+    tls_config:
+      ca_file: /etc/prometheus/secrets/alertmanager-ca-tls/tls.ca
+      cert_file: /etc/prometheus/secrets/alertmanager-cert-tls/tls.ca
+      key_file: /etc/prometheus/secrets/alertmanager-key-tls/tls.ca
+      server_name: alertmanager-remote.com
+      insecure_skip_verify: false
+  static_configs:
+  - alertmanager1-remote.com
+  - alertmanager1-remotex.com
+`,
+		},
+		{
+			name: "full configuration",
+			config: `thanosRuler:
+  additionalAlertManagerConfigs:
+  - apiVersion: v2
+    scheme: https
+    bearerToken:
+      name: alertmanager-bearer-token
+      key: token
+    tlsConfig:
+      ca:
+        name: alertmanager-ca-tls
+        key: tls.ca
+      cert:
+        name: alertmanager-cert-tls
+        key: tls.ca
+      key:
+        name: alertmanager-key-tls
+        key: tls.ca
+      serverName: alertmanager-remote.com
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com`,
+			expected: `"alertmanagers":
+- "api_version": "v2"
+  "http_config":
+    "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    "tls_config":
+      "ca_file": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+      "server_name": "alertmanager-main.openshift-monitoring.svc"
+  "scheme": "https"
+  "static_configs":
+  - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
+- scheme: https
+  api_version: v2
+  http_config:
+    bearer_token_file: /etc/prometheus/secrets/alertmanager-bearer-token/token
+    tls_config:
+      ca_file: /etc/prometheus/secrets/alertmanager-ca-tls/tls.ca
+      cert_file: /etc/prometheus/secrets/alertmanager-cert-tls/tls.ca
+      key_file: /etc/prometheus/secrets/alertmanager-key-tls/tls.ca
+      server_name: alertmanager-remote.com
+      insecure_skip_verify: false
+  static_configs:
+  - alertmanager1-remote.com
+  - alertmanager1-remotex.com
+`,
+		},
 	}
 
-	alertManagerConfigs := f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs
-	s, err := f.AdditionalAlertManagerConfigsSecret("secret-name", "secret-namespace", alertManagerConfigs)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewDefaultConfig()
+			uwc, err := NewUserConfigFromString(tt.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.UserWorkloadConfiguration = uwc
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath))
 
-	if !reflect.DeepEqual(string(s.Data[AdditionalAlertmanagerConfigSecretKey]), expected) {
-		t.Fatalf("additionalAlertManagerConfigs is not configured correctly\n\ngot:\n\n%#+v\n\nexpected:\n\n%#+v\n", string(s.Data[AdditionalAlertmanagerConfigSecretKey]), expected)
+			s, err := f.ThanosRulerAlertmanagerConfigSecret()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if s.Name != "thanos-ruler-alertmanagers-config" {
+				t.Fatalf("invalid secret name, got %s, want %s", s.Name, "thanos-ruler-alertmanagers-config")
+			}
+
+			if s.Namespace != "openshift-user-workload-monitoring" {
+				t.Fatalf("invalid secret namepace, got %s, want %s", s.Namespace, "openshift-user-workload-monitoring")
+			}
+
+			if !reflect.DeepEqual(s.StringData["alertmanagers.yaml"], tt.expected) {
+				t.Fatalf("additionalAlertManagerConfigs is not configured correctly\n\ngot:\n\n%#+v\n\nexpected:\n\n%#+v\n", s.StringData["alertmanagers.yaml"], tt.expected)
+			}
+		})
 	}
 }
 
@@ -1636,6 +2010,7 @@ func TestThanosRulerConfiguration(t *testing.T) {
 		"",
 		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1724,6 +2099,7 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 					"",
 					&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 					&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+					nil,
 				)
 				if err != nil {
 					return spec{}, err

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1067,9 +1067,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
     - alertmanager1-remote.com
     - alertmanager1-remotex.com
 `,
-			expected: `- tls_config:
-    insecure_skip_verify: false
-  static_configs:
+			expected: `- static_configs:
   - targets:
     - alertmanager1-remote.com
     - alertmanager1-remotex.com
@@ -1090,8 +1088,6 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			expected: `- scheme: ftp
   path_prefix: /path
   api_version: v1
-  tls_config:
-    insecure_skip_verify: false
   static_configs:
   - targets:
     - alertmanager1-remote.com
@@ -1115,8 +1111,6 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
   api_version: v2
   authorization:
     credentials_file: /etc/prometheus/secrets/alertmanager1-bearer-token/token
-  tls_config:
-    insecure_skip_verify: false
   static_configs:
   - targets:
     - alertmanager1-remote.com
@@ -1151,7 +1145,6 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
     cert_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
     key_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
     server_name: alertmanager-remote.com
-    insecure_skip_verify: false
   static_configs:
   - targets:
     - alertmanager1-remote.com
@@ -1176,6 +1169,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
         name: alertmanager-key-tls
         key: tls.ca
       serverName: alertmanager-remote.com
+      insecureSkipVerify: true
     staticConfigs:
     - alertmanager1-remote.com
     - alertmanager1-remotex.com`,
@@ -1186,7 +1180,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
     cert_file: /etc/prometheus/secrets/alertmanager-cert-tls/tls.ca
     key_file: /etc/prometheus/secrets/alertmanager-key-tls/tls.ca
     server_name: alertmanager-remote.com
-    insecure_skip_verify: false
+    insecure_skip_verify: true
   static_configs:
   - targets:
     - alertmanager1-remote.com
@@ -1226,7 +1220,6 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
     cert_file: /etc/prometheus/secrets/alertmanager-cert-tls/tls.ca
     key_file: /etc/prometheus/secrets/alertmanager-key-tls/tls.ca
     server_name: alertmanager-remote.com
-    insecure_skip_verify: false
   static_configs:
   - targets:
     - alertmanager1-remote.com
@@ -1320,10 +1313,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
   "scheme": "https"
   "static_configs":
   - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
-- http_config:
-    tls_config:
-      insecure_skip_verify: false
-  static_configs:
+- static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com
 `,
@@ -1351,9 +1341,6 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
   - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
 - scheme: ftp
   path_prefix: /path-prefix
-  http_config:
-    tls_config:
-      insecure_skip_verify: false
   static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com
@@ -1382,8 +1369,6 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
   - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
 - http_config:
     bearer_token_file: /etc/prometheus/secrets/bearer-token/key
-    tls_config:
-      insecure_skip_verify: false
   static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com
@@ -1404,6 +1389,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
         name: alertmanager-tls
         key: tls.ca
       serverName: alertmanager-remote.com
+      insecureSkipVerify: true
     staticConfigs:
     - alertmanager1-remote.com
     - alertmanager1-remotex.com`,
@@ -1423,7 +1409,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
       cert_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
       key_file: /etc/prometheus/secrets/alertmanager-tls/tls.ca
       server_name: alertmanager-remote.com
-      insecure_skip_verify: false
+      insecure_skip_verify: true
   static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com
@@ -1463,7 +1449,6 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
       cert_file: /etc/prometheus/secrets/alertmanager-cert-tls/tls.ca
       key_file: /etc/prometheus/secrets/alertmanager-key-tls/tls.ca
       server_name: alertmanager-remote.com
-      insecure_skip_verify: false
   static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com
@@ -1511,7 +1496,6 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
       cert_file: /etc/prometheus/secrets/alertmanager-cert-tls/tls.ca
       key_file: /etc/prometheus/secrets/alertmanager-key-tls/tls.ca
       server_name: alertmanager-remote.com
-      insecure_skip_verify: false
   static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -319,13 +319,13 @@ func (t *PrometheusTask) Run() error {
 
 		secret, err := t.factory.PrometheusK8sAdditionalAlertManagerConfigsSecret()
 		if err != nil {
-			return errors.Wrap(err, "initializing Prometheus additionalAlertManagerConfigs secret failed")
+			return errors.Wrap(err, "initializing Prometheus additionalAlertmanagerConfigs secret failed")
 		}
 		if secret != nil {
-			klog.V(4).Info("initializing Prometheus additionalAlertManagerConfigs secret")
+			klog.V(4).Info("initializing Prometheus additionalAlertmanagerConfigs secret")
 			err = t.client.CreateOrUpdateSecret(secret)
 			if err != nil {
-				return errors.Wrap(err, "reconciling Prometheus additionalAlertManagerConfigs secret failed")
+				return errors.Wrap(err, "reconciling Prometheus additionalAlertmanagerConfigs secret failed")
 			}
 		} else {
 			err = t.client.DeleteSecret(&v1.Secret{
@@ -335,7 +335,7 @@ func (t *PrometheusTask) Run() error {
 				},
 			})
 			if err != nil {
-				return errors.Wrap(err, "deleting Prometheus additionalAlertManagerConfigs Secret failed")
+				return errors.Wrap(err, "deleting Prometheus additionalAlertmanagerConfigs Secret failed")
 			}
 		}
 

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -317,7 +317,7 @@ func (t *PrometheusTask) Run() error {
 			return errors.Wrap(err, "syncing Prometheus trusted CA bundle ConfigMap failed")
 		}
 
-		secret, err := t.factory.AdditionalAlertManagerConfigsSecret()
+		secret, err := t.factory.PrometheusK8sAdditionalAlertManagerConfigsSecret()
 		if err != nil {
 			return errors.Wrap(err, "initializing Prometheus additionalAlertManagerConfigs secret failed")
 		}
@@ -330,7 +330,7 @@ func (t *PrometheusTask) Run() error {
 		} else {
 			err = t.client.DeleteSecret(&v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      t.factory.GetAdditionalAlertmanagerConfigSecretName(),
+					Name:      manifests.PrometheusK8sAdditionalAlertmanagerConfigSecretName,
 					Namespace: t.client.Namespace(),
 				},
 			})

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -20,8 +20,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -321,22 +319,9 @@ func (t *PrometheusTask) Run() error {
 		if err != nil {
 			return errors.Wrap(err, "initializing Prometheus additionalAlertmanagerConfigs secret failed")
 		}
-		if secret != nil {
-			klog.V(4).Info("initializing Prometheus additionalAlertmanagerConfigs secret")
-			err = t.client.CreateOrUpdateSecret(secret)
-			if err != nil {
-				return errors.Wrap(err, "reconciling Prometheus additionalAlertmanagerConfigs secret failed")
-			}
-		} else {
-			err = t.client.DeleteSecret(&v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      manifests.PrometheusK8sAdditionalAlertmanagerConfigSecretName,
-					Namespace: t.client.Namespace(),
-				},
-			})
-			if err != nil {
-				return errors.Wrap(err, "deleting Prometheus additionalAlertmanagerConfigs Secret failed")
-			}
+		klog.V(4).Info("reconciling Prometheus additionalAlertmanagerConfigs secret")
+		if err = t.client.CreateOrUpdateSecret(secret); err != nil {
+			return errors.Wrap(err, "reconciling Prometheus additionalAlertmanagerConfigs secret failed")
 		}
 
 		klog.V(4).Info("initializing Prometheus object")

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -191,13 +191,13 @@ func (t *PrometheusUserWorkloadTask) create() error {
 
 	secret, err := t.factory.PrometheusUserWorkloadAdditionalAlertManagerConfigsSecret()
 	if err != nil {
-		return errors.Wrap(err, "initializing UserWorkload Prometheus additionalAlertManagerConfigs secret failed")
+		return errors.Wrap(err, "initializing UserWorkload Prometheus additionalAlertmanagerConfigs secret failed")
 	}
 	if secret != nil {
-		klog.V(4).Info("initializing UserWorkload Prometheus additionalAlertManagerConfigs secret")
+		klog.V(4).Info("initializing UserWorkload Prometheus additionalAlertmanagerConfigs secret")
 		err = t.client.CreateOrUpdateSecret(secret)
 		if err != nil {
-			return errors.Wrap(err, "reconciling UserWorkload Prometheus additionalAlertManagerConfigs secret failed")
+			return errors.Wrap(err, "reconciling UserWorkload Prometheus additionalAlertmanagerConfigs secret failed")
 		}
 	} else {
 		err = t.client.DeleteSecret(&v1.Secret{
@@ -207,7 +207,7 @@ func (t *PrometheusUserWorkloadTask) create() error {
 			},
 		})
 		if err != nil {
-			return errors.Wrap(err, "deleting Prometheus additionalAlertManagerConfigs Secret failed")
+			return errors.Wrap(err, "deleting Prometheus additionalAlertmanagerConfigs Secret failed")
 		}
 	}
 
@@ -424,7 +424,7 @@ func (t *PrometheusUserWorkloadTask) destroy() error {
 			Namespace: t.client.UserWorkloadNamespace(),
 		},
 	}); err != nil {
-		return errors.Wrap(err, "deleting Prometheus additionalAlertManagerConfigs Secret failed")
+		return errors.Wrap(err, "deleting Prometheus additionalAlertmanagerConfigs Secret failed")
 	}
 
 	err = t.client.DeleteConfigMap(cacm)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -16,14 +16,21 @@ package framework
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -51,6 +58,7 @@ const (
 )
 
 type Framework struct {
+	RestConfig          *rest.Config
 	OperatorClient      *client.Client
 	KubeClient          kubernetes.Interface
 	ThanosQuerierClient *PrometheusClient
@@ -117,6 +125,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 	}
 
 	f := &Framework{
+		RestConfig:               config,
 		OperatorClient:           operatorClient,
 		KubeClient:               kubeClient,
 		APIServicesClient:        apiServicesClient,
@@ -200,7 +209,7 @@ func (f *Framework) setup() (cleanUpFunc, error) {
 	}
 
 	cleanUpFuncs = append(cleanUpFuncs, cf)
-	
+
 	return func() error {
 		var errs []error
 		for _, f := range cleanUpFuncs {
@@ -335,7 +344,7 @@ func (f *Framework) CreateRoleBindingFromRole(namespace, serviceAccount, role st
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "Role",
-			Name:    role,
+			Name:     role,
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 	}
@@ -437,4 +446,35 @@ func Poll(interval, timeout time.Duration, f func() error) error {
 	}
 
 	return err
+}
+
+// StartPortForward initiates a port forwarding connection to a pod on the localhost interface.
+//
+// StartPortForward blocks until the port forwarding proxy server is ready to receive connections.
+func (f *Framework) StartPortForward(scheme string, name string, ns string, port string) error {
+	roundTripper, upgrader, err := spdy.RoundTripperFor(f.RestConfig)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", ns, name)
+	hostIP := strings.TrimLeft(f.RestConfig.Host, "htps:/")
+	serverURL := url.URL{Scheme: scheme, Path: path, Host: hostIP}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL)
+
+	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
+	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+	forwarder, err := portforward.New(dialer, []string{port}, stopChan, readyChan, out, errOut)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		if err := forwarder.ForwardPorts(); err != nil {
+			panic(err)
+		}
+	}()
+
+	<-readyChan
+	return nil
 }

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -1,0 +1,164 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestUserWorkloadThanosRulerWithAdditionalAlertmanagers(t *testing.T) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterMonitorConfigMapName,
+			Namespace: f.Ns,
+		},
+		Data: map[string]string{
+			"config.yaml": `enableUserWorkload: true`,
+		},
+	}
+
+	uwmCM := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userWorkloadMonitorConfigMapName,
+			Namespace: f.UserWorkloadMonitoringNs,
+		},
+		Data: map[string]string{
+			"config.yaml": `thanosRuler:
+  additionalAlertManagerConfigs:
+  - scheme: http
+    apiVersion: v2
+    staticConfigs: ["dnssrv+_web._tcp.alertmanager-operated.openshift-user-workload-monitoring.svc"]
+`,
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		scenarios []scenario
+	}{
+		{
+			name: "Test enabling and disabling additional alertmanager configs",
+			scenarios: []scenario{
+				{"enable user workload monitoring", updateConfigmap(cm)},
+				{"assert thanos ruler rollout", assertThanosRulerDeployment},
+				{"create additional alertmanager", createAlertmanager},
+				{"configure thanos ruler with additional alertmanager", updateConfigmap(uwmCM)},
+				{"create alerting rule that always fires", createPrometheusRule},
+				{"start alertmanager port forward", startAlertmanagerPortForward},
+				{"verify alertmanager received the alert", verifyAlertmanagerAlertReceived},
+				{"delete additional alertmanager", deleteAlertmanager},
+				{"disable additional alertmanagers", assertDeletedUserWorkloadAssets(cm)},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if err := f.OperatorClient.CreateOrUpdateConfigMap(cm); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := f.OperatorClient.CreateOrUpdateConfigMap(uwmCM); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, scenario := range tt.scenarios {
+				t.Run(scenario.name, scenario.assertion)
+			}
+		})
+	}
+}
+
+func createAlertmanager(t *testing.T) {
+	replicas := int32(1)
+	additionalAlertmanager := monitoringv1.Alertmanager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alertmanager-e2e-test",
+			Namespace: f.UserWorkloadMonitoringNs,
+		},
+		Spec: monitoringv1.AlertmanagerSpec{
+			Replicas: &replicas,
+		},
+	}
+	if err := f.OperatorClient.CreateOrUpdateAlertmanager(&additionalAlertmanager); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.OperatorClient.WaitForAlertmanager(&additionalAlertmanager); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createPrometheusRule(t *testing.T) {
+	if err := f.OperatorClient.CreateOrUpdatePrometheusRule(&monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "non-monitoring-prometheus-rules",
+			Namespace: "default",
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "test-group",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "AdditionalTestAlertRule",
+							Expr:  intstr.FromString("vector(1)"),
+						},
+					},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func startAlertmanagerPortForward(t *testing.T) {
+	if err := f.StartPortForward(
+		"https",
+		"alertmanager-alertmanager-e2e-test-0",
+		f.UserWorkloadMonitoringNs,
+		"9093",
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func verifyAlertmanagerAlertReceived(t *testing.T) {
+	err := framework.Poll(time.Second, 5*time.Minute, func() error {
+		resp, err := http.Get("http://localhost:9093/api/v2/alerts")
+		if err != nil {
+			return err
+		}
+
+		payload, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		if string(payload) == "[]\n" {
+			return fmt.Errorf("alertmanager received no alerts")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func deleteAlertmanager(t *testing.T) {
+	amClient := f.MonitoringClient.Alertmanagers(f.UserWorkloadMonitoringNs)
+	if err := amClient.Delete(context.Background(), "alertmanager-e2e-test", metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -33,7 +33,7 @@ func TestUserWorkloadThanosRulerWithAdditionalAlertmanagers(t *testing.T) {
 		},
 		Data: map[string]string{
 			"config.yaml": `thanosRuler:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - scheme: http
     apiVersion: v2
     staticConfigs: ["dnssrv+_web._tcp.alertmanager-operated.openshift-user-workload-monitoring.svc"]

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -139,7 +139,7 @@ func TestUserWorkloadMonitoringWithAdditionalAlertmanagerConfigs(t *testing.T) {
 		},
 		Data: map[string]string{
 			"config.yaml": `prometheus:
-  additionalAlertManagerConfigs:
+  additionalAlertmanagerConfigs:
   - scheme: https
     pathPrefix: /prefix
     timeout: "30s"

--- a/vendor/k8s.io/client-go/tools/portforward/doc.go
+++ b/vendor/k8s.io/client-go/tools/portforward/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package portforward adds support for SSH-like port forwarding from the client's
+// local host to remote containers.
+package portforward // import "k8s.io/client-go/tools/portforward"

--- a/vendor/k8s.io/client-go/tools/portforward/portforward.go
+++ b/vendor/k8s.io/client-go/tools/portforward/portforward.go
@@ -1,0 +1,429 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// PortForwardProtocolV1Name is the subprotocol used for port forwarding.
+// TODO move to API machinery and re-unify with kubelet/server/portfoward
+const PortForwardProtocolV1Name = "portforward.k8s.io"
+
+// PortForwarder knows how to listen for local connections and forward them to
+// a remote pod via an upgraded HTTP request.
+type PortForwarder struct {
+	addresses []listenAddress
+	ports     []ForwardedPort
+	stopChan  <-chan struct{}
+
+	dialer        httpstream.Dialer
+	streamConn    httpstream.Connection
+	listeners     []io.Closer
+	Ready         chan struct{}
+	requestIDLock sync.Mutex
+	requestID     int
+	out           io.Writer
+	errOut        io.Writer
+}
+
+// ForwardedPort contains a Local:Remote port pairing.
+type ForwardedPort struct {
+	Local  uint16
+	Remote uint16
+}
+
+/*
+	valid port specifications:
+
+	5000
+	- forwards from localhost:5000 to pod:5000
+
+	8888:5000
+	- forwards from localhost:8888 to pod:5000
+
+	0:5000
+	:5000
+	- selects a random available local port,
+	  forwards from localhost:<random port> to pod:5000
+*/
+func parsePorts(ports []string) ([]ForwardedPort, error) {
+	var forwards []ForwardedPort
+	for _, portString := range ports {
+		parts := strings.Split(portString, ":")
+		var localString, remoteString string
+		if len(parts) == 1 {
+			localString = parts[0]
+			remoteString = parts[0]
+		} else if len(parts) == 2 {
+			localString = parts[0]
+			if localString == "" {
+				// support :5000
+				localString = "0"
+			}
+			remoteString = parts[1]
+		} else {
+			return nil, fmt.Errorf("invalid port format '%s'", portString)
+		}
+
+		localPort, err := strconv.ParseUint(localString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing local port '%s': %s", localString, err)
+		}
+
+		remotePort, err := strconv.ParseUint(remoteString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing remote port '%s': %s", remoteString, err)
+		}
+		if remotePort == 0 {
+			return nil, fmt.Errorf("remote port must be > 0")
+		}
+
+		forwards = append(forwards, ForwardedPort{uint16(localPort), uint16(remotePort)})
+	}
+
+	return forwards, nil
+}
+
+type listenAddress struct {
+	address     string
+	protocol    string
+	failureMode string
+}
+
+func parseAddresses(addressesToParse []string) ([]listenAddress, error) {
+	var addresses []listenAddress
+	parsed := make(map[string]listenAddress)
+	for _, address := range addressesToParse {
+		if address == "localhost" {
+			if _, exists := parsed["127.0.0.1"]; !exists {
+				ip := listenAddress{address: "127.0.0.1", protocol: "tcp4", failureMode: "all"}
+				parsed[ip.address] = ip
+			}
+			if _, exists := parsed["::1"]; !exists {
+				ip := listenAddress{address: "::1", protocol: "tcp6", failureMode: "all"}
+				parsed[ip.address] = ip
+			}
+		} else if net.ParseIP(address).To4() != nil {
+			parsed[address] = listenAddress{address: address, protocol: "tcp4", failureMode: "any"}
+		} else if net.ParseIP(address) != nil {
+			parsed[address] = listenAddress{address: address, protocol: "tcp6", failureMode: "any"}
+		} else {
+			return nil, fmt.Errorf("%s is not a valid IP", address)
+		}
+	}
+	addresses = make([]listenAddress, len(parsed))
+	id := 0
+	for _, v := range parsed {
+		addresses[id] = v
+		id++
+	}
+	// Sort addresses before returning to get a stable order
+	sort.Slice(addresses, func(i, j int) bool { return addresses[i].address < addresses[j].address })
+
+	return addresses, nil
+}
+
+// New creates a new PortForwarder with localhost listen addresses.
+func New(dialer httpstream.Dialer, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	return NewOnAddresses(dialer, []string{"localhost"}, ports, stopChan, readyChan, out, errOut)
+}
+
+// NewOnAddresses creates a new PortForwarder with custom listen addresses.
+func NewOnAddresses(dialer httpstream.Dialer, addresses []string, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	if len(addresses) == 0 {
+		return nil, errors.New("you must specify at least 1 address")
+	}
+	parsedAddresses, err := parseAddresses(addresses)
+	if err != nil {
+		return nil, err
+	}
+	if len(ports) == 0 {
+		return nil, errors.New("you must specify at least 1 port")
+	}
+	parsedPorts, err := parsePorts(ports)
+	if err != nil {
+		return nil, err
+	}
+	return &PortForwarder{
+		dialer:    dialer,
+		addresses: parsedAddresses,
+		ports:     parsedPorts,
+		stopChan:  stopChan,
+		Ready:     readyChan,
+		out:       out,
+		errOut:    errOut,
+	}, nil
+}
+
+// ForwardPorts formats and executes a port forwarding request. The connection will remain
+// open until stopChan is closed.
+func (pf *PortForwarder) ForwardPorts() error {
+	defer pf.Close()
+
+	var err error
+	pf.streamConn, _, err = pf.dialer.Dial(PortForwardProtocolV1Name)
+	if err != nil {
+		return fmt.Errorf("error upgrading connection: %s", err)
+	}
+	defer pf.streamConn.Close()
+
+	return pf.forward()
+}
+
+// forward dials the remote host specific in req, upgrades the request, starts
+// listeners for each port specified in ports, and forwards local connections
+// to the remote host via streams.
+func (pf *PortForwarder) forward() error {
+	var err error
+
+	listenSuccess := false
+	for i := range pf.ports {
+		port := &pf.ports[i]
+		err = pf.listenOnPort(port)
+		switch {
+		case err == nil:
+			listenSuccess = true
+		default:
+			if pf.errOut != nil {
+				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", port.Local, err)
+			}
+		}
+	}
+
+	if !listenSuccess {
+		return fmt.Errorf("unable to listen on any of the requested ports: %v", pf.ports)
+	}
+
+	if pf.Ready != nil {
+		close(pf.Ready)
+	}
+
+	// wait for interrupt or conn closure
+	select {
+	case <-pf.stopChan:
+	case <-pf.streamConn.CloseChan():
+		runtime.HandleError(errors.New("lost connection to pod"))
+	}
+
+	return nil
+}
+
+// listenOnPort delegates listener creation and waits for connections on requested bind addresses.
+// An error is raised based on address groups (default and localhost) and their failure modes
+func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
+	var errors []error
+	failCounters := make(map[string]int, 2)
+	successCounters := make(map[string]int, 2)
+	for _, addr := range pf.addresses {
+		err := pf.listenOnPortAndAddress(port, addr.protocol, addr.address)
+		if err != nil {
+			errors = append(errors, err)
+			failCounters[addr.failureMode]++
+		} else {
+			successCounters[addr.failureMode]++
+		}
+	}
+	if successCounters["all"] == 0 && failCounters["all"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	if failCounters["any"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	return nil
+}
+
+// listenOnPortAndAddress delegates listener creation and waits for new connections
+// in the background f
+func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
+	listener, err := pf.getListener(protocol, address, port)
+	if err != nil {
+		return err
+	}
+	pf.listeners = append(pf.listeners, listener)
+	go pf.waitForConnection(listener, *port)
+	return nil
+}
+
+// getListener creates a listener on the interface targeted by the given hostname on the given port with
+// the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
+func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
+	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create listener: Error %s", err)
+	}
+	listenerAddress := listener.Addr().String()
+	host, localPort, _ := net.SplitHostPort(listenerAddress)
+	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+
+	if err != nil {
+		fmt.Fprintf(pf.out, "Failed to forward from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+		return nil, fmt.Errorf("error parsing local port: %s from %s (%s)", err, listenerAddress, host)
+	}
+	port.Local = uint16(localPortUInt)
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Forwarding from %s -> %d\n", net.JoinHostPort(hostname, strconv.Itoa(int(localPortUInt))), port.Remote)
+	}
+
+	return listener, nil
+}
+
+// waitForConnection waits for new connections to listener and handles them in
+// the background.
+func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
+			if !strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
+				runtime.HandleError(fmt.Errorf("error accepting connection on port %d: %v", port.Local, err))
+			}
+			return
+		}
+		go pf.handleConnection(conn, port)
+	}
+}
+
+func (pf *PortForwarder) nextRequestID() int {
+	pf.requestIDLock.Lock()
+	defer pf.requestIDLock.Unlock()
+	id := pf.requestID
+	pf.requestID++
+	return id
+}
+
+// handleConnection copies data between the local connection and the stream to
+// the remote server.
+func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
+	defer conn.Close()
+
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Handling connection for %d\n", port.Local)
+	}
+
+	requestID := pf.nextRequestID()
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
+	errorStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+	// we're not writing to this stream
+	errorStream.Close()
+
+	errorChan := make(chan error)
+	go func() {
+		message, err := ioutil.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			errorChan <- fmt.Errorf("error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		case len(message) > 0:
+			errorChan <- fmt.Errorf("an error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
+		}
+		close(errorChan)
+	}()
+
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+
+	localError := make(chan struct{})
+	remoteDone := make(chan struct{})
+
+	go func() {
+		// Copy from the remote side to the local port.
+		if _, err := io.Copy(conn, dataStream); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from remote stream to local connection: %v", err))
+		}
+
+		// inform the select below that the remote copy is done
+		close(remoteDone)
+	}()
+
+	go func() {
+		// inform server we're not sending any more data after copy unblocks
+		defer dataStream.Close()
+
+		// Copy from the local port to the remote side.
+		if _, err := io.Copy(dataStream, conn); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from local connection to remote stream: %v", err))
+			// break out of the select below without waiting for the other copy to finish
+			close(localError)
+		}
+	}()
+
+	// wait for either a local->remote error or for copying from remote->local to finish
+	select {
+	case <-remoteDone:
+	case <-localError:
+	}
+
+	// always expect something on errorChan (it may be nil)
+	err = <-errorChan
+	if err != nil {
+		runtime.HandleError(err)
+	}
+}
+
+// Close stops all listeners of PortForwarder.
+func (pf *PortForwarder) Close() {
+	// stop all listeners
+	for _, l := range pf.listeners {
+		if err := l.Close(); err != nil {
+			runtime.HandleError(fmt.Errorf("error closing listener: %v", err))
+		}
+	}
+}
+
+// GetPorts will return the ports that were forwarded; this can be used to
+// retrieve the locally-bound port in cases where the input was port 0. This
+// function will signal an error if the Ready channel is nil or if the
+// listeners are not ready yet; this function will succeed after the Ready
+// channel has been closed.
+func (pf *PortForwarder) GetPorts() ([]ForwardedPort, error) {
+	if pf.Ready == nil {
+		return nil, fmt.Errorf("no Ready channel provided")
+	}
+	select {
+	case <-pf.Ready:
+		return pf.ports, nil
+	default:
+		return nil, fmt.Errorf("listeners not ready")
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -676,6 +676,7 @@ k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
+k8s.io/client-go/tools/portforward
 k8s.io/client-go/tools/record
 k8s.io/client-go/tools/record/util
 k8s.io/client-go/tools/reference


### PR DESCRIPTION
This commit is a follow up on the work done in https://github.com/openshift/cluster-monitoring-operator/pull/1132 and allows users to configure additional Alertmanagers for the Prometheus instance and the Thanos Ruler in User Workload Monitoring.
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
