### PR TITLE
jsonnet: Enable federated targets in thanos-querier

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -54,6 +54,7 @@ spec:
         - --grpc-client-tls-ca=/etc/tls/grpc/ca.crt
         - --grpc-client-server-name=prometheus-grpc
         - --rule=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local
+        - --target=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local
         env:
         - name: HOST_IP_ADDRESS
           valueFrom:

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -362,6 +362,7 @@ function(params)
                   '--grpc-client-tls-ca=/etc/tls/grpc/ca.crt',
                   '--grpc-client-server-name=prometheus-grpc',
                   '--rule=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local',
+                  '--target=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local',
                 ],
                 resources: {
                   requests: {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2973,6 +2973,7 @@ func (f *Factory) ThanosQuerierDeployment(grpcTLS *v1.Secret, enableUserWorkload
 					"--store=dnssrv+_grpc._tcp.thanos-ruler-operated.openshift-user-workload-monitoring.svc.cluster.local",
 					"--rule=dnssrv+_grpc._tcp.prometheus-operated.openshift-user-workload-monitoring.svc.cluster.local",
 					"--rule=dnssrv+_grpc._tcp.thanos-ruler-operated.openshift-user-workload-monitoring.svc.cluster.local",
+					"--target=dnssrv+_grpc._tcp.prometheus-operated.openshift-user-workload-monitoring.svc.cluster.local",
 				)
 			}
 


### PR DESCRIPTION
This adds the argument to thanos-querier to enable the new federated
targets functionality.  When user workload monitoring is enabled,
targets will be fetched from that Prometheus instance as well as from
the platform Prometheus.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
