### PR TITLE
BUG 1980888: jsonnet: Favour http probes for thanos querier

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -61,26 +61,10 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: quay.io/thanos/thanos:v0.20.2
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/healthy;
-              elif [ -x "$(command -v wget)" ]; then exec wget --quiet --tries=1 --spider
-              http://localhost:9090/-/healthy; else exit 1; fi
         name: thanos-query
         ports:
         - containerPort: 9090
           name: http
-        readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-              elif [ -x "$(command -v wget)" ]; then exec wget --quiet --tries=1 --spider
-              http://localhost:9090/-/ready; else exit 1; fi
         resources:
           requests:
             cpu: 10m
@@ -104,6 +88,7 @@ spec:
         - -cookie-secret-file=/etc/proxy/secrets/session_secret
         - -openshift-ca=/etc/pki/tls/cert.pem
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -bypass-auth-for=^/-/(healthy|ready)$
         env:
         - name: HTTP_PROXY
           value: ""
@@ -112,10 +97,26 @@ spec:
         - name: NO_PROXY
           value: ""
         image: quay.io/openshift/oauth-proxy:latest
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 9091
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 30
         name: oauth-proxy
         ports:
         - containerPort: 9091
           name: web
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 9091
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 5
         resources:
           requests:
             cpu: 1m

--- a/jsonnet/thanos-querier.libsonnet
+++ b/jsonnet/thanos-querier.libsonnet
@@ -336,18 +336,8 @@ function(params)
             securityContext:: {},
             containers: [
               super.containers[0] {
-                livenessProbe: {
-                  httpGet:: {},
-                  exec: {
-                    command: ['sh', '-c', 'if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/healthy; elif [ -x "$(command -v wget)" ]; then exec wget --quiet --tries=1 --spider http://localhost:9090/-/healthy; else exit 1; fi'],
-                  },
-                },
-                readinessProbe: {
-                  httpGet:: {},
-                  exec: {
-                    command: ['sh', '-c', 'if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready; elif [ -x "$(command -v wget)" ]; then exec wget --quiet --tries=1 --spider http://localhost:9090/-/ready; else exit 1; fi'],
-                  },
-                },
+                livenessProbe:: {},
+                readinessProbe:: {},
                 args: std.map(
                   function(a)
                     if std.startsWith(a, '--grpc-address=') then '--grpc-address=127.0.0.1:10901'
@@ -401,6 +391,26 @@ function(params)
                   { name: 'HTTPS_PROXY', value: '' },
                   { name: 'NO_PROXY', value: '' },
                 ],
+                livenessProbe: {
+                  httpGet: {
+                    path: '/-/healthy',
+                    port: 9091,
+                    scheme: 'HTTPS',
+                  },
+                  initialDelaySeconds: 5,
+                  periodSeconds: 30,
+                  failureThreshold: 4,
+                },
+                readinessProbe: {
+                  httpGet: {
+                    path: '/-/ready',
+                    port: 9091,
+                    scheme: 'HTTPS',
+                  },
+                  initialDelaySeconds: 5,
+                  periodSeconds: 5,
+                  failureThreshold: 20,
+                },
                 args: [
                   // NOTE: The following is injected at runtime if Grafana is enabled:
                   // '-htpasswd-file=/etc/proxy/htpasswd/auth'
@@ -418,6 +428,7 @@ function(params)
                   '-cookie-secret-file=/etc/proxy/secrets/session_secret',
                   '-openshift-ca=/etc/pki/tls/cert.pem',
                   '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+                  '-bypass-auth-for=^/-/(healthy|ready)$',
                 ],
                 terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [


### PR DESCRIPTION
    The exec probe is timing out intermittently. This coud be caused in part
    by the timing on the probe not being sufficient, or there may be an underlying
    issue with the (exec, cri-o) combo.
    
    This change takes the config for httpGet probes from upstream thanos and proxies
    to thanos via the oauth-gateway where we bypass the health check endpoints.
    
    The HTTP probe cannot directly ping thanos since it listens on localhost
    and is unreachable from kubelet. This is by design.

I have not increased the timeout here because if there is an issue with query after setting the rest of the config to match what is upstream, I would prefer to observe that as an issue and report it upstream to find out when/why it might occur. We will of course, see some additional latency by going through the proxy but I would still expect a health endpoint to return sub 1 second over http

cc @simonpasquier - would you be able to take a look at this potential solution?


* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
