### PR TITLE
pkg/manifests: Add EnforcedTargetLimit for user-workload monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.9
 
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Add config option to disable Grafana deployment.
+- [#1278](https://github.com/openshift/cluster-monitoring-operator/pull/1278) Add EnforcedTargetLimit option for user-workload Prometheus.
 
 ## 4.8
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -403,6 +403,7 @@ type PrometheusRestrictedConfig struct {
 	VolumeClaimTemplate *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
 	RemoteWrite         []monv1.RemoteWriteSpec              `json:"remoteWrite"`
 	EnforcedSampleLimit *uint64                              `json:"enforcedSampleLimit"`
+	EnforcedTargetLimit *uint64                              `json:"enforcedTargetLimit"`
 }
 
 func (u *UserWorkloadConfiguration) applyDefaults() {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1592,6 +1592,10 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		p.Spec.EnforcedSampleLimit = f.config.UserWorkloadConfiguration.Prometheus.EnforcedSampleLimit
 	}
 
+	if f.config.UserWorkloadConfiguration.Prometheus.EnforcedTargetLimit != nil {
+		p.Spec.EnforcedTargetLimit = f.config.UserWorkloadConfiguration.Prometheus.EnforcedTargetLimit
+	}
+
 	// end removal
 	if f.config.Images.Thanos != "" {
 		p.Spec.Thanos.Image = &f.config.Images.Thanos


### PR DESCRIPTION
This adds support for configuring the EnforcedTargetLimit for the
user-workload Prometheus instance.  This lets admins set an overall
limit on the number of targets scraped.

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
