### PR TITLE
test:e2e: Split UWM tests and cleanup duplicated tests across e2e config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	github.com/Jeffail/gabs v1.4.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/gogo/protobuf v1.3.2
 	github.com/imdario/mergo v0.3.7
 	github.com/openshift/api v0.0.0-20210706092853-b63d499a70ce
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -3,10 +3,20 @@ package framework
 import (
 	"context"
 	"fmt"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	ctx = context.Background()
 )
 
 type AssertionFunc func(t *testing.T)
@@ -14,7 +24,7 @@ type AssertionFunc func(t *testing.T)
 func (f *Framework) AssertStatefulsetExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -22,7 +32,7 @@ func (f *Framework) AssertStatefulsetExists(name string, namespace string) func(
 func (f *Framework) AssertStatefulsetDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -30,7 +40,7 @@ func (f *Framework) AssertStatefulsetDoesNotExist(name string, namespace string)
 func (f *Framework) AssertRouteExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.OpenShiftRouteClient.Routes(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.OpenShiftRouteClient.Routes(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -38,7 +48,7 @@ func (f *Framework) AssertRouteExists(name string, namespace string) func(t *tes
 func (f *Framework) AssertRouteDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.OpenShiftRouteClient.Routes(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.OpenShiftRouteClient.Routes(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -46,7 +56,7 @@ func (f *Framework) AssertRouteDoesNotExist(name string, namespace string) func(
 func (f *Framework) AssertSecretExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -54,7 +64,7 @@ func (f *Framework) AssertSecretExists(name string, namespace string) func(t *te
 func (f *Framework) AssertSecretDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -62,7 +72,7 @@ func (f *Framework) AssertSecretDoesNotExist(name string, namespace string) func
 func (f *Framework) AssertServiceExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -70,7 +80,7 @@ func (f *Framework) AssertServiceExists(name string, namespace string) func(t *t
 func (f *Framework) AssertServiceDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -78,7 +88,7 @@ func (f *Framework) AssertServiceDoesNotExist(name string, namespace string) fun
 func (f *Framework) AssertConfigmapExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -86,7 +96,7 @@ func (f *Framework) AssertConfigmapExists(name string, namespace string) func(t 
 func (f *Framework) AssertConfigmapDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -94,7 +104,7 @@ func (f *Framework) AssertConfigmapDoesNotExist(name string, namespace string) f
 func (f *Framework) AssertServiceAccountExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -102,7 +112,7 @@ func (f *Framework) AssertServiceAccountExists(name string, namespace string) fu
 func (f *Framework) AssertServiceAccountDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -110,7 +120,7 @@ func (f *Framework) AssertServiceAccountDoesNotExist(name string, namespace stri
 func (f *Framework) AssertRoleExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.RbacV1().Roles(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -118,7 +128,7 @@ func (f *Framework) AssertRoleExists(name string, namespace string) func(t *test
 func (f *Framework) AssertRoleDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.RbacV1().Roles(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -126,7 +136,7 @@ func (f *Framework) AssertRoleDoesNotExist(name string, namespace string) func(t
 func (f *Framework) AssertRoleBindingExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.RbacV1().RoleBindings(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -134,7 +144,7 @@ func (f *Framework) AssertRoleBindingExists(name string, namespace string) func(
 func (f *Framework) AssertRoleBindingDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.RbacV1().RoleBindings(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -142,7 +152,7 @@ func (f *Framework) AssertRoleBindingDoesNotExist(name string, namespace string)
 func (f *Framework) AssertClusterRoleExists(name string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.RbacV1().ClusterRoles().Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -150,7 +160,7 @@ func (f *Framework) AssertClusterRoleExists(name string) func(t *testing.T) {
 func (f *Framework) AssertClusterRoleDoesNotExist(name string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.RbacV1().ClusterRoles().Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -158,7 +168,7 @@ func (f *Framework) AssertClusterRoleDoesNotExist(name string) func(t *testing.T
 func (f *Framework) AssertClusterRoleBindingExists(name string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.RbacV1().ClusterRoleBindings().Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -166,7 +176,23 @@ func (f *Framework) AssertClusterRoleBindingExists(name string) func(t *testing.
 func (f *Framework) AssertClusterRoleBindingDoesNotExist(name string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.KubeClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+			return f.KubeClient.RbacV1().ClusterRoleBindings().Get(ctx, name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertNamespaceExists(name string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertNamespaceDoesNotExist(name string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -174,7 +200,7 @@ func (f *Framework) AssertClusterRoleBindingDoesNotExist(name string) func(t *te
 func (f *Framework) AssertPrometheusRuleExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.MonitoringClient.PrometheusRules(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.MonitoringClient.PrometheusRules(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -182,7 +208,7 @@ func (f *Framework) AssertPrometheusRuleExists(name string, namespace string) fu
 func (f *Framework) AssertPrometheusRuleDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.MonitoringClient.PrometheusRules(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.MonitoringClient.PrometheusRules(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -190,7 +216,7 @@ func (f *Framework) AssertPrometheusRuleDoesNotExist(name string, namespace stri
 func (f *Framework) AssertServiceMonitorExists(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {
-			return f.MonitoringClient.ServiceMonitors(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.MonitoringClient.ServiceMonitors(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
 	}
 }
@@ -198,8 +224,147 @@ func (f *Framework) AssertServiceMonitorExists(name string, namespace string) fu
 func (f *Framework) AssertServiceMonitorDoesNotExist(name string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
-			return f.MonitoringClient.ServiceMonitors(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+			return f.MonitoringClient.ServiceMonitors(namespace).Get(ctx, name, metav1.GetOptions{})
 		})
+	}
+}
+
+func (f *Framework) AssertDeploymentExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertDeploymentExistsAndRollout(name, namespace string) func(*testing.T) {
+	return func(t *testing.T) {
+		f.AssertDeploymentExists(name, namespace)(t)
+		err := f.OperatorClient.WaitForDeploymentRollout(ctx, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (f *Framework) AssertDeploymentDoesNotExist(name, namespace string) func(*testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertPersistentVolumeClaimsExist(name, namespace string) func(*testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertStatefulSetExistsAndRollout(name, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		f.AssertStatefulsetExists(name, namespace)(t)
+		err := f.OperatorClient.WaitForStatefulsetRollout(ctx, &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (f *Framework) AssertThanosRulerExists(name, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		err := f.OperatorClient.WaitForThanosRuler(ctx, &monitoringv1.ThanosRuler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (f *Framework) AssertPrometheusExists(name, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		err := f.OperatorClient.WaitForPrometheus(ctx, &monitoringv1.Prometheus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+type PodAssertion func(pod v1.Pod) error
+
+// AssertPodConfiguration for each pod in the namespace that matches the label selector
+// Each pod in the returned list will be run through the list of provided assertions
+func (f *Framework) AssertPodConfiguration(namespace, labelSelector string, assertions []PodAssertion) func(*testing.T) {
+	return func(t *testing.T) {
+		err := Poll(time.Second, 5*time.Minute, func() error {
+			pods, err := f.KubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: "status.phase=Running"},
+			)
+
+			if err != nil {
+				return fmt.Errorf("%w - failed to get Pods", err)
+			}
+
+			// for each pod in the list of matching labels run each assertion
+			for _, p := range pods.Items {
+				for _, assertion := range assertions {
+					if err := assertion(p); err != nil {
+						return fmt.Errorf("failed assertion for %s - %w", p.Name, err)
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (f *Framework) AssertOperatorCondition(t *testing.T, conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus) func(t *testing.T) {
+	return func(t *testing.T) {
+		reporter := f.OperatorClient.StatusReporter()
+		err := Poll(time.Second, 5*time.Minute, func() error {
+			co, err := reporter.Get(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, c := range co.Status.Conditions {
+				if c.Type == conditionType {
+					if c.Status == conditionStatus {
+						return nil
+					}
+					return fmt.Errorf("expecting condition %q to be %q, got %q", conditionType, conditionStatus, c.Status)
+				}
+			}
+			return fmt.Errorf("failed to find condition %q", conditionType)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -1,0 +1,20 @@
+package framework
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	ClusterMonitorConfigMapName      = "cluster-monitoring-config"
+	UserWorkloadMonitorConfigMapName = "user-workload-monitoring-config"
+)
+
+// MustCreateOrUpdateConfigMap or fail the test
+func (f *Framework) MustCreateOrUpdateConfigMap(t *testing.T, cm *v1.ConfigMap) {
+	t.Helper()
+	if err := f.OperatorClient.CreateOrUpdateConfigMap(ctx, cm); err != nil {
+		t.Fatalf("failed to create/update configmap - %s", err.Error())
+	}
+}

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -1,0 +1,275 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	userWorkloadTestNs = "user-workload-test"
+)
+
+var (
+	ctx = context.Background()
+)
+
+func assertDeletionOfUserWorkloadAssets(f *framework.Framework) func(*testing.T) {
+	return func(t *testing.T) {
+		tearDownUserWorkloadAssets(t, f)
+
+		f.AssertDeploymentDoesNotExist("prometheus-operator", f.UserWorkloadMonitoringNs)(t)
+		f.AssertStatefulsetDoesNotExist("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
+		f.AssertSecretDoesNotExist(manifests.PrometheusUWAdditionalAlertmanagerConfigSecretName, f.UserWorkloadMonitoringNs)(t)
+	}
+}
+
+// getUserWorkloadEnabledConfigMap returns a config map with uwm enabled
+func getUserWorkloadEnabledConfigMap(t *testing.T, f *framework.Framework) *v1.ConfigMap {
+	t.Helper()
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      framework.ClusterMonitorConfigMapName,
+			Namespace: f.Ns,
+		},
+		Data: map[string]string{
+			"config.yaml": `enableUserWorkload: true
+`,
+		},
+	}
+}
+
+// setupUserWorkloadAssets enables UWM via the config map and asserts resources are up and running
+func setupUserWorkloadAssets(t *testing.T, f *framework.Framework) {
+	t.Helper()
+
+	f.MustCreateOrUpdateConfigMap(t, getUserWorkloadEnabledConfigMap(t, f))
+	f.AssertDeploymentExists("prometheus-operator", f.UserWorkloadMonitoringNs)(t)
+	f.AssertStatefulSetExistsAndRollout("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
+	f.AssertPrometheusExists("user-workload", f.UserWorkloadMonitoringNs)(t)
+}
+
+// tearDownUserWorkloadAssets deletes the uwm enabled config map
+func tearDownUserWorkloadAssets(t *testing.T, f *framework.Framework) {
+	t.Helper()
+	f.OperatorClient.DeleteConfigMap(context.Background(), getUserWorkloadEnabledConfigMap(t, f))
+}
+
+// setupUserApplication is idempotent and deploys the sample app and resources in UserWorkloadTestNs
+func setupUserApplication(t *testing.T, f *framework.Framework) {
+	t.Helper()
+	deployUserApplication(t, f)
+	createPrometheusAlertmanagerInUserNamespace(t, f)
+}
+
+// tearDownUserApplication deletes the UserWorkloadTestNs and waits for deletion
+func tearDownUserApplication(t *testing.T, f *framework.Framework) {
+	// check if its deleted and return if true
+	err := framework.Poll(time.Second, 5*time.Minute, func() error {
+		return f.OperatorClient.DeleteIfExists(ctx, userWorkloadTestNs)
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.AssertNamespaceDoesNotExist(userWorkloadTestNs)(t)
+}
+
+func deployUserApplication(t *testing.T, f *framework.Framework) error {
+	t.Helper()
+	_, err := f.KubeClient.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: userWorkloadTestNs,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	f.AssertNamespaceExists(userWorkloadTestNs)(t)
+
+	app, err := f.KubeClient.AppsV1().Deployments(userWorkloadTestNs).Create(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prometheus-example-app",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: toInt32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "prometheus-example-app",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "prometheus-example-app",
+							Image: "ghcr.io/rhobs/prometheus-example-app:0.3.0",
+						},
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "prometheus-example-app",
+					},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	_, err = f.KubeClient.CoreV1().Services(userWorkloadTestNs).Create(ctx, &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prometheus-example-app",
+			Labels: map[string]string{
+				"app": "prometheus-example-app",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:       "web",
+					Protocol:   "TCP",
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+			Selector: map[string]string{
+				"app": "prometheus-example-app",
+			},
+			Type: v1.ServiceTypeClusterIP,
+		},
+	}, metav1.CreateOptions{})
+
+	_, err = f.MonitoringClient.ServiceMonitors(userWorkloadTestNs).Create(ctx, &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prometheus-example-monitor",
+			Labels: map[string]string{
+				"k8s-app": "prometheus-example-monitor",
+			},
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port:     "web",
+					Scheme:   "http",
+					Interval: "30s",
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "prometheus-example-app",
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	_, err = f.MonitoringClient.PrometheusRules(userWorkloadTestNs).Create(ctx, &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prometheus-example-rule",
+			Labels: map[string]string{
+				"k8s-app": "prometheus-example-rule",
+			},
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "example",
+					Rules: []monitoringv1.Rule{
+						{
+							Record: "version:blah:count",
+							Expr:   intstr.FromString(`count(version)`),
+						},
+						{
+							Alert: "VersionAlert",
+							Expr:  intstr.FromString(fmt.Sprintf(`version{namespace="%s",job="prometheus-example-app"} == 1`, userWorkloadTestNs)),
+							For:   "1s",
+						},
+					},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	_, err = f.MonitoringClient.PrometheusRules(userWorkloadTestNs).Create(ctx, &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prometheus-example-rule-leaf",
+			Labels: map[string]string{
+				"k8s-app": "prometheus-example-rule-leaf",
+				"openshift.io/prometheus-rule-evaluation-scope": "leaf-prometheus",
+			},
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "example",
+					Rules: []monitoringv1.Rule{
+						{
+							Record: "version:blah:leaf:count",
+							Expr:   intstr.FromString(`count(version)`),
+						},
+					},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	err = f.OperatorClient.WaitForDeploymentRollout(ctx, app)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createPrometheusAlertmanagerInUserNamespace(t *testing.T, f *framework.Framework) error {
+	t.Helper()
+	_, err := f.MonitoringClient.Alertmanagers(userWorkloadTestNs).Create(ctx, &monitoringv1.Alertmanager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "not-to-be-reconciled",
+		},
+		Spec: monitoringv1.AlertmanagerSpec{
+			Replicas: toInt32(1),
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	_, err = f.MonitoringClient.Prometheuses(userWorkloadTestNs).Create(ctx, &monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "not-to-be-reconciled",
+		},
+		Spec: monitoringv1.PrometheusSpec{
+			Replicas: toInt32(1),
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func toInt32(v int32) *int32 { return &v }

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -24,16 +23,6 @@ const (
 var (
 	ctx = context.Background()
 )
-
-func assertDeletionOfUserWorkloadAssets(f *framework.Framework) func(*testing.T) {
-	return func(t *testing.T) {
-		tearDownUserWorkloadAssets(t, f)
-
-		f.AssertDeploymentDoesNotExist("prometheus-operator", f.UserWorkloadMonitoringNs)(t)
-		f.AssertStatefulsetDoesNotExist("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
-		f.AssertSecretDoesNotExist(manifests.PrometheusUWAdditionalAlertmanagerConfigSecretName, f.UserWorkloadMonitoringNs)(t)
-	}
-}
 
 // getUserWorkloadEnabledConfigMap returns a config map with uwm enabled
 func getUserWorkloadEnabledConfigMap(t *testing.T, f *framework.Framework) *v1.ConfigMap {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,6 @@ github.com/go-openapi/validate
 # github.com/go-stack/stack v1.8.0
 github.com/go-stack/stack
 # github.com/gogo/protobuf v1.3.2
-## explicit
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da


### PR DESCRIPTION
See [#MON-1170](https://issues.redhat.com/browse/MON-1170) for context on change.

This change splits the growing UWM e2e table driven tests into their own individual tests. The downside to this is there is a lot of setup/teardown to UWM so it is going to take longer to run.

I have deleted some tests since they were already covered by the config tests for uwm. I have moved a test into the config test suite where it is more appropriate and have extracted common functions used across the suite into their own file.
 
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
