### PR TITLE
Bug 1976765:Update AlertmanagerMembersInconsistent rule

### DIFF
--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -38,7 +38,7 @@ spec:
           max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="openshift-monitoring"}[5m])
         < on (namespace,service) group_left
           count by (namespace,service) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="openshift-monitoring"}[5m]))
-      for: 10m
+      for: 15m
       labels:
         severity: critical
     - alert: AlertmanagerFailedToSendAlerts

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -138,6 +138,15 @@ local patchedRules = [
       },
     ],
   },
+  {
+    name: 'alertmanager.rules',
+    rules: [
+      {
+        alert: 'AlertmanagerMembersInconsistent',
+        'for': '15m',
+      },
+    ],
+  },
 ];
 
 local patchOrExcludeRule(rule, ruleSet, operation) =


### PR DESCRIPTION
Fixing this by patching in CMO since this doesn't look to be ideal candidate for backporting in upstream alertmanager repo

Upstream fix in master https://github.com/prometheus/alertmanager/pull/2613 
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
