### PR TITLE
Fix shellcheck errors

### DIFF
--- a/hack/generate-versions.sh
+++ b/hack/generate-versions.sh
@@ -25,7 +25,7 @@ get_version() {
   if [[ "$v" == "" ]]; then
      v="$(get_version_from_user "${component}")"
   fi
-  echo "$v" | sed 's/v//g'
+  echo "${v//v/}"
 }
 
 


### PR DESCRIPTION
Running `make format` throws the following error:
```
./hack/generate-versions.sh:28:3: note: See if you can use ${variable//search/replace} instead. [SC2001]
make: *** [Makefile:144: shellcheck] Error 1
```
The expression which causes the error is https://github.com/openshift/cluster-monitoring-operator/blob/master/hack/generate-versions.sh#L28

This commit replaces the expression with the one recommended by shellcheck[1] in order to make the `format` target work again.

[1] https://github.com/koalaman/shellcheck/wiki/SC2001

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
