### PR TITLE
Remove manual CRI-O metrics modification

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -93,11 +93,6 @@ spec:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
       insecureSkipVerify: false
   - interval: 30s
-    metricRelabelings:
-    - action: drop
-      regex: container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_.+
-      sourceLabels:
-      - __name__
     port: https-metrics
     relabelings:
     - action: replace

--- a/jsonnet/control-plane.libsonnet
+++ b/jsonnet/control-plane.libsonnet
@@ -117,14 +117,6 @@ function(params)
                 replacement: 'crio',
               },
             ],
-            // Drop metrics with excessive label cardinality.
-            metricRelabelings: [
-              {
-                sourceLabels: ['__name__'],
-                regex: 'container_runtime_crio_image_layer_reuse|container_runtime_crio_image_pulls_.+',
-                action: 'drop',
-              },
-            ],
           }],
       },
     },


### PR DESCRIPTION
The metrics have been dropped manually because we were not able to
configure them. Now https://github.com/cri-o/cri-o/pull/5061 has been
merged and the list of enabled metrics will be handled in the Machine
Config Operator.

No user facing change required if merged together with https://github.com/openshift/machine-config-operator/pull/2678