### PR TITLE
Bug 1982778: jsonnet: thanosquery: Use HTTP probes as opposed to exec

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -54,26 +54,10 @@ spec:
         - --grpc-client-server-name=prometheus-grpc
         - --rule=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local
         image: quay.io/thanos/thanos:v0.20.2
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/healthy;
-              elif [ -x "$(command -v wget)" ]; then exec wget --quiet --tries=1 --spider
-              http://localhost:9090/-/healthy; else exit 1; fi
         name: thanos-query
         ports:
         - containerPort: 9090
           name: http
-        readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-              elif [ -x "$(command -v wget)" ]; then exec wget --quiet --tries=1 --spider
-              http://localhost:9090/-/ready; else exit 1; fi
         resources:
           requests:
             cpu: 10m
@@ -98,6 +82,7 @@ spec:
         - -cookie-secret-file=/etc/proxy/secrets/session_secret
         - -openshift-ca=/etc/pki/tls/cert.pem
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -bypass-auth-for=^/-/(healthy|ready)$
         env:
         - name: HTTP_PROXY
           value: ""
@@ -106,10 +91,26 @@ spec:
         - name: NO_PROXY
           value: ""
         image: quay.io/openshift/oauth-proxy:latest
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 9091
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 30
         name: oauth-proxy
         ports:
         - containerPort: 9091
           name: web
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 9091
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 5
         resources:
           requests:
             cpu: 1m


### PR DESCRIPTION
This is cherry pick of #1277 which backports to 4.8.z

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
