### PR TITLE
Remove context field from structs

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1321,7 +1321,7 @@ func (c *Client) CRDReady(ctx context.Context, crd *extensionsobj.CustomResource
 }
 
 func (c *Client) StatusReporter() *StatusReporter {
-	return NewStatusReporter(c.oscclient.ConfigV1().ClusterOperators(), "monitoring",  c.namespace, c.userWorkloadNamespace, c.version)
+	return NewStatusReporter(c.oscclient.ConfigV1().ClusterOperators(), "monitoring", c.namespace, c.userWorkloadNamespace, c.version)
 }
 
 func (c *Client) DeleteRoleBinding(ctx context.Context, binding *rbacv1.RoleBinding) error {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -109,6 +109,7 @@ func TestMergeMetadata(t *testing.T) {
 }
 
 func TestCreateOrUpdateDeployment(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialSpec         appsv1.DeploymentSpec
@@ -192,21 +193,20 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(dep.DeepCopy()),
-				ctx:     context.Background(),
 			}
 
-			if _, err := c.kclient.AppsV1().Deployments(ns).Get(c.ctx, dep.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			dep.SetLabels(tc.updatedLabels)
 			dep.SetAnnotations(tc.updatedAnnotations)
 			dep.Spec = tc.updatedSpec
-			if err := c.CreateOrUpdateDeployment(dep); err != nil {
+			if err := c.CreateOrUpdateDeployment(ctx, dep); err != nil {
 				t.Fatal(err)
 			}
 
-			after, err := c.kclient.AppsV1().Deployments(ns).Get(c.ctx, dep.Name, metav1.GetOptions{})
+			after, err := c.kclient.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -223,6 +223,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 }
 
 func TestCreateOrUpdateDaemonSet(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -288,18 +289,17 @@ func TestCreateOrUpdateDaemonSet(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(ds.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			if _, err := c.kclient.AppsV1().DaemonSets(ns).Get(c.ctx, ds.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			ds.SetLabels(tc.updatedLabels)
 			ds.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdateDaemonSet(ds); err != nil {
+			if err := c.CreateOrUpdateDaemonSet(ctx, ds); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.AppsV1().DaemonSets(ns).Get(c.ctx, ds.Name, metav1.GetOptions{})
+			after, err := c.kclient.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -315,6 +315,7 @@ func TestCreateOrUpdateDaemonSet(t *testing.T) {
 }
 
 func TestCreateOrUpdateSecret(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -380,19 +381,18 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(s.DeepCopy()),
-				ctx:     context.Background(),
 			}
 
-			if _, err := c.kclient.CoreV1().Secrets(ns).Get(c.ctx, s.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.CoreV1().Secrets(ns).Get(ctx, s.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			s.SetLabels(tc.updatedLabels)
 			s.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdateSecret(s); err != nil {
+			if err := c.CreateOrUpdateSecret(ctx, s); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.CoreV1().Secrets(ns).Get(c.ctx, s.Name, metav1.GetOptions{})
+			after, err := c.kclient.CoreV1().Secrets(ns).Get(ctx, s.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -408,6 +408,7 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 }
 
 func TestCreateOrUpdateConfigMap(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -473,20 +474,19 @@ func TestCreateOrUpdateConfigMap(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(cm),
-				ctx:     context.Background(),
 			}
 
-			if _, err := c.kclient.CoreV1().ConfigMaps(ns).Get(c.ctx, cm.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.CoreV1().ConfigMaps(ns).Get(ctx, cm.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			cm.SetLabels(tc.updatedLabels)
 			cm.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdateConfigMap(cm); err != nil {
+			if err := c.CreateOrUpdateConfigMap(ctx, cm); err != nil {
 				t.Fatal(err)
 			}
 
-			after, err := c.kclient.CoreV1().ConfigMaps(ns).Get(c.ctx, cm.Name, metav1.GetOptions{})
+			after, err := c.kclient.CoreV1().ConfigMaps(ns).Get(ctx, cm.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -502,6 +502,7 @@ func TestCreateOrUpdateConfigMap(t *testing.T) {
 }
 
 func TestCreateOrUpdateService(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                   string
 		initialSessionAffinity v1.ServiceAffinity
@@ -615,10 +616,9 @@ func TestCreateOrUpdateService(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(svc.DeepCopy()),
-				ctx:     context.Background(),
 			}
 
-			before, err := c.kclient.CoreV1().Services(ns).Get(c.ctx, svc.Name, metav1.GetOptions{})
+			before, err := c.kclient.CoreV1().Services(ns).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -626,11 +626,11 @@ func TestCreateOrUpdateService(t *testing.T) {
 			svc.SetLabels(tc.updatedLabels)
 			svc.SetAnnotations(tc.updatedAnnotations)
 			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
-			if err := c.CreateOrUpdateService(svc); err != nil {
+			if err := c.CreateOrUpdateService(ctx, svc); err != nil {
 				t.Fatal(err)
 			}
 
-			after, err := c.kclient.CoreV1().Services(ns).Get(c.ctx, svc.Name, metav1.GetOptions{})
+			after, err := c.kclient.CoreV1().Services(ns).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -650,6 +650,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 }
 
 func TestCreateOrUpdateRole(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -714,18 +715,17 @@ func TestCreateOrUpdateRole(t *testing.T) {
 			}
 			c := Client{
 				kclient: fake.NewSimpleClientset(role.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			if _, err := c.kclient.RbacV1().Roles(ns).Get(c.ctx, role.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.RbacV1().Roles(ns).Get(ctx, role.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			role.SetLabels(tc.updatedLabels)
 			role.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdateRole(role); err != nil {
+			if err := c.CreateOrUpdateRole(ctx, role); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.RbacV1().Roles(ns).Get(c.ctx, role.Name, metav1.GetOptions{})
+			after, err := c.kclient.RbacV1().Roles(ns).Get(ctx, role.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -741,6 +741,7 @@ func TestCreateOrUpdateRole(t *testing.T) {
 }
 
 func TestCreateOrUpdateRoleBinding(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name               string
 		initialLabels      map[string]string
@@ -851,9 +852,8 @@ func TestCreateOrUpdateRoleBinding(t *testing.T) {
 			}
 			c := Client{
 				kclient: fake.NewSimpleClientset(roleBinding.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			before, err := c.kclient.RbacV1().RoleBindings(ns).Get(c.ctx, roleBinding.Name, metav1.GetOptions{})
+			before, err := c.kclient.RbacV1().RoleBindings(ns).Get(ctx, roleBinding.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -862,11 +862,11 @@ func TestCreateOrUpdateRoleBinding(t *testing.T) {
 			roleBinding.SetAnnotations(tc.updatedAnnotations)
 			roleBinding.RoleRef = tc.updatedRoleRef
 			roleBinding.Subjects = tc.updatedSubjects
-			err = c.CreateOrUpdateRoleBinding(roleBinding)
+			err = c.CreateOrUpdateRoleBinding(ctx, roleBinding)
 			if err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.RbacV1().RoleBindings(ns).Get(c.ctx, roleBinding.Name, metav1.GetOptions{})
+			after, err := c.kclient.RbacV1().RoleBindings(ns).Get(ctx, roleBinding.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -886,6 +886,7 @@ func TestCreateOrUpdateRoleBinding(t *testing.T) {
 }
 
 func TestCreateOrUpdateClusterRole(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -949,18 +950,17 @@ func TestCreateOrUpdateClusterRole(t *testing.T) {
 			}
 			c := Client{
 				kclient: fake.NewSimpleClientset(clusterRole.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			if _, err := c.kclient.RbacV1().ClusterRoles().Get(c.ctx, clusterRole.Name, metav1.GetOptions{}); err != nil {
+			if _, err := c.kclient.RbacV1().ClusterRoles().Get(ctx, clusterRole.Name, metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			clusterRole.SetLabels(tc.updatedLabels)
 			clusterRole.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdateClusterRole(clusterRole); err != nil {
+			if err := c.CreateOrUpdateClusterRole(ctx, clusterRole); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.RbacV1().ClusterRoles().Get(c.ctx, clusterRole.Name, metav1.GetOptions{})
+			after, err := c.kclient.RbacV1().ClusterRoles().Get(ctx, clusterRole.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -976,6 +976,7 @@ func TestCreateOrUpdateClusterRole(t *testing.T) {
 }
 
 func TestCreateOrUpdateClusterRoleBinding(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name               string
 		initialLabels      map[string]string
@@ -1086,9 +1087,8 @@ func TestCreateOrUpdateClusterRoleBinding(t *testing.T) {
 
 			c := Client{
 				kclient: fake.NewSimpleClientset(clusterRoleBinding.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			before, err := c.kclient.RbacV1().ClusterRoleBindings().Get(c.ctx, clusterRoleBinding.Name, metav1.GetOptions{})
+			before, err := c.kclient.RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleBinding.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1097,10 +1097,10 @@ func TestCreateOrUpdateClusterRoleBinding(t *testing.T) {
 			clusterRoleBinding.SetAnnotations(tc.updatedAnnotations)
 			clusterRoleBinding.RoleRef = tc.updatedRoleRef
 			clusterRoleBinding.Subjects = tc.updatedSubjects
-			if err := c.CreateOrUpdateClusterRoleBinding(clusterRoleBinding); err != nil {
+			if err := c.CreateOrUpdateClusterRoleBinding(ctx, clusterRoleBinding); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.kclient.RbacV1().ClusterRoleBindings().Get(c.ctx, clusterRoleBinding.Name, metav1.GetOptions{})
+			after, err := c.kclient.RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleBinding.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1120,6 +1120,7 @@ func TestCreateOrUpdateClusterRoleBinding(t *testing.T) {
 }
 
 func TestCreateOrUpdateSecurityContextConstraints(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -1184,21 +1185,20 @@ func TestCreateOrUpdateSecurityContextConstraints(t *testing.T) {
 
 			c := Client{
 				ossclient: ossfake.NewSimpleClientset(),
-				ctx:       context.Background(),
 			}
-			c.ossclient.SecurityV1().SecurityContextConstraints().Create(c.ctx, scc.DeepCopy(), metav1.CreateOptions{})
+			c.ossclient.SecurityV1().SecurityContextConstraints().Create(ctx, scc.DeepCopy(), metav1.CreateOptions{})
 
-			if _, err := c.ossclient.SecurityV1().SecurityContextConstraints().Get(c.ctx, scc.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.ossclient.SecurityV1().SecurityContextConstraints().Get(ctx, scc.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			scc.SetLabels(tc.updatedLabels)
 			scc.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdateSecurityContextConstraints(scc); err != nil {
+			if err := c.CreateOrUpdateSecurityContextConstraints(ctx, scc); err != nil {
 				t.Fatal(err)
 			}
 
-			after, err := c.ossclient.SecurityV1().SecurityContextConstraints().Get(c.ctx, scc.GetName(), metav1.GetOptions{})
+			after, err := c.ossclient.SecurityV1().SecurityContextConstraints().Get(ctx, scc.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1214,6 +1214,7 @@ func TestCreateOrUpdateSecurityContextConstraints(t *testing.T) {
 }
 
 func TestCreateOrUpdateServiceMonitor(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -1279,18 +1280,17 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(serviceMonitor.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			if _, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(c.ctx, serviceMonitor.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(ctx, serviceMonitor.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			serviceMonitor.SetLabels(tc.updatedLabels)
 			serviceMonitor.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdateServiceMonitor(serviceMonitor); err != nil {
+			if err := c.CreateOrUpdateServiceMonitor(ctx, serviceMonitor); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(c.ctx, serviceMonitor.GetName(), metav1.GetOptions{})
+			after, err := c.mclient.MonitoringV1().ServiceMonitors(ns).Get(ctx, serviceMonitor.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1306,6 +1306,7 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 }
 
 func TestCreateOrUpdatePrometheusRule(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -1371,18 +1372,17 @@ func TestCreateOrUpdatePrometheusRule(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(rule.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			if _, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(c.ctx, rule.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(ctx, rule.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			rule.SetLabels(tc.updatedLabels)
 			rule.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdatePrometheusRule(rule); err != nil {
+			if err := c.CreateOrUpdatePrometheusRule(ctx, rule); err != nil {
 				t.Fatal(err)
 			}
-			after, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(c.ctx, rule.GetName(), metav1.GetOptions{})
+			after, err := c.mclient.MonitoringV1().PrometheusRules(ns).Get(ctx, rule.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1398,6 +1398,7 @@ func TestCreateOrUpdatePrometheusRule(t *testing.T) {
 }
 
 func TestCreateOrUpdatePrometheus(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -1463,19 +1464,18 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(prometheus.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			if _, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(c.ctx, prometheus.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(ctx, prometheus.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			prometheus.SetLabels(tc.updatedLabels)
 			prometheus.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdatePrometheus(prometheus); err != nil {
+			if err := c.CreateOrUpdatePrometheus(ctx, prometheus); err != nil {
 				t.Fatal(err)
 			}
 
-			after, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(c.ctx, prometheus.GetName(), metav1.GetOptions{})
+			after, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(ctx, prometheus.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1491,6 +1491,7 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 }
 
 func TestCreateOrUpdateAlertmanager(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		initialLabels       map[string]string
@@ -1556,19 +1557,18 @@ func TestCreateOrUpdateAlertmanager(t *testing.T) {
 
 			c := Client{
 				mclient: monfake.NewSimpleClientset(alertmanager.DeepCopy()),
-				ctx:     context.Background(),
 			}
-			if _, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(c.ctx, alertmanager.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(ctx, alertmanager.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			alertmanager.SetLabels(tc.updatedLabels)
 			alertmanager.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdateAlertmanager(alertmanager); err != nil {
+			if err := c.CreateOrUpdateAlertmanager(ctx, alertmanager); err != nil {
 				t.Fatal(err)
 			}
 
-			after, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(c.ctx, alertmanager.GetName(), metav1.GetOptions{})
+			after, err := c.mclient.MonitoringV1().Alertmanagers(ns).Get(ctx, alertmanager.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	unavailableMessage string = "Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error."
-	asExpectedReason   string = "AsExpected"
-	StorageNotConfiguredMessage = "Prometheus is running without persistent storage which can lead to data loss during upgrades and cluster disruptions. Please refer to the official documentation to see how to configure storage for Prometheus: https://docs.openshift.com/container-platform/4.8/monitoring/configuring-the-monitoring-stack.html"
-	StorageNotConfiguredReason  = "PrometheusDataPersistenceNotConfigured"
+	unavailableMessage          string = "Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error."
+	asExpectedReason            string = "AsExpected"
+	StorageNotConfiguredMessage        = "Prometheus is running without persistent storage which can lead to data loss during upgrades and cluster disruptions. Please refer to the official documentation to see how to configure storage for Prometheus: https://docs.openshift.com/container-platform/4.8/monitoring/configuring-the-monitoring-stack.html"
+	StorageNotConfiguredReason         = "PrometheusDataPersistenceNotConfigured"
 )
 
 type StatusReporter struct {
@@ -41,7 +41,7 @@ type StatusReporter struct {
 	version               string
 }
 
-func NewStatusReporter(client clientv1.ClusterOperatorInterface, name string, namespace, userWorkloadNamespace, version string) *StatusReporter {
+func NewStatusReporter(client clientv1.ClusterOperatorInterface, name, namespace, userWorkloadNamespace, version string) *StatusReporter {
 	return &StatusReporter{
 		client:                client,
 		clusterOperatorName:   name,

--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -112,7 +112,6 @@ func TestStatusReporterSetDone(t *testing.T) {
 				w(mock)
 			}
 
-
 			got := sr.SetDone(ctx, "", "")
 
 			for _, check := range tc.check {

--- a/pkg/client/status_reporter_test.go
+++ b/pkg/client/status_reporter_test.go
@@ -101,7 +101,6 @@ func TestStatusReporterSetDone(t *testing.T) {
 			mock := &clusterOperatorMock{}
 
 			sr := NewStatusReporter(
-				ctx,
 				mock,
 				tc.given.operatorName,
 				tc.given.namespace,
@@ -113,7 +112,8 @@ func TestStatusReporterSetDone(t *testing.T) {
 				w(mock)
 			}
 
-			got := sr.SetDone("", "")
+
+			got := sr.SetDone(ctx, "", "")
 
 			for _, check := range tc.check {
 				if err := check(mock, got); err != nil {
@@ -194,7 +194,6 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 			mock := &clusterOperatorMock{}
 
 			sr := NewStatusReporter(
-				ctx,
 				mock,
 				tc.given.operatorName,
 				tc.given.namespace,
@@ -206,7 +205,7 @@ func TestStatusReporterSetInProgress(t *testing.T) {
 				w(mock)
 			}
 
-			got := sr.SetInProgress()
+			got := sr.SetInProgress(ctx)
 
 			for _, check := range tc.check {
 				if err := check(mock, got); err != nil {
@@ -292,7 +291,6 @@ func TestStatusReporterSetFailed(t *testing.T) {
 			mock := &clusterOperatorMock{}
 
 			sr := NewStatusReporter(
-				ctx,
 				mock,
 				tc.given.operatorName,
 				tc.given.namespace,
@@ -304,7 +302,7 @@ func TestStatusReporterSetFailed(t *testing.T) {
 				w(mock)
 			}
 
-			got := sr.SetFailed(tc.given.err, "")
+			got := sr.SetFailed(ctx, tc.given.err, "")
 
 			for _, check := range tc.check {
 				if err := check(mock, got); err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -541,7 +541,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		klog.Errorf("error occurred while setting status to in progress: %v", err)
 	}
 
-	taskName, err := tl.RunAll()
+	taskName, err := tl.RunAll(ctx)
 	if err != nil {
 		o.reportError(ctx, err, taskName)
 		return err

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -132,8 +132,6 @@ const (
 )
 
 type Operator struct {
-	ctx context.Context
-
 	namespace, namespaceUserWorkload string
 
 	configMapName             string
@@ -177,7 +175,6 @@ func New(
 	}
 
 	o := &Operator{
-		ctx:                       ctx,
 		images:                    images,
 		telemetryMatches:          telemetryMatches,
 		configMapName:             configMapName,
@@ -250,7 +247,7 @@ func New(
 	o.informers = append(o.informers, informer)
 
 	informer = cache.NewSharedIndexInformer(
-		o.client.InfrastructureListWatchForResource(o.ctx, clusterResourceName),
+		o.client.InfrastructureListWatchForResource(ctx, clusterResourceName),
 		&configv1.Infrastructure{}, resyncPeriod, cache.Indexers{},
 	)
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -373,7 +370,7 @@ func (o *Operator) Run(ctx context.Context) error {
 		go r(ctx, 1)
 	}
 
-	go o.worker()
+	go o.worker(ctx)
 
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
@@ -449,12 +446,12 @@ func (o *Operator) handleEvent(obj interface{}) {
 	o.enqueue(cmoConfigMap)
 }
 
-func (o *Operator) worker() {
-	for o.processNextWorkItem() {
+func (o *Operator) worker(ctx context.Context) {
+	for o.processNextWorkItem(ctx) {
 	}
 }
 
-func (o *Operator) processNextWorkItem() bool {
+func (o *Operator) processNextWorkItem(ctx context.Context) bool {
 	key, quit := o.queue.Get()
 	if quit {
 		return false
@@ -462,7 +459,7 @@ func (o *Operator) processNextWorkItem() bool {
 	defer o.queue.Done(key)
 
 	o.reconcileAttempts.Inc()
-	err := o.sync(key.(string))
+	err := o.sync(ctx, key.(string))
 	if err == nil {
 		o.reconcileStatus.Set(1)
 		o.queue.Forget(key)
@@ -493,10 +490,10 @@ func (o *Operator) enqueue(obj interface{}) {
 	o.queue.Add(key)
 }
 
-func (o *Operator) sync(key string) error {
-	config, err := o.Config(key)
+func (o *Operator) sync(ctx context.Context, key string) error {
+	config, err := o.Config(ctx, key)
 	if err != nil {
-		o.reportError(err, "InvalidConfiguration")
+		o.reportError(ctx, err, "InvalidConfiguration")
 		return err
 	}
 	config.SetImages(o.images)
@@ -504,12 +501,12 @@ func (o *Operator) sync(key string) error {
 	config.SetRemoteWrite(o.remoteWrite)
 
 	var proxyConfig manifests.ProxyReader
-	proxyConfig, err = o.loadProxyConfig()
+	proxyConfig, err = o.loadProxyConfig(ctx)
 	if err != nil {
 		klog.Warningf("using proxy config from CMO configmap: %v", err)
 		proxyConfig = config
 	}
-	factory := manifests.NewFactory(o.namespace, o.namespaceUserWorkload, config, o.loadInfrastructureConfig(), proxyConfig, o.assets)
+	factory := manifests.NewFactory(o.namespace, o.namespaceUserWorkload, config, o.loadInfrastructureConfig(ctx), proxyConfig, o.assets)
 
 	tl := tasks.NewTaskRunner(
 		o.client,
@@ -530,7 +527,7 @@ func (o *Operator) sync(key string) error {
 				tasks.NewTaskSpec("Updating node-exporter", tasks.NewNodeExporterTask(o.client, factory)),
 				tasks.NewTaskSpec("Updating kube-state-metrics", tasks.NewKubeStateMetricsTask(o.client, factory)),
 				tasks.NewTaskSpec("Updating openshift-state-metrics", tasks.NewOpenShiftStateMetricsTask(o.client, factory)),
-				tasks.NewTaskSpec("Updating prometheus-adapter", tasks.NewPrometheusAdapterTask(o.ctx, o.namespace, o.client, factory)),
+				tasks.NewTaskSpec("Updating prometheus-adapter", tasks.NewPrometheusAdapterTask(ctx, o.namespace, o.client, factory)),
 				tasks.NewTaskSpec("Updating Telemeter client", tasks.NewTelemeterClientTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating configuration sharing", tasks.NewConfigSharingTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Thanos Querier", tasks.NewThanosQuerierTask(o.client, factory, config)),
@@ -539,14 +536,14 @@ func (o *Operator) sync(key string) error {
 			}),
 	)
 	klog.Info("Updating ClusterOperator status to in progress.")
-	err = o.client.StatusReporter().SetInProgress()
+	err = o.client.StatusReporter().SetInProgress(ctx)
 	if err != nil {
 		klog.Errorf("error occurred while setting status to in progress: %v", err)
 	}
 
 	taskName, err := tl.RunAll()
 	if err != nil {
-		o.reportError(err, taskName)
+		o.reportError(ctx, err, taskName)
 		return err
 	}
 
@@ -557,7 +554,8 @@ func (o *Operator) sync(key string) error {
 	}
 	klog.Info("Updating ClusterOperator status to done.")
 	o.failedReconcileAttempts = 0
-	err = o.client.StatusReporter().SetDone(degradedConditionMessage, degradedConditionReason)
+	err = o.client.StatusReporter().SetDone(ctx, degradedConditionMessage, degradedConditionReason)
+
 	if err != nil {
 		klog.Errorf("error occurred while setting status to done: %v", err)
 	}
@@ -565,13 +563,13 @@ func (o *Operator) sync(key string) error {
 	return nil
 }
 
-func (o *Operator) reportError(err error, taskName string) {
+func (o *Operator) reportError(ctx context.Context, err error, taskName string) {
 	klog.Infof("ClusterOperator reconciliation failed (attempt %d), retrying. Err: %v", o.failedReconcileAttempts+1, err)
 	if o.failedReconcileAttempts == 2 {
 		// Only update the ClusterOperator status after 3 retries have been attempted to avoid flapping status.
 		klog.Infof("Updating ClusterOperator status to failed after %d attempts. Err: %v", o.failedReconcileAttempts+1, err)
 		failedTaskReason := strings.Join(strings.Fields(taskName+"Failed"), "")
-		reportErr := o.client.StatusReporter().SetFailed(err, failedTaskReason)
+		reportErr := o.client.StatusReporter().SetFailed(ctx, err, failedTaskReason)
 		if reportErr != nil {
 			klog.Errorf("error occurred while setting status to failed: %v", reportErr)
 		}
@@ -579,10 +577,10 @@ func (o *Operator) reportError(err error, taskName string) {
 	o.failedReconcileAttempts++
 }
 
-func (o *Operator) loadInfrastructureConfig() *InfrastructureConfig {
+func (o *Operator) loadInfrastructureConfig(ctx context.Context) *InfrastructureConfig {
 	var infrastructureConfig *InfrastructureConfig
 
-	infrastructure, err := o.client.GetInfrastructure(clusterResourceName)
+	infrastructure, err := o.client.GetInfrastructure(ctx, clusterResourceName)
 	if err != nil {
 		klog.Warningf("Error getting cluster infrastructure: %v", err)
 
@@ -602,10 +600,10 @@ func (o *Operator) loadInfrastructureConfig() *InfrastructureConfig {
 	return o.lastKnowInfrastructureConfig
 }
 
-func (o *Operator) loadProxyConfig() (*ProxyConfig, error) {
+func (o *Operator) loadProxyConfig(ctx context.Context) (*ProxyConfig, error) {
 	var proxyConfig *ProxyConfig
 
-	proxy, err := o.client.GetProxy(clusterResourceName)
+	proxy, err := o.client.GetProxy(ctx, clusterResourceName)
 	if err != nil {
 		klog.Warningf("Error getting cluster proxy configuration: %v", err)
 
@@ -622,10 +620,10 @@ func (o *Operator) loadProxyConfig() (*ProxyConfig, error) {
 	return o.lastKnowProxyConfig, nil
 }
 
-func (o *Operator) loadUserWorkloadConfig() (*manifests.UserWorkloadConfiguration, error) {
+func (o *Operator) loadUserWorkloadConfig(ctx context.Context) (*manifests.UserWorkloadConfiguration, error) {
 	cmKey := fmt.Sprintf("%s/%s", o.namespaceUserWorkload, o.userWorkloadConfigMapName)
 
-	userCM, err := o.client.GetConfigmap(o.namespaceUserWorkload, o.userWorkloadConfigMapName)
+	userCM, err := o.client.GetConfigmap(ctx, o.namespaceUserWorkload, o.userWorkloadConfigMapName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Warningf("User Workload Monitoring %q ConfigMap not found. Using defaults.", cmKey)
@@ -676,7 +674,7 @@ func (o *Operator) loadConfig(key string) (*manifests.Config, error) {
 	return cParsed, nil
 }
 
-func (o *Operator) Config(key string) (*manifests.Config, error) {
+func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, error) {
 	c, err := o.loadConfig(key)
 	if err != nil {
 		return nil, err
@@ -687,7 +685,7 @@ func (o *Operator) Config(key string) (*manifests.Config, error) {
 	// loadConfig() already initializes the structs with nil values for
 	// UserWorkloadConfiguration struct.
 	if *c.ClusterMonitoringConfiguration.UserWorkloadEnabled {
-		c.UserWorkloadConfiguration, err = o.loadUserWorkloadConfig()
+		c.UserWorkloadConfiguration, err = o.loadUserWorkloadConfig(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -696,7 +694,7 @@ func (o *Operator) Config(key string) (*manifests.Config, error) {
 	// Only fetch the token and cluster ID if they have not been specified in the config.
 	if c.ClusterMonitoringConfiguration.TelemeterClientConfig.ClusterID == "" || c.ClusterMonitoringConfiguration.TelemeterClientConfig.Token == "" {
 		err := c.LoadClusterID(func() (*configv1.ClusterVersion, error) {
-			return o.client.GetClusterVersion("version")
+			return o.client.GetClusterVersion(ctx, "version")
 		})
 
 		if err != nil {
@@ -704,7 +702,7 @@ func (o *Operator) Config(key string) (*manifests.Config, error) {
 		}
 
 		err = c.LoadToken(func() (*v1.Secret, error) {
-			return o.client.KubernetesInterface().CoreV1().Secrets("openshift-config").Get(o.ctx, "pull-secret", metav1.GetOptions{})
+			return o.client.KubernetesInterface().CoreV1().Secrets("openshift-config").Get(ctx, "pull-secret", metav1.GetOptions{})
 		})
 
 		if err != nil {
@@ -712,13 +710,13 @@ func (o *Operator) Config(key string) (*manifests.Config, error) {
 		}
 	}
 
-	cm, err := o.client.GetConfigmap("openshift-config", "etcd-metric-serving-ca")
+	cm, err := o.client.GetConfigmap(ctx, "openshift-config", "etcd-metric-serving-ca")
 	if err != nil {
 		klog.Warningf("Error loading etcd CA certificates for Prometheus. Proceeding with etcd disabled. Error: %v", err)
 		return c, nil
 	}
 
-	s, err := o.client.GetSecret("openshift-config", "etcd-metric-client")
+	s, err := o.client.GetSecret(ctx, "openshift-config", "etcd-metric-client")
 	if err != nil {
 		klog.Warningf("Error loading etcd client secrets for Prometheus. Proceeding with etcd disabled. Error: %v", err)
 		return c, nil

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -32,18 +33,18 @@ func NewAlertmanagerTask(client *client.Client, factory *manifests.Factory) *Ale
 	}
 }
 
-func (t *AlertmanagerTask) Run() error {
+func (t *AlertmanagerTask) Run(ctx context.Context) error {
 	r, err := t.factory.AlertmanagerRoute()
 	if err != nil {
 		return errors.Wrap(err, "initializing Alertmanager Route failed")
 	}
 
-	err = t.client.CreateRouteIfNotExists(r)
+	err = t.client.CreateRouteIfNotExists(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "creating Alertmanager Route failed")
 	}
 
-	host, err := t.client.WaitForRouteReady(r)
+	host, err := t.client.WaitForRouteReady(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Alertmanager Route to become ready failed")
 	}
@@ -53,7 +54,7 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "initializing Alertmanager configuration Secret failed")
 	}
 
-	err = t.client.CreateIfNotExistSecret(s)
+	err = t.client.CreateIfNotExistSecret(ctx, s)
 	if err != nil {
 		return errors.Wrap(err, "creating Alertmanager configuration Secret failed")
 	}
@@ -63,7 +64,7 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "initializing Alertmanager RBAC proxy Secret failed")
 	}
 
-	err = t.client.CreateIfNotExistSecret(rs)
+	err = t.client.CreateIfNotExistSecret(ctx, rs)
 	if err != nil {
 		return errors.Wrap(err, "creating Alertmanager RBAC proxy Secret failed")
 	}
@@ -73,7 +74,7 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "initializing Alertmanager ClusterRole failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRole(cr)
+	err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Alertmanager ClusterRole failed")
 	}
@@ -83,7 +84,7 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "initializing Alertmanager ClusterRoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+	err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Alertmanager ClusterRoleBinding failed")
 	}
@@ -93,7 +94,7 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "initializing Alertmanager ServiceAccount failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceAccount(sa)
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Alertmanager ServiceAccount failed")
 	}
@@ -103,7 +104,7 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "initializing Alertmanager proxy Secret failed")
 	}
 
-	err = t.client.CreateIfNotExistSecret(ps)
+	err = t.client.CreateIfNotExistSecret(ctx, ps)
 	if err != nil {
 		return errors.Wrap(err, "creating Alertmanager proxy Secret failed")
 	}
@@ -113,7 +114,7 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "initializing Alertmanager Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Alertmanager Service failed")
 	}
@@ -130,7 +131,7 @@ func (t *AlertmanagerTask) Run() error {
 			factory: t.factory,
 			prefix:  "alertmanager",
 		}
-		trustedCA, err = cbs.syncTrustedCABundle(trustedCA)
+		trustedCA, err = cbs.syncTrustedCABundle(ctx, trustedCA)
 		if err != nil {
 			return errors.Wrap(err, "syncing Thanos Querier trusted CA bundle ConfigMap failed")
 		}
@@ -140,11 +141,11 @@ func (t *AlertmanagerTask) Run() error {
 			return errors.Wrap(err, "initializing Alertmanager object failed")
 		}
 
-		err = t.client.CreateOrUpdateAlertmanager(a)
+		err = t.client.CreateOrUpdateAlertmanager(ctx, a)
 		if err != nil {
 			return errors.Wrap(err, "reconciling Alertmanager object failed")
 		}
-		err = t.client.WaitForAlertmanager(a)
+		err = t.client.WaitForAlertmanager(ctx, a)
 		if err != nil {
 			return errors.Wrap(err, "waiting for Alertmanager object changes failed")
 		}
@@ -153,7 +154,7 @@ func (t *AlertmanagerTask) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "initializing alertmanager rules PrometheusRule failed")
 	}
-	err = t.client.CreateOrUpdatePrometheusRule(pr)
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling alertmanager rules PrometheusRule failed")
 	}
@@ -163,6 +164,6 @@ func (t *AlertmanagerTask) Run() error {
 		return errors.Wrap(err, "initializing Alertmanager ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(smam)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smam)
 	return errors.Wrap(err, "reconciling Alertmanager ServiceMonitor failed")
 }

--- a/pkg/tasks/clustermonitoringoperator.go
+++ b/pkg/tasks/clustermonitoringoperator.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -35,13 +36,13 @@ func NewClusterMonitoringOperatorTask(client *client.Client, factory *manifests.
 	}
 }
 
-func (t *ClusterMonitoringOperatorTask) Run() error {
+func (t *ClusterMonitoringOperatorTask) Run(ctx context.Context) error {
 	svc, err := t.factory.ClusterMonitoringOperatorService()
 	if err != nil {
 		return errors.Wrap(err, "initializing Cluster Monitoring Operator Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Cluster Monitoring Operator Service failed")
 	}
@@ -57,7 +58,7 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 			return errors.Wrapf(err, "initializing %s ClusterRole failed", name)
 		}
 
-		err = t.client.CreateOrUpdateClusterRole(cr)
+		err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 		if err != nil {
 			return errors.Wrapf(err, "reconciling %s ClusterRole failed", name)
 		}
@@ -68,7 +69,7 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing UserWorkloadConfigEdit Role failed")
 	}
 
-	err = t.client.CreateOrUpdateRole(uwcr)
+	err = t.client.CreateOrUpdateRole(ctx, uwcr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling UserWorkloadConfigEdit Role failed")
 	}
@@ -78,7 +79,7 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing AlertmanagerWrite Role failed")
 	}
 
-	err = t.client.CreateOrUpdateRole(amwr)
+	err = t.client.CreateOrUpdateRole(ctx, amwr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Alertmanager Role failed")
 	}
@@ -87,7 +88,7 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "initializing cluster-monitoring-operator rules PrometheusRule failed")
 	}
-	err = t.client.CreateOrUpdatePrometheusRule(pr)
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling cluster-monitoring-operator rules PrometheusRule failed")
 	}
@@ -97,7 +98,7 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing Cluster Monitoring Operator ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(smcmo)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smcmo)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Cluster Monitoring Operator ServiceMonitor failed")
 	}
@@ -107,7 +108,7 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 		return errors.Wrap(err, "error initializing Cluster Monitoring Operator GRPC TLS secret")
 	}
 
-	loaded, err := t.client.GetSecret(s.Namespace, s.Name)
+	loaded, err := t.client.GetSecret(ctx, s.Namespace, s.Name)
 	switch {
 	case apierrors.IsNotFound(err):
 		// No secret was found, proceed with the default empty secret from manifests.
@@ -125,7 +126,7 @@ func (t *ClusterMonitoringOperatorTask) Run() error {
 		return errors.Wrap(err, "error rotating Cluster Monitoring Operator GRPC TLS secret")
 	}
 
-	err = t.client.CreateOrUpdateSecret(s)
+	err = t.client.CreateOrUpdateSecret(ctx, s)
 	if err != nil {
 		return errors.Wrap(err, "error creating Cluster Monitoring Operator GRPC TLS secret")
 	}

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -38,7 +38,7 @@ func NewControlPlaneTask(client *client.Client, factory *manifests.Factory, conf
 func (t *ControlPlaneTask) Run(ctx context.Context) error {
 	// TODO: remove in 4.10
 	// This was needed when etcd rule was moved to cluster-etcd-operator.
-	err := t.client.DeletePrometheusRuleByNamespaceAndName(ctx,"openshift-monitoring", "etcd-prometheus-rules")
+	err := t.client.DeletePrometheusRuleByNamespaceAndName(ctx, "openshift-monitoring", "etcd-prometheus-rules")
 	if err != nil {
 		return errors.Wrap(err, "deleting etcd rules PrometheusRule failed")
 	}
@@ -72,12 +72,12 @@ func (t *ControlPlaneTask) Run(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "reconciling control-plane etcd ServiceMonitor failed")
 		}
-		etcdCA, err := t.client.GetConfigmap(ctx,"openshift-config", "etcd-metric-serving-ca")
+		etcdCA, err := t.client.GetConfigmap(ctx, "openshift-config", "etcd-metric-serving-ca")
 		if err != nil {
 			return errors.Wrap(err, "failed to load etcd client CA")
 		}
 
-		etcdClientSecret, err := t.client.GetSecret(ctx,"openshift-config", "etcd-metric-client")
+		etcdClientSecret, err := t.client.GetSecret(ctx, "openshift-config", "etcd-metric-client")
 		if err != nil {
 			return errors.Wrap(err, "failed to load etcd client secret")
 		}

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -34,10 +35,10 @@ func NewControlPlaneTask(client *client.Client, factory *manifests.Factory, conf
 	}
 }
 
-func (t *ControlPlaneTask) Run() error {
+func (t *ControlPlaneTask) Run(ctx context.Context) error {
 	// TODO: remove in 4.10
 	// This was needed when etcd rule was moved to cluster-etcd-operator.
-	err := t.client.DeletePrometheusRuleByNamespaceAndName("openshift-monitoring", "etcd-prometheus-rules")
+	err := t.client.DeletePrometheusRuleByNamespaceAndName(ctx,"openshift-monitoring", "etcd-prometheus-rules")
 	if err != nil {
 		return errors.Wrap(err, "deleting etcd rules PrometheusRule failed")
 	}
@@ -46,7 +47,7 @@ func (t *ControlPlaneTask) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "initializing kubernetes mixin rules PrometheusRule failed")
 	}
-	err = t.client.CreateOrUpdatePrometheusRule(pr)
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling kubernetes mixin rules PrometheusRule failed")
 	}
@@ -56,7 +57,7 @@ func (t *ControlPlaneTask) Run() error {
 		return errors.Wrap(err, "initializing control-plane kubelet ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(smk)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smk)
 	if err != nil {
 		return errors.Wrap(err, "reconciling control-plane kubelet ServiceMonitor failed")
 	}
@@ -67,16 +68,16 @@ func (t *ControlPlaneTask) Run() error {
 	}
 
 	if t.config.ClusterMonitoringConfiguration.EtcdConfig.IsEnabled() {
-		err = t.client.CreateOrUpdateServiceMonitor(sme)
+		err = t.client.CreateOrUpdateServiceMonitor(ctx, sme)
 		if err != nil {
 			return errors.Wrap(err, "reconciling control-plane etcd ServiceMonitor failed")
 		}
-		etcdCA, err := t.client.GetConfigmap("openshift-config", "etcd-metric-serving-ca")
+		etcdCA, err := t.client.GetConfigmap(ctx,"openshift-config", "etcd-metric-serving-ca")
 		if err != nil {
 			return errors.Wrap(err, "failed to load etcd client CA")
 		}
 
-		etcdClientSecret, err := t.client.GetSecret("openshift-config", "etcd-metric-client")
+		etcdClientSecret, err := t.client.GetSecret(ctx,"openshift-config", "etcd-metric-client")
 		if err != nil {
 			return errors.Wrap(err, "failed to load etcd client secret")
 		}
@@ -86,12 +87,12 @@ func (t *ControlPlaneTask) Run() error {
 			return errors.Wrap(err, "initializing prometheus etcd service monitor secret failed")
 		}
 
-		err = t.client.CreateOrUpdateSecret(promEtcdSecret)
+		err = t.client.CreateOrUpdateSecret(ctx, promEtcdSecret)
 		if err != nil {
 			return errors.Wrap(err, "reconciling prometheus etcd service monitor secret")
 		}
 	} else {
-		err = t.client.DeleteServiceMonitor(sme)
+		err = t.client.DeleteServiceMonitor(ctx, sme)
 		if err != nil {
 			return errors.Wrap(err, "deleting control-plane etcd ServiceMonitor failed")
 		}

--- a/pkg/tasks/kubestatemetrics.go
+++ b/pkg/tasks/kubestatemetrics.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -32,13 +33,13 @@ func NewKubeStateMetricsTask(client *client.Client, factory *manifests.Factory) 
 	}
 }
 
-func (t *KubeStateMetricsTask) Run() error {
+func (t *KubeStateMetricsTask) Run(ctx context.Context) error {
 	sa, err := t.factory.KubeStateMetricsServiceAccount()
 	if err != nil {
 		return errors.Wrap(err, "initializing kube-state-metrics Service failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceAccount(sa)
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
 	if err != nil {
 		return errors.Wrap(err, "reconciling kube-state-metrics ServiceAccount failed")
 	}
@@ -48,7 +49,7 @@ func (t *KubeStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing kube-state-metrics ClusterRole failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRole(cr)
+	err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling kube-state-metrics ClusterRole failed")
 	}
@@ -58,7 +59,7 @@ func (t *KubeStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing kube-state-metrics ClusterRoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+	err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling kube-state-metrics ClusterRoleBinding failed")
 	}
@@ -68,7 +69,7 @@ func (t *KubeStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing kube-state-metrics Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling kube-state-metrics Service failed")
 	}
@@ -78,7 +79,7 @@ func (t *KubeStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing kube-state-metrics Deployment failed")
 	}
 
-	err = t.client.CreateOrUpdateDeployment(dep)
+	err = t.client.CreateOrUpdateDeployment(ctx, dep)
 	if err != nil {
 		return errors.Wrap(err, "reconciling kube-state-metrics Deployment failed")
 	}
@@ -87,7 +88,7 @@ func (t *KubeStateMetricsTask) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "initializing kube-state-metrics rules PrometheusRule failed")
 	}
-	err = t.client.CreateOrUpdatePrometheusRule(pr)
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling kube-state-metrics rules PrometheusRule failed")
 	}
@@ -97,6 +98,6 @@ func (t *KubeStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing kube-state-metrics ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(sm)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, sm)
 	return errors.Wrap(err, "reconciling kube-state-metrics ServiceMonitor failed")
 }

--- a/pkg/tasks/metrics_client_ca.go
+++ b/pkg/tasks/metrics_client_ca.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -22,8 +23,8 @@ func NewMetricsClientCATask(client *client.Client, factory *manifests.Factory) *
 	}
 }
 
-func (t *MetricsClientCATask) Run() error {
-	apiAuthConfigmap, err := t.client.GetConfigmap("kube-system", "extension-apiserver-authentication")
+func (t *MetricsClientCATask) Run(ctx context.Context) error {
+	apiAuthConfigmap, err := t.client.GetConfigmap(ctx, "kube-system", "extension-apiserver-authentication")
 	if err != nil {
 		return errors.Wrap(err, "failed to load kube-system/extension-apiserver-authentication configmap")
 	}
@@ -33,7 +34,7 @@ func (t *MetricsClientCATask) Run() error {
 		return errors.Wrap(err, "initializing Metrics Client CA failed")
 	}
 
-	err = t.client.CreateOrUpdateConfigMap(cm)
+	err = t.client.CreateOrUpdateConfigMap(ctx, cm)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Metrics Client CA ConfigMap failed")
 	}

--- a/pkg/tasks/nodeexporter.go
+++ b/pkg/tasks/nodeexporter.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -32,13 +33,13 @@ func NewNodeExporterTask(client *client.Client, factory *manifests.Factory) *Nod
 	}
 }
 
-func (t *NodeExporterTask) Run() error {
+func (t *NodeExporterTask) Run(ctx context.Context) error {
 	scc, err := t.factory.NodeExporterSecurityContextConstraints()
 	if err != nil {
 		return errors.Wrap(err, "initializing node-exporter SecurityContextConstraints failed")
 	}
 
-	err = t.client.CreateOrUpdateSecurityContextConstraints(scc)
+	err = t.client.CreateOrUpdateSecurityContextConstraints(ctx, scc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling node-exporter SecurityContextConstraints failed")
 	}
@@ -48,7 +49,7 @@ func (t *NodeExporterTask) Run() error {
 		return errors.Wrap(err, "initializing node-exporter Service failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceAccount(sa)
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
 	if err != nil {
 		return errors.Wrap(err, "reconciling node-exporter ServiceAccount failed")
 	}
@@ -58,7 +59,7 @@ func (t *NodeExporterTask) Run() error {
 		return errors.Wrap(err, "initializing node-exporter ClusterRole failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRole(cr)
+	err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling node-exporter ClusterRole failed")
 	}
@@ -68,7 +69,7 @@ func (t *NodeExporterTask) Run() error {
 		return errors.Wrap(err, "initializing node-exporter ClusterRoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+	err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling node-exporter ClusterRoleBinding failed")
 	}
@@ -78,7 +79,7 @@ func (t *NodeExporterTask) Run() error {
 		return errors.Wrap(err, "initializing node-exporter Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling node-exporter Service failed")
 	}
@@ -88,7 +89,7 @@ func (t *NodeExporterTask) Run() error {
 		return errors.Wrap(err, "initializing node-exporter DaemonSet failed")
 	}
 
-	err = t.client.CreateOrUpdateDaemonSet(ds)
+	err = t.client.CreateOrUpdateDaemonSet(ctx, ds)
 	if err != nil {
 		return errors.Wrap(err, "reconciling node-exporter DaemonSet failed")
 	}
@@ -97,7 +98,7 @@ func (t *NodeExporterTask) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "initializing node-exporter rules PrometheusRule failed")
 	}
-	err = t.client.CreateOrUpdatePrometheusRule(pr)
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling node-exporter rules PrometheusRule failed")
 	}
@@ -107,6 +108,6 @@ func (t *NodeExporterTask) Run() error {
 		return errors.Wrap(err, "initializing node-exporter ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(smn)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smn)
 	return errors.Wrap(err, "reconciling node-exporter ServiceMonitor failed")
 }

--- a/pkg/tasks/openshiftstatemetrics.go
+++ b/pkg/tasks/openshiftstatemetrics.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -32,13 +33,13 @@ func NewOpenShiftStateMetricsTask(client *client.Client, factory *manifests.Fact
 	}
 }
 
-func (t *OpenShiftStateMetricsTask) Run() error {
+func (t *OpenShiftStateMetricsTask) Run(ctx context.Context) error {
 	sa, err := t.factory.OpenShiftStateMetricsServiceAccount()
 	if err != nil {
 		return errors.Wrap(err, "initializing openshift-state-metrics Service failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceAccount(sa)
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
 	if err != nil {
 		return errors.Wrap(err, "reconciling openshift-state-metrics ServiceAccount failed")
 	}
@@ -48,7 +49,7 @@ func (t *OpenShiftStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing openshift-state-metrics ClusterRole failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRole(cr)
+	err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling openshift-state-metrics ClusterRole failed")
 	}
@@ -58,7 +59,7 @@ func (t *OpenShiftStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing openshift-state-metrics ClusterRoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+	err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling openshift-state-metrics ClusterRoleBinding failed")
 	}
@@ -68,7 +69,7 @@ func (t *OpenShiftStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing openshift-state-metrics Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling openshift-state-metrics Service failed")
 	}
@@ -78,7 +79,7 @@ func (t *OpenShiftStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing openshift-state-metrics Deployment failed")
 	}
 
-	err = t.client.CreateOrUpdateDeployment(dep)
+	err = t.client.CreateOrUpdateDeployment(ctx, dep)
 	if err != nil {
 		return errors.Wrap(err, "reconciling openshift-state-metrics Deployment failed")
 	}
@@ -88,6 +89,6 @@ func (t *OpenShiftStateMetricsTask) Run() error {
 		return errors.Wrap(err, "initializing openshift-state-metrics ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(sm)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, sm)
 	return errors.Wrap(err, "reconciling openshift-state-metrics ServiceMonitor failed")
 }

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -49,7 +49,7 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "creating serving certs CA Bundle ConfigMap failed")
 	}
 
-	kscm, err := t.client.GetConfigmap(ctx,"openshift-config-managed", "kubelet-serving-ca")
+	kscm, err := t.client.GetConfigmap(ctx, "openshift-config-managed", "kubelet-serving-ca")
 	if err != nil {
 		return errors.Wrap(err, "openshift-config-managed/kubelet-serving-ca")
 	}

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -256,7 +256,7 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Metrics Client Certs secret failed")
 	}
 
-	metricsCerts, err = t.client.WaitForSecret(metricsCerts)
+	metricsCerts, err = t.client.WaitForSecret(ctx, metricsCerts)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Metrics Client Certs secret failed")
 	}

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
@@ -37,18 +38,18 @@ func NewPrometheusTask(client *client.Client, factory *manifests.Factory, config
 	}
 }
 
-func (t *PrometheusTask) Run() error {
+func (t *PrometheusTask) Run(ctx context.Context) error {
 	cacm, err := t.factory.PrometheusK8sServingCertsCABundle()
 	if err != nil {
 		return errors.Wrap(err, "initializing serving certs CA Bundle ConfigMap failed")
 	}
 
-	_, err = t.client.CreateIfNotExistConfigMap(cacm)
+	_, err = t.client.CreateIfNotExistConfigMap(ctx, cacm)
 	if err != nil {
 		return errors.Wrap(err, "creating serving certs CA Bundle ConfigMap failed")
 	}
 
-	kscm, err := t.client.GetConfigmap("openshift-config-managed", "kubelet-serving-ca")
+	kscm, err := t.client.GetConfigmap(ctx,"openshift-config-managed", "kubelet-serving-ca")
 	if err != nil {
 		return errors.Wrap(err, "openshift-config-managed/kubelet-serving-ca")
 	}
@@ -58,7 +59,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing kubelet serving CA Bundle ConfigMap failed")
 	}
 
-	err = t.client.CreateOrUpdateConfigMap(cacm)
+	err = t.client.CreateOrUpdateConfigMap(ctx, cacm)
 	if err != nil {
 		return errors.Wrap(err, "creating kubelet serving CA Bundle ConfigMap failed")
 	}
@@ -68,12 +69,12 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Route failed")
 	}
 
-	err = t.client.CreateRouteIfNotExists(r)
+	err = t.client.CreateRouteIfNotExists(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "creating Prometheus Route failed")
 	}
 
-	host, err := t.client.WaitForRouteReady(r)
+	host, err := t.client.WaitForRouteReady(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Prometheus Route to become ready failed")
 	}
@@ -83,7 +84,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus proxy Secret failed")
 	}
 
-	err = t.client.CreateIfNotExistSecret(ps)
+	err = t.client.CreateIfNotExistSecret(ctx, ps)
 	if err != nil {
 		return errors.Wrap(err, "creating Prometheus proxy Secret failed")
 	}
@@ -95,7 +96,7 @@ func (t *PrometheusTask) Run() error {
 			return errors.Wrap(err, "initializing Grafana Datasources Secret failed")
 		}
 
-		gs, err = t.client.WaitForSecret(gs)
+		gs, err = t.client.WaitForSecret(ctx, gs)
 		if err != nil {
 			return errors.Wrap(err, "waiting for Grafana Datasources Secret failed")
 		}
@@ -113,7 +114,7 @@ func (t *PrometheusTask) Run() error {
 			return errors.Wrap(err, "initializing Prometheus htpasswd Secret failed")
 		}
 
-		err = t.client.CreateOrUpdateSecret(htpasswdSecret)
+		err = t.client.CreateOrUpdateSecret(ctx, htpasswdSecret)
 		if err != nil {
 			return errors.Wrap(err, "creating Prometheus htpasswd Secret failed")
 		}
@@ -124,7 +125,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus RBAC proxy Secret failed")
 	}
 
-	err = t.client.CreateIfNotExistSecret(rs)
+	err = t.client.CreateIfNotExistSecret(ctx, rs)
 	if err != nil {
 		return errors.Wrap(err, "creating Prometheus RBAC proxy Secret failed")
 	}
@@ -134,7 +135,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus ServiceAccount failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceAccount(sa)
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus ServiceAccount failed")
 	}
@@ -144,7 +145,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus ClusterRole failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRole(cr)
+	err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus ClusterRole failed")
 	}
@@ -154,7 +155,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus ClusterRoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+	err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus ClusterRoleBinding failed")
 	}
@@ -164,7 +165,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Alertmanager RoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateRoleBinding(amrb)
+	err = t.client.CreateOrUpdateRoleBinding(ctx, amrb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Alertmanager RoleBinding failed")
 	}
@@ -174,7 +175,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Role config failed")
 	}
 
-	err = t.client.CreateOrUpdateRole(rc)
+	err = t.client.CreateOrUpdateRole(ctx, rc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Role config failed")
 	}
@@ -185,7 +186,7 @@ func (t *PrometheusTask) Run() error {
 	}
 
 	for _, r := range rl.Items {
-		err = t.client.CreateOrUpdateRole(&r)
+		err = t.client.CreateOrUpdateRole(ctx, &r)
 		if err != nil {
 			return errors.Wrapf(err, "reconciling Prometheus Role %q failed", r.Name)
 		}
@@ -197,7 +198,7 @@ func (t *PrometheusTask) Run() error {
 	}
 
 	for _, rb := range rbl.Items {
-		err = t.client.CreateOrUpdateRoleBinding(&rb)
+		err = t.client.CreateOrUpdateRoleBinding(ctx, &rb)
 		if err != nil {
 			return errors.Wrapf(err, "reconciling Prometheus RoleBinding %q failed", rb.Name)
 		}
@@ -208,13 +209,13 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus config RoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateRoleBinding(rbc)
+	err = t.client.CreateOrUpdateRoleBinding(ctx, rbc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus config RoleBinding failed")
 	}
 
 	// TODO(paulfantom): Can be removed after OpenShift 4.7 and earlier are no longer supported
-	err = t.client.DeletePrometheusRuleByNamespaceAndName(t.client.Namespace(), "prometheus-k8s-rules")
+	err = t.client.DeletePrometheusRuleByNamespaceAndName(ctx, t.client.Namespace(), "prometheus-k8s-rules")
 	if err != nil {
 		return errors.Wrap(err, "removing old Prometheus rules PrometheusRule failed")
 	}
@@ -224,7 +225,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus rules PrometheusRule failed")
 	}
 
-	err = t.client.CreateOrUpdatePrometheusRule(pm)
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pm)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus rules PrometheusRule failed")
 	}
@@ -234,7 +235,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Service failed")
 	}
@@ -244,7 +245,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Thanos sidecar Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Thanos sidecar Service failed")
 	}
@@ -265,7 +266,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus GRPC secret failed")
 	}
 
-	grpcTLS, err = t.client.WaitForSecret(grpcTLS)
+	grpcTLS, err = t.client.WaitForSecret(ctx, grpcTLS)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Prometheus GRPC secret failed")
 	}
@@ -284,12 +285,13 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "error hashing Prometheus Client GRPC TLS secret")
 	}
 
-	err = t.client.CreateOrUpdateSecret(s)
+	err = t.client.CreateOrUpdateSecret(ctx, s)
 	if err != nil {
 		return errors.Wrap(err, "error creating Prometheus Client GRPC TLS secret")
 	}
 
 	err = t.client.DeleteHashedSecret(
+		ctx,
 		s.GetNamespace(),
 		"prometheus-k8s-grpc-tls",
 		string(s.Labels["monitoring.openshift.io/hash"]),
@@ -310,7 +312,7 @@ func (t *PrometheusTask) Run() error {
 			factory: t.factory,
 			prefix:  "prometheus",
 		}
-		trustedCA, err = cbs.syncTrustedCABundle(trustedCA)
+		trustedCA, err = cbs.syncTrustedCABundle(ctx, trustedCA)
 		if err != nil {
 			return errors.Wrap(err, "syncing Prometheus trusted CA bundle ConfigMap failed")
 		}
@@ -319,8 +321,9 @@ func (t *PrometheusTask) Run() error {
 		if err != nil {
 			return errors.Wrap(err, "initializing Prometheus additionalAlertmanagerConfigs secret failed")
 		}
+
 		klog.V(4).Info("reconciling Prometheus additionalAlertmanagerConfigs secret")
-		if err = t.client.CreateOrUpdateSecret(secret); err != nil {
+		if err = t.client.CreateOrUpdateSecret(ctx, secret); err != nil {
 			return errors.Wrap(err, "reconciling Prometheus additionalAlertmanagerConfigs secret failed")
 		}
 
@@ -331,13 +334,13 @@ func (t *PrometheusTask) Run() error {
 		}
 
 		klog.V(4).Info("reconciling Prometheus object")
-		err = t.client.CreateOrUpdatePrometheus(p)
+		err = t.client.CreateOrUpdatePrometheus(ctx, p)
 		if err != nil {
 			return errors.Wrap(err, "reconciling Prometheus object failed")
 		}
 
 		klog.V(4).Info("waiting for Prometheus object changes")
-		err = t.client.WaitForPrometheus(p)
+		err = t.client.WaitForPrometheus(ctx, p)
 		if err != nil {
 			return errors.Wrap(err, "waiting for Prometheus object changes failed")
 		}
@@ -348,7 +351,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Prometheus ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(smp)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smp)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Prometheus ServiceMonitor failed")
 	}
@@ -358,7 +361,7 @@ func (t *PrometheusTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Thanos sidecar ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(smt)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smt)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Thanos sidecar ServiceMonitor failed")
 	}
@@ -375,7 +378,7 @@ func (t *PrometheusTask) Run() error {
 	}
 
 	for _, name := range deprecatedServiceMonitors {
-		err := t.client.DeleteServiceMonitorByNamespaceAndName(t.client.Namespace(), name)
+		err := t.client.DeleteServiceMonitorByNamespaceAndName(ctx, t.client.Namespace(), name)
 		if err != nil {
 			return errors.Wrapf(err, "deleting Prometheus %s ServiceMonitor failed", name)
 		}

--- a/pkg/tasks/prometheusadapter.go
+++ b/pkg/tasks/prometheusadapter.go
@@ -25,14 +25,14 @@ func NewPrometheusAdapterTask(ctx context.Context, namespace string, client *cli
 	}
 }
 
-func (t *PrometheusAdapterTask) Run() error {
+func (t *PrometheusAdapterTask) Run(ctx context.Context) error {
 	{
 		cr, err := t.factory.PrometheusAdapterClusterRole()
 		if err != nil {
 			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRole failed")
 		}
 
-		err = t.client.CreateOrUpdateClusterRole(cr)
+		err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ClusterRole failed")
 		}
@@ -43,7 +43,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRole for server resources failed")
 		}
 
-		err = t.client.CreateOrUpdateClusterRole(cr)
+		err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ClusterRole for server resources failed")
 		}
@@ -54,7 +54,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRole aggregating resource metrics read permissions failed")
 		}
 
-		err = t.client.CreateOrUpdateClusterRole(cr)
+		err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ClusterRole aggregating resource metrics read permissions failed")
 		}
@@ -65,7 +65,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRoleBinding failed")
 		}
 
-		err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+		err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ClusterRoleBinding failed")
 		}
@@ -76,7 +76,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRoleBinding for delegator failed")
 		}
 
-		err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+		err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ClusterRoleBinding for delegator failed")
 		}
@@ -87,7 +87,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRoleBinding for view failed")
 		}
 
-		err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+		err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ClusterRoleBinding for view failed")
 		}
@@ -98,7 +98,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter RoleBinding for auth-reader failed")
 		}
 
-		err = t.client.CreateOrUpdateRoleBinding(rb)
+		err = t.client.CreateOrUpdateRoleBinding(ctx, rb)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter RoleBinding for auth-reader failed")
 		}
@@ -109,7 +109,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ServiceAccount failed")
 		}
 
-		err = t.client.CreateOrUpdateServiceAccount(sa)
+		err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ServiceAccount failed")
 		}
@@ -120,7 +120,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ConfigMap failed")
 		}
 
-		err = t.client.CreateOrUpdateConfigMap(cm)
+		err = t.client.CreateOrUpdateConfigMap(ctx, cm)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ConfigMap failed")
 		}
@@ -131,7 +131,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ConfigMap for Prometheus failed")
 		}
 
-		err = t.client.CreateOrUpdateConfigMap(cm)
+		err = t.client.CreateOrUpdateConfigMap(ctx, cm)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ConfigMap for Prometheus failed")
 		}
@@ -142,18 +142,18 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter Service failed")
 		}
 
-		err = t.client.CreateOrUpdateService(s)
+		err = t.client.CreateOrUpdateService(ctx, s)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter Service failed")
 		}
 	}
 	{
-		tlsSecret, err := t.client.GetSecret(t.namespace, "prometheus-adapter-tls")
+		tlsSecret, err := t.client.GetSecret(ctx, t.namespace, "prometheus-adapter-tls")
 		if err != nil {
 			return errors.Wrap(err, "failed to load prometheus-adapter-tls secret")
 		}
 
-		apiAuthConfigmap, err := t.client.GetConfigmap("kube-system", "extension-apiserver-authentication")
+		apiAuthConfigmap, err := t.client.GetConfigmap(ctx, "kube-system", "extension-apiserver-authentication")
 		if err != nil {
 			return errors.Wrap(err, "failed to load kube-system/extension-apiserver-authentication configmap")
 		}
@@ -168,7 +168,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "deleting old prometheus adapter secrets failed")
 		}
 
-		err = t.client.CreateOrUpdateSecret(secret)
+		err = t.client.CreateOrUpdateSecret(ctx, secret)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter Secret failed")
 		}
@@ -178,7 +178,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter Deployment failed")
 		}
 
-		err = t.client.CreateOrUpdateDeployment(dep)
+		err = t.client.CreateOrUpdateDeployment(ctx, dep)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter Deployment failed")
 		}
@@ -190,7 +190,7 @@ func (t *PrometheusAdapterTask) Run() error {
 		}
 
 		if pdb != nil {
-			err = t.client.CreateOrUpdatePodDisruptionBudget(pdb)
+			err = t.client.CreateOrUpdatePodDisruptionBudget(ctx, pdb)
 			if err != nil {
 				return errors.Wrap(err, "reconciling PrometheusAdapter PodDisruptionBudget failed")
 			}
@@ -202,7 +202,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter ServiceMonitor failed")
 		}
 
-		err = t.client.CreateOrUpdateServiceMonitor(sm)
+		err = t.client.CreateOrUpdateServiceMonitor(ctx, sm)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter ServiceMonitor failed")
 		}
@@ -213,7 +213,7 @@ func (t *PrometheusAdapterTask) Run() error {
 			return errors.Wrap(err, "initializing PrometheusAdapter APIService failed")
 		}
 
-		err = t.client.CreateOrUpdateAPIService(api)
+		err = t.client.CreateOrUpdateAPIService(ctx, api)
 		if err != nil {
 			return errors.Wrap(err, "reconciling PrometheusAdapter APIService failed")
 		}

--- a/pkg/tasks/prometheusoperator.go
+++ b/pkg/tasks/prometheusoperator.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -32,13 +33,13 @@ func NewPrometheusOperatorTask(client *client.Client, factory *manifests.Factory
 	}
 }
 
-func (t *PrometheusOperatorTask) Run() error {
+func (t *PrometheusOperatorTask) Run(ctx context.Context) error {
 	cacm, err := t.factory.PrometheusOperatorCertsCABundle()
 	if err != nil {
 		return errors.Wrap(err, "initializing serving certs CA Bundle ConfigMap failed")
 	}
 
-	_, err = t.client.CreateIfNotExistConfigMap(cacm)
+	_, err = t.client.CreateIfNotExistConfigMap(ctx, cacm)
 	if err != nil {
 		return errors.Wrap(err, "creating serving certs CA Bundle ConfigMap failed")
 	}
@@ -48,7 +49,7 @@ func (t *PrometheusOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Operator ServiceAccount failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceAccount(sa)
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Operator ServiceAccount failed")
 	}
@@ -58,7 +59,7 @@ func (t *PrometheusOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Operator ClusterRole failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRole(cr)
+	err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Operator ClusterRole failed")
 	}
@@ -68,7 +69,7 @@ func (t *PrometheusOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Operator ClusterRoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+	err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Operator ClusterRoleBinding failed")
 	}
@@ -78,7 +79,7 @@ func (t *PrometheusOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Operator Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Operator Service failed")
 	}
@@ -88,12 +89,12 @@ func (t *PrometheusOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Operator Deployment failed")
 	}
 
-	err = t.client.CreateOrUpdateDeployment(d)
+	err = t.client.CreateOrUpdateDeployment(ctx, d)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Operator Deployment failed")
 	}
 
-	err = t.client.AssurePrometheusOperatorCRsExist()
+	err = t.client.AssurePrometheusOperatorCRsExist(ctx)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Prometheus Operator CRs to become available failed")
 	}
@@ -103,7 +104,7 @@ func (t *PrometheusOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Rule Validating Webhook failed")
 	}
 
-	err = t.client.CreateOrUpdateValidatingWebhookConfiguration(w)
+	err = t.client.CreateOrUpdateValidatingWebhookConfiguration(ctx, w)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Rule Validating Webhook failed")
 	}
@@ -112,7 +113,7 @@ func (t *PrometheusOperatorTask) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "initializing prometheus-operator rules PrometheusRule failed")
 	}
-	err = t.client.CreateOrUpdatePrometheusRule(pr)
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling prometheus-operator rules PrometheusRule failed")
 	}
@@ -122,6 +123,6 @@ func (t *PrometheusOperatorTask) Run() error {
 		return errors.Wrap(err, "initializing Prometheus Operator ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(smpo)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smpo)
 	return errors.Wrap(err, "reconciling Prometheus Operator ServiceMonitor failed")
 }

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -15,6 +15,7 @@
 package tasks
 
 import (
+	"context"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 
@@ -35,21 +36,21 @@ func NewPrometheusOperatorUserWorkloadTask(client *client.Client, factory *manif
 	}
 }
 
-func (t *PrometheusOperatorUserWorkloadTask) Run() error {
+func (t *PrometheusOperatorUserWorkloadTask) Run(ctx context.Context) error {
 	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
-		return t.create()
+		return t.create(ctx)
 	}
 
-	return t.destroy()
+	return t.destroy(ctx)
 }
 
-func (t *PrometheusOperatorUserWorkloadTask) create() error {
+func (t *PrometheusOperatorUserWorkloadTask) create(ctx context.Context) error {
 	sa, err := t.factory.PrometheusOperatorUserWorkloadServiceAccount()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ServiceAccount failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceAccount(sa)
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
 	if err != nil {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator ServiceAccount failed")
 	}
@@ -59,7 +60,7 @@ func (t *PrometheusOperatorUserWorkloadTask) create() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ClusterRole failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRole(cr)
+	err = t.client.CreateOrUpdateClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator ClusterRole failed")
 	}
@@ -69,7 +70,7 @@ func (t *PrometheusOperatorUserWorkloadTask) create() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ClusterRoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateClusterRoleBinding(crb)
+	err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator ClusterRoleBinding failed")
 	}
@@ -79,7 +80,7 @@ func (t *PrometheusOperatorUserWorkloadTask) create() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator Service failed")
 	}
 
-	err = t.client.CreateOrUpdateService(svc)
+	err = t.client.CreateOrUpdateService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator Service failed")
 	}
@@ -89,7 +90,7 @@ func (t *PrometheusOperatorUserWorkloadTask) create() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator Deployment failed")
 	}
 
-	err = t.client.CreateOrUpdateDeployment(d)
+	err = t.client.CreateOrUpdateDeployment(ctx, d)
 	if err != nil {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator Deployment failed")
 	}
@@ -99,14 +100,14 @@ func (t *PrometheusOperatorUserWorkloadTask) create() error {
 		return errors.Wrap(err, "initializing UserWorkload Alertmanager Role Binding failed")
 	}
 
-	err = t.client.CreateOrUpdateRoleBinding(arb)
+	err = t.client.CreateOrUpdateRoleBinding(ctx, arb)
 	if err != nil {
 		return errors.Wrap(err, "reconciling UserWorkload Alertmanager Role Binding failed")
 	}
 
 	// The CRs will be created externally,
 	// but we still have to wait for them here.
-	err = t.client.AssurePrometheusOperatorCRsExist()
+	err = t.client.AssurePrometheusOperatorCRsExist(ctx)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Prometheus Operator CRs to become available failed")
 	}
@@ -116,17 +117,17 @@ func (t *PrometheusOperatorUserWorkloadTask) create() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ServiceMonitor failed")
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(smpo)
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smpo)
 	return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator ServiceMonitor failed")
 }
 
-func (t *PrometheusOperatorUserWorkloadTask) destroy() error {
+func (t *PrometheusOperatorUserWorkloadTask) destroy(ctx context.Context) error {
 	dep, err := t.factory.PrometheusOperatorUserWorkloadDeployment()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator Deployment failed")
 	}
 
-	err = t.client.DeleteDeployment(dep)
+	err = t.client.DeleteDeployment(ctx, dep)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus Operator Deployment failed")
 	}
@@ -136,7 +137,7 @@ func (t *PrometheusOperatorUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ServiceMonitor failed")
 	}
 
-	err = t.client.DeleteServiceMonitor(sm)
+	err = t.client.DeleteServiceMonitor(ctx, sm)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus Operator ServiceMonitor failed")
 	}
@@ -146,7 +147,7 @@ func (t *PrometheusOperatorUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator Service failed")
 	}
 
-	err = t.client.DeleteService(svc)
+	err = t.client.DeleteService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus Operator Service failed")
 	}
@@ -156,7 +157,7 @@ func (t *PrometheusOperatorUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ClusterRoleBinding failed")
 	}
 
-	err = t.client.DeleteClusterRoleBinding(crb)
+	err = t.client.DeleteClusterRoleBinding(ctx, crb)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus Operator ClusterRoleBinding failed")
 	}
@@ -166,7 +167,7 @@ func (t *PrometheusOperatorUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "initializing UserWorkload Alertmanager Role Binding failed")
 	}
 
-	err = t.client.DeleteRoleBinding(arb)
+	err = t.client.DeleteRoleBinding(ctx, arb)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Alertmanager Role Binding failed")
 	}
@@ -176,7 +177,7 @@ func (t *PrometheusOperatorUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ClusterRole failed")
 	}
 
-	err = t.client.DeleteClusterRole(cr)
+	err = t.client.DeleteClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus Operator ClusterRoleBinding failed")
 	}
@@ -186,6 +187,6 @@ func (t *PrometheusOperatorUserWorkloadTask) destroy() error {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ServiceAccount failed")
 	}
 
-	err = t.client.DeleteServiceAccount(sa)
+	err = t.client.DeleteServiceAccount(ctx, sa)
 	return errors.Wrap(err, "deleting Telemeter client ServiceAccount failed")
 }

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -44,8 +44,8 @@ type PrometheusClient struct {
 
 // NewPrometheusClientFromRoute creates and returns a new PrometheusClient from the given OpenShift route.
 func NewPrometheusClientFromRoute(
-	routeClient routev1.RouteV1Interface,
 	ctx context.Context,
+	routeClient routev1.RouteV1Interface,
 	namespace, name string,
 	token string,
 ) (*PrometheusClient, error) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -150,8 +150,8 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 
 	// Prometheus client depends on setup above.
 	f.ThanosQuerierClient, err = NewPrometheusClientFromRoute(
-		openshiftRouteClient,
 		ctx,
+		openshiftRouteClient,
 		namespaceName, "thanos-querier",
 		token,
 	)
@@ -160,8 +160,8 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 	}
 
 	f.PrometheusK8sClient, err = NewPrometheusClientFromRoute(
-		openshiftRouteClient,
 		ctx,
+		openshiftRouteClient,
 		namespaceName, "prometheus-k8s",
 		token,
 	)
@@ -170,8 +170,8 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 	}
 
 	f.AlertmanagerClient, err = NewPrometheusClientFromRoute(
-		openshiftRouteClient,
 		ctx,
+		openshiftRouteClient,
 		namespaceName, "alertmanager-main",
 		token,
 	)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -42,6 +43,7 @@ func TestMain(m *testing.M) {
 // `os.Exit` does not honor `defer` statements. For more details see:
 // http://blog.englund.nu/golang,/testing/2017/03/12/using-defer-in-testmain.html
 func testMain(m *testing.M) error {
+	ctx := context.Background()
 	kubeConfigPath := flag.String(
 		"kubeconfig",
 		clientcmd.RecommendedHomeFile,
@@ -65,7 +67,7 @@ func testMain(m *testing.M) error {
 
 	// Wait for Prometheus operator.
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(f.Ctx, "prometheus-operator", metav1.GetOptions{})
+		_, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(ctx, "prometheus-operator", metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -28,8 +29,9 @@ import (
 )
 
 func TestMultinamespacePrometheusRule(t *testing.T) {
-	t.Parallel()
+	ctx := context.Background()
 
+	t.Parallel()
 	nsName := "openshift-test-prometheus-rules" + strconv.FormatInt(time.Now().Unix(), 36)
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -39,13 +41,14 @@ func TestMultinamespacePrometheusRule(t *testing.T) {
 			},
 		},
 	}
-	_, err := f.KubeClient.CoreV1().Namespaces().Create(f.Ctx, ns, metav1.CreateOptions{})
+	_, err := f.KubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.OperatorClient.DeleteIfExists(nsName)
 
-	err = f.OperatorClient.CreateOrUpdatePrometheusRule(&monv1.PrometheusRule{
+	defer f.OperatorClient.DeleteIfExists(ctx, nsName)
+
+	err = f.OperatorClient.CreateOrUpdatePrometheusRule(ctx, &monv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "non-monitoring-prometheus-rules",
 			Namespace: nsName,

--- a/test/e2e/priority_class_test.go
+++ b/test/e2e/priority_class_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,17 +27,19 @@ import (
 // system-cluster-critical   2000000000   false            114m
 // system-node-critical      2000001000   false            114m
 func TestToEnsureUserPriorityClassIsPresentAndLower(t *testing.T) {
+	ctx := context.Background()
+
 	// Get system priority class values.
-	systemClusterPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(f.Ctx, "system-cluster-critical", v1.GetOptions{})
+	systemClusterPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(ctx, "system-cluster-critical", v1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	systemNodePriorityClass, err := f.SchedulingClient.PriorityClasses().Get(f.Ctx, "system-node-critical", v1.GetOptions{})
+	systemNodePriorityClass, err := f.SchedulingClient.PriorityClasses().Get(ctx, "system-node-critical", v1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Get our user priority class value.
-	userPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(f.Ctx, "openshift-user-critical", v1.GetOptions{})
+	userPriorityClass, err := f.SchedulingClient.PriorityClasses().Get(ctx, "openshift-user-critical", v1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -52,7 +53,8 @@ func TestPrometheusMetrics(t *testing.T) {
 }
 
 func TestPrometheusAlertmanagerAntiAffinity(t *testing.T) {
-	pods, err := f.KubeClient.CoreV1().Pods(f.Ns).List(f.Ctx, metav1.ListOptions{FieldSelector: "status.phase=Running"})
+	ctx := context.Background()
+	pods, err := f.KubeClient.CoreV1().Pods(f.Ns).List(ctx, metav1.ListOptions{FieldSelector: "status.phase=Running"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/thanos_querier_test.go
+++ b/test/e2e/thanos_querier_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 )
 
 func TestThanosQuerierTrustedCA(t *testing.T) {
+	ctx := context.Background()
 	var (
 		factory = manifests.NewFactory("openshift-monitoring", "", nil, nil, nil, manifests.NewAssets(assetsPath))
 		newCM   *v1.ConfigMap
@@ -35,7 +37,7 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 
 	// Wait for the new ConfigMap to be created
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		cm, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(f.Ctx, "thanos-querier-trusted-ca-bundle", metav1.GetOptions{})
+		cm, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(ctx, "thanos-querier-trusted-ca-bundle", metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting new trusted CA ConfigMap failed")
 		if err != nil {
 			return false, nil
@@ -58,7 +60,7 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 
 	// Wait for the new hashed trusted CA bundle ConfigMap to be created
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(f.Ctx, newCM.Name, metav1.GetOptions{})
+		_, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(ctx, newCM.Name, metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting new CA ConfigMap failed")
 		if err != nil {
 			return false, nil
@@ -74,7 +76,7 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 
 	// Get Thanos Querier Deployment and make sure it has a volume mounted.
 	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		ss, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(f.Ctx, "thanos-querier", metav1.GetOptions{})
+		ss, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(ctx, "thanos-querier", metav1.GetOptions{})
 		lastErr = errors.Wrap(err, "getting Thanos Querier deployment failed")
 		if err != nil {
 			return false, nil

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestUserWorkloadThanosRulerWithAdditionalAlertmanagers(t *testing.T) {
+	ctx := context.Background()
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterMonitorConfigMapName,
@@ -64,11 +65,11 @@ func TestUserWorkloadThanosRulerWithAdditionalAlertmanagers(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			if err := f.OperatorClient.CreateOrUpdateConfigMap(cm); err != nil {
+			if err := f.OperatorClient.CreateOrUpdateConfigMap(ctx, cm); err != nil {
 				t.Fatal(err)
 			}
 
-			if err := f.OperatorClient.CreateOrUpdateConfigMap(uwmCM); err != nil {
+			if err := f.OperatorClient.CreateOrUpdateConfigMap(ctx, uwmCM); err != nil {
 				t.Fatal(err)
 			}
 
@@ -80,6 +81,7 @@ func TestUserWorkloadThanosRulerWithAdditionalAlertmanagers(t *testing.T) {
 }
 
 func createAlertmanager(t *testing.T) {
+	ctx := context.Background()
 	replicas := int32(1)
 	additionalAlertmanager := monitoringv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{
@@ -90,17 +92,18 @@ func createAlertmanager(t *testing.T) {
 			Replicas: &replicas,
 		},
 	}
-	if err := f.OperatorClient.CreateOrUpdateAlertmanager(&additionalAlertmanager); err != nil {
+	if err := f.OperatorClient.CreateOrUpdateAlertmanager(ctx, &additionalAlertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := f.OperatorClient.WaitForAlertmanager(&additionalAlertmanager); err != nil {
+	if err := f.OperatorClient.WaitForAlertmanager(ctx, &additionalAlertmanager); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func createPrometheusRule(t *testing.T) {
-	if err := f.OperatorClient.CreateOrUpdatePrometheusRule(&monitoringv1.PrometheusRule{
+	ctx := context.Background()
+	if err := f.OperatorClient.CreateOrUpdatePrometheusRule(ctx, &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "non-monitoring-prometheus-rules",
 			Namespace: "default",

--- a/test/e2e/validatingwebhook_test.go
+++ b/test/e2e/validatingwebhook_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 
 	yaml "github.com/ghodss/yaml"
@@ -55,7 +56,9 @@ spec:
 )
 
 func TestPrometheusRuleValidatingWebhook(t *testing.T) {
-	_, err := f.AdmissionClient.ValidatingWebhookConfigurations().Get(f.Ctx, webhookName, metav1.GetOptions{})
+	ctx := context.Background()
+
+	_, err := f.AdmissionClient.ValidatingWebhookConfigurations().Get(ctx, webhookName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("unable to get prometheus rules validating webhook", err)
 	}
@@ -65,7 +68,7 @@ func TestPrometheusRuleValidatingWebhook(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to unmarshal prometheus rule", err)
 	}
-	_, err = f.MonitoringClient.PrometheusRules(f.Ns).Create(f.Ctx, &validPromRule, metav1.CreateOptions{})
+	_, err = f.MonitoringClient.PrometheusRules(f.Ns).Create(ctx, &validPromRule, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("unable to create prometheus rule", err)
 	}
@@ -75,7 +78,7 @@ func TestPrometheusRuleValidatingWebhook(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to unmarshal prometheus rule", err)
 	}
-	_, err = f.MonitoringClient.PrometheusRules(f.Ns).Create(f.Ctx, &invalidPromRule, metav1.CreateOptions{})
+	_, err = f.MonitoringClient.PrometheusRules(f.Ns).Create(ctx, &invalidPromRule, metav1.CreateOptions{})
 	if err == nil {
 		t.Fatal("invalid rule was accepted by validatingwebhook")
 	}


### PR DESCRIPTION
Following the discussion in slack we need to remove context from struct field. Removing the context from struct field and passing it as first argument to functions that require it

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
