### PR TITLE
MON-1749: Allow users to disable the local Alertmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1291](https://github.com/openshift/cluster-monitoring-operator/pull/1291) Drop high caredinality cAdvisor metrics via [kube-prometheus #1250](https://github.com/prometheus-operator/kube-prometheus/pull/1250)
 - [#1270](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Show a message in the degraded condition when Platform Monitoring Prometheus runs without persistent storage.
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Allow configuring additional Alertmanagers in User Workload Prometheus and Thanos Ruler.
+- [#1293](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Allow disabling the local Alertmanager.
 
 ## 4.8
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -343,6 +343,16 @@ func (c *Client) CreateOrUpdateAlertmanager(ctx context.Context, a *monv1.Alertm
 	return errors.Wrap(err, "updating Alertmanager object failed")
 }
 
+func (c *Client) DeleteAlertmanager(ctx context.Context, a *monv1.Alertmanager) error {
+	aclient := c.mclient.MonitoringV1().Alertmanagers(a.GetNamespace())
+	err := aclient.Delete(ctx, a.GetName(), metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
+}
+
 func (c *Client) CreateOrUpdateThanosRuler(ctx context.Context, t *monv1.ThanosRuler) error {
 	trclient := c.mclient.MonitoringV1().ThanosRulers(t.GetNamespace())
 	existing, err := trclient.Get(ctx, t.GetName(), metav1.GetOptions{})

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -180,11 +180,16 @@ type TLSConfig struct {
 }
 
 type AlertmanagerMainConfig struct {
+	Enabled             *bool                                `json:"enabled"`
 	LogLevel            string                               `json:"logLevel"`
 	NodeSelector        map[string]string                    `json:"nodeSelector"`
 	Tolerations         []v1.Toleration                      `json:"tolerations"`
 	Resources           *v1.ResourceRequirements             `json:"resources"`
 	VolumeClaimTemplate *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+}
+
+func (a AlertmanagerMainConfig) IsEnabled() bool {
+	return a.Enabled == nil || *a.Enabled
 }
 
 type ThanosRulerConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1054,8 +1054,13 @@ func (f *Factory) ThanosRulerAlertmanagerConfigSecret() (*v1.Secret, error) {
 	}
 	s.Namespace = f.namespaceUserWorkload
 
+	alertmanagerEnabled := f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.IsEnabled()
 	amConfigs := f.config.GetThanosRulerAlertmanagerConfigs()
-	if amConfigs == nil {
+	if amConfigs == nil && alertmanagerEnabled {
+		return s, nil
+	}
+	if amConfigs == nil && !alertmanagerEnabled {
+		s.StringData["alertmanagers.yaml"] = `alertmanagers: []`
 		return s, nil
 	}
 
@@ -1065,7 +1070,11 @@ func (f *Factory) ThanosRulerAlertmanagerConfigSecret() (*v1.Secret, error) {
 		return nil, err
 	}
 
-	s.StringData["alertmanagers.yaml"] += "\n" + string(additionalConfig)
+	if alertmanagerEnabled {
+		s.StringData["alertmanagers.yaml"] += "\n" + string(additionalConfig)
+	} else {
+		s.StringData["alertmanagers.yaml"] = `alertmanagers:` + "\n" + string(additionalConfig)
+	}
 
 	return s, nil
 }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1056,11 +1056,10 @@ func (f *Factory) ThanosRulerAlertmanagerConfigSecret() (*v1.Secret, error) {
 
 	alertmanagerEnabled := f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.IsEnabled()
 	amConfigs := f.config.GetThanosRulerAlertmanagerConfigs()
-	if amConfigs == nil && alertmanagerEnabled {
-		return s, nil
-	}
-	if amConfigs == nil && !alertmanagerEnabled {
-		s.StringData["alertmanagers.yaml"] = `alertmanagers: []`
+	if amConfigs == nil {
+		if !alertmanagerEnabled {
+			s.StringData["alertmanagers.yaml"] = `alertmanagers: []`
+		}
 		return s, nil
 	}
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1288,6 +1288,12 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		expected string
 	}{
 		{
+			name:   "no config with alertmanager disabled",
+			config: `alertmanagerMain:
+  enabled: false`,
+			expected: `alertmanagers: []`,
+		},
+		{
 			name:   "no config",
 			config: ``,
 			expected: `"alertmanagers":
@@ -1319,6 +1325,23 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
   "scheme": "https"
   "static_configs":
   - "dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc"
+- static_configs:
+  - alertmanager1-remote.com
+  - alertmanager1-remotex.com
+`,
+		},
+		{
+			name: "basic config with alertmanager disabled",
+			config:
+`thanosRuler:
+  additionalAlertmanagerConfigs:
+  - staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+alertmanagerMain:
+  enabled: false
+`,
+			expected: `alertmanagers:
 - static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com
@@ -1512,7 +1535,10 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewDefaultConfig()
+			c, err := NewConfigFromString(tt.config)
+			if err != nil {
+				t.Fatal(err)
+			}
 			uwc, err := NewUserConfigFromString(tt.config)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -523,7 +523,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 				tasks.NewTaskSpec("Updating Grafana", tasks.NewGrafanaTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Prometheus-k8s", tasks.NewPrometheusTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Prometheus-user-workload", tasks.NewPrometheusUserWorkloadTask(o.client, factory, config)),
-				tasks.NewTaskSpec("Updating Alertmanager", tasks.NewAlertmanagerTask(o.client, factory)),
+				tasks.NewTaskSpec("Updating Alertmanager", tasks.NewAlertmanagerTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating node-exporter", tasks.NewNodeExporterTask(o.client, factory)),
 				tasks.NewTaskSpec("Updating kube-state-metrics", tasks.NewKubeStateMetricsTask(o.client, factory)),
 				tasks.NewTaskSpec("Updating openshift-state-metrics", tasks.NewOpenShiftStateMetricsTask(o.client, factory)),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -519,7 +519,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		tasks.NewTaskGroup(
 			[]*tasks.TaskSpec{
 				tasks.NewTaskSpec("Updating user workload Prometheus Operator", tasks.NewPrometheusOperatorUserWorkloadTask(o.client, factory, config)),
-				tasks.NewTaskSpec("Updating Cluster Monitoring Operator", tasks.NewClusterMonitoringOperatorTask(o.client, factory)),
+				tasks.NewTaskSpec("Updating Cluster Monitoring Operator", tasks.NewClusterMonitoringOperatorTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Grafana", tasks.NewGrafanaTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Prometheus-k8s", tasks.NewPrometheusTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Prometheus-user-workload", tasks.NewPrometheusUserWorkloadTask(o.client, factory, config)),

--- a/pkg/tasks/configsharing.go
+++ b/pkg/tasks/configsharing.go
@@ -48,14 +48,17 @@ func (t *ConfigSharingTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "failed to retrieve Prometheus host")
 	}
 
-	amRoute, err := t.factory.AlertmanagerRoute()
-	if err != nil {
-		return errors.Wrap(err, "initializing Alertmanager Route failed")
-	}
+	var amURL *url.URL
+	if t.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.IsEnabled() {
+		amRoute, err := t.factory.AlertmanagerRoute()
+		if err != nil {
+			return errors.Wrap(err, "initializing Alertmanager Route failed")
+		}
 
-	amURL, err := t.client.GetRouteURL(ctx, amRoute)
-	if err != nil {
-		return errors.Wrap(err, "failed to retrieve Alertmanager host")
+		amURL, err = t.client.GetRouteURL(ctx, amRoute)
+		if err != nil {
+			return errors.Wrap(err, "failed to retrieve Alertmanager host")
+		}
 	}
 
 	var grafanaURL *url.URL

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -165,9 +165,14 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Prometheus Alertmanager RoleBinding failed")
 	}
 
-	err = t.client.CreateOrUpdateRoleBinding(ctx, amrb)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Prometheus Alertmanager RoleBinding failed")
+	if t.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.IsEnabled() {
+		if err = t.client.CreateOrUpdateRoleBinding(ctx, amrb); err != nil {
+			return errors.Wrap(err, "reconciling Prometheus Alertmanager RoleBinding failed")
+		}
+	} else {
+		if err = t.client.DeleteRoleBinding(ctx, amrb); err != nil {
+			return errors.Wrap(err, "deleting Prometheus Alertmanager RoleBinding failed")
+		}
 	}
 
 	rc, err := t.factory.PrometheusK8sRoleConfig()

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -100,9 +100,14 @@ func (t *PrometheusOperatorUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing UserWorkload Alertmanager Role Binding failed")
 	}
 
-	err = t.client.CreateOrUpdateRoleBinding(ctx, arb)
-	if err != nil {
-		return errors.Wrap(err, "reconciling UserWorkload Alertmanager Role Binding failed")
+	if t.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.IsEnabled() {
+		if err = t.client.CreateOrUpdateRoleBinding(ctx, arb); err != nil {
+			return errors.Wrap(err, "reconciling UserWorkload Alertmanager Role Binding failed")
+		}
+	} else {
+		if err = t.client.DeleteRoleBinding(ctx, arb); err != nil {
+			return errors.Wrap(err, "deleting UserWorkload Alertmanager Role Binding failed")
+		}
 	}
 
 	// The CRs will be created externally,

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -248,10 +248,16 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Thanos Ruler Alertmanager Role Binding failed")
 	}
 
-	err = t.client.CreateOrUpdateRoleBinding(ctx, tramrb)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Thanos Ruler Alertmanager Role Binding failed")
+	if t.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.IsEnabled() {
+		if err = t.client.CreateOrUpdateRoleBinding(ctx, tramrb); err != nil {
+			return errors.Wrap(err, "reconciling Thanos Ruler Alertmanager Role Binding failed")
+		}
+	} else {
+		if err = t.client.DeleteRoleBinding(ctx, tramrb); err != nil {
+			return errors.Wrap(err, "deleting Thanos Ruler Alertmanager Role Binding failed")
+		}
 	}
+
 	return nil
 }
 

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	statusv1 "github.com/openshift/api/config/v1"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -381,6 +382,8 @@ func TestAlertmanagerDisabling(t *testing.T) {
 		{name: "assert trusted-ca-bundle does not exist", assertion: f.AssertConfigmapDoesNotExist("alertmanager-trusted-ca-bundle", f.Ns)},
 		{name: "assert prometheus rule does not exist", assertion: f.AssertPrometheusRuleDoesNotExist("alertmanager-main-rules", f.Ns)},
 		{name: "assert service monitor does not exist", assertion: f.AssertServiceMonitorDoesNotExist("alertmanager", f.Ns)},
+		{name: "alertmanager public URL is unset", assertion: assertAlertmanagerURLIsNotSet(f)},
+		{name: "assert operator not degraded", assertion: assertOperatorIsNotDegraded(f)},
 	}
 	t.Run("disable alertmanager", func(t *testing.T) {
 		for _, assertion := range assertions {
@@ -412,9 +415,11 @@ func TestAlertmanagerDisabling(t *testing.T) {
 		{name: "assert serviceaccount alertmanager exists", assertion: f.AssertServiceAccountExists("alertmanager-main", f.Ns)},
 		{name: "assert clusterrole alertmanager-main exists", assertion: f.AssertClusterRoleExists("alertmanager-main")},
 		{name: "assert clusterrolebinding alertmanager-main exists", assertion: f.AssertClusterRoleBindingExists("alertmanager-main")},
-		{name: "assert trusted-ca-bundle exists", assertion: f.AssertConfigmapExists(	"alertmanager-trusted-ca-bundle", f.Ns)},
+		{name: "assert trusted-ca-bundle exists", assertion: f.AssertConfigmapExists("alertmanager-trusted-ca-bundle", f.Ns)},
 		{name: "assert prometheus rule exists", assertion: f.AssertPrometheusRuleExists("alertmanager-main-rules", f.Ns)},
 		{name: "assert service monitor exists", assertion: f.AssertServiceMonitorExists("alertmanager", f.Ns)},
+		{name: "alertmanager public URL properly set", assertion: assertAlertmanagerURLIsSet(f)},
+		{name: "assert operator not degraded", assertion: assertOperatorIsNotDegraded(f)},
 	}
 	t.Run("enable alertmanager", func(t *testing.T) {
 		for _, assertion := range assertions {
@@ -423,3 +428,59 @@ func TestAlertmanagerDisabling(t *testing.T) {
 	})
 }
 
+func assertAlertmanagerURLIsSet(f *framework.Framework) framework.AssertionFunc {
+	return func(t *testing.T) {
+		cm := getMonitoringSharedConfig(t, f)
+		if cm.Data["alertmanagerPublicURL"] == "" {
+			t.Fatal("expected alertmanagerPublicURL to be set")
+		}
+	}
+}
+
+func assertAlertmanagerURLIsNotSet(f *framework.Framework) framework.AssertionFunc {
+	return func(t *testing.T) {
+		cm := getMonitoringSharedConfig(t, f)
+		if cm.Data["alertmanagerPublicURL"] != "" {
+			t.Fatal("expected alertmanagerPublicURL to not be set")
+		}
+	}
+}
+
+func getMonitoringSharedConfig(t *testing.T, f *framework.Framework) *v1.ConfigMap {
+	cm, err := f.OperatorClient.GetConfigmap(context.Background(), "openshift-config-managed", "monitoring-shared-config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cm
+}
+
+func assertOperatorIsNotDegraded(f *framework.Framework) framework.AssertionFunc {
+	return func(t *testing.T) {
+		status := getStatusCondition(f, statusv1.OperatorDegraded)
+		if status == nil {
+			t.Fatalf("status condition with type %s not found", statusv1.OperatorDegraded)
+		}
+
+		if *status != statusv1.ConditionFalse {
+			t.Fatalf("expected operator status %s to be false", statusv1.OperatorDegraded)
+		}
+	}
+}
+
+func getStatusCondition(
+	f *framework.Framework,
+	conditionType statusv1.ClusterStatusConditionType,
+) *statusv1.ConditionStatus {
+	status, err := f.OperatorClient.StatusReporter().Get(context.Background())
+	if err != nil {
+		return nil
+	}
+
+	for _, condition := range status.Status.Conditions {
+		if condition.Type == conditionType {
+			return &condition.Status
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -377,7 +377,7 @@ func TestAlertmanagerDisabling(t *testing.T) {
 		{name: "assert service alertmanager-main does not exist", assertion: f.AssertServiceDoesNotExist("alertmanager-main", f.Ns)},
 		{name: "assert service alertmanager-operated does not exist", assertion: f.AssertServiceDoesNotExist("alertmanager-operated", f.Ns)},
 		{name: "assert serviceaccount alertmanager-main does not exist", assertion: f.AssertServiceAccountDoesNotExist("alertmanager-main", f.Ns)},
-		{name: "assert role monitoring-alertmanager-edit exists does not exist", assertion: f.AssertRoleDoesNotExist("monitoring-alertmanager-edit", "openshift-monitoring")},
+		{name: "assert role monitoring-alertmanager-edit does not exist", assertion: f.AssertRoleDoesNotExist("monitoring-alertmanager-edit", "openshift-monitoring")},
 		{name: "assert rolebinding alertmanager-prometheusk8s does not exist", assertion: f.AssertRoleBindingDoesNotExist("alertmanager-prometheusk8s", "openshift-monitoring")},
 		{name: "assert rolebinding alertmanager-prometheususer-workload does not exist", assertion: f.AssertRoleBindingDoesNotExist("alertmanager-prometheususer-workload", "openshift-monitoring")},
 		{name: "assert rolebinding alertmanager-thanos-ruler does not exist", assertion: f.AssertRoleBindingDoesNotExist("alertmanager-thanos-ruler", "openshift-monitoring")},

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -377,6 +377,10 @@ func TestAlertmanagerDisabling(t *testing.T) {
 		{name: "assert service alertmanager-main does not exist", assertion: f.AssertServiceDoesNotExist("alertmanager-main", f.Ns)},
 		{name: "assert service alertmanager-operated does not exist", assertion: f.AssertServiceDoesNotExist("alertmanager-operated", f.Ns)},
 		{name: "assert serviceaccount alertmanager-main does not exist", assertion: f.AssertServiceAccountDoesNotExist("alertmanager-main", f.Ns)},
+		{name: "assert role monitoring-alertmanager-edit exists does not exist", assertion: f.AssertRoleDoesNotExist("monitoring-alertmanager-edit", "openshift-monitoring")},
+		{name: "assert rolebinding alertmanager-prometheusk8s does not exist", assertion: f.AssertRoleBindingDoesNotExist("alertmanager-prometheusk8s", "openshift-monitoring")},
+		{name: "assert rolebinding alertmanager-prometheususer-workload does not exist", assertion: f.AssertRoleBindingDoesNotExist("alertmanager-prometheususer-workload", "openshift-monitoring")},
+		{name: "assert rolebinding alertmanager-thanos-ruler does not exist", assertion: f.AssertRoleBindingDoesNotExist("alertmanager-thanos-ruler", "openshift-monitoring")},
 		{name: "assert clusterrole alertmanager-main does not exist", assertion: f.AssertClusterRoleDoesNotExist("alertmanager-main")},
 		{name: "assert clusterrolebinding alertmanager-main does not exist", assertion: f.AssertClusterRoleBindingDoesNotExist("alertmanager-main")},
 		{name: "assert trusted-ca-bundle does not exist", assertion: f.AssertConfigmapDoesNotExist("alertmanager-trusted-ca-bundle", f.Ns)},
@@ -391,11 +395,14 @@ func TestAlertmanagerDisabling(t *testing.T) {
 		}
 	})
 
-	// Re-enable alertmanager
-	if err := f.OperatorClient.DeleteConfigMap(context.Background(), &v1.ConfigMap{
+	// Re-enable alertmanager with user workload monitoring
+	if err := f.OperatorClient.CreateOrUpdateConfigMap(context.Background(), &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterMonitorConfigMapName,
 			Namespace: f.Ns,
+		},
+		Data: map[string]string{
+			"config.yaml": `enableUserWorkload: true`,
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -413,6 +420,10 @@ func TestAlertmanagerDisabling(t *testing.T) {
 		{name: "assert service alertmanager-main exists", assertion: f.AssertServiceExists("alertmanager-main", f.Ns)},
 		{name: "assert service alertmanager-operated exists", assertion: f.AssertServiceExists("alertmanager-operated", f.Ns)},
 		{name: "assert serviceaccount alertmanager exists", assertion: f.AssertServiceAccountExists("alertmanager-main", f.Ns)},
+		{name: "assert role monitoring-alertmanager-edit exists", assertion: f.AssertRoleExists("monitoring-alertmanager-edit", "openshift-monitoring")},
+		{name: "assert rolebinding alertmanager-prometheusk8s exists", assertion: f.AssertRoleBindingExists("alertmanager-prometheusk8s", "openshift-monitoring")},
+		{name: "assert rolebinding alertmanager-prometheususer-workload exists", assertion: f.AssertRoleBindingExists("alertmanager-prometheususer-workload", "openshift-monitoring")},
+		{name: "assert rolebinding alertmanager-thanos-ruler exists", assertion: f.AssertRoleBindingExists("alertmanager-thanos-ruler", "openshift-monitoring")},
 		{name: "assert clusterrole alertmanager-main exists", assertion: f.AssertClusterRoleExists("alertmanager-main")},
 		{name: "assert clusterrolebinding alertmanager-main exists", assertion: f.AssertClusterRoleBindingExists("alertmanager-main")},
 		{name: "assert trusted-ca-bundle exists", assertion: f.AssertConfigmapExists("alertmanager-trusted-ca-bundle", f.Ns)},

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -1,0 +1,198 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+type AssertionFunc func(t *testing.T)
+
+func (f *Framework) AssertStatefulsetExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertStatefulsetDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertRouteExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.OpenShiftRouteClient.Routes(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertRouteDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.OpenShiftRouteClient.Routes(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertSecretExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertSecretDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertServiceExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertServiceDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertConfigmapExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertConfigmapDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertServiceAccountExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertServiceAccountDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertClusterRoleExists(name string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertClusterRoleDoesNotExist(name string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertClusterRoleBindingExists(name string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertClusterRoleBindingDoesNotExist(name string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertPrometheusRuleExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.MonitoringClient.PrometheusRules(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertPrometheusRuleDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.MonitoringClient.PrometheusRules(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertServiceMonitorExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.MonitoringClient.ServiceMonitors(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertServiceMonitorDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.MonitoringClient.ServiceMonitors(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+type getResourceFunc func() (metav1.Object, error)
+
+func assertResourceExists(t *testing.T, getResource getResourceFunc) {
+	if err := Poll(5*time.Second, 10*time.Minute, func() error {
+		_, err := getResource()
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertResourceDoesNotExists(t *testing.T, getResource getResourceFunc) {
+	if err := Poll(5*time.Second, 10*time.Minute, func() error {
+		_, err := getResource()
+		if err == nil {
+			return fmt.Errorf("expected resource to not exist")
+		}
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -107,6 +107,38 @@ func (f *Framework) AssertServiceAccountDoesNotExist(name string, namespace stri
 	}
 }
 
+func (f *Framework) AssertRoleExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertRoleDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertRoleBindingExists(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
+func (f *Framework) AssertRoleBindingDoesNotExist(name string, namespace string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertResourceDoesNotExists(t, func() (metav1.Object, error) {
+			return f.KubeClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		})
+	}
+}
+
 func (f *Framework) AssertClusterRoleExists(name string) func(t *testing.T) {
 	return func(t *testing.T) {
 		assertResourceExists(t, func() (metav1.Object, error) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -59,16 +59,17 @@ const (
 
 type Framework struct {
 	RestConfig          *rest.Config
-	OperatorClient      *client.Client
-	KubeClient          kubernetes.Interface
-	ThanosQuerierClient *PrometheusClient
-	PrometheusK8sClient *PrometheusClient
-	AlertmanagerClient  *PrometheusClient
-	APIServicesClient   *apiservicesclient.Clientset
-	AdmissionClient     *admissionclient.AdmissionregistrationV1Client
-	MetricsClient       *metricsclient.Clientset
-	SchedulingClient    *schedulingv1client.SchedulingV1Client
-	kubeConfigPath      string
+	OperatorClient       *client.Client
+	OpenShiftRouteClient *routev1.RouteV1Client
+	KubeClient           kubernetes.Interface
+	ThanosQuerierClient  *PrometheusClient
+	PrometheusK8sClient  *PrometheusClient
+	AlertmanagerClient   *PrometheusClient
+	APIServicesClient    *apiservicesclient.Clientset
+	AdmissionClient      *admissionclient.AdmissionregistrationV1Client
+	MetricsClient        *metricsclient.Clientset
+	SchedulingClient     *schedulingv1client.SchedulingV1Client
+	kubeConfigPath       string
 
 	MonitoringClient             *monClient.MonitoringV1Client
 	Ns, UserWorkloadMonitoringNs string
@@ -127,6 +128,7 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 	f := &Framework{
 		RestConfig:               config,
 		OperatorClient:           operatorClient,
+		OpenShiftRouteClient:     openshiftRouteClient,
 		KubeClient:               kubeClient,
 		APIServicesClient:        apiServicesClient,
 		AdmissionClient:          admissionClient,


### PR DESCRIPTION
The ACM would like to funnel all alerts from a fleet of OpenShift
clusters through a single external Alertmanager. As a result, they
would like to trim down the monitoring stack and disable the local
alertmanager.

This commit exposes a binary field in the cluster-monitoring-configmap
which allows users to fully disable the built-in alertmanager.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
