### PR TITLE
Add new label to show grafana dashboards in ODC

### DIFF
--- a/jsonnet/grafana.libsonnet
+++ b/jsonnet/grafana.libsonnet
@@ -2,6 +2,15 @@ local grafana = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/k
 
 function(params)
   local cfg = params;
+
+  // List of dashboards which should be shown in OCP developer perspective.
+  local odcDashboards = [
+    'grafana-dashboard-k8s-resources-namespace',
+    'grafana-dashboard-k8s-resources-workloads-namespace',
+    'grafana-dashboard-k8s-resources-pod',
+    'grafana-dashboard-k8s-resources-workload',
+  ];
+
   grafana(cfg) {
 
     consoleDashboardDefinitions: {
@@ -12,7 +21,11 @@ function(params)
           d {
             metadata+: {
               namespace: 'openshift-config-managed',
-              labels+: { 'console.openshift.io/dashboard': 'true' },
+              labels+: {
+                'console.openshift.io/dashboard': 'true',
+              } + if std.count(odcDashboards, d.metadata.name) > 0 then {
+                'console.openshift.io/odc-dashboard': 'true',
+              } else {},
             },
           },
         $.dashboardDefinitions.items,

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -8872,6 +8872,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.5.5
     console.openshift.io/dashboard: "true"
+    console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-namespace
   namespace: openshift-config-managed
 ---
@@ -12267,6 +12268,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.5.5
     console.openshift.io/dashboard: "true"
+    console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-pod
   namespace: openshift-config-managed
 ---
@@ -14248,6 +14250,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.5.5
     console.openshift.io/dashboard: "true"
+    console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-workload
   namespace: openshift-config-managed
 ---
@@ -16394,6 +16397,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 7.5.5
     console.openshift.io/dashboard: "true"
+    console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-workloads-namespace
   namespace: openshift-config-managed
 ---


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ODC-6066

I added a list of dashboard we want show in developer console (OCP) and a new label (`"console.openshift.io/odc-dashboard": "true")` if the Grafana dashboard is part of that list.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

(At least no facing changes without the additional changes we will do in developer console.