### PR TITLE
Bug 1973576: Bump thanos to v0.22.0

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -208,10 +208,10 @@ spec:
       openshift.io/cluster-monitoring: "true"
   serviceMonitorSelector: {}
   thanos:
-    image: quay.io/thanos/thanos:v0.20.2
+    image: quay.io/thanos/thanos:v0.22.0
     resources:
       requests:
         cpu: 1m
         memory: 100Mi
-    version: 0.20.2
+    version: 0.22.0
   version: 2.26.1

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -171,10 +171,10 @@ spec:
       - "true"
   serviceMonitorSelector: {}
   thanos:
-    image: quay.io/thanos/thanos:v0.20.2
+    image: quay.io/thanos/thanos:v0.22.0
     resources:
       requests:
         cpu: 1m
         memory: 100Mi
-    version: 0.20.2
+    version: 0.22.0
   version: 2.26.1

--- a/assets/thanos-querier/cluster-role-binding.yaml
+++ b/assets/thanos-querier/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/thanos-querier/cluster-role.yaml
+++ b/assets/thanos-querier/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier
 rules:
 - apiGroups:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring
 spec:
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-querier
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: 0.20.2
+        app.kubernetes.io/version: 0.22.0
     spec:
       affinity:
         podAntiAffinity:
@@ -60,7 +60,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: quay.io/thanos/thanos:v0.20.2
+        image: quay.io/thanos/thanos:v0.22.0
         name: thanos-query
         ports:
         - containerPort: 9090

--- a/assets/thanos-querier/grpc-tls-secret.yaml
+++ b/assets/thanos-querier/grpc-tls-secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier-grpc-tls
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/thanos-querier/kube-rbac-proxy-rules-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-rules-secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier-kube-rbac-proxy-rules
   namespace: openshift-monitoring
 stringData:

--- a/assets/thanos-querier/kube-rbac-proxy-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier-kube-rbac-proxy
   namespace: openshift-monitoring
 stringData:

--- a/assets/thanos-querier/oauth-cookie-secret.yaml
+++ b/assets/thanos-querier/oauth-cookie-secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier-oauth-cookie
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/thanos-querier/oauth-htpasswd-secret.yaml
+++ b/assets/thanos-querier/oauth-htpasswd-secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier-oauth-htpasswd
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/thanos-querier/pod-disruption-budget.yaml
+++ b/assets/thanos-querier/pod-disruption-budget.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier-pdb
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/route.yaml
+++ b/assets/thanos-querier/route.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/service-account.yaml
+++ b/assets/thanos-querier/service-account.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring

--- a/assets/thanos-querier/service-monitor.yaml
+++ b/assets/thanos-querier/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/service.yaml
+++ b/assets/thanos-querier/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: 0.20.2
+    app.kubernetes.io/version: 0.22.0
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -66,7 +66,7 @@ spec:
     caFile: /etc/tls/grpc/ca.crt
     certFile: /etc/tls/grpc/server.crt
     keyFile: /etc/tls/grpc/server.key
-  image: quay.io/thanos/thanos:v0.20.2
+  image: quay.io/thanos/thanos:v0.22.0
   listenLocal: true
   podMetadata:
     annotations:

--- a/jsonnet/versions.json
+++ b/jsonnet/versions.json
@@ -8,5 +8,5 @@
   "prometheusOperator": "0.49.0",
   "promLabelProxy": "0.3.0",
   "kubeRbacProxy": "0.9.0",
-  "thanos": "0.20.2"
+  "thanos": "0.22.0"
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->
Downstream thanos bump PR: https://github.com/openshift/thanos/pull/63

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
