### PR TITLE
[MON-1695] expose /api/v1/labels end point for Thanos query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.10
 
 - [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose expose /api/v1/labels endpoint for Thanos query.
+
 ## 4.9
 
 - [#1312](https://github.com/openshift/cluster-monitoring-operator/pull/1312) Support label to exclude namespaces from user-workload monitoring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.10
+
+- [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose expose /api/v1/labels endpoint for Thanos query.
 ## 4.9
 
 - [#1312](https://github.com/openshift/cluster-monitoring-operator/pull/1312) Support label to exclude namespaces from user-workload monitoring.

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
-        - --allow-paths=/api/v1/query,/api/v1/query_range
+        - --allow-paths="/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values"
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:
@@ -155,6 +155,7 @@ spec:
         - --insecure-listen-address=127.0.0.1:9095
         - --upstream=http://127.0.0.1:9090
         - --label=namespace
+        - --enable-label-apis
         image: quay.io/prometheuscommunity/prom-label-proxy:v0.3.0
         name: prom-label-proxy
         resources:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
-        - --allow-paths="/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values"
+        - --allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -479,7 +479,7 @@ function(params)
                   '--tls-private-key-file=/etc/tls/private/tls.key',
                   '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                   '--logtostderr=true',
-                  '--allow-paths="/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values"',
+                  '--allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values',
                 ],
                 terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -479,7 +479,7 @@ function(params)
                   '--tls-private-key-file=/etc/tls/private/tls.key',
                   '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                   '--logtostderr=true',
-                  '--allow-paths=/api/v1/query,/api/v1/query_range',
+                  '--allow-paths="/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values"',
                 ],
                 terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [
@@ -500,6 +500,7 @@ function(params)
                   '--insecure-listen-address=127.0.0.1:9095',
                   '--upstream=http://127.0.0.1:9090',
                   '--label=namespace',
+                  '--enable-label-apis',
                 ],
                 resources: {
                   requests: {

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -211,6 +211,27 @@ func (c *PrometheusClient) PrometheusRules() ([]byte, error) {
 	return body, nil
 }
 
+// PrometheusRules runs an HTTP GET request against the Prometheus label API and returns
+// the response body.
+func (c *PrometheusClient) PrometheusLabel(label string) ([]byte, error) {
+	resp, err := c.Do("GET", fmt.Sprintf("/api/v1/label/%s/values", url.QueryEscape(label)), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code response, want %d, got %d (%q)", http.StatusOK, resp.StatusCode, ClampMax(body))
+	}
+
+	return body, nil
+}
+
 // AlertmanagerQueryAlerts runs an HTTP GET request against the Alertmanager
 // /api/v2/alerts endpoint and returns the response body.
 func (c *PrometheusClient) AlertmanagerQueryAlerts(kvs ...string) ([]byte, error) {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

Expose /api/v1/labels end point for Thanos query.
End point for /api/v1/label/<name>/values is added but not working yet, need to update kube-rbac-proxy to support at least trailing wildcard patterns. 

This PR requires the 2 PRs below done before merge, and they are merged now:
1. [This PR](https://github.com/brancz/kube-rbac-proxy/pull/135) is merged for allowing trailing wildcard in kube-rbac-proxy  --allow-paths .
2. [This PR](https://github.com/openshift/kube-rbac-proxy/pull/50) is merged for version bump to 0.11. 