### PR TITLE
[release-4.7] Bug 1986591: node exporter calls /proc/cpuinfo multiple times causing the node to freeze

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -26,6 +26,7 @@ spec:
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
+        - --no-collector.cpufreq
         image: openshift/prometheus-node-exporter:v1.0.1
         name: node-exporter
         resources:

--- a/jsonnet/node-exporter.jsonnet
+++ b/jsonnet/node-exporter.jsonnet
@@ -138,7 +138,19 @@ local wtmpVolumeName = 'node-exporter-wtmp';
                         // Remove the flag to disable hwmon that is set upstream so we
                         // gather that data (especially for bare metal clusters), and
                         // add flags to collect data not included by default.
-                        args: [a for a in c.args if a != '--no-collector.hwmon'] + ['--collector.cpu.info', '--collector.textfile.directory=' + textfileDir],
+                        args: [a for a in c.args if a != '--no-collector.hwmon'] +
+                              [
+                                '--collector.cpu.info',
+                                '--collector.textfile.directory=' + textfileDir,
+
+                                // The cpufreq collector seems to be causing high
+                                // load on some nodes with lots of cores.  Disable
+                                // it temporarily as a workaround.
+                                //
+                                // https://bugzilla.redhat.com/show_bug.cgi?id=1972076
+                                // https://github.com/prometheus/node_exporter/issues/1880
+                                '--no-collector.cpufreq',
+                              ],
                         terminationMessagePolicy: 'FallbackToLogsOnError',
                         volumeMounts+: [{
                           mountPath: textfileDir,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Cherry-pick https://github.com/openshift/cluster-monitoring-operator/pull/1272

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
