### PR TITLE
Bug 1987143: Update prometheus resources label to 2.28.1

### DIFF
--- a/assets/prometheus-k8s/cluster-role-binding.yaml
+++ b/assets/prometheus-k8s/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-k8s/cluster-role.yaml
+++ b/assets/prometheus-k8s/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-k8s
 rules:
 - apiGroups:

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: k8s
     role: alert-rules
   name: prometheus-k8s-prometheus-rules

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: k8s
   name: k8s
   namespace: openshift-monitoring
@@ -162,7 +162,7 @@ spec:
         memory: 10Mi
   enableFeatures: []
   externalLabels: {}
-  image: quay.io/prometheus/prometheus:v2.26.1
+  image: quay.io/prometheus/prometheus:v2.28.1
   listenLocal: true
   nodeSelector:
     kubernetes.io/os: linux
@@ -173,7 +173,7 @@ spec:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
   podMonitorNamespaceSelector:
     matchLabels:
       openshift.io/cluster-monitoring: "true"
@@ -215,4 +215,4 @@ spec:
         cpu: 1m
         memory: 100Mi
     version: 0.22.0
-  version: 2.26.1
+  version: 2.28.1

--- a/assets/prometheus-k8s/role-binding-config.yaml
+++ b/assets/prometheus-k8s/role-binding-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-k8s-config
   namespace: openshift-monitoring
 roleRef:

--- a/assets/prometheus-k8s/role-binding-specific-namespaces.yaml
+++ b/assets/prometheus-k8s/role-binding-specific-namespaces.yaml
@@ -7,7 +7,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: default
   roleRef:
@@ -25,7 +25,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: kube-system
   roleRef:
@@ -43,7 +43,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: openshift-monitoring
   roleRef:
@@ -61,7 +61,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: openshift-etcd
   roleRef:
@@ -79,7 +79,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: openshift-user-workload-monitoring
   roleRef:

--- a/assets/prometheus-k8s/role-config.yaml
+++ b/assets/prometheus-k8s/role-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-k8s-config
   namespace: openshift-monitoring
 rules:

--- a/assets/prometheus-k8s/role-specific-namespaces.yaml
+++ b/assets/prometheus-k8s/role-specific-namespaces.yaml
@@ -7,7 +7,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: default
   rules:
@@ -44,7 +44,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: kube-system
   rules:
@@ -81,7 +81,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: openshift-monitoring
   rules:
@@ -118,7 +118,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: openshift-etcd
   rules:
@@ -155,7 +155,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-k8s
     namespace: openshift-user-workload-monitoring
   rules:

--- a/assets/prometheus-k8s/service-account.yaml
+++ b/assets/prometheus-k8s/service-account.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-k8s
   namespace: openshift-monitoring

--- a/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: thanos-sidecar
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: k8s
   name: thanos-sidecar
   namespace: openshift-monitoring

--- a/assets/prometheus-k8s/service-monitor.yaml
+++ b/assets/prometheus-k8s/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-k8s
   namespace: openshift-monitoring
 spec:

--- a/assets/prometheus-k8s/service-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-thanos-sidecar.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: thanos-sidecar
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: k8s
   name: prometheus-k8s-thanos-sidecar
   namespace: openshift-monitoring

--- a/assets/prometheus-k8s/service.yaml
+++ b/assets/prometheus-k8s/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: k8s
   name: prometheus-k8s
   namespace: openshift-monitoring

--- a/assets/prometheus-user-workload/cluster-role-binding.yaml
+++ b/assets/prometheus-user-workload/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-user-workload
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-user-workload/cluster-role.yaml
+++ b/assets/prometheus-user-workload/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-user-workload
 rules:
 - apiGroups:

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: user-workload
   name: user-workload
   namespace: openshift-user-workload-monitoring
@@ -112,7 +112,7 @@ spec:
   enforcedNamespaceLabel: namespace
   externalLabels: {}
   ignoreNamespaceSelectors: true
-  image: quay.io/prometheus/prometheus:v2.26.1
+  image: quay.io/prometheus/prometheus:v2.28.1
   listenLocal: true
   nodeSelector:
     kubernetes.io/os: linux
@@ -125,7 +125,7 @@ spec:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
   podMonitorNamespaceSelector:
     matchExpressions:
     - key: openshift.io/cluster-monitoring
@@ -177,4 +177,4 @@ spec:
         cpu: 1m
         memory: 100Mi
     version: 0.22.0
-  version: 2.26.1
+  version: 2.28.1

--- a/assets/prometheus-user-workload/role-binding-config.yaml
+++ b/assets/prometheus-user-workload/role-binding-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-user-workload-config
   namespace: openshift-user-workload-monitoring
 roleRef:

--- a/assets/prometheus-user-workload/role-binding-specific-namespaces.yaml
+++ b/assets/prometheus-user-workload/role-binding-specific-namespaces.yaml
@@ -7,7 +7,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-user-workload
     namespace: openshift-user-workload-monitoring
   roleRef:

--- a/assets/prometheus-user-workload/role-config.yaml
+++ b/assets/prometheus-user-workload/role-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-user-workload-config
   namespace: openshift-user-workload-monitoring
 rules:

--- a/assets/prometheus-user-workload/role-specific-namespaces.yaml
+++ b/assets/prometheus-user-workload/role-specific-namespaces.yaml
@@ -7,7 +7,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.26.1
+      app.kubernetes.io/version: 2.28.1
     name: prometheus-user-workload
     namespace: openshift-user-workload-monitoring
   rules:

--- a/assets/prometheus-user-workload/service-account.yaml
+++ b/assets/prometheus-user-workload/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-user-workload
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: thanos-sidecar
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: user-workload
   name: thanos-sidecar
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-user-workload/service-monitor.yaml
+++ b/assets/prometheus-user-workload/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
   name: prometheus-user-workload
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/prometheus-user-workload/service-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-thanos-sidecar.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: thanos-sidecar
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: user-workload
   name: prometheus-user-workload-thanos-sidecar
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-user-workload/service.yaml
+++ b/assets/prometheus-user-workload/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.26.1
+    app.kubernetes.io/version: 2.28.1
     prometheus: user-workload
   name: prometheus-user-workload
   namespace: openshift-user-workload-monitoring

--- a/jsonnet/versions.json
+++ b/jsonnet/versions.json
@@ -1,6 +1,6 @@
-{ 
+{
   "alertmanager": "0.21.0",
-  "prometheus": "2.26.1",
+  "prometheus": "2.28.1",
   "grafana": "7.5.5",
   "kubeStateMetrics": "2.0.0",
   "nodeExporter": "1.1.2",


### PR DESCRIPTION
This is a follow-up PR to update prometheus resource label after https://github.com/openshift/prometheus/pull/89.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
