### PR TITLE
Bug 1988291: pkg/client/client.go: Add retry logic for daemonset create

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -927,9 +927,11 @@ func (c *Client) CreateOrUpdateDaemonSet(ctx context.Context, ds *appsv1.DaemonS
 			if err != nil {
 				return errors.Wrap(err, "deleting DaemonSet object failed")
 			}
-			err = c.CreateDaemonSet(ctx, required)
-			if err != nil {
-				return errors.Wrap(err, "creating DaemonSet object failed after update failed")
+			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				return c.CreateDaemonSet(ctx, required)
+			})
+			if retryErr != nil {
+				return errors.Wrap(retryErr, "creating DaemonSet object failed after update failed")
 			}
 		}
 		return errors.Wrap(err, "updating DaemonSet object failed")


### PR DESCRIPTION
Signed-off-by: Jayapriya Pai <janantha@redhat.com>

Allow retry for daemon set creation as commented in https://github.com/openshift/cluster-monitoring-operator/pull/1257/#pullrequestreview-700719930

cc: @dgrisonnet @simonpasquier 
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
