### PR TITLE
Bug 1986981: Update Alert Configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1270](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Show a message in the degraded condition when Platform Monitoring Prometheus runs without persistent storage.
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Allow configuring additional Alertmanagers in User Workload Prometheus and Thanos Ruler.
 - [#1293](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Allow disabling the local Alertmanager.
+- [#1310](https://github.com/openshift/cluster-monitoring-operator/pull/1310) Update Alert Configs, fewer critical alerts with more accurate triggering condition.
 
 ## 4.8
 
@@ -16,7 +17,7 @@
 - [#1087](https://github.com/openshift/cluster-monitoring-operator/pull/1087) Remove ThanosQueryInstantLatencyHigh and ThanosQueryRangeLatencyHigh alerts.
 - [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Decrease alert severity to "warning" for all Thanos sidecar alerts.
 - [#1090](https://github.com/openshift/cluster-monitoring-operator/pull/1090) Increase "for" duration to 1 hour for all Thanos sidecar alerts.
-- [#1093](https://github.com/openshift/cluster-monitoring-operator/pull/1093) Bump kube-state-metrics to major new release v2.0.0-rc.1. This changes a lot of metrics and flags, see kube-state-metrics CHANGELOG for full changes. 
+- [#1093](https://github.com/openshift/cluster-monitoring-operator/pull/1093) Bump kube-state-metrics to major new release v2.0.0-rc.1. This changes a lot of metrics and flags, see kube-state-metrics CHANGELOG for full changes.
 - [#1126](https://github.com/openshift/cluster-monitoring-operator/pull/1126) Remove deprecated techPreviewUserWorkload field from CMO's configmap.
 - [#1136](https://github.com/openshift/cluster-monitoring-operator/pull/1136) Add recording rule for builds by strategy
 - [#1210](https://github.com/openshift/cluster-monitoring-operator/pull/1210) Bump Grafana version to 7.5.5

--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -40,7 +40,7 @@ spec:
           count by (namespace,service) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="openshift-monitoring"}[5m]))
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: AlertmanagerFailedToSendAlerts
       annotations:
         description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -73,7 +73,7 @@ spec:
         > 0.01
       for: 5m
       labels:
-        severity: critical
+        severity: warning
     - alert: AlertmanagerClusterFailedToSendAlerts
       annotations:
         description: The minimum notification failure rate to {{ $labels.integration
@@ -103,7 +103,7 @@ spec:
         != 1
       for: 20m
       labels:
-        severity: critical
+        severity: warning
     - alert: AlertmanagerClusterDown
       annotations:
         description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -124,25 +124,4 @@ spec:
         >= 0.5
       for: 5m
       labels:
-        severity: critical
-    - alert: AlertmanagerClusterCrashlooping
-      annotations:
-        description: '{{ $value | humanizePercentage }} of Alertmanager instances
-          within the {{$labels.job}} cluster have restarted at least 5 times in the
-          last 10m.'
-        summary: Half or more of the Alertmanager instances within the same cluster
-          are crashlooping.
-      expr: |
-        (
-          count by (namespace,service) (
-            changes(process_start_time_seconds{job="alertmanager-main",namespace="openshift-monitoring"}[10m]) > 4
-          )
-        /
-          count by (namespace,service) (
-            up{job="alertmanager-main",namespace="openshift-monitoring"}
-          )
-        )
-        >= 0.5
-      for: 5m
-      labels:
-        severity: critical
+        severity: warning

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -339,7 +339,7 @@ spec:
         ) < 0.03
         and
         kubelet_volume_stats_used_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
-      for: 1m
+      for: 5m
       labels:
         severity: critical
     - alert: KubePersistentVolumeFillingUp
@@ -371,7 +371,7 @@ spec:
         kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0
       for: 5m
       labels:
-        severity: critical
+        severity: warning
   - name: kubernetes-system
     rules:
     - alert: KubeClientErrors

--- a/assets/kube-state-metrics/prometheus-rule.yaml
+++ b/assets/kube-state-metrics/prometheus-rule.yaml
@@ -27,7 +27,7 @@ spec:
         > 0.01
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeStateMetricsWatchErrors
       annotations:
         description: kube-state-metrics is experiencing errors at an elevated rate
@@ -41,7 +41,7 @@ spec:
         > 0.01
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeStateMetricsShardingMismatch
       annotations:
         description: kube-state-metrics pods are running with different --total-shards

--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -41,7 +41,7 @@ spec:
         (
           node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 15
         and
-          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 2*60*60) < 0
         and
           node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
         )
@@ -103,7 +103,7 @@ spec:
         (
           node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 20
         and
-          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 2*60*60) < 0
         and
           node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
         )

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -25,7 +25,7 @@ spec:
         max_over_time(prometheus_config_last_reload_successful{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) == 0
       for: 10m
       labels:
-        severity: critical
+        severity: warning
     - alert: PrometheusNotificationQueueRunningFull
       annotations:
         description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -148,10 +148,10 @@ spec:
           )
         )
         * 100
-        > 1
+        > 10
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: PrometheusRemoteWriteBehind
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -169,7 +169,7 @@ spec:
         > 120
       for: 15m
       labels:
-        severity: critical
+        severity: info
     - alert: PrometheusRemoteWriteDesiredShards
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -199,7 +199,7 @@ spec:
         increase(prometheus_rule_evaluation_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: PrometheusMissingRuleEvaluations
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed {{
@@ -244,22 +244,6 @@ spec:
       for: 5m
       labels:
         severity: critical
-    - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
-      annotations:
-        description: '{{ printf "%.1f" $value }}% minimum errors while sending alerts
-          from Prometheus {{$labels.namespace}}/{{$labels.pod}} to any Alertmanager.'
-        summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
-      expr: |
-        min without (alertmanager) (
-          rate(prometheus_notifications_errors_total{job=~"prometheus-k8s|prometheus-user-workload",alertmanager!~``}[5m])
-        /
-          rate(prometheus_notifications_sent_total{job=~"prometheus-k8s|prometheus-user-workload",alertmanager!~``}[5m])
-        )
-        * 100
-        > 3
-      for: 15m
-      labels:
-        severity: critical
   - name: thanos-sidecar
     rules:
     - alert: ThanosSidecarPrometheusDown
@@ -268,18 +252,18 @@ spec:
         summary: Thanos Sidecar cannot connect to Prometheus
       expr: |
         thanos_sidecar_prometheus_up{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"} == 0
-      for: 1h
+      for: 5m
       labels:
-        severity: warning
+        severity: critical
     - alert: ThanosSidecarBucketOperationsFailed
       annotations:
         description: Thanos Sidecar {{$labels.instance}} bucket operations are failing
         summary: Thanos Sidecar bucket operations are failing
       expr: |
         sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}[5m])) > 0
-      for: 1h
+      for: 5m
       labels:
-        severity: warning
+        severity: critical
     - alert: ThanosSidecarUnhealthy
       annotations:
         description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than
@@ -287,6 +271,6 @@ spec:
         summary: Thanos Sidecar is unhealthy.
       expr: |
         time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}) >= 240
-      for: 1h
+      for: 5m
       labels:
-        severity: warning
+        severity: critical

--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -23,9 +23,9 @@ spec:
         /
           sum by (job) (rate(http_requests_total{job="thanos-querier", handler="query"}[5m]))
         ) * 100 > 5
-      for: 1h
+      for: 5m
       labels:
-        severity: warning
+        severity: critical
     - alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
       annotations:
         description: Thanos Query {{$labels.job}} is failing to handle {{$value |
@@ -37,9 +37,9 @@ spec:
         /
           sum by (job) (rate(http_requests_total{job="thanos-querier", handler="query_range"}[5m]))
         ) * 100 > 5
-      for: 1h
+      for: 5m
       labels:
-        severity: warning
+        severity: critical
     - alert: ThanosQueryGrpcServerErrorRate
       annotations:
         description: Thanos Query {{$labels.job}} is failing to handle {{$value |
@@ -52,7 +52,7 @@ spec:
           sum by (job) (rate(grpc_server_started_total{job="thanos-querier"}[5m]))
         * 100 > 5
         )
-      for: 1h
+      for: 5m
       labels:
         severity: warning
     - alert: ThanosQueryGrpcClientErrorRate
@@ -66,7 +66,7 @@ spec:
         /
           sum by (job) (rate(grpc_client_started_total{job="thanos-querier"}[5m]))
         ) * 100 > 5
-      for: 1h
+      for: 5m
       labels:
         severity: warning
     - alert: ThanosQueryHighDNSFailures
@@ -80,6 +80,6 @@ spec:
         /
           sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job="thanos-querier"}[5m]))
         ) * 100 > 1
-      for: 1h
+      for: 15m
       labels:
         severity: warning

--- a/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
+++ b/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
@@ -25,7 +25,7 @@ spec:
         sum by (job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0
       for: 5m
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosRuleHighRuleEvaluationFailures
       annotations:
         description: Thanos Rule {{$labels.instance}} is failing to evaluate rules.
@@ -39,7 +39,7 @@ spec:
         )
       for: 5m
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosRuleHighRuleEvaluationWarnings
       annotations:
         description: Thanos Rule {{$labels.instance}} has high number of evaluation
@@ -141,4 +141,4 @@ spec:
         sum by (job, instance) (thanos_rule_loaded_rules{job="thanos-ruler"}) > 0
       for: 5m
       labels:
-        severity: critical
+        severity: warning

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -12,6 +12,12 @@ local excludedRuleGroups = [
 
 local excludedRules = [
   {
+    name: 'alertmanager.rules',
+    rules: [
+      { alert: 'AlertmanagerClusterCrashlooping' },
+    ],
+  },
+  {
     name: 'general.rules',
     rules: [
       { alert: 'TargetDown' },
@@ -60,6 +66,12 @@ local excludedRules = [
     ],
   },
   {
+    name: 'prometheus',
+    rules: [
+      { alert: 'PrometheusErrorSendingAlertsToAnyAlertmanager' },
+    ],
+  },
+  {
     name: 'thanos-query',
     rules: [
       { alert: 'ThanosQueryInstantLatencyHigh' },
@@ -69,6 +81,35 @@ local excludedRules = [
 ];
 
 local patchedRules = [
+  {
+    name: 'alertmanager.rules',
+    rules: [
+      {
+        alert: 'AlertmanagerMembersInconsistent',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'AlertmanagerClusterFailedToSendAlerts',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'AlertmanagerConfigInconsistent',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'AlertmanagerClusterDown',
+        labels: {
+          severity: 'warning',
+        },
+      },
+    ],
+  },
   {
     name: 'kubernetes-apps',
     rules: [
@@ -83,6 +124,107 @@ local patchedRules = [
     ],
   },
   {
+    name: 'kube-state-metrics',
+    rules: [
+      {
+        alert: 'KubeStateMetricsListErrors',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'KubeStateMetricsWatchErrors',
+        labels: {
+          severity: 'warning',
+        },
+      },
+    ],
+  },
+  {
+    name: 'kubernetes-storage',
+    local kubernetesStorageConfig = { prefixedNamespaceSelector: 'namespace=~"(openshift-.*|kube-.*|default)",', kubeletSelector: 'job="kubelet", metrics_path="/metrics"' },
+    rules: [
+      {
+        alert: 'KubePersistentVolumeErrors',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'KubePersistentVolumeFillingUp',
+        expr: |||
+          (
+            kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
+              /
+            kubelet_volume_stats_capacity_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
+          ) < 0.03
+          and
+          kubelet_volume_stats_used_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s} > 0
+        ||| % kubernetesStorageConfig,
+        'for': '5m',
+        labels: {
+          severity: 'critical',
+        },
+      },
+      {
+        alert: 'KubePersistentVolumeFillingUp',
+        labels: {
+          severity: 'warning',
+        },
+      },
+    ],
+  },
+  {
+    name: 'node-exporter',
+    local nodeExporterConfig = { nodeExporterSelector: 'job="node-exporter"', fsSelector: 'fstype!=""', fsSpaceFillingUpCriticalThreshold: 15 },
+    rules: [
+      {
+        alert: 'NodeFilesystemSpaceFillingUp',
+        expr: |||
+          (
+            node_filesystem_avail_bytes{%(nodeExporterSelector)s,%(fsSelector)s} / node_filesystem_size_bytes{%(nodeExporterSelector)s,%(fsSelector)s} * 100 < %(fsSpaceFillingUpCriticalThreshold)d
+          and
+            predict_linear(node_filesystem_avail_bytes{%(nodeExporterSelector)s,%(fsSelector)s}[6h], 2*60*60) < 0
+          and
+            node_filesystem_readonly{%(nodeExporterSelector)s,%(fsSelector)s} == 0
+          )
+        ||| % nodeExporterConfig,
+        'for': '1h',
+        labels: {
+          severity: 'critical',
+        },
+      },
+      {
+        alert: 'NodeFilesystemSpaceFillingUp',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'NodeFilesystemFilesFillingUp',
+        expr: |||
+          (
+            node_filesystem_files_free{%(nodeExporterSelector)s,%(fsSelector)s} / node_filesystem_files{%(nodeExporterSelector)s,%(fsSelector)s} * 100 < 20
+          and
+            predict_linear(node_filesystem_files_free{%(nodeExporterSelector)s,%(fsSelector)s}[6h], 2*60*60) < 0
+          and
+            node_filesystem_readonly{%(nodeExporterSelector)s,%(fsSelector)s} == 0
+          )
+        ||| % nodeExporterConfig,
+        'for': '1h',
+        labels: {
+          severity: 'critical',
+        },
+      },
+      {
+        alert: 'NodeFilesystemFilesFillingUp',
+        labels: {
+          severity: 'warning',
+        },
+      },
+    ],
+  },
+  {
     name: 'prometheus',
     rules: [
       {
@@ -92,6 +234,68 @@ local patchedRules = [
       {
         alert: 'PrometheusOutOfOrderTimestamps',
         'for': '1h',
+      },
+      {
+        alert: 'PrometheusBadConfig',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'PrometheusRemoteStorageFailures',
+        expr: |||
+          (
+            (rate(prometheus_remote_storage_failed_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_failed_total{%(prometheusSelector)s}[5m]))
+          /
+            (
+              (rate(prometheus_remote_storage_failed_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_failed_total{%(prometheusSelector)s}[5m]))
+            +
+              (rate(prometheus_remote_storage_succeeded_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_total{%(prometheusSelector)s}[5m]))
+            )
+          )
+          * 100
+          > 10
+        ||| % { prometheusSelector: 'job=~"prometheus-k8s|prometheus-user-workload"' },
+        'for': '15m',
+        labels: {
+          severity: 'warning',
+        },
+
+      },
+      {
+        alert: 'PrometheusRuleFailures',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'PrometheusRemoteWriteBehind',
+        labels: {
+          severity: 'info',
+        },
+      },
+    ],
+  },
+  {
+    name: 'thanos-rule',
+    rules: [
+      {
+        alert: 'ThanosNoRuleEvaluations',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'ThanosRuleHighRuleEvaluationFailures',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'ThanosRuleSenderIsFailingAlerts',
+        labels: {
+          severity: 'warning',
+        },
       },
     ],
   },
@@ -124,19 +328,70 @@ local patchedRules = [
 local patchOrExcludeRule(rule, ruleSet, operation) =
   if std.length(ruleSet) == 0 then
     [rule]
-  else if (('alert' in rule && 'alert' in ruleSet[0]) && std.startsWith(rule.alert, ruleSet[0].alert)) ||
-          (('record' in rule && 'record' in ruleSet[0]) && std.startsWith(rule.record, ruleSet[0].record)) then
-    if operation == 'patch' then
-      local patch = {
-        [k]: ruleSet[0][k]
-        for k in std.objectFields(ruleSet[0])
-        if k != 'alert' && k != 'record'
-      };
-      [std.mergePatch(rule, patch)]
-    else
+  else if ('alert' in rule) then
+    local matchedRules = std.filter(function(ruleItem) ('alert' in ruleItem) && (ruleItem.alert == rule.alert), ruleSet);
+    local matchedRulesSeverity = std.filter(function(ruleItem) if ('labels' in ruleItem) && ('severity' in ruleItem.labels) then ruleItem.labels.severity == rule.labels.severity else false, matchedRules);
+
+    if std.length(matchedRules) > 1 && std.length(matchedRulesSeverity) >= 1 then
+      local targetRule = matchedRulesSeverity[0];
+      if operation == 'patch' then
+        local patch = {
+          [k]: targetRule[k]
+          for k in std.objectFields(targetRule)
+          if k != 'alert' && k != 'record'
+        };
+        [std.mergePatch(rule, patch)]
+      else if operation == 'exclude' then
+        []
+      else
+        assert false : 'operation not support ' + operation;
+        []
+
+    else if std.length(matchedRules) > 1 && std.length(matchedRulesSeverity) == 0 then
+      assert false : 'Duplicated patch rules without matching severity for rule: ' + std.toString(rule);
       []
+    else if std.length(matchedRules) == 1 && std.length(matchedRulesSeverity) <= 1 then
+      local targetRule = matchedRules[0];
+      if operation == 'patch' then
+        local patch = {
+          [k]: targetRule[k]
+          for k in std.objectFields(targetRule)
+          if k != 'alert' && k != 'record'
+        };
+        [std.mergePatch(rule, patch)]
+      else if operation == 'exclude' then
+        []
+      else
+        assert false : 'operation not support ' + operation;
+        []
+
+    else
+      [rule]
+  else if ('record' in rule) then
+
+    local matchedRules = std.filter(function(ruleItem) ('record' in ruleItem) && (ruleItem.record == rule.record), ruleSet);
+
+    if std.length(matchedRules) == 1 then
+      local targetRule = matchedRules[0];
+      if operation == 'patch' then
+        local patch = {
+          [k]: targetRule[k]
+          for k in std.objectFields(targetRule)
+          if k != 'alert' && k != 'record'
+        };
+        [std.mergePatch(rule, patch)]
+      else
+        []
+    else if std.length(matchedRules) > 1 then
+      assert false : 'Duplicated patch for record rules: ' + std.toString(rule) + ' matching patches: ' + std.toString(matchedRules);
+      []
+    else
+      [rule]
+
   else
-    [] + patchOrExcludeRule(rule, ruleSet[1:], operation);
+    // neither alert nor record rule, leave it as is
+    [rule];
+
 
 local patchOrExcludeRuleGroup(group, groupSet, operation) =
   if std.length(groupSet) == 0 then


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

Ready to review and merge :D

[Bugzilla #1986981](https://bugzilla.redhat.com/show_bug.cgi?id=1986981)

After reviewing critical alerts in OCP, we find out the 21 alerts that need adjustments:

(✅ for already modified alerts, 🛠 for work in progress)

Recommend changing Critical to Warning: 13

- KubePersistentVolumeErrors✅
- PrometheusBadConfig✅
- PrometheusRemoteStorageFailures✅
- PrometheusRuleFailures✅
- AlertmanagerMembersInconsistent✅
- AlertmanagerClusterFailedToSendAlerts✅
- AlertmanagerConfigInconsistent✅
- AlertmanagerClusterDown✅
- KubeStateMetricsListErrors✅
- KubeStateMetricsWatchErrors✅
- ThanosRuleSenderIsFailingAlerts✅
- ThanosRuleHighRuleEvaluationFailures✅
- ThanosNoRuleEvaluations✅

Recommend removing alert: 2
- PrometheusErrorSendingAlertsToAnyAlertmanager✅
- AlertmanagerClusterCrashlooping✅

Recommend changing Critical to Info: 1
- PrometheusRemoteWriteBehind✅

Threshold Tweaks: 5
- KubePersistentVolumeFillingUp ✅
- KubeletDown ✅ (no modification after reviewing)
- NodeFilesystemFilesFillingUp✅
- NodeFilesystemSpaceFillingUp✅
- PrometheusRemoteStorageFailures✅

Please refer to this table for details(proposed modification are in column F "Comments") : https://docs.google.com/spreadsheets/d/10rL3loHz6a8lBfKsU2W9TVZSrSqndrnVmkzDeA3Z2kI/edit?usp=sharing
