### PR TITLE
Bug 1990258: cleaning up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GOJSONTOYAML_BIN=$(BIN_DIR)/gojsontoyaml
 JSONNET_BIN=$(BIN_DIR)/jsonnet
 JSONNETFMT_BIN=$(BIN_DIR)/jsonnetfmt
 PROMTOOL_BIN=$(BIN_DIR)/promtool
-TOOLING=$(EMBEDMD_BIN) $(GOBINDATA_BIN) $(JB_BIN) $(GOJSONTOYAML) $(JSONNET_BIN) $(JSONNETFMT_BIN) $(PROMTOOL_BIN)
+TOOLING=$(EMBEDMD_BIN) $(JB_BIN) $(GOJSONTOYAML_BIN) $(JSONNET_BIN) $(JSONNETFMT_BIN) $(PROMTOOL_BIN)
 
 MANIFESTS_DIR ?= $(shell pwd)/manifests
 JSON_MANIFESTS_DIR ?= $(shell pwd)/tmp/json-manifests/manifests
@@ -87,6 +87,7 @@ vendor:
 .PHONY: generate
 generate: build-jsonnet docs check-assets check-runbooks
 
+# TODO(paulfantom): generate-in-docker can be completely removed after OpenShift 4.7 is EOL
 .PHONY: generate-in-docker
 generate-in-docker:
 	echo -e "FROM golang:1.14 \n RUN apt update && apt install python-yaml jq -y \n RUN mkdir /.cache && chown $(shell id -u):$(shell id -g) /.cache" | docker build -t cmo-tooling -


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

Noticed during https://github.com/openshift/release/pull/20887 development. Without this, on clean repository `make versions` fails as it cannot install `gojsontoyaml` dependency due to incorrectly named make targets.

Additionally, I added a note of deprecating `generate-in-docker` as it is no longer needed after we switched to use jsonnet and not python script.

`$(GOBINDATA_BIN)` wasn't used for a long time (I think around 4.6 we did a switch).