### PR TITLE
jsonnet: Support exluding namespaces from user-workload monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.9
 
+- [#1312](https://github.com/openshift/cluster-monitoring-operator/pull/1312) Support label to exclude namespaces from user-workload monitoring.
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Add config option to disable Grafana deployment.
 - [#1278](https://github.com/openshift/cluster-monitoring-operator/pull/1278) Add EnforcedTargetLimit option for user-workload Prometheus.
 - [#1291](https://github.com/openshift/cluster-monitoring-operator/pull/1291) Drop high caredinality cAdvisor metrics via [kube-prometheus #1250](https://github.com/prometheus-operator/kube-prometheus/pull/1250)

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -132,6 +132,10 @@ spec:
       operator: NotIn
       values:
       - "true"
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
   podMonitorSelector: {}
   priorityClassName: openshift-user-critical
   probeNamespaceSelector:
@@ -140,6 +144,10 @@ spec:
       operator: NotIn
       values:
       - "true"
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
   probeSelector: {}
   replicas: 2
   resources:
@@ -152,6 +160,10 @@ spec:
       operator: NotIn
       values:
       - "true"
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
   ruleSelector:
     matchLabels:
       openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
@@ -169,6 +181,10 @@ spec:
       operator: NotIn
       values:
       - "true"
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
   serviceMonitorSelector: {}
   thanos:
     image: quay.io/thanos/thanos:v0.22.0

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -86,6 +86,10 @@ spec:
       operator: NotIn
       values:
       - "true"
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
   ruleSelector:
     matchExpressions:
     - key: openshift.io/prometheus-rule-evaluation-scope

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -46,6 +46,11 @@ local commonConfig = {
         operator: 'NotIn',
         values: ['true'],
       },
+      {
+        key: 'openshift.io/user-monitoring',
+        operator: 'NotIn',
+        values: ['false'],
+      },
     ],
   },
   mixinNamespaceSelector: 'namespace=~"(openshift-.*|kube-.*|default)"',

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -20,6 +20,28 @@ import (
 	"github.com/Jeffail/gabs"
 )
 
+func getActiveTarget(body []byte, jobName string) error {
+	j, err := gabs.ParseJSON([]byte(body))
+	if err != nil {
+		return err
+	}
+
+	activeJobs, err := j.Path("data.activeTargets").Children()
+	if err != nil {
+		return err
+	}
+
+	for _, job := range activeJobs {
+		name := job.S("discoveredLabels").S("job").Data().(string)
+
+		if name == jobName {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("job name '%s' not found in active targets", jobName)
+}
+
 func getThanosRules(body []byte, expGroupName, expRuleName string) error {
 	j, err := gabs.ParseJSON([]byte(body))
 	if err != nil {


### PR DESCRIPTION
This adds support for setting an `openshift.io/user-monitoring` label
on namespaces to exclude them from user-workload monitoring.  This is
in addition to the exclusion of namespaces that have set a `true`
value for the `openshift.io/cluster-monitoring` label.

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
