### PR TITLE
Bug 1996785: [MON-1536]Remove unused rules.

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -63,10 +63,6 @@ spec:
         severity: warning
   - name: openshift-kubernetes.rules
     rules:
-    - expr: sum(container_memory_usage_bytes{container="",pod!=""}) BY (pod, namespace)
-      record: pod:container_memory_usage_bytes:sum
-    - expr: sum(container_spec_cpu_shares{container="",pod!=""}) BY (pod, namespace)
-      record: pod:container_spec_cpu_shares:sum
     - expr: sum(rate(container_cpu_usage_seconds_total{container="",pod!=""}[5m]))
         BY (pod, namespace)
       record: pod:container_cpu_usage:sum
@@ -74,8 +70,6 @@ spec:
       record: pod:container_fs_usage_bytes:sum
     - expr: sum(container_memory_usage_bytes{container!=""}) BY (namespace)
       record: namespace:container_memory_usage_bytes:sum
-    - expr: sum(container_spec_cpu_shares{container!=""}) BY (namespace)
-      record: namespace:container_spec_cpu_shares:sum
     - expr: sum(rate(container_cpu_usage_seconds_total{container!="POD",container!=""}[5m]))
         BY (namespace)
       record: namespace:container_cpu_usage:sum
@@ -389,8 +383,6 @@ spec:
       record: cluster:usage:openshift:ingress_request_total:irate5m
   - name: openshift-build.rules
     rules:
-    - expr: sum(openshift_build_total{job="kubernetes-apiservers",phase="Error"})/(sum(openshift_build_total{job="kubernetes-apiservers",phase=~"Failed|Complete|Error"}))
-      record: build_error_rate
     - expr: sum by (strategy) (openshift_build_status_phase_total)
       record: openshift:build_by_strategy:sum
   - name: openshift-monitoring.rules
@@ -436,15 +428,6 @@ spec:
     rules:
     - expr: sum(rate(apiserver_request_total{job="apiserver"}[10m])) BY (code)
       record: code:apiserver_request_total:rate:sum
-    - expr: sum(rate(apiserver_request_total{job="apiserver",resource=~"image.*",verb!="WATCH"}[10m]))
-        BY (code)
-      record: code:registry_api_request_count:rate:sum
-    - expr: sum(kube_pod_status_ready{condition="true",namespace="openshift-etcd",pod=~"etcd.*"})
-        by(condition)
-      record: kube_pod_status_ready:etcd:sum
-    - expr: sum(kube_pod_status_ready{condition="true",namespace="openshift-image-registry",pod=~"image-registry.*"})
-        by(condition)
-      record: kube_pod_status_ready:image_registry:sum
   - name: general.rules
     rules:
     - alert: Watchdog
@@ -481,10 +464,6 @@ spec:
       record: instance:node_network_receive_bytes:rate:sum
     - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)
       record: instance:node_network_transmit_bytes:rate:sum
-    - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
-        WITHOUT (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu_seconds_total)
-        BY (instance, cpu)) BY (instance)
-      record: instance:node_cpu:ratio
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
       record: cluster:node_cpu:sum_rate5m
     - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -525,35 +525,6 @@ spec:
       for: 15m
       labels:
         severity: critical
-  - name: kube-apiserver-histogram.rules
-    rules:
-    - expr: |
-        histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET"}[5m]))) > 0
-      labels:
-        quantile: "0.99"
-        verb: read
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))) > 0
-      labels:
-        quantile: "0.99"
-        verb: write
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.99"
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.9"
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.5"
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
   - name: k8s.rules
     rules:
     - expr: |
@@ -747,13 +718,6 @@ spec:
             label_replace(kube_pod_info{job="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
         ))
       record: 'node_namespace_pod:kube_pod_info:'
-    - expr: |
-        count by (cluster, node) (sum by (node, cpu) (
-          node_cpu_seconds_total{job="node-exporter"}
-        * on (namespace, pod) group_left(node)
-          topk by(namespace, pod) (1, node_namespace_pod:kube_pod_info:)
-        ))
-      record: node:node_num_cpu:sum
     - expr: |
         sum(
           node_memory_MemAvailable_bytes{job="node-exporter"} or

--- a/hack/check-rec-rule-usage.sh
+++ b/hack/check-rec-rule-usage.sh
@@ -4,16 +4,19 @@ set -e
 TMP=$(mktemp -d)
 echo "Created temporary directory at $TMP"
 
-findrules="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/find-rules.sh"
+findrules="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/find-rules.sh"
 
-"$findrules" > "$TMP/rule-groups"
+"$findrules" >"$TMP/rule-groups"
 # extract recording rules
-tmp/bin/gojsontoyaml -yamltojson <  "$TMP/rule-groups" | jq -s '.. | objects | select(.record) | .record' | tr -d '"' | sort -u > "$TMP/rec-rules"
+tmp/bin/gojsontoyaml -yamltojson <"$TMP/rule-groups" | jq -s '.. | objects | select(.record) | .record' | tr -d '"' | sort -u >"$TMP/rec-rules"
 # and alerting rules
-tmp/bin/gojsontoyaml -yamltojson <  "$TMP/rule-groups" | jq -s '.. | objects | select(.alert) | .expr' | grep "\w\+{" -o | tr -d "{" | sort -u > "$TMP/alert-rules"
-# the first grep outputs all recording rules that are not used in alerts
-# and then greps for the remaining rules in the dashboard defs and outputs the ones that are not found
-grep -Fxvf "$TMP/alert-rules" "$TMP/rec-rules" | while read -r r; do grep "$r" assets/grafana/dashboard-definitions.yaml -q || echo "$r"; done > "$TMP/unused-rules"
+tmp/bin/gojsontoyaml -yamltojson <"$TMP/rule-groups" | jq -s '.. | objects | select(.alert) | .expr' | grep "\w\+{" -o | tr -d "{" | sort -u >"$TMP/used-rules"
+# and telemetry client's metrics
+tmp/bin/gojsontoyaml -yamltojson <manifests/*-config.yaml | jq '.data."metrics.yaml"' | sed "s;\\\\n;\n;g" | grep "^-\s'{__name__=\\\\\"" | sed -e "s/^- '{__name__=\\\\\"//" | sed -e "s/\\\\\"[^}]*}'//" | sort | uniq >>"$TMP/used-rules"
 
-echo "Found $(wc -l < "$TMP/unused-rules") unused rules"
+# the first grep outputs all recording rules that are used neither in alerts nor telemetry metrics
+# and then greps for the remaining rules in the dashboard defs and outputs the ones that are not found
+grep -Fxvf "$TMP/used-rules" "$TMP/rec-rules" | while read -r r; do grep "$r" assets/grafana/dashboard-definitions.yaml -q || echo "$r"; done >"$TMP/unused-rules"
+
+echo "Found $(wc -l <"$TMP/unused-rules") unused rules"
 echo "Find the unused rules in $TMP/unused-rules"

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -510,10 +510,6 @@ function(params) {
       name: 'openshift-build.rules',
       rules: [
         {
-          expr: 'sum(openshift_build_total{job="kubernetes-apiservers",phase="Error"})/(sum(openshift_build_total{job="kubernetes-apiservers",phase=~"Failed|Complete|Error"}))',
-          record: 'build_error_rate',
-        },
-        {
           expr: 'sum by (strategy) (openshift_build_status_phase_total)',
           record: 'openshift:build_by_strategy:sum',
         },
@@ -591,18 +587,6 @@ function(params) {
         {
           expr: 'sum(rate(apiserver_request_total{job="apiserver"}[10m])) BY (code)',
           record: 'code:apiserver_request_total:rate:sum',
-        },
-        {
-          expr: 'sum(rate(apiserver_request_total{job="apiserver",resource=~"image.*",verb!="WATCH"}[10m])) BY (code)',
-          record: 'code:registry_api_request_count:rate:sum',
-        },
-        {
-          expr: 'sum(kube_pod_status_ready{condition="true",namespace="openshift-etcd",pod=~"etcd.*"}) by(condition)',
-          record: 'kube_pod_status_ready:etcd:sum',
-        },
-        {
-          expr: 'sum(kube_pod_status_ready{condition="true",namespace="openshift-image-registry",pod=~"image-registry.*"}) by(condition)',
-          record: 'kube_pod_status_ready:image_registry:sum',
         },
       ],
     },

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -10,6 +10,7 @@ local excludedRuleGroups = [
   'kube-apiserver-slos',
   'kube-apiserver.rules',
   'kube-apiserver-burnrate.rules',
+  'kube-apiserver-histogram.rules',
 ];
 
 local excludedRules = [
@@ -71,6 +72,28 @@ local excludedRules = [
     name: 'prometheus',
     rules: [
       { alert: 'PrometheusErrorSendingAlertsToAnyAlertmanager' },
+    ],
+  },
+  // The following rules are removed due to lack of usefulness
+  // Refer to https://bugzilla.redhat.com/show_bug.cgi?id=1996785 for details.
+  {
+    name: 'kube-prometheus-node-recording.rules',
+    rules: [
+      { record: 'instance:node_cpu:ratio' },
+    ],
+  },
+  {
+    name: 'node.rules',
+    rules: [
+      { record: 'node:node_num_cpu:sum' },
+    ],
+  },
+  {
+    name: 'openshift-kubernetes.rules',
+    rules: [
+      { record: 'namespace:container_spec_cpu_shares:sum' },
+      { record: 'pod:container_memory_usage_bytes:sum' },
+      { record: 'pod:container_spec_cpu_shares:sum' },
     ],
   },
   {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

The recording rules that are not unused in alerts, telemetry metrics, console, or dashboard definitions are removed.

The following rules are removed:
- build_error_rate
- cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
- code:registry_api_request_count:rate:sum
- instance:node_cpu:ratio
- kube_pod_status_ready:etcd:sum
- kube_pod_status_ready:image_registry:sum
- namespace:container_spec_cpu_shares:sum
- node:node_num_cpu:sum
- pod:container_spec_cpu_shares:sum
