### PR TITLE
Bug 1986981: Alert Config update - Patch to PR#1310

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -339,7 +339,7 @@ spec:
         ) < 0.03
         and
         kubelet_volume_stats_used_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
-      for: 5m
+      for: 1m
       labels:
         severity: critical
     - alert: KubePersistentVolumeFillingUp

--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -41,7 +41,7 @@ spec:
         (
           node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 15
         and
-          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 2*60*60) < 0
+          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
         and
           node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
         )
@@ -103,7 +103,7 @@ spec:
         (
           node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 20
         and
-          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 2*60*60) < 0
+          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
         and
           node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
         )

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -148,7 +148,7 @@ spec:
           )
         )
         * 100
-        > 10
+        > 1
       for: 15m
       labels:
         severity: warning

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -252,18 +252,18 @@ spec:
         summary: Thanos Sidecar cannot connect to Prometheus
       expr: |
         thanos_sidecar_prometheus_up{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"} == 0
-      for: 5m
+      for: 1h
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosSidecarBucketOperationsFailed
       annotations:
         description: Thanos Sidecar {{$labels.instance}} bucket operations are failing
         summary: Thanos Sidecar bucket operations are failing
       expr: |
         sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}[5m])) > 0
-      for: 5m
+      for: 1h
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosSidecarUnhealthy
       annotations:
         description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than
@@ -271,6 +271,6 @@ spec:
         summary: Thanos Sidecar is unhealthy.
       expr: |
         time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}) >= 240
-      for: 5m
+      for: 1h
       labels:
-        severity: critical
+        severity: warning

--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -23,9 +23,9 @@ spec:
         /
           sum by (job) (rate(http_requests_total{job="thanos-querier", handler="query"}[5m]))
         ) * 100 > 5
-      for: 5m
+      for: 1h
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
       annotations:
         description: Thanos Query {{$labels.job}} is failing to handle {{$value |
@@ -37,9 +37,9 @@ spec:
         /
           sum by (job) (rate(http_requests_total{job="thanos-querier", handler="query_range"}[5m]))
         ) * 100 > 5
-      for: 5m
+      for: 1h
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosQueryGrpcServerErrorRate
       annotations:
         description: Thanos Query {{$labels.job}} is failing to handle {{$value |
@@ -52,7 +52,7 @@ spec:
           sum by (job) (rate(grpc_server_started_total{job="thanos-querier"}[5m]))
         * 100 > 5
         )
-      for: 5m
+      for: 1h
       labels:
         severity: warning
     - alert: ThanosQueryGrpcClientErrorRate
@@ -66,7 +66,7 @@ spec:
         /
           sum by (job) (rate(grpc_client_started_total{job="thanos-querier"}[5m]))
         ) * 100 > 5
-      for: 5m
+      for: 1h
       labels:
         severity: warning
     - alert: ThanosQueryHighDNSFailures
@@ -80,6 +80,6 @@ spec:
         /
           sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job="thanos-querier"}[5m]))
         ) * 100 > 1
-      for: 15m
+      for: 1h
       labels:
         severity: warning

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -152,78 +152,6 @@ local patchedRules = [
           severity: 'warning',
         },
       },
-      {
-        alert: 'KubePersistentVolumeFillingUp',
-        expr: |||
-          (
-            kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
-              /
-            kubelet_volume_stats_capacity_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
-          ) < 0.03
-          and
-          kubelet_volume_stats_used_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s} > 0
-        ||| % kubernetesStorageConfig,
-        'for': '5m',
-        labels: {
-          severity: 'critical',
-        },
-      },
-      {
-        alert: 'KubePersistentVolumeFillingUp',
-        labels: {
-          severity: 'warning',
-        },
-      },
-    ],
-  },
-  {
-    name: 'node-exporter',
-    local nodeExporterConfig = { nodeExporterSelector: 'job="node-exporter"', fsSelector: 'fstype!=""', fsSpaceFillingUpCriticalThreshold: 15 },
-    rules: [
-      {
-        alert: 'NodeFilesystemSpaceFillingUp',
-        expr: |||
-          (
-            node_filesystem_avail_bytes{%(nodeExporterSelector)s,%(fsSelector)s} / node_filesystem_size_bytes{%(nodeExporterSelector)s,%(fsSelector)s} * 100 < %(fsSpaceFillingUpCriticalThreshold)d
-          and
-            predict_linear(node_filesystem_avail_bytes{%(nodeExporterSelector)s,%(fsSelector)s}[6h], 2*60*60) < 0
-          and
-            node_filesystem_readonly{%(nodeExporterSelector)s,%(fsSelector)s} == 0
-          )
-        ||| % nodeExporterConfig,
-        'for': '1h',
-        labels: {
-          severity: 'critical',
-        },
-      },
-      {
-        alert: 'NodeFilesystemSpaceFillingUp',
-        labels: {
-          severity: 'warning',
-        },
-      },
-      {
-        alert: 'NodeFilesystemFilesFillingUp',
-        expr: |||
-          (
-            node_filesystem_files_free{%(nodeExporterSelector)s,%(fsSelector)s} / node_filesystem_files{%(nodeExporterSelector)s,%(fsSelector)s} * 100 < 20
-          and
-            predict_linear(node_filesystem_files_free{%(nodeExporterSelector)s,%(fsSelector)s}[6h], 2*60*60) < 0
-          and
-            node_filesystem_readonly{%(nodeExporterSelector)s,%(fsSelector)s} == 0
-          )
-        ||| % nodeExporterConfig,
-        'for': '1h',
-        labels: {
-          severity: 'critical',
-        },
-      },
-      {
-        alert: 'NodeFilesystemFilesFillingUp',
-        labels: {
-          severity: 'warning',
-        },
-      },
     ],
   },
   {
@@ -245,20 +173,6 @@ local patchedRules = [
       },
       {
         alert: 'PrometheusRemoteStorageFailures',
-        expr: |||
-          (
-            (rate(prometheus_remote_storage_failed_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_failed_total{%(prometheusSelector)s}[5m]))
-          /
-            (
-              (rate(prometheus_remote_storage_failed_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_failed_total{%(prometheusSelector)s}[5m]))
-            +
-              (rate(prometheus_remote_storage_succeeded_samples_total{%(prometheusSelector)s}[5m]) or rate(prometheus_remote_storage_samples_total{%(prometheusSelector)s}[5m]))
-            )
-          )
-          * 100
-          > 10
-        ||| % { prometheusSelector: 'job=~"prometheus-k8s|prometheus-user-workload"' },
-        'for': '15m',
         labels: {
           severity: 'warning',
         },

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -342,7 +342,8 @@ local patchOrExcludeRule(rule, ruleSet, operation) =
   if std.length(ruleSet) == 0 then
     [rule]
   else if ('alert' in rule) then
-    local matchedRules = std.filter(function(ruleItem) ('alert' in ruleItem) && (ruleItem.alert == rule.alert), ruleSet);
+    // empty alert name is matching-all
+    local matchedRules = std.filter(function(ruleItem) ('alert' in ruleItem) && ((ruleItem.alert == rule.alert) || (ruleItem.alert == '')), ruleSet);
     local matchedRulesSeverity = std.filter(function(ruleItem) if ('labels' in ruleItem) && ('severity' in ruleItem.labels) then ruleItem.labels.severity == rule.labels.severity else false, matchedRules);
 
     if std.length(matchedRules) > 1 && std.length(matchedRulesSeverity) >= 1 then
@@ -381,8 +382,8 @@ local patchOrExcludeRule(rule, ruleSet, operation) =
     else
       [rule]
   else if ('record' in rule) then
-
-    local matchedRules = std.filter(function(ruleItem) ('record' in ruleItem) && (ruleItem.record == rule.record), ruleSet);
+    // empty record name is matching-all
+    local matchedRules = std.filter(function(ruleItem) ('record' in ruleItem) && ((ruleItem.record == rule.record) || (ruleItem.record == '')), ruleSet);
 
     if std.length(matchedRules) == 1 then
       local targetRule = matchedRules[0];


### PR DESCRIPTION
This PR includes 2 amendments to PR#1310:
1. This PR patches Thanos-related alerts to warning severity and triggering time window to 1h. In PR#1310 I have introduced a bug in the patching function that does not take empty alert/record name as an all-matching wildcard. 😅
2. remove patch for "expr" field in rules KubePersistentVolumeFillingUp, NodeFilesystemFilesFillingUp, and NodeFilesystemSpaceFillingUp, leaving it to upstream

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
