### PR TITLE
MON-1679: adding static auth to KSM

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -66,6 +66,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
+        - --config-file=/etc/kube-rbac-policy/config.yaml
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy-main
         ports:
@@ -84,6 +85,9 @@ spec:
         - mountPath: /etc/tls/client
           name: metrics-client-ca
           readOnly: false
+        - mountPath: /etc/kube-rbac-policy
+          name: kube-state-metrics-kube-rbac-proxy-config
+          readOnly: true
       - args:
         - --logtostderr
         - --secure-listen-address=:9443
@@ -92,6 +96,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
+        - --config-file=/etc/kube-rbac-policy/config.yaml
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy-self
         ports:
@@ -110,6 +115,9 @@ spec:
         - mountPath: /etc/tls/client
           name: metrics-client-ca
           readOnly: false
+        - mountPath: /etc/kube-rbac-policy
+          name: kube-state-metrics-kube-rbac-proxy-config
+          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
@@ -124,3 +132,6 @@ spec:
       - configMap:
           name: metrics-client-ca
         name: metrics-client-ca
+      - name: kube-state-metrics-kube-rbac-proxy-config
+        secret:
+          secretName: kube-state-metrics-kube-rbac-proxy-config

--- a/assets/kube-state-metrics/kube-rbac-proxy-secret.yaml
+++ b/assets/kube-state-metrics/kube-rbac-proxy-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: kube-state-metrics-kube-rbac-proxy-config
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/jsonnet/utils/generate-secret.libsonnet
+++ b/jsonnet/utils/generate-secret.libsonnet
@@ -1,0 +1,29 @@
+{
+  staticAuthSecret(cfgNamespace, cfgCommonLabels, cfgName):: {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name: cfgName,
+      namespace: cfgNamespace,
+      labels: cfgCommonLabels,
+    },
+    type: 'Opaque',
+    data: {},
+    stringData: {
+      'config.yaml': std.manifestYamlDoc({
+        authorization: {
+          static: [
+            {
+              user: {
+                name: 'system:serviceaccount:openshift-monitoring:prometheus-k8s',
+              },
+              verb: 'get',
+              path: '/metrics',
+              resourceRequest: false,
+            },
+          ],
+        },
+      },),
+    },
+  },
+}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -66,13 +66,14 @@ var (
 	AlertmanagerTrustedCABundle    = "alertmanager/trusted-ca-bundle.yaml"
 	AlertmanagerPrometheusRule     = "alertmanager/prometheus-rule.yaml"
 
-	KubeStateMetricsClusterRoleBinding = "kube-state-metrics/cluster-role-binding.yaml"
-	KubeStateMetricsClusterRole        = "kube-state-metrics/cluster-role.yaml"
-	KubeStateMetricsDeployment         = "kube-state-metrics/deployment.yaml"
-	KubeStateMetricsServiceAccount     = "kube-state-metrics/service-account.yaml"
-	KubeStateMetricsService            = "kube-state-metrics/service.yaml"
-	KubeStateMetricsServiceMonitor     = "kube-state-metrics/service-monitor.yaml"
-	KubeStateMetricsPrometheusRule     = "kube-state-metrics/prometheus-rule.yaml"
+	KubeStateMetricsClusterRoleBinding  = "kube-state-metrics/cluster-role-binding.yaml"
+	KubeStateMetricsClusterRole         = "kube-state-metrics/cluster-role.yaml"
+	KubeStateMetricsDeployment          = "kube-state-metrics/deployment.yaml"
+	KubeStateMetricsServiceAccount      = "kube-state-metrics/service-account.yaml"
+	KubeStateMetricsService             = "kube-state-metrics/service.yaml"
+	KubeStateMetricsServiceMonitor      = "kube-state-metrics/service-monitor.yaml"
+	KubeStateMetricsPrometheusRule      = "kube-state-metrics/prometheus-rule.yaml"
+	KubeStateMetricsKubeRbacProxySecret = "kube-state-metrics/kube-rbac-proxy-secret.yaml"
 
 	OpenShiftStateMetricsClusterRoleBinding = "openshift-state-metrics/cluster-role-binding.yaml"
 	OpenShiftStateMetricsClusterRole        = "openshift-state-metrics/cluster-role.yaml"
@@ -569,6 +570,17 @@ func (f *Factory) KubeStateMetricsServiceAccount() (*v1.ServiceAccount, error) {
 
 func (f *Factory) KubeStateMetricsService() (*v1.Service, error) {
 	s, err := f.NewService(f.assets.MustNewAssetReader(KubeStateMetricsService))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespace
+
+	return s, nil
+}
+
+func (f *Factory) KubeStateMetricsRBACProxySecret() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetReader(KubeStateMetricsKubeRbacProxySecret))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tasks/kubestatemetrics.go
+++ b/pkg/tasks/kubestatemetrics.go
@@ -64,6 +64,16 @@ func (t *KubeStateMetricsTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling kube-state-metrics ClusterRoleBinding failed")
 	}
 
+	rs, err := t.factory.KubeStateMetricsRBACProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing kube-state-metrics RBAC proxy Secret failed")
+	}
+
+	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	if err != nil {
+		return errors.Wrap(err, "creating kube-state-metrics RBAC proxy Secret failed")
+	}
+
 	svc, err := t.factory.KubeStateMetricsService()
 	if err != nil {
 		return errors.Wrap(err, "initializing kube-state-metrics Service failed")
@@ -99,5 +109,9 @@ func (t *KubeStateMetricsTask) Run(ctx context.Context) error {
 	}
 
 	err = t.client.CreateOrUpdateServiceMonitor(ctx, sm)
-	return errors.Wrap(err, "reconciling kube-state-metrics ServiceMonitor failed")
+	if err != nil {
+		errors.Wrap(err, "reconciling kube-state-metrics ServiceMonitor failed")
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
