### PR TITLE
jsonnet: Add missing namespace labels to alerting rules

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -298,6 +298,7 @@ spec:
       expr: cluster:alertmanager_integrations:max == 0
       for: 10m
       labels:
+        namespace: openshift-monitoring
         severity: warning
     - alert: KubeDeploymentReplicasMismatch
       annotations:
@@ -333,6 +334,7 @@ spec:
         == 1) > 5
       for: 15m
       labels:
+        namespace: kube-system
         severity: info
     - expr: avg_over_time((((count((max by (node) (up{job="kubelet",metrics_path="/metrics"}
         == 1) and max by (node) (kube_node_status_condition{condition="Ready",status="true"}
@@ -454,6 +456,7 @@ spec:
           is working properly.
       expr: vector(1)
       labels:
+        namespace: openshift-monitoring
         severity: none
   - name: node-network
     rules:

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -243,6 +243,7 @@ spec:
         ((count(kube_node_status_allocatable{resource="cpu"}) > 1) - 1) / count(kube_node_status_allocatable{resource="cpu"})
       for: 5m
       labels:
+        namespace: kube-system
         severity: warning
     - alert: KubeMemoryOvercommit
       annotations:
@@ -259,6 +260,7 @@ spec:
         count(kube_node_status_allocatable{resource="memory"})
       for: 5m
       labels:
+        namespace: kube-system
         severity: warning
     - alert: KubeCPUQuotaOvercommit
       annotations:
@@ -524,6 +526,7 @@ spec:
         absent(up{job="kubelet", metrics_path="/metrics"} == 1)
       for: 15m
       labels:
+        namespace: kube-system
         severity: critical
   - name: kube-apiserver-histogram.rules
     rules:

--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -19,9 +19,9 @@ spec:
         summary: Thanos Query is failing to handle requests.
       expr: |
         (
-          sum by (job) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query"}[5m]))
+          sum by (job, namespace) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query"}[5m]))
         /
-          sum by (job) (rate(http_requests_total{job="thanos-querier", handler="query"}[5m]))
+          sum by (job, namespace) (rate(http_requests_total{job="thanos-querier", handler="query"}[5m]))
         ) * 100 > 5
       for: 5m
       labels:
@@ -33,9 +33,9 @@ spec:
         summary: Thanos Query is failing to handle requests.
       expr: |
         (
-          sum by (job) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query_range"}[5m]))
+          sum by (job, namespace) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query_range"}[5m]))
         /
-          sum by (job) (rate(http_requests_total{job="thanos-querier", handler="query_range"}[5m]))
+          sum by (job, namespace) (rate(http_requests_total{job="thanos-querier", handler="query_range"}[5m]))
         ) * 100 > 5
       for: 5m
       labels:
@@ -47,9 +47,9 @@ spec:
         summary: Thanos Query is failing to handle requests.
       expr: |
         (
-          sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job="thanos-querier"}[5m]))
+          sum by (job, namespace) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job="thanos-querier"}[5m]))
         /
-          sum by (job) (rate(grpc_server_started_total{job="thanos-querier"}[5m]))
+          sum by (job, namespace) (rate(grpc_server_started_total{job="thanos-querier"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -62,9 +62,9 @@ spec:
         summary: Thanos Query is failing to send requests.
       expr: |
         (
-          sum by (job) (rate(grpc_client_handled_total{grpc_code!="OK", job="thanos-querier"}[5m]))
+          sum by (job, namespace) (rate(grpc_client_handled_total{grpc_code!="OK", job="thanos-querier"}[5m]))
         /
-          sum by (job) (rate(grpc_client_started_total{job="thanos-querier"}[5m]))
+          sum by (job, namespace) (rate(grpc_client_started_total{job="thanos-querier"}[5m]))
         ) * 100 > 5
       for: 5m
       labels:
@@ -76,9 +76,9 @@ spec:
         summary: Thanos Query is having high number of DNS failures.
       expr: |
         (
-          sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job="thanos-querier"}[5m]))
+          sum by (job, namespace) (rate(thanos_query_store_apis_dns_failures_total{job="thanos-querier"}[5m]))
         /
-          sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job="thanos-querier"}[5m]))
+          sum by (job, namespace) (rate(thanos_query_store_apis_dns_lookups_total{job="thanos-querier"}[5m]))
         ) * 100 > 1
       for: 15m
       labels:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -8,6 +8,9 @@ function(params)
       targetGroups: {},
       query+:: {
         selector: 'job="thanos-querier"',
+        // All OpenShift alerts should include a namespace label.
+        // See: https://issues.redhat.com/browse/MON-939
+        dimensions: 'job, namespace',
       },
     },
 

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -381,6 +381,9 @@ function(params) {
           },
           labels: {
             severity: 'warning',
+            // All OpenShift alerts should have a namespace label.
+            // See: https://issues.redhat.com/browse/MON-939
+            namespace: 'openshift-monitoring',
           },
         },
         {
@@ -414,6 +417,9 @@ function(params) {
           },
           labels: {
             severity: 'info',
+            // All OpenShift alerts should have a namespace label.
+            // See: https://issues.redhat.com/browse/MON-939
+            namespace: 'kube-system',
           },
         },
         {

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -113,6 +113,19 @@ local patchedRules = [
     ],
   },
   {
+    name: 'general.rules',
+    rules: [
+      {
+        alert: 'Watchdog',
+        labels: {
+          // All OpenShift alerts should include a namespace label.
+          // See: https://issues.redhat.com/browse/MON-939
+          namespace: 'openshift-monitoring',
+        },
+      },
+    ],
+  },
+  {
     name: 'kubernetes-apps',
     rules: [
       // Stop-gap fix for https://bugzilla.redhat.com/show_bug.cgi?id=1943667
@@ -122,6 +135,43 @@ local patchedRules = [
           description: 'DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} has not finished or progressed for at least 30 minutes.',
         },
         'for': '30m',
+      },
+    ],
+  },
+  {
+    name: 'kubernetes-resources',
+    rules: [
+      // The expression for these alerts are cross-namespace, but all OpenShift
+      // alerts should include a namespace label for routing purposes, so we set
+      // one statically here.
+      //
+      // See: https://issues.redhat.com/browse/MON-939
+      {
+        alert: 'KubeCPUOvercommit',
+        labels: {
+          namespace: 'kube-system',
+        },
+      },
+      {
+        alert: 'KubeMemoryOvercommit',
+        labels: {
+          namespace: 'kube-system',
+        },
+      },
+    ],
+  },
+  {
+    name: 'kubernetes-system-kubelet',
+    rules: [
+      // Similar to above, the expression for this alert uses 'absent()' and
+      // doesn't include a namespace label, so we set one statically.
+      //
+      // See: https://issues.redhat.com/browse/MON-939
+      {
+        alert: 'KubeletDown',
+        labels: {
+          namespace: 'kube-system',
+        },
       },
     ],
   },


### PR DESCRIPTION
All OpenShift alerts should include a namespace label for routing.
We've queried Telemeter data and identified several shipped by CMO
that don't include a namespace.  This adds the labels to these by
either adjusting the expressions in the rules, or simply adding static
labels were appropriate.

See: https://issues.redhat.com/browse/MON-939

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
