### PR TITLE
Bug 1989438: changing error message to indicate deployment status

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -795,7 +795,8 @@ func (c *Client) WaitForDeploymentRollout(ctx context.Context, dep *appsv1.Deplo
 			return false, nil
 		}
 		if d.Status.UpdatedReplicas != d.Status.Replicas {
-			lastErr = errors.Errorf("expected %d replicas, got %d updated replicas",
+			lastErr = errors.Errorf("the number of pods targeted by the deployment (%d pods) is different "+
+				"from the number of pods targeted by the deployment that have the desired template spec (%d pods)",
 				d.Status.Replicas, d.Status.UpdatedReplicas)
 			return false, nil
 		}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
