### PR TITLE
Bug 1984365: Dashboard Prometheus/Overview can't filter instance by job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Allow configuring additional Alertmanagers in User Workload Prometheus and Thanos Ruler.
 - [#1293](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Allow disabling the local Alertmanager.
 - [#1310](https://github.com/openshift/cluster-monitoring-operator/pull/1310) Update Alert Configs, fewer critical alerts with more accurate triggering condition.
+- [#1324](https://github.com/openshift/cluster-monitoring-operator/pull/1324) Allow filtering by job in 'Prometheus/Overview' dashboard.
 
 ## 4.8
 

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -22337,7 +22337,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(prometheus_build_info, job)",
+                      "query": "label_values(prometheus_build_info{job=~\"prometheus-k8s|prometheus-user-workload\"}, job)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,
@@ -22365,7 +22365,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(prometheus_build_info, instance)",
+                      "query": "label_values(prometheus_build_info{job=~\"$job\"}, instance)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -173,8 +173,8 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "ed24e51e7c73177e48fa8d2846dcbee26f872207",
-      "sum": "G3mFWvwIrrhG6hlPz/hQdE6ZNSim88DlbSDJN7enkhY=",
+      "version": "9dfdc3eb3668971523d7d2f24f87f5b1333b545a",
+      "sum": "AS8WYFi/z10BZSF6DFkKBscjB32XDMM7iIso7CO/FyI=",
       "name": "prometheus"
     },
     {

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -22364,7 +22364,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(prometheus_build_info, job)",
+                    "query": "label_values(prometheus_build_info{job=~\"prometheus-k8s|prometheus-user-workload\"}, job)",
                     "refresh": 1,
                     "regex": "",
                     "sort": 2,
@@ -22392,7 +22392,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(prometheus_build_info, instance)",
+                    "query": "label_values(prometheus_build_info{job=~\"$job\"}, instance)",
                     "refresh": 1,
                     "regex": "",
                     "sort": 2,


### PR DESCRIPTION
EDIT: reduced scope of this PR to only include issues related to the bug.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.

