### PR TITLE
Bug 1956830: Update prometheus-adapter to v0.9.0

### DIFF
--- a/assets/prometheus-adapter/api-service.yaml
+++ b/assets/prometheus-adapter/api-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io

--- a/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
+++ b/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/assets/prometheus-adapter/cluster-role-binding-delegator.yaml
+++ b/assets/prometheus-adapter/cluster-role-binding-delegator.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: resource-metrics:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-adapter/cluster-role-binding.yaml
+++ b/assets/prometheus-adapter/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-adapter/cluster-role-server-resources.yaml
+++ b/assets/prometheus-adapter/cluster-role-server-resources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: resource-metrics-server-resources
 rules:
 - apiGroups:

--- a/assets/prometheus-adapter/cluster-role.yaml
+++ b/assets/prometheus-adapter/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
 rules:
 - apiGroups:

--- a/assets/prometheus-adapter/config-map.yaml
+++ b/assets/prometheus-adapter/config-map.yaml
@@ -64,6 +64,6 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: adapter-config
   namespace: openshift-monitoring

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
   namespace: openshift-monitoring
 spec:
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/component: metrics-adapter
         app.kubernetes.io/name: prometheus-adapter
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 0.8.4
+        app.kubernetes.io/version: 0.9.0
     spec:
       affinity:
         podAntiAffinity:
@@ -48,7 +48,7 @@ spec:
         - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc:9091
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        image: directxman12/k8s-prometheus-adapter:v0.8.4
+        image: directxman12/k8s-prometheus-adapter:v0.9.0
         name: prometheus-adapter
         ports:
         - containerPort: 6443

--- a/assets/prometheus-adapter/pod-disruption-budget.yaml
+++ b/assets/prometheus-adapter/pod-disruption-budget.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
   namespace: openshift-monitoring
 spec:

--- a/assets/prometheus-adapter/role-binding-auth-reader.yaml
+++ b/assets/prometheus-adapter/role-binding-auth-reader.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: resource-metrics-auth-reader
   namespace: kube-system
 roleRef:

--- a/assets/prometheus-adapter/service-account.yaml
+++ b/assets/prometheus-adapter/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
   namespace: openshift-monitoring

--- a/assets/prometheus-adapter/service-monitor.yaml
+++ b/assets/prometheus-adapter/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
   namespace: openshift-monitoring
 spec:

--- a/assets/prometheus-adapter/service.yaml
+++ b/assets/prometheus-adapter/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.8.4
+    app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -21,6 +21,6 @@ versions:
   nodeExporter: 1.1.2
   promLabelProxy: 0.3.0
   prometheus: 2.28.1
-  prometheusAdapter: 0.8.4
+  prometheusAdapter: 0.9.0
   prometheusOperator: 0.49.0
   thanos: 0.22.0


### PR DESCRIPTION
Updating manually to block the Bugzillas fixed by the new version from moving ON_QA without the labels being updated.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
