### PR TITLE
Bug 1992493: jsonnet:rules: Adds missing summary and description to rules.

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -282,8 +282,10 @@ spec:
       record: cluster:control_plane:all_nodes_ready
     - alert: ClusterMonitoringOperatorReconciliationErrors
       annotations:
-        message: Cluster Monitoring Operator is experiencing unexpected reconciliation
-          errors. Inspect the cluster-monitoring-operator log for potential root causes.
+        description: Errors are occurring during reconciliation cycles. Inspect the
+          cluster-monitoring-operator log for potential root causes.
+        summary: Cluster Monitoring Operator is experiencing unexpected reconciliation
+          errors.
       expr: max_over_time(cluster_monitoring_operator_last_reconciliation_successful[5m])
         == 0
       for: 1h
@@ -291,10 +293,11 @@ spec:
         severity: warning
     - alert: AlertmanagerReceiversNotConfigured
       annotations:
-        message: Alerts are not configured to be sent to a notification system, meaning
-          that you may not be notified in a timely fashion when important failures
-          occur. Check the OpenShift documentation to learn how to configure notifications
-          with Alertmanager.
+        description: Alerts are not configured to be sent to a notification system,
+          meaning that you may not be notified in a timely fashion when important
+          failures occur. Check the OpenShift documentation to learn how to configure
+          notifications with Alertmanager.
+        summary: Receivers (notification integrations) are not configured on Alertmanager
       expr: cluster:alertmanager_integrations:max == 0
       for: 10m
       labels:
@@ -326,8 +329,10 @@ spec:
         severity: warning
     - alert: MultipleContainersOOMKilled
       annotations:
-        message: Multiple containers were out of memory killed within the past 15
-          minutes.
+        description: Multiple containers were out of memory killed within the past
+          15 minutes. There are many potential causes of OOM errors, however issues
+          on a specific node or containers breaching their limits is common.
+        summary: Containers are being killed due to OOM
       expr: sum(max by(namespace, container, pod) (increase(kube_pod_container_status_restarts_total[12m]))
         and max by(namespace, container, pod) (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"})
         == 1) > 5

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -366,7 +366,8 @@ function(params) {
           alert: 'ClusterMonitoringOperatorReconciliationErrors',
           'for': '1h',
           annotations: {
-            message: 'Cluster Monitoring Operator is experiencing unexpected reconciliation errors. Inspect the cluster-monitoring-operator log for potential root causes.',
+            summary: 'Cluster Monitoring Operator is experiencing unexpected reconciliation errors.',
+            description: 'Errors are occurring during reconciliation cycles. Inspect the cluster-monitoring-operator log for potential root causes.',
           },
           labels: {
             severity: 'warning',
@@ -377,7 +378,8 @@ function(params) {
           alert: 'AlertmanagerReceiversNotConfigured',
           'for': '10m',
           annotations: {
-            message: 'Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager.',
+            summary: 'Receivers (notification integrations) are not configured on Alertmanager',
+            description: 'Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager.',
           },
           labels: {
             severity: 'warning',
@@ -410,7 +412,8 @@ function(params) {
           alert: 'MultipleContainersOOMKilled',
           'for': '15m',
           annotations: {
-            message: 'Multiple containers were out of memory killed within the past 15 minutes.',
+            summary: 'Containers are being killed due to OOM',
+            description: 'Multiple containers were out of memory killed within the past 15 minutes. There are many potential causes of OOM errors, however issues on a specific node or containers breaching their limits is common.',
           },
           labels: {
             severity: 'info',


### PR DESCRIPTION
This changes makes us compliant with https://github.com/openshift/enhancements/blob/01422f157a206463c5581362aec69c401bc67ae5/enhancements/monitoring/alerting-consistency.md#documentation-required

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
