### PR TITLE
test/e2e: add remote_write http e2e test

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -275,6 +275,21 @@ func (f *Framework) GetServiceAccountToken(namespace, name string) (string, erro
 	return token, err
 }
 
+func (f *Framework) GetLogs(namespace string, podName, containerName string) (string, error) {
+	ctx := context.Background()
+	logs, err := f.KubeClient.CoreV1().RESTClient().Get().
+		Resource("pods").
+		Namespace(namespace).
+		Name(podName).SubResource("log").
+		Param("container", containerName).
+		Do(ctx).
+		Raw()
+	if err != nil {
+		return "", err
+	}
+	return string(logs), err
+}
+
 func (f *Framework) CreateClusterRoleBinding(namespace, serviceAccount, clusterRole string) (cleanUpFunc, error) {
 	ctx := context.Background()
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -15,13 +15,21 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	osConfigv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
+	"github.com/pkg/errors"
 )
 
 func TestPrometheusMetrics(t *testing.T) {
@@ -90,5 +98,250 @@ func TestPrometheusAlertmanagerAntiAffinity(t *testing.T) {
 
 	if !almOk == true || !k8sOk == true {
 		t.Fatal("Can not find pods: prometheus-k8s or alertmanager-main")
+	}
+}
+
+func TestPrometheusRemoteWrite(t *testing.T) {
+	ctx := context.Background()
+
+	name := "remote-write-e2e-test"
+
+	// deploy a service for our remote write target
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"group": name,
+			},
+			Namespace: f.Ns,
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeLoadBalancer,
+			Ports: []v1.ServicePort{
+				{
+					Name: "web",
+					Port: 8080,
+				},
+				{
+					Name: "mtls",
+					Port: 8081,
+				},
+			},
+			Selector: map[string]string{
+				"group": name,
+			},
+		},
+	}
+
+	if err := f.OperatorClient.CreateOrUpdateService(ctx, svc); err != nil {
+		t.Fatal(err)
+	}
+	deployedService, err := f.KubeClient.CoreV1().Services(f.Ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// setup a self-signed ca and store the artifacts in a secret
+	tlsSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "selfsigned-mtls-bundle",
+			Namespace: f.Ns,
+			Labels: map[string]string{
+				"group": name,
+			},
+		},
+		Data: map[string][]byte{
+			"client-cert-name": []byte("test-client"),
+			"serving-cert-url": []byte(deployedService.Spec.ClusterIP),
+		},
+	}
+	if err := createSelfSignedMTLSArtifacts(tlsSecret); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.OperatorClient.CreateOrUpdateSecret(ctx, tlsSecret); err != nil {
+		t.Fatal(err)
+	}
+
+	// deploy remote write target
+	targetDeployment := fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: instrumented-sample-app
+  namespace: openshift-monitoring
+  labels:
+    group: %[1]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      group: %[1]s
+  template:
+    metadata:
+      labels:
+        group: %[1]s
+    spec:
+      containers:
+      - name: example-app
+        args:
+        - --cert-path=/etc/certs
+        image: quay.io/coreos/instrumented-sample-app:0.2.0-bearer-mtls-1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: web
+          containerPort: 8080
+        - name: mtls
+          containerPort: 8081
+        volumeMounts:
+        - mountPath: /etc/certs
+          name: certs
+      volumes:
+      - name: certs
+        secret:
+          secretName: selfsigned-mtls-bundle
+          items:
+          - key: server-ca.pem
+            path: cert.pem
+          - key: server.key
+            path: key.pem
+`, name)
+	rwTestDeployment, err := manifests.NewDeployment(bytes.NewReader([]byte(targetDeployment)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.OperatorClient.CreateOrUpdateDeployment(ctx, rwTestDeployment); err != nil {
+		t.Fatal(err)
+	}
+	for _, scenario := range []struct {
+		name   string
+		port   string
+		rwSpec string
+	}{
+		// check remote write logs
+		{
+			name: "assert remote write to http works",
+			port: "8080",
+			rwSpec: `
+  - url: http://%s`,
+		},
+		{
+			name: "assert mtls remote write works",
+			port: "8081",
+			rwSpec: `
+  - url: https://%s
+    tlsConfig:
+      ca:
+        secret:
+          name: selfsigned-mtls-bundle
+          key: ca.crt
+      cert:
+        secret:
+          name: selfsigned-mtls-bundle
+          key: client.crt
+      keySecret:
+        name: selfsigned-mtls-bundle
+        key: client.key
+`,
+		},
+	} {
+		rw := fmt.Sprintf(scenario.rwSpec, deployedService.Spec.ClusterIP+":"+scenario.port)
+
+		cmoConfigMap := fmt.Sprintf(`prometheusK8s:
+  logLevel: debug
+  remoteWrite: %s
+`, rw)
+		if err := f.OperatorClient.CreateOrUpdateConfigMap(ctx, configMapWithData(t, cmoConfigMap)); err != nil {
+			t.Fatal(err)
+		}
+
+		reporter := f.OperatorClient.StatusReporter()
+		err := framework.Poll(5*time.Second, 2*time.Minute, func() error {
+			co, err := reporter.Get(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, c := range co.Status.Conditions {
+				if c.Type == osConfigv1.OperatorDegraded {
+					if c.Status == osConfigv1.ConditionTrue {
+						return errors.Errorf("expected ClusterOperator to not be degraded")
+					}
+				}
+				if c.Type == osConfigv1.OperatorProgressing {
+					if c.Status == osConfigv1.ConditionTrue {
+						return errors.Errorf("expected ClusterOperator to cease progressing")
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Run(scenario.name, checkRemoteWrite(name, ctx))
+	}
+}
+
+func checkRemoteWrite(rwEndpointName string, ctx context.Context) func(*testing.T) {
+	return func(t *testing.T) {
+		remoteWriteCheckLogs(ctx, rwEndpointName, t)
+
+		remoteWriteCheckMetrics(ctx, t)
+	}
+}
+
+func remoteWriteCheckLogs(ctx context.Context, rwEndpointName string, t *testing.T) {
+	promLogs0, err := f.GetLogs(f.Ns, "prometheus-k8s-0", "prometheus")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	promLogs1, err := f.GetLogs(f.Ns, "prometheus-k8s-1", "prometheus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var promLogs strings.Builder
+	promLogErr := "prometheus logs are empty, expected to find log messages"
+	if i, _ := promLogs.WriteString(promLogs0); i == 0 {
+		t.Fatal(promLogErr)
+	}
+	if i, _ := promLogs.WriteString(promLogs1); i == 0 {
+		t.Fatal(promLogErr)
+	}
+
+	rwEndpointOpts := metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"group": rwEndpointName})}
+
+	rwEndpointPodList, err := f.KubeClient.CoreV1().Pods(f.Ns).List(ctx, rwEndpointOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rwEndpointLogs, err := f.GetLogs(f.Ns, rwEndpointPodList.Items[0].ObjectMeta.Name, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(promLogs.String(), `msg="Failed to send batch, retrying`) {
+		t.Fatal("unexpected prometheus log message, failed to send batch to remote write endpoint")
+	}
+	if strings.Contains(rwEndpointLogs, "remote error: tls: bad certificate") {
+		t.Fatal("remote write tls endpoint sees bad or no certificate")
+	}
+}
+
+func remoteWriteCheckMetrics(ctx context.Context, t *testing.T) {
+	time.Sleep(1 * time.Minute)
+	for _, pod := range []string{
+		"prometheus-k8s-0",
+		"prometheus-k8s-1",
+	} {
+		f.ThanosQuerierClient.WaitForQueryReturn(
+			t, 1*time.Minute, fmt.Sprintf(`ceil(delta(prometheus_remote_storage_samples_pending{pod="%s"}[1m]))`, pod),
+			func(v int) error {
+				if v == 0 {
+					return fmt.Errorf("prometheus_remote_storage_samples_pending indicates no remote write progress, expected a continuously changing delta")
+				}
+
+				return nil
+			},
+		)
 	}
 }


### PR DESCRIPTION
This only adds a test for an unencrypted enpoint. An mTLS test will follow in a separate PR, but use the same test function.
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] No user facing changes, so no entry in CHANGELOG was needed.
