### PR TITLE
[WIP] Bug 1955490: Add hard affinity set to Thanos ruler Statefulsets 

### DIFF
--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -6,6 +6,13 @@ metadata:
   name: user-workload
   namespace: openshift-user-workload-monitoring
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: user-workload
+        topologyKey: kubernetes.io/hostname
   alertmanagersConfig:
     key: alertmanagers.yaml
     name: thanos-ruler-alertmanagers-config

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -333,6 +333,19 @@ function(params) {
         runAsUser: 65534,
       },
       replicas: cfg.replicas,
+      affinity+: {
+        podAntiAffinity: {
+          // Apply HA conventions
+          requiredDuringSchedulingIgnoredDuringExecution: [
+            {
+              labelSelector: {
+                matchLabels: cfg.labels,
+              },
+              topologyKey: 'kubernetes.io/hostname',
+            },
+          ],
+        },
+      },
       resources: {
         requests: {
           memory: '21Mi',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This PR fixes [bug 1955490](https://bugzilla.redhat.com/show_bug.cgi?id=1955490).
It avoids deploying both 2 Thanos-rulers on the same node. 
