### PR TITLE
issue template kube-prometheus location: coreos -> prometheus-operator

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -23,7 +23,7 @@ about: Create release checklist
 
 - [ ] cut new release in [kubernetes-monitoring/kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin)
 - [ ] cut new release in [thanos-io/kube-thanos](https://github.com/thanos-io/kube-thanos)
-- [ ] cut new release in [coreos/kube-prometheus](https://github.com/coreos/kube-prometheus)
+- [ ] cut new release in [prometheus-operator/kube-prometheus](https://github.com/prometheus-operator/kube-prometheus)
   - update dependencies before doing release
 
 ## Cluster Monitoring Operator


### PR DESCRIPTION
The old links work fine (forwarded) but might as well fix it to reduce confusion.

This can wait.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
