### PR TITLE
Bug 1991836: Revise Alert Severity in OCP 4.8

### DIFF
--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -40,7 +40,7 @@ spec:
           count by (namespace,service) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="openshift-monitoring"}[5m]))
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: AlertmanagerFailedToSendAlerts
       annotations:
         description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
@@ -73,7 +73,7 @@ spec:
         > 0.01
       for: 5m
       labels:
-        severity: critical
+        severity: warning
     - alert: AlertmanagerClusterFailedToSendAlerts
       annotations:
         description: The minimum notification failure rate to {{ $labels.integration
@@ -103,7 +103,7 @@ spec:
         != 1
       for: 20m
       labels:
-        severity: critical
+        severity: warning
     - alert: AlertmanagerClusterDown
       annotations:
         description: '{{ $value | humanizePercentage }} of Alertmanager instances
@@ -124,25 +124,4 @@ spec:
         >= 0.5
       for: 5m
       labels:
-        severity: critical
-    - alert: AlertmanagerClusterCrashlooping
-      annotations:
-        description: '{{ $value | humanizePercentage }} of Alertmanager instances
-          within the {{$labels.job}} cluster have restarted at least 5 times in the
-          last 10m.'
-        summary: Half or more of the Alertmanager instances within the same cluster
-          are crashlooping.
-      expr: |
-        (
-          count by (namespace,service) (
-            changes(process_start_time_seconds{job="alertmanager-main",namespace="openshift-monitoring"}[10m]) > 4
-          )
-        /
-          count by (namespace,service) (
-            up{job="alertmanager-main",namespace="openshift-monitoring"}
-          )
-        )
-        >= 0.5
-      for: 5m
-      labels:
-        severity: critical
+        severity: warning

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -369,7 +369,7 @@ spec:
         kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"(openshift-.*|kube-.*|default|logging)",job="kube-state-metrics"} > 0
       for: 5m
       labels:
-        severity: critical
+        severity: warning
   - name: kubernetes-system
     rules:
     - alert: KubeClientErrors

--- a/assets/kube-state-metrics/prometheus-rule.yaml
+++ b/assets/kube-state-metrics/prometheus-rule.yaml
@@ -27,7 +27,7 @@ spec:
         > 0.01
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeStateMetricsWatchErrors
       annotations:
         description: kube-state-metrics is experiencing errors at an elevated rate
@@ -41,4 +41,4 @@ spec:
         > 0.01
       for: 15m
       labels:
-        severity: critical
+        severity: warning

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -25,7 +25,7 @@ spec:
         max_over_time(prometheus_config_last_reload_successful{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) == 0
       for: 10m
       labels:
-        severity: critical
+        severity: warning
     - alert: PrometheusNotificationQueueRunningFull
       annotations:
         description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
@@ -151,7 +151,7 @@ spec:
         > 1
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: PrometheusRemoteWriteBehind
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -169,7 +169,7 @@ spec:
         > 120
       for: 15m
       labels:
-        severity: critical
+        severity: info
     - alert: PrometheusRemoteWriteDesiredShards
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
@@ -199,7 +199,7 @@ spec:
         increase(prometheus_rule_evaluation_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: PrometheusMissingRuleEvaluations
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed {{
@@ -222,22 +222,6 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
-      annotations:
-        description: '{{ printf "%.1f" $value }}% minimum errors while sending alerts
-          from Prometheus {{$labels.namespace}}/{{$labels.pod}} to any Alertmanager.'
-        summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
-      expr: |
-        min without (alertmanager) (
-          rate(prometheus_notifications_errors_total{job=~"prometheus-k8s|prometheus-user-workload",alertmanager!~``}[5m])
-        /
-          rate(prometheus_notifications_sent_total{job=~"prometheus-k8s|prometheus-user-workload",alertmanager!~``}[5m])
-        )
-        * 100
-        > 3
-      for: 15m
-      labels:
-        severity: critical
   - name: thanos-sidecar
     rules:
     - alert: ThanosSidecarPrometheusDown

--- a/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
+++ b/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
@@ -26,7 +26,7 @@ spec:
         sum by (job) (rate(thanos_alert_sender_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0
       for: 5m
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosRuleHighRuleEvaluationFailures
       annotations:
         description: Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to evaluate
@@ -41,7 +41,7 @@ spec:
         )
       for: 5m
       labels:
-        severity: critical
+        severity: warning
     - alert: ThanosRuleHighRuleEvaluationWarnings
       annotations:
         description: Thanos Rule {{$labels.job}} {{$labels.pod}} has high number of
@@ -143,4 +143,4 @@ spec:
         sum(thanos_rule_loaded_rules{job="thanos-ruler"}) > 0
       for: 3m
       labels:
-        severity: critical
+        severity: warning

--- a/jsonnet/patch-rules.libsonnet
+++ b/jsonnet/patch-rules.libsonnet
@@ -18,6 +18,12 @@ local excludedRules = [
     ],
   },
   {
+    name: 'alertmanager.rules',
+    rules: [
+      { alert: 'AlertmanagerClusterCrashlooping' },
+    ],
+  },
+  {
     name: 'general.rules',
     rules: [
       { alert: 'TargetDown' },
@@ -66,6 +72,12 @@ local excludedRules = [
     ],
   },
   {
+    name: 'prometheus',
+    rules: [
+      { alert: 'PrometheusErrorSendingAlertsToAnyAlertmanager' },
+    ],
+  },
+  {
     name: 'thanos-query',
     rules: [
       { alert: 'ThanosQueryInstantLatencyHigh' },
@@ -75,6 +87,36 @@ local excludedRules = [
 ];
 
 local patchedRules = [
+  {
+    name: 'alertmanager.rules',
+    rules: [
+      {
+        alert: 'AlertmanagerClusterFailedToSendAlerts',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'AlertmanagerConfigInconsistent',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'AlertmanagerClusterDown',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'AlertmanagerMembersInconsistent',
+        'for': '15m',
+        labels: {
+          severity: 'warning',
+        },
+      },
+    ],
+  },
   {
     name: 'kubernetes-apps',
     rules: [
@@ -102,6 +144,35 @@ local patchedRules = [
     ],
   },
   {
+    name: 'kube-state-metrics',
+    rules: [
+      {
+        alert: 'KubeStateMetricsListErrors',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'KubeStateMetricsWatchErrors',
+        labels: {
+          severity: 'warning',
+        },
+      },
+    ],
+  },
+  {
+    name: 'kubernetes-storage',
+    local kubernetesStorageConfig = { prefixedNamespaceSelector: 'namespace=~"(openshift-.*|kube-.*|default)",', kubeletSelector: 'job="kubelet", metrics_path="/metrics"' },
+    rules: [
+      {
+        alert: 'KubePersistentVolumeErrors',
+        labels: {
+          severity: 'warning',
+        },
+      },
+    ],
+  },
+  {
     name: 'prometheus',
     rules: [
       {
@@ -111,6 +182,54 @@ local patchedRules = [
       {
         alert: 'PrometheusOutOfOrderTimestamps',
         'for': '1h',
+      },
+      {
+        alert: 'PrometheusBadConfig',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'PrometheusRemoteStorageFailures',
+        labels: {
+          severity: 'warning',
+        },
+
+      },
+      {
+        alert: 'PrometheusRuleFailures',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'PrometheusRemoteWriteBehind',
+        labels: {
+          severity: 'info',
+        },
+      },
+    ],
+  },
+  {
+    name: 'thanos-rule',
+    rules: [
+      {
+        alert: 'ThanosNoRuleEvaluations',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'ThanosRuleHighRuleEvaluationFailures',
+        labels: {
+          severity: 'warning',
+        },
+      },
+      {
+        alert: 'ThanosRuleSenderIsFailingAlerts',
+        labels: {
+          severity: 'warning',
+        },
       },
     ],
   },
@@ -152,15 +271,6 @@ local patchedRules = [
         labels: {
           severity: 'warning',
         },
-      },
-    ],
-  },
-  {
-    name: 'alertmanager.rules',
-    rules: [
-      {
-        alert: 'AlertmanagerMembersInconsistent',
-        'for': '15m',
       },
     ],
   },


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This pull request brings alert severity revision of [Bugzilla record 1986981](https://bugzilla.redhat.com/show_bug.cgi?id=1986981) into version 4.8. 
