### PR TITLE
Bug 1997528: remove use of etcd_object_counts metric

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -243,9 +243,9 @@ spec:
           )
         )
       record: cluster:kubelet_volume_stats_used_bytes:provisioner:sum
-    - expr: sum(etcd_object_counts) BY (instance)
+    - expr: sum by (instance) (apiserver_storage_objects)
       record: instance:etcd_object_counts:sum
-    - expr: topk(500, max(etcd_object_counts) by (resource))
+    - expr: topk(500, max by(resource) (apiserver_storage_objects))
       record: cluster:usage:resources:sum
     - expr: count(count (kube_pod_restart_policy{type!="Always",namespace!~"openshift-.+"})
         by (namespace,pod))

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -302,11 +302,14 @@ function(params) {
           record: 'cluster:kubelet_volume_stats_used_bytes:provisioner:sum',
         },
         {
-          expr: 'sum(etcd_object_counts) BY (instance)',
+          // This recording rule was based on the now deprecated
+          // etcd_object_counts metric which explains the name.
+          // TODO: rename the recording rule and add it to the telemetry allow-list.
+          expr: 'sum by (instance) (apiserver_storage_objects)',
           record: 'instance:etcd_object_counts:sum',
         },
         {
-          expr: 'topk(500, max(etcd_object_counts) by (resource))',
+          expr: 'topk(500, max by(resource) (apiserver_storage_objects))',
           record: 'cluster:usage:resources:sum',
         },
         {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
