### PR TITLE
jsonnet: Sync with kube-prometheus

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -33,7 +33,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|object_counts|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
       sourceLabels:
       - __name__
     - action: drop

--- a/assets/prometheus-k8s/prometheus-rule-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/prometheus-rule-thanos-sidecar.yaml
@@ -1,0 +1,44 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 2.28.1
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-k8s-thanos-sidecar-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: thanos-sidecar
+    rules:
+    - alert: ThanosSidecarPrometheusDown
+      annotations:
+        description: Thanos Sidecar {{$labels.instance}} cannot connect to Prometheus.
+        summary: Thanos Sidecar cannot connect to Prometheus
+      expr: |
+        thanos_sidecar_prometheus_up{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"} == 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: ThanosSidecarBucketOperationsFailed
+      annotations:
+        description: Thanos Sidecar {{$labels.instance}} bucket operations are failing
+        summary: Thanos Sidecar bucket operations are failing
+      expr: |
+        sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}[5m])) > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: ThanosSidecarUnhealthy
+      annotations:
+        description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than
+          {{$value}} seconds.
+        summary: Thanos Sidecar is unhealthy.
+      expr: |
+        time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}) >= 240
+      for: 1h
+      labels:
+        severity: warning

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -244,33 +244,3 @@ spec:
       for: 5m
       labels:
         severity: critical
-  - name: thanos-sidecar
-    rules:
-    - alert: ThanosSidecarPrometheusDown
-      annotations:
-        description: Thanos Sidecar {{$labels.instance}} cannot connect to Prometheus.
-        summary: Thanos Sidecar cannot connect to Prometheus
-      expr: |
-        thanos_sidecar_prometheus_up{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"} == 0
-      for: 1h
-      labels:
-        severity: warning
-    - alert: ThanosSidecarBucketOperationsFailed
-      annotations:
-        description: Thanos Sidecar {{$labels.instance}} bucket operations are failing
-        summary: Thanos Sidecar bucket operations are failing
-      expr: |
-        sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}[5m])) > 0
-      for: 1h
-      labels:
-        severity: warning
-    - alert: ThanosSidecarUnhealthy
-      annotations:
-        description: Thanos Sidecar {{$labels.instance}} is unhealthy for more than
-          {{$value}} seconds.
-        summary: Thanos Sidecar is unhealthy.
-      expr: |
-        time() - max by (job, instance) (thanos_sidecar_last_heartbeat_success_time_seconds{job=~"prometheus-(k8s|user-workload)-thanos-sidecar"}) >= 240
-      for: 1h
-      labels:
-        severity: warning

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -6,6 +6,7 @@ function(params)
 
     // Hide not needed resources
     prometheusRule:: {},
+    prometheusRuleThanosSidecar:: {},
     endpointsEtcd:: {},
     serviceEtcd:: {},
     serviceMonitorEtcd:: {},

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -121,8 +121,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "b9c73c7b29e20a4b8f691e057e862c9485117b15",
-      "sum": "U0CcqVkRJPJR2nfVobk7h1aNljxaS2Cr+nDCYdlgEGY="
+      "version": "996d5163639371925e101d24e36406871991b8b1",
+      "sum": "o89gU5wATJUcKWbzipfm1qCRsunmDAn51vFvh2TXIgY="
     },
     {
       "source": {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -960,6 +960,10 @@ func (f *Factory) PrometheusK8sGrpcTLSSecret() (*v1.Secret, error) {
 	return s, nil
 }
 
+func (f *Factory) PrometheusK8sThanosSidecarPrometheusRule() (*monv1.PrometheusRule, error) {
+	return f.NewPrometheusRule(f.assets.MustNewAssetReader(PrometheusK8sThanosSidecarPrometheusRule))
+}
+
 func (f *Factory) PrometheusUserWorkloadGrpcTLSSecret() (*v1.Secret, error) {
 	s, err := f.NewSecret(f.assets.MustNewAssetReader(PrometheusUserWorkloadGrpcTLSSecret))
 	if err != nil {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -98,6 +98,7 @@ var (
 	PrometheusK8sRoleConfig                  = "prometheus-k8s/role-config.yaml"
 	PrometheusK8sRoleList                    = "prometheus-k8s/role-specific-namespaces.yaml"
 	PrometheusK8sPrometheusRule              = "prometheus-k8s/prometheus-rule.yaml"
+	PrometheusK8sThanosSidecarPrometheusRule = "prometheus-k8s/prometheus-rule-thanos-sidecar.yaml"
 	PrometheusK8sServiceAccount              = "prometheus-k8s/service-account.yaml"
 	PrometheusK8s                            = "prometheus-k8s/prometheus.yaml"
 	PrometheusK8sPrometheusServiceMonitor    = "prometheus-k8s/service-monitor.yaml"

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -357,6 +357,11 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = f.PrometheusK8sThanosSidecarPrometheusRule()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = f.PrometheusK8sServiceAccount()
 	if err != nil {
 		t.Fatal(err)
@@ -1288,7 +1293,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		expected string
 	}{
 		{
-			name:   "no config with alertmanager disabled",
+			name: "no config with alertmanager disabled",
 			config: `alertmanagerMain:
   enabled: false`,
 			expected: `alertmanagers: []`,
@@ -1332,8 +1337,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		},
 		{
 			name: "basic config with alertmanager disabled",
-			config:
-`thanosRuler:
+			config: `thanosRuler:
   additionalAlertmanagerConfigs:
   - staticConfigs:
     - alertmanager1-remote.com

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -235,6 +235,16 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Prometheus rules PrometheusRule failed")
 	}
 
+	tsRule, err := t.factory.PrometheusK8sThanosSidecarPrometheusRule()
+	if err != nil {
+		return errors.Wrap(err, "initializing Thanos Sidecar rules failed")
+	}
+
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, tsRule)
+	if err != nil {
+		return errors.Wrap(err, "reconciling Thanos Sidecar rules PrometheusRule failed")
+	}
+
 	svc, err := t.factory.PrometheusK8sService()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus Service failed")

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -231,6 +231,7 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 		containerName   = "prometheus"
 		labelSelector   = "app.kubernetes.io/component=prometheus"
 		crName          = "k8s"
+		thanosRule      = "prometheus-k8s-thanos-sidecar-rules"
 	)
 
 	data := fmt.Sprintf(`prometheusK8s:
@@ -292,6 +293,10 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 		{
 			name: "assert remote write url value in set in CR",
 			f:    assertRemoteWriteWasSet(f.Ns, crName, "https://test.remotewrite.com/api/write"),
+		},
+		{
+			name: "assert rule for Thanos sidecar exists",
+			f:    f.AssertPrometheusRuleExists(thanosRule, f.Ns),
 		},
 	} {
 		t.Run(scenario.name, scenario.f)


### PR DESCRIPTION
Sync with kube-prometheus via `jb update`

Because of prometheus-operator/kube-prometheus#1308 we had two additional assets to deal with.

The first was UWM related and is discarded via openshift/cluster-monitoring-operator@c24f2d3

The second is handled by deploying the PrometheusRule via the operator.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
