### PR TITLE
Bug 1995614: Fix beta.kubernetes.io/os deprecated warning

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -187,7 +187,7 @@ spec:
         - mountPath: /etc/kube-rbac-proxy
           name: secret-thanos-querier-kube-rbac-proxy-rules
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: thanos-querier
       terminationGracePeriodSeconds: 120

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -288,7 +288,7 @@ function(params)
           spec+: {
             // TODO(slashpai): remove once new kube-thanos is released which has this change
             nodeSelector: {
-            'kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
             // TODO(dgrisonnet): remove once the upstream anti-affinity addon
             // can be extended.

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -286,6 +286,10 @@ function(params)
         },
         template+: {
           spec+: {
+            // TODO(slashpai): remove once new kube-thanos is released which has this change
+            nodeSelector: {
+            'kubernetes.io/os': 'linux',
+            },
             // TODO(dgrisonnet): remove once the upstream anti-affinity addon
             // can be extended.
             affinity+: {

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -77,7 +77,7 @@ spec:
         - mountPath: /etc/cluster-monitoring-operator/telemetry
           name: telemetry-config
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: cluster-monitoring-operator
       tolerations:

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       serviceAccountName: cluster-monitoring-operator
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
       tolerations:


### PR DESCRIPTION
Fix "beta.kubernetes.io/os" is deprecated since v1.14

Other upstream changes I made are pulled in https://github.com/openshift/cluster-monitoring-operator/pull/1340/files but kube-thanos couldn't since its not available in [0.22 release](https://github.com/openshift/cluster-monitoring-operator/blob/master/jsonnet/jsonnetfile.json#L58) hence patching it in jsonnet here

cc: @simonpasquier 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
