### PR TITLE
[MON-1851] upgrade unused rule checking script

### DIFF
--- a/hack/check-rec-rule-usage.sh
+++ b/hack/check-rec-rule-usage.sh
@@ -4,19 +4,45 @@ set -e
 TMP=$(mktemp -d)
 echo "Created temporary directory at $TMP"
 
+# This directory should be a local copy of github.com/openshift/console
+CONSOLE_DIR="${1:-../console}"
+
+if [ ! -d "$CONSOLE_DIR" ]; then
+    echo "Couldn't find a local copy of github.com/openshift/console: directory $CONSOLE_DIR does not exist"
+    exit 1
+fi
+
 findrules="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/find-rules.sh"
 
 "$findrules" >"$TMP/rule-groups"
-# extract recording rules
+# Extract recording rules
 tmp/bin/gojsontoyaml -yamltojson <"$TMP/rule-groups" | jq -s '.. | objects | select(.record) | .record' | tr -d '"' | sort -u >"$TMP/rec-rules"
-# and alerting rules
-tmp/bin/gojsontoyaml -yamltojson <"$TMP/rule-groups" | jq -s '.. | objects | select(.alert) | .expr' | grep "\w\+{" -o | tr -d "{" | sort -u >"$TMP/used-rules"
-# and telemetry client's metrics
-tmp/bin/gojsontoyaml -yamltojson <manifests/*-config.yaml | jq '.data."metrics.yaml"' | sed "s;\\\\n;\n;g" | grep "^-\s'{__name__=\\\\\"" | sed -e "s/^- '{__name__=\\\\\"//" | sed -e "s/\\\\\"[^}]*}'//" | sort | uniq >>"$TMP/used-rules"
 
-# the first grep outputs all recording rules that are used neither in alerts nor telemetry metrics
+# Extract alerting rules
+tmp/bin/gojsontoyaml -yamltojson <"$TMP/rule-groups" | jq -s '.. | objects | select(.alert) | .expr' | grep "\w\+{" -o | tr -d "{" | sort -u >"$TMP/used-rules"
+
+# Extract recording rules which are used in other recording or alerting rules.
+go run -mod=vendor hack/promql_rule/main.go "$TMP/rule-groups" >"$TMP/rule-expr-names"
+grep -Fxf "$TMP/rec-rules" "$TMP/rule-expr-names" >>"$TMP/used-rules"
+
+# Extract Telemetry Client's metrics
+# Put plain text matching rule names into used-rules
+tmp/bin/gojsontoyaml -yamltojson <manifests/*-config.yaml | jq '.data."metrics.yaml"' | sed "s;\\\\n;\n;g" | grep "^-\s'{__name__=\\\\\"" | sed -e "s/^- '{__name__=\\\\\"//" | sed -e "s/\\\\\"[^}]*}'//" | sort | uniq >>"$TMP/used-rules"
+# Put regex pattern matching rule names into used-rules-regex
+tmp/bin/gojsontoyaml -yamltojson <manifests/*-config.yaml | jq '.data."metrics.yaml"' | sed "s;\\\\n;\n;g" | grep "^-\s'{__name__=~\\\\\"" | sed -e "s/^- '{__name__=~\\\\\"//" | sed -e "s/\\\\\"[^}]*}'//" | sort | uniq >"$TMP/used-rules-regex"
+# The first grep outputs all recording rules that are used neither in alerts nor telemetry metrics
 # and then greps for the remaining rules in the dashboard defs and outputs the ones that are not found
-grep -Fxvf "$TMP/used-rules" "$TMP/rec-rules" | while read -r r; do grep "$r" assets/grafana/dashboard-definitions.yaml -q || echo "$r"; done >"$TMP/unused-rules"
+grep -Fxvf "$TMP/used-rules" "$TMP/rec-rules" | while read -r r; do grep "$r" assets/grafana/dashboard-definitions.yaml -q || echo "$r"; done >"$TMP/unused-rules-fixstr"
+grep -Exvf "$TMP/used-rules-regex" "$TMP/unused-rules-fixstr" >"$TMP/unused-rules-cmo"
+
+# Find out the rules used in console. The console TypeScript codes contain reference to rule names by exact text matching.
+find "${CONSOLE_DIR}" -type f -regex ".*\.ts[x]*" | while read -r filename; do
+    grep -Ff "$TMP/unused-rules-cmo" "$filename" | { grep -Eo "[a-zA-Z_][a-zA-Z0-9_:]*" || true; } >>"$TMP/used-rules-console-tmp"
+done
+sort "$TMP/used-rules-console-tmp" | uniq | { grep -Fxf "$TMP/unused-rules-cmo" || true; } >"$TMP/used-rules-console"
+# Eliminate rules used by console from unused rules in CMO.
+# Now we get rules neither used in CMO nor in console.
+grep -Fxvf "$TMP/used-rules-console" "$TMP/unused-rules-cmo" >"$TMP/unused-rules"
 
 echo "Found $(wc -l <"$TMP/unused-rules") unused rules"
 echo "Find the unused rules in $TMP/unused-rules"

--- a/hack/find-rules.sh
+++ b/hack/find-rules.sh
@@ -3,8 +3,11 @@ set -e
 
 # find all rule groups and aggregate them
 # returns a json list of groups
-
-find assets/ -type f -name "*prometheus-rule.yaml" | while read -r f
-do
-    tmp/bin/gojsontoyaml -yamltojson < "$f" | jq .spec
+find assets/ -type f -name "*.yaml" | while read -r f; do
+    JSONIFIED=$(tmp/bin/gojsontoyaml -yamltojson <"$f")
+    KIND=$(jq .kind <<<"$JSONIFIED")
+    if [ "$KIND" != "\"PrometheusRule\"" ]; then
+        continue
+    fi
+    jq .spec <<<"$JSONIFIED"
 done | jq -s '[.[]] | { groups: map(.groups[]) }'

--- a/hack/promql_rule/main.go
+++ b/hack/promql_rule/main.go
@@ -1,0 +1,94 @@
+// Copyright 2021 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	promql "github.com/prometheus/prometheus/promql/parser"
+)
+
+type Rule struct {
+	Expr string `json:"expr"`
+}
+
+type RuleGroup struct {
+	Rules []Rule `json:"rules"`
+}
+
+type RuleGroups struct {
+	Groups []RuleGroup `json:"groups"`
+}
+
+func extractMetricNamesNew(fileName string) ([]string, error) {
+
+	var metricNames []string
+	metricNamesMap := map[string]struct{}{}
+	var ruleGroups RuleGroups
+
+	fileContent, _ := os.ReadFile(fileName)
+	err := json.Unmarshal(fileContent, &ruleGroups)
+	if err != nil {
+		return metricNames, err
+	}
+
+	for _, group := range ruleGroups.Groups {
+		for _, rule := range group.Rules {
+			expr, err := promql.ParseExpr(rule.Expr)
+			if err != nil {
+				return nil, err
+			}
+			promql.Inspect(expr, func(node promql.Node, _ []promql.Node) error {
+				vs, ok := node.(*promql.VectorSelector)
+				if ok {
+					metricNamesMap[vs.Name] = struct{}{}
+				}
+				return nil
+			})
+		}
+	}
+
+	for key := range metricNamesMap {
+		metricNames = append(metricNames, key)
+	}
+	sort.Strings(metricNames)
+
+	return metricNames, nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		panic("expecting at least 1 argument, got 0")
+	}
+
+	f, err := os.Open(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	metricNames, err := extractMetricNamesNew(os.Args[1])
+
+	if err != nil {
+		panic(err)
+	}
+
+	for _, metricName := range metricNames {
+		fmt.Printf("%s\n", metricName)
+	}
+}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This PR improves unused rule checking by including openshift console code and rule expression references in CMO component.

[JIRA ticket MON-1851](https://issues.redhat.com/browse/MON-1851)
