### PR TITLE
Bug 2000490: Add runbooks for all critical alerts

### DIFF
--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         description: Configuration has failed to load for {{ $labels.namespace }}/{{
           $labels.pod}}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/AlertmanagerFailedReload.md
         summary: Reloading an Alertmanager configuration has failed.
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see

--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -314,6 +314,7 @@ spec:
           version of a cluster component cannot start due to a bug or configuration
           error. Assess the pods for this deployment to verify they are running on
           healthy nodes and then contact support.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeDeploymentReplicasMismatch.md
         summary: Deployment has not matched the expected number of replicas
       expr: |
         (((

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -28,6 +28,7 @@ spec:
       annotations:
         description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
           state for longer than 15 minutes.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePodNotReady.md
         summary: Pod has been in a non-ready state for more than 15 minutes.
       expr: |
         sum by (namespace, pod) (
@@ -188,6 +189,7 @@ spec:
       annotations:
         description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to
           complete. Removing failed job after investigation should clear this alert.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeJobFailed.md
         summary: Job failed to complete.
       expr: |
         kube_job_failed{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}  > 0
@@ -326,6 +328,7 @@ spec:
         description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
           }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage
           }} free.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md
         summary: PersistentVolume is filling up.
       expr: |
         (
@@ -344,6 +347,7 @@ spec:
           $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is
           expected to fill up within four days. Currently {{ $value | humanizePercentage
           }} is available.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md
         summary: PersistentVolume is filling up.
       expr: |
         (
@@ -408,6 +412,7 @@ spec:
     - alert: KubeAPIDown
       annotations:
         description: KubeAPI has disappeared from Prometheus target discovery.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeAPIDown.md
         summary: Target disappeared from Prometheus target discovery.
       expr: |
         absent(up{job="apiserver"} == 1)
@@ -430,6 +435,7 @@ spec:
     - alert: KubeNodeNotReady
       annotations:
         description: '{{ $labels.node }} has been unready for more than 15 minutes.'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeNodeNotReady.md
         summary: Node is not ready.
       expr: |
         kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
@@ -515,6 +521,7 @@ spec:
     - alert: KubeletDown
       annotations:
         description: Kubelet has disappeared from Prometheus target discovery.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeletDown.md
         summary: Target disappeared from Prometheus target discovery.
       expr: |
         absent(up{job="kubelet", metrics_path="/metrics"} == 1)

--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -19,6 +19,7 @@ spec:
         description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
           has only {{ printf "%.2f" $value }}% available space left and is filling
           up.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
         summary: Filesystem is predicted to run out of space within the next 24 hours.
       expr: |
         (
@@ -36,6 +37,7 @@ spec:
         description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
           has only {{ printf "%.2f" $value }}% available space left and is filling
           up fast.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
         summary: Filesystem is predicted to run out of space within the next 4 hours.
       expr: |
         (
@@ -52,6 +54,7 @@ spec:
       annotations:
         description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
           has only {{ printf "%.2f" $value }}% available space left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
         summary: Filesystem has less than 5% space left.
       expr: |
         (
@@ -66,6 +69,7 @@ spec:
       annotations:
         description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
           has only {{ printf "%.2f" $value }}% available space left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
         summary: Filesystem has less than 3% space left.
       expr: |
         (
@@ -81,6 +85,7 @@ spec:
         description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
           has only {{ printf "%.2f" $value }}% available inodes left and is filling
           up.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
         summary: Filesystem is predicted to run out of inodes within the next 24 hours.
       expr: |
         (
@@ -98,6 +103,7 @@ spec:
         description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
           has only {{ printf "%.2f" $value }}% available inodes left and is filling
           up fast.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
         summary: Filesystem is predicted to run out of inodes within the next 4 hours.
       expr: |
         (
@@ -114,6 +120,7 @@ spec:
       annotations:
         description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
           has only {{ printf "%.2f" $value }}% available inodes left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
         summary: Filesystem has less than 5% inodes left.
       expr: |
         (
@@ -128,6 +135,7 @@ spec:
       annotations:
         description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
           has only {{ printf "%.2f" $value }}% available inodes left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
         summary: Filesystem has less than 3% inodes left.
       expr: |
         (
@@ -211,6 +219,7 @@ spec:
         description: RAID array '{{ $labels.device }}' on {{ $labels.instance }} is
           in degraded state due to one or more disks failures. Number of spare drives
           is insufficient to fix issue automatically.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeRAIDDegraded.md
         summary: RAID Array is degraded
       expr: |
         node_md_disks_required - ignoring (state) (node_md_disks{state="active"}) > 0
@@ -230,6 +239,7 @@ spec:
       annotations:
         description: File descriptors limit at {{ $labels.instance }} is currently
           at {{ printf "%.2f" $value }}%.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFileDescriptorLimit.md
         summary: Kernel is predicted to exhaust file descriptors limit soon.
       expr: |
         (
@@ -242,6 +252,7 @@ spec:
       annotations:
         description: File descriptors limit at {{ $labels.instance }} is currently
           at {{ printf "%.2f" $value }}%.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFileDescriptorLimit.md
         summary: Kernel is predicted to exhaust file descriptors limit soon.
       expr: |
         (

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -238,6 +238,7 @@ spec:
       annotations:
         description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
           have failed to sync because invalid configuration was supplied.'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/PrometheusTargetSyncFailure.md
         summary: Prometheus has failed to sync targets.
       expr: |
         increase(prometheus_target_sync_failed_total{job=~"prometheus-k8s|prometheus-user-workload"}[30m]) > 0

--- a/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
+++ b/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
@@ -10,6 +10,7 @@ spec:
     - alert: ThanosRuleQueueIsDroppingAlerts
       annotations:
         description: Thanos Rule {{$labels.instance}} is failing to queue alerts.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ThanosRuleQueueIsDroppingAlerts.md
         summary: Thanos Rule is failing to queue alerts.
       expr: |
         sum by (job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0

--- a/test/rules/bz1974830.yaml
+++ b/test/rules/bz1974830.yaml
@@ -57,6 +57,7 @@ tests:
               summary: 'Deployment has not matched the expected number of replicas'
               description: >-
                 Deployment openshift-apiserver/apiserver has not matched the expected number of replicas for longer than 15 minutes. This indicates that cluster infrastructure is unable to start or restart the necessary components. This most often occurs when one or more nodes are down or partioned from the cluster, or a fault occurs on the node that prevents the workload from starting. In rare cases this may indicate a new version of a cluster component cannot start due to a bug or configuration error. Assess the pods for this deployment to verify they are running on healthy nodes and then contact support.
+              runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeDeploymentReplicasMismatch.md'
     # Test the 'KubeDeploymentReplicasMismatch' will not fire if all replicas are available
   - interval: 5m
     input_series:


### PR DESCRIPTION
All critical alerts in OpenShift should have an associated runbook. We've recently added basic runbooks for all critical alerts shipped by CMO: https://github.com/openshift/runbooks/pull/16 -- This adds links to these in the `runbook_url` annotation.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
