### PR TITLE
Bug 1956308: pkg/client/client.go: log apierrors.StatusError

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -743,6 +743,7 @@ func (c *Client) CreateOrUpdateDeployment(ctx context.Context, dep *appsv1.Deplo
 	err = c.UpdateDeployment(ctx, required)
 	if err != nil {
 		uErr, ok := err.(*apierrors.StatusError)
+		klog.V(4).ErrorS(uErr, "APIError while updating Deployment")
 		if ok && uErr.ErrStatus.Code == 422 && uErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 			// try to delete Deployment
 			err = c.DeleteDeployment(ctx, existing)
@@ -931,6 +932,7 @@ func (c *Client) CreateOrUpdateDaemonSet(ctx context.Context, ds *appsv1.DaemonS
 	err = c.UpdateDaemonSet(ctx, required)
 	if err != nil {
 		uErr, ok := err.(*apierrors.StatusError)
+		klog.V(4).ErrorS(uErr, "APIError while updating DaemonSet")
 		if ok && uErr.ErrStatus.Code == 422 && uErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 			// try to delete DaemonSet
 			err = c.DeleteDaemonSet(ctx, existing)


### PR DESCRIPTION
Signed-off-by: Jayapriya Pai <janantha@redhat.com>

log apierrors.StatusError for understanding update failure
cc: @simonpasquier

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
