### PR TITLE
WIP:Support scraping config-reloader metrics from Prometheus and AlertMan…

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -90,6 +90,27 @@ spec:
     - mountPath: /etc/tls/private
       name: secret-alertmanager-main-tls
   - args:
+    - --secure-listen-address=0.0.0.0:8081
+    - --upstream=http://127.0.0.1:8080
+    - --tls-cert-file=/etc/tls/private/tls.crt
+    - --tls-private-key-file=/etc/tls/private/tls.key
+    - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    - --logtostderr=true
+    - --v=10
+    image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+    name: kube-rbac-proxy-alertmanager-config-reloader
+    ports:
+    - containerPort: 8081
+      name: config-reloader
+    resources:
+      requests:
+        cpu: 1m
+        memory: 15Mi
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /etc/tls/private
+      name: secret-alertmanager-main-tls
+  - args:
     - --insecure-listen-address=127.0.0.1:9096
     - --upstream=http://127.0.0.1:9093
     - --label=namespace

--- a/assets/alertmanager/service-monitor.yaml
+++ b/assets/alertmanager/service-monitor.yaml
@@ -18,7 +18,16 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-      serverName: alertmanager-main
+      serverName: server-name-replaced-at-runtime
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: config-reloader
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+      serverName: server-name-replaced-at-runtime
   selector:
     matchLabels:
       alertmanager: main

--- a/assets/alertmanager/service.yaml
+++ b/assets/alertmanager/service.yaml
@@ -19,6 +19,9 @@ spec:
   - name: tenancy
     port: 9092
     targetPort: tenancy
+  - name: config-reloader
+    port: 8081
+    targetPort: config-reloader
   selector:
     alertmanager: main
     app: alertmanager

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -101,6 +101,28 @@ spec:
     - mountPath: /etc/kube-rbac-proxy
       name: secret-kube-rbac-proxy
   - args:
+    - --secure-listen-address=0.0.0.0:8081
+    - --upstream=http://127.0.0.1:8080
+    - --allow-paths=/metrics
+    - --tls-cert-file=/etc/tls/private/tls.crt
+    - --tls-private-key-file=/etc/tls/private/tls.key
+    - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    - --logtostderr=true
+    - --v=10
+    image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+    name: kube-rbac-proxy-prometheus-config-reloader
+    ports:
+    - containerPort: 8081
+      name: config-reloader
+    resources:
+      requests:
+        cpu: 1m
+        memory: 15Mi
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /etc/tls/private
+      name: secret-prometheus-k8s-tls
+  - args:
     - --insecure-listen-address=127.0.0.1:9095
     - --upstream=http://127.0.0.1:9090
     - --label=namespace

--- a/assets/prometheus-k8s/service-monitor.yaml
+++ b/assets/prometheus-k8s/service-monitor.yaml
@@ -18,7 +18,16 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-      serverName: prometheus-k8s
+      serverName: server-name-replaced-at-runtime
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: config-reloader
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+      serverName: server-name-replaced-at-runtime
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus

--- a/assets/prometheus-k8s/service.yaml
+++ b/assets/prometheus-k8s/service.yaml
@@ -19,6 +19,9 @@ spec:
   - name: tenancy
     port: 9092
     targetPort: tenancy
+  - name: config-reloader
+    port: 8081
+    targetPort: config-reloader
   selector:
     app: prometheus
     app.kubernetes.io/component: prometheus

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -86,6 +86,11 @@ function(params)
             port: 9092,
             targetPort: 'tenancy',
           },
+          {
+            name: 'config-reloader',
+            port: 8081,
+            targetPort: 'config-reloader',
+          },
         ],
         type: 'ClusterIP',
       },
@@ -194,7 +199,19 @@ function(params)
             scheme: 'https',
             tlsConfig: {
               caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-              serverName: 'alertmanager-main',
+              serverName: 'server-name-replaced-at-runtime',
+              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
+            },
+            bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+          },
+          {
+            port: 'config-reloader',
+            interval: '30s',
+            scheme: 'https',
+            tlsConfig: {
+              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+              serverName: 'server-name-replaced-at-runtime',
               certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
               keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
             },
@@ -315,6 +332,38 @@ function(params)
                 mountPath: '/etc/kube-rbac-proxy',
                 name: 'secret-' + $.kubeRbacProxySecret.metadata.name,
               },
+              {
+                mountPath: '/etc/tls/private',
+                name: 'secret-alertmanager-main-tls',
+              },
+            ],
+          },
+          {
+            name: 'kube-rbac-proxy-alertmanager-config-reloader',
+            image: cfg.kubeRbacProxyImage,
+            resources: {
+              requests: {
+                cpu: '1m',
+                memory: '15Mi',
+              },
+            },
+            ports: [
+              {
+                containerPort: 8081,
+                name: 'config-reloader',
+              },
+            ],
+            args: [
+              '--secure-listen-address=0.0.0.0:8081',
+              '--upstream=http://127.0.0.1:8080',
+              '--tls-cert-file=/etc/tls/private/tls.crt',
+              '--tls-private-key-file=/etc/tls/private/tls.key',
+              '--tls-cipher-suites=' + cfg.tlsCipherSuites,
+              '--logtostderr=true',
+              '--v=10',
+            ],
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+            volumeMounts: [
               {
                 mountPath: '/etc/tls/private',
                 name: 'secret-alertmanager-main-tls',

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/promqlgen"
 	"github.com/pkg/errors"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"golang.org/x/crypto/bcrypt"
 	yaml2 "gopkg.in/yaml.v2"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -376,6 +376,7 @@ func (f *Factory) AlertmanagerServiceMonitor() (*monv1.ServiceMonitor, error) {
 	}
 
 	sm.Spec.Endpoints[0].TLSConfig.ServerName = fmt.Sprintf("alertmanager-main.%s.svc", f.namespace)
+	sm.Spec.Endpoints[1].TLSConfig.ServerName = fmt.Sprintf("alertmanager-main.%s.svc", f.namespace)
 	sm.Namespace = f.namespace
 
 	return sm, nil
@@ -1613,6 +1614,7 @@ func (f *Factory) PrometheusK8sPrometheusServiceMonitor() (*monv1.ServiceMonitor
 	}
 
 	sm.Spec.Endpoints[0].TLSConfig.ServerName = fmt.Sprintf("prometheus-k8s.%s.svc", f.namespace)
+	sm.Spec.Endpoints[1].TLSConfig.ServerName = fmt.Sprintf("prometheus-k8s.%s.svc", f.namespace)
 	sm.Namespace = f.namespace
 
 	return sm, nil


### PR DESCRIPTION
…ager sidecar

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
