### PR TITLE
Bug 1999057: jsonnet: Sync with kube-prometheus

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -64,6 +64,12 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
+      regex: (container_fs_.*|container_spec_.*|container_blkio_device_usage_total|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      sourceLabels:
+      - __name__
+      - pod
+      - namespace
+    - action: drop
       regex: container_memory_failures_total
       sourceLabels:
       - __name__

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -121,8 +121,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "ffced1bd3ee49e5eb329034bb56a09df095a2473",
-      "sum": "UDD4YtjntcyZL63Q7NA5IcfXII9qeowBBv4YV4BUwbg="
+      "version": "ccb46bfb1b3d1d982a51a27b6c7dd723ffe8b427",
+      "sum": "ptC76ApucKJNurMsumtvLEeNAxXonHq9ia9jS+IU7jk="
     },
     {
       "source": {


### PR DESCRIPTION
This is a backport of https://github.com/openshift/cluster-monitoring-operator/pull/1291 which pulls in https://github.com/prometheus-operator/kube-prometheus/pull/1353

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
