### PR TITLE
Bug 1999072: jsonnet: Sync with kube-prometheus

### DIFF
--- a/assets/prometheus-k8s/service-monitor-kubelet.yaml
+++ b/assets/prometheus-k8s/service-monitor-kubelet.yaml
@@ -62,6 +62,12 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
+      regex: (container_fs_.*|container_spec_.*|container_blkio_device_usage_total|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      sourceLabels:
+      - __name__
+      - pod
+      - namespace
+    - action: drop
       regex: container_memory_failures_total
       sourceLabels:
       - __name__

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -25,10 +25,10 @@
       "source": {
         "git": {
           "remote": "https://github.com/etcd-io/etcd.git",
-          "subdir": "Documentation/etcd-mixin"
+          "subdir": "contrib/mixin"
         }
       },
-      "version": "855eeb75c551879fe11b9718bceb8bee9b178905",
+      "version": "60d5159091ab06e80ad446ce9e4f415e5f53439e",
       "sum": "EgKKzxcW3ttt7gjPMX//DNTqNcn/0o2VAIaWJ/HSLEc="
     },
     {
@@ -131,8 +131,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "84f24095d6a057a969bae3b6f40762d2a0dbb8b4",
-      "sum": "jFye1wML1JcRjuuha2HFKwrMDvHqbo/+ABRdH8LRCV8="
+      "version": "55df3c1e20371af1acbdb27a1e5d60c90ec769f0",
+      "sum": "8bfBA4iDFMIhm1xUdMPkLFQwtzeoWz+IOscJZsTzXO8="
     },
     {
       "source": {


### PR DESCRIPTION
This change is a backport of #1291 and pulls in upstream https://github.com/prometheus-operator/kube-prometheus/pull/1354

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
