### PR TITLE
Bug 2001566: Enabling alerts for prometheus operator in UWM

### DIFF
--- a/assets/prometheus-operator-user-workload/prometheus-rule.yaml
+++ b/assets/prometheus-operator-user-workload/prometheus-rule.yaml
@@ -1,0 +1,88 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.49.0
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-operator-user-workload-rules
+  namespace: openshift-user-workload-monitoring
+spec:
+  groups:
+  - name: prometheus-operator-user-workload
+    rules:
+    - alert: PrometheusOperatorListErrors
+      annotations:
+        description: Errors while performing List operations in controller {{$labels.controller}}
+          in {{$labels.namespace}} namespace.
+        summary: Errors while performing list operations in controller.
+      expr: |
+        (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[10m]))) > 0.4
+      for: 15m
+      labels:
+        severity: warning
+    - alert: PrometheusOperatorWatchErrors
+      annotations:
+        description: Errors while performing watch operations in controller {{$labels.controller}}
+          in {{$labels.namespace}} namespace.
+        summary: Errors while performing watch operations in controller.
+      expr: |
+        (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[10m]))) > 0.4
+      for: 15m
+      labels:
+        severity: warning
+    - alert: PrometheusOperatorSyncFailed
+      annotations:
+        description: Controller {{ $labels.controller }} in {{ $labels.namespace }}
+          namespace fails to reconcile {{ $value }} objects.
+        summary: Last controller reconciliation failed
+      expr: |
+        min_over_time(prometheus_operator_syncs{status="failed",job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[5m]) > 0
+      for: 10m
+      labels:
+        severity: warning
+    - alert: PrometheusOperatorReconcileErrors
+      annotations:
+        description: '{{ $value | humanizePercentage }} of reconciling operations
+          failed for {{ $labels.controller }} controller in {{ $labels.namespace }}
+          namespace.'
+        summary: Errors while reconciling controller.
+      expr: |
+        (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[5m]))) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: PrometheusOperatorNodeLookupErrors
+      annotations:
+        description: Errors while reconciling Prometheus in {{ $labels.namespace }}
+          Namespace.
+        summary: Errors while reconciling Prometheus.
+      expr: |
+        rate(prometheus_operator_node_address_lookup_errors_total{job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[5m]) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: PrometheusOperatorNotReady
+      annotations:
+        description: Prometheus operator in {{ $labels.namespace }} namespace isn't
+          ready to reconcile {{ $labels.controller }} resources.
+        summary: Prometheus operator not ready
+      expr: |
+        min by(namespace, controller) (max_over_time(prometheus_operator_ready{job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[5m]) == 0)
+      for: 5m
+      labels:
+        severity: warning
+    - alert: PrometheusOperatorRejectedResources
+      annotations:
+        description: Prometheus operator in {{ $labels.namespace }} namespace rejected
+          {{ printf "%0.0f" $value }} {{ $labels.controller }}/{{ $labels.resource
+          }} resources.
+        summary: Resources rejected by Prometheus operator
+      expr: |
+        min_over_time(prometheus_operator_managed_resources{state="rejected",job="prometheus-operator",namespace="openshift-user-workload-monitoring"}[5m]) > 0
+      for: 5m
+      labels:
+        severity: warning

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -6,8 +6,6 @@ function(params)
   local cfg = params;
   operator(cfg) + {
 
-    mixin:: null,
-    prometheusRule:: null,
     '0alertmanagerCustomResourceDefinition':: {},
     '0alertmanagerConfigCustomResourceDefinition':: {},
     '0prometheusCustomResourceDefinition':: {},
@@ -111,6 +109,22 @@ function(params)
         annotations+: {
           'service.beta.openshift.io/serving-cert-secret-name': 'prometheus-operator-user-workload-tls',
         },
+      },
+    },
+    prometheusRule+: {
+      metadata+: {
+        name: 'prometheus-operator-user-workload-rules',
+      },
+      spec+: {
+        groups:
+          std.mapWithIndex(
+            function(i, v) if i == 0 then
+              v {
+                name: 'prometheus-operator-user-workload',
+                rules: v.rules,
+              },
+            super.groups
+          ),
       },
     },
     serviceMonitor+: {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -794,6 +794,7 @@ func (c *Client) WaitForDeploymentRollout(ctx context.Context, dep *appsv1.Deplo
 				d.Generation, d.Status.ObservedGeneration)
 			return false, nil
 		}
+
 		if d.Status.UpdatedReplicas != d.Status.Replicas {
 			lastErr = errors.Errorf("expected %d replicas, got %d updated replicas",
 				d.Status.Replicas, d.Status.UpdatedReplicas)

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/promqlgen"
 	"github.com/pkg/errors"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"golang.org/x/crypto/bcrypt"
 	yaml2 "gopkg.in/yaml.v2"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -162,6 +162,7 @@ var (
 	PrometheusOperatorUserWorkloadService            = "prometheus-operator-user-workload/service.yaml"
 	PrometheusOperatorUserWorkloadDeployment         = "prometheus-operator-user-workload/deployment.yaml"
 	PrometheusOperatorUserWorkloadServiceMonitor     = "prometheus-operator-user-workload/service-monitor.yaml"
+	PrometheusOperatorUserWorkloadPrometheusRule     = "prometheus-operator-user-workload/prometheus-rule.yaml"
 
 	GrafanaClusterRoleBinding   = "grafana/cluster-role-binding.yaml"
 	GrafanaClusterRole          = "grafana/cluster-role.yaml"
@@ -1885,6 +1886,10 @@ func (f *Factory) PrometheusOperatorServiceMonitor() (*monv1.ServiceMonitor, err
 
 func (f *Factory) PrometheusOperatorPrometheusRule() (*monv1.PrometheusRule, error) {
 	return f.NewPrometheusRule(f.assets.MustNewAssetReader(PrometheusOperatorPrometheusRule))
+}
+
+func (f *Factory) PrometheusOperatorUserWorkloadPrometheusRule() (*monv1.PrometheusRule, error) {
+	return f.NewPrometheusRule(f.assets.MustNewAssetReader(PrometheusOperatorUserWorkloadPrometheusRule))
 }
 
 func (f *Factory) PrometheusOperatorUserWorkloadServiceMonitor() (*monv1.ServiceMonitor, error) {

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -117,6 +117,15 @@ func (t *PrometheusOperatorUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "waiting for Prometheus Operator CRs to become available failed")
 	}
 
+	pr, err := t.factory.PrometheusOperatorUserWorkloadPrometheusRule()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator PrometheusRule failed")
+	}
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
+	if err != nil {
+		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator PrometheusRule failed")
+	}
+
 	smpo, err := t.factory.PrometheusOperatorUserWorkloadServiceMonitor()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator ServiceMonitor failed")
@@ -185,6 +194,15 @@ func (t *PrometheusOperatorUserWorkloadTask) destroy(ctx context.Context) error 
 	err = t.client.DeleteClusterRole(ctx, cr)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus Operator ClusterRoleBinding failed")
+	}
+
+	pr, err := t.factory.PrometheusOperatorUserWorkloadPrometheusRule()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator PrometheusRule failed")
+	}
+	err = t.client.DeletePrometheusRule(ctx, pr)
+	if err != nil {
+		return errors.Wrap(err, "deleting UserWorkload Prometheus Operator PrometheusRule failed")
 	}
 
 	sa, err := t.factory.PrometheusOperatorUserWorkloadServiceAccount()


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
