### PR TITLE
Bug 2000490: jsonnet: Drop unnecessary kube-state-metrics alerts

### DIFF
--- a/assets/kube-state-metrics/prometheus-rule.yaml
+++ b/assets/kube-state-metrics/prometheus-rule.yaml
@@ -42,27 +42,3 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: KubeStateMetricsShardingMismatch
-      annotations:
-        description: kube-state-metrics pods are running with different --total-shards
-          configuration, some Kubernetes objects may be exposed multiple times or
-          not exposed at all.
-        summary: kube-state-metrics sharding is misconfigured.
-      expr: |
-        stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
-      for: 15m
-      labels:
-        severity: critical
-    - alert: KubeStateMetricsShardsMissing
-      annotations:
-        description: kube-state-metrics shards are missing, some Kubernetes objects
-          are not being exposed.
-        summary: kube-state-metrics shards are missing.
-      expr: |
-        2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
-          -
-        sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
-        != 0
-      for: 15m
-      labels:
-        severity: critical

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -27,6 +27,14 @@ local excludedRules = [
     ],
   },
   {
+    name: 'kube-state-metrics',
+    rules: [
+      // We do not configure sharding for kube-state-metrics.
+      { alert: 'KubeStateMetricsShardingMismatch' },
+      { alert: 'KubeStateMetricsShardsMissing' },
+    ],
+  },
+  {
     name: 'kubernetes-system',
     rules: [
       { alert: 'KubeVersionMismatch' },


### PR DESCRIPTION
We don't configure sharding for kube-state-metrics, so there's no
reason to ship the critical alerts for them, or maintain runbooks for
them, etc. This drops the two critical alerts related to sharding.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
