### PR TITLE
Bug 1997028: drop [$(POD_IP)] from --grpc-address argument for thanos sidecar

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -141,7 +141,6 @@ spec:
     - sidecar
     - --prometheus.url=http://localhost:9090/
     - --tsdb.path=/prometheus
-    - --grpc-address=[$(POD_IP)]:10901
     - --http-address=127.0.0.1:10902
     - --grpc-server-tls-cert=/etc/tls/grpc/server.crt
     - --grpc-server-tls-key=/etc/tls/grpc/server.key

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -90,7 +90,6 @@ spec:
     - sidecar
     - --prometheus.url=http://localhost:9090/
     - --tsdb.path=/prometheus
-    - --grpc-address=[$(POD_IP)]:10901
     - --http-address=127.0.0.1:10902
     - --grpc-server-tls-cert=/etc/tls/grpc/server.crt
     - --grpc-server-tls-key=/etc/tls/grpc/server.key

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -324,7 +324,6 @@ function(params)
               'sidecar',
               '--prometheus.url=http://localhost:9090/',
               '--tsdb.path=/prometheus',
-              '--grpc-address=[$(POD_IP)]:10901',
               '--http-address=127.0.0.1:10902',
               '--grpc-server-tls-cert=/etc/tls/grpc/server.crt',
               '--grpc-server-tls-key=/etc/tls/grpc/server.key',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -514,7 +514,6 @@ function(params)
               'sidecar',
               '--prometheus.url=http://localhost:9090/',
               '--tsdb.path=/prometheus',
-              '--grpc-address=[$(POD_IP)]:10901',
               '--http-address=127.0.0.1:10902',
               '--grpc-server-tls-cert=/etc/tls/grpc/server.crt',
               '--grpc-server-tls-key=/etc/tls/grpc/server.key',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
