### PR TITLE
Bug 2001566: enabling alerts for prometheus operator in uwm

### DIFF
--- a/assets/prometheus-operator/prometheus-rule.yaml
+++ b/assets/prometheus-operator/prometheus-rule.yaml
@@ -20,7 +20,7 @@ spec:
           in {{$labels.namespace}} namespace.
         summary: Errors while performing list operations in controller.
       expr: |
-        (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{job="prometheus-operator",namespace="openshift-monitoring"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{job="prometheus-operator",namespace="openshift-monitoring"}[10m]))) > 0.4
+        (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[10m]))) > 0.4
       for: 15m
       labels:
         severity: warning
@@ -30,7 +30,7 @@ spec:
           in {{$labels.namespace}} namespace.
         summary: Errors while performing watch operations in controller.
       expr: |
-        (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator",namespace="openshift-monitoring"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator",namespace="openshift-monitoring"}[10m]))) > 0.4
+        (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[10m]))) > 0.4
       for: 15m
       labels:
         severity: warning
@@ -40,7 +40,7 @@ spec:
           namespace fails to reconcile {{ $value }} objects.
         summary: Last controller reconciliation failed
       expr: |
-        min_over_time(prometheus_operator_syncs{status="failed",job="prometheus-operator",namespace="openshift-monitoring"}[5m]) > 0
+        min_over_time(prometheus_operator_syncs{status="failed",job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) > 0
       for: 10m
       labels:
         severity: warning
@@ -51,7 +51,7 @@ spec:
           namespace.'
         summary: Errors while reconciling controller.
       expr: |
-        (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{job="prometheus-operator",namespace="openshift-monitoring"}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{job="prometheus-operator",namespace="openshift-monitoring"}[5m]))) > 0.1
+        (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]))) > 0.1
       for: 10m
       labels:
         severity: warning
@@ -61,7 +61,7 @@ spec:
           Namespace.
         summary: Errors while reconciling Prometheus.
       expr: |
-        rate(prometheus_operator_node_address_lookup_errors_total{job="prometheus-operator",namespace="openshift-monitoring"}[5m]) > 0.1
+        rate(prometheus_operator_node_address_lookup_errors_total{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) > 0.1
       for: 10m
       labels:
         severity: warning
@@ -71,7 +71,7 @@ spec:
           ready to reconcile {{ $labels.controller }} resources.
         summary: Prometheus operator not ready
       expr: |
-        min by(namespace, controller) (max_over_time(prometheus_operator_ready{job="prometheus-operator",namespace="openshift-monitoring"}[5m]) == 0)
+        min by(namespace, controller) (max_over_time(prometheus_operator_ready{job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) == 0)
       for: 5m
       labels:
         severity: warning
@@ -82,7 +82,7 @@ spec:
           }} resources.
         summary: Resources rejected by Prometheus operator
       expr: |
-        min_over_time(prometheus_operator_managed_resources{state="rejected",job="prometheus-operator",namespace="openshift-monitoring"}[5m]) > 0
+        min_over_time(prometheus_operator_managed_resources{state="rejected",job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) > 0
       for: 5m
       labels:
         severity: warning

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -271,7 +271,7 @@ local inCluster =
         mixin+: {
           ruleLabels: $.values.common.ruleLabels,
           _config+: {
-            prometheusSelector: 'job=~"prometheus-k8s|prometheus-user-workload"',
+            prometheusOperatorSelector: 'job="prometheus-operator", namespace=~"%(namespace)s|%(namespaceUserWorkload)s"' % ($.values.common),
           },
         },
         tlsCipherSuites: $.values.common.tlsCipherSuites,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
