### PR TITLE
Bug 2000536:  jsonnet: Remove redundant KSM alerts

### DIFF
--- a/assets/kube-state-metrics/prometheus-rule.yaml
+++ b/assets/kube-state-metrics/prometheus-rule.yaml
@@ -42,27 +42,3 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: KubeStateMetricsShardingMismatch
-      annotations:
-        description: kube-state-metrics pods are running with different --total-shards
-          configuration, some Kubernetes objects may be exposed multiple times or
-          not exposed at all.
-        summary: kube-state-metrics sharding is misconfigured.
-      expr: |
-        stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
-      for: 15m
-      labels:
-        severity: critical
-    - alert: KubeStateMetricsShardsMissing
-      annotations:
-        description: kube-state-metrics shards are missing, some Kubernetes objects
-          are not being exposed.
-        summary: kube-state-metrics shards are missing.
-      expr: |
-        2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
-          -
-        sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
-        != 0
-      for: 15m
-      labels:
-        severity: critical

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -103,6 +103,14 @@ local excludedRules = [
       { alert: 'ThanosQueryRangeLatencyHigh' },
     ],
   },
+  {
+    // For ksm, sharding is not applicable to CMO
+    name: 'kube-state-metrics',
+    rules: [
+      { alert: 'KubeStateMetricsShardingMismatch' },
+      { alert: 'KubeStateMetricsShardsMissing' },
+    ],
+  },
 ];
 
 local patchedRules = [


### PR DESCRIPTION
Removes kube-state-metrics alerts that will not fire on OCP
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
