### PR TITLE
Support enabling the `query_log_file` config for Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1439](https://github.com/openshift/cluster-monitoring-operator/pull/1439) Expose PodDisruptionBudget labels from kube-state-metrics metrics.
 - [#1377](https://github.com/openshift/cluster-monitoring-operator/pull/1377) Allow OpenShift users to configure audit logs for prometheus-adapter
 - [#1481](https://github.com/openshift/cluster-monitoring-operator/pull/1481) Removing one of the AlertmanagerClusterFailedToSendAlerts alerts
+- [#1373](https://github.com/openshift/cluster-monitoring-operator/pull/1373) Enable admins to toggle the [query_log_file](https://prometheus.io/docs/guides/query-log/#enable-the-query-log) setting for Prometheus.
 
 ## 4.9
 

--- a/Documentation/user-guides/configuring-cluster-monitoring.md
+++ b/Documentation/user-guides/configuring-cluster-monitoring.md
@@ -83,6 +83,10 @@ resources: [v1.ResourceRequirements](https://kubernetes.io/docs/api-reference/v1
 # specified by users
 externalLabels:
   [ - <labelname>: <labelvalue> ]
+# log all the queries run by the engine to a log file
+# this option should be enabled temporarily only to support debugging
+# as there is no option to support or manage log rotation
+queryLogFile: string
 ```
 
 ### AlertmanagerMainConfig

--- a/examples/user-workload/README.md
+++ b/examples/user-workload/README.md
@@ -18,25 +18,26 @@ data:
 Configuration example is located in this directory, with the following supported configuration fields:
 ```
 prometheusOperator:
-logLevel     string
-nodeSelector map[string]string
-tolerations  []v1.Toleration
+  logLevel     string
+  nodeSelector map[string]string
+  tolerations  []v1.Toleration
 
 thanosRuler:
-logLevel     string
-nodeSelector map[string]string
-tolerations  []v1.Toleration
-resources           *v1.ResourceRequirements
-volumeClaimTemplate *v1.PersistentVolumeClaim
+  logLevel            string
+  nodeSelector        map[string]string
+  tolerations         []v1.Toleration
+  resources           *v1.ResourceRequirements
+  volumeClaimTemplate *v1.PersistentVolumeClaim
 
 prometheus:
-logLevel     string
-nodeSelector map[string]string
-tolerations  []v1.Toleration
-retention string
-resources           *v1.ResourceRequirements
-externalLabels      map[string]string
-volumeClaimTemplate *v1.PersistentVolumeClaim
-hostport            string
-remoteWrite         []monv1.RemoteWriteSpec
+  logLevel            string
+  nodeSelector        map[string]string
+  tolerations         []v1.Toleration
+  retention           string
+  resources           *v1.ResourceRequirements
+  externalLabels      map[string]string
+  volumeClaimTemplate *v1.PersistentVolumeClaim
+  hostport            string
+  remoteWrite         []monv1.RemoteWriteSpec
+  queryLogFile        string
 ```

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -178,6 +178,7 @@ type PrometheusK8sConfig struct {
 	RemoteWrite         []RemoteWriteSpec                    `json:"remoteWrite"`
 	TelemetryMatches    []string                             `json:"-"`
 	AlertmanagerConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
+	QueryLogFile        string                               `json:"queryLogFile"`
 }
 
 type AdditionalAlertmanagerConfig struct {
@@ -508,6 +509,7 @@ type PrometheusRestrictedConfig struct {
 	EnforcedSampleLimit *uint64                              `json:"enforcedSampleLimit"`
 	EnforcedTargetLimit *uint64                              `json:"enforcedTargetLimit"`
 	AlertmanagerConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
+	QueryLogFile        string                               `json:"queryLogFile"`
 }
 
 func (u *UserWorkloadConfiguration) applyDefaults() {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1376,6 +1376,10 @@ func (f *Factory) PrometheusK8s(host string, grpcTLS *v1.Secret, trustedCABundle
 		}
 	}
 
+	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile != "" {
+		p.Spec.QueryLogFile = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile
+	}
+
 	telemetryEnabled := f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.IsEnabled()
 	if telemetryEnabled && f.config.RemoteWrite {
 
@@ -1668,6 +1672,10 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 
 	if f.config.Images.Thanos != "" {
 		p.Spec.Thanos.Image = &f.config.Images.Thanos
+	}
+
+	if f.config.UserWorkloadConfiguration.Prometheus.QueryLogFile != "" {
+		p.Spec.QueryLogFile = f.config.UserWorkloadConfiguration.Prometheus.QueryLogFile
 	}
 
 	for i, container := range p.Spec.Containers {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1035,6 +1035,7 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
     datacenter: eu-west
   remoteWrite:
   - url: "https://test.remotewrite.com/api/write"
+  queryLogFile: /tmp/test
 ingress:
   baseAddress: monitoring-demo.staging.core-os.net
 `)
@@ -1167,6 +1168,10 @@ ingress:
 
 	if p.Spec.RemoteWrite[0].URL != "https://test.remotewrite.com/api/write" {
 		t.Fatal("Prometheus remote-write is not configured correctly")
+	}
+
+	if p.Spec.QueryLogFile != "/tmp/test" {
+		t.Fatal("Prometheus query log is not configured correctly")
 	}
 }
 


### PR DESCRIPTION
Enables setting https://prometheus.io/docs/guides/query-log/#enable-the-query-log on/off via the ConfigMap for both platform and user workload monitoring.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
