### PR TITLE
Configure prometheus operator TLS based on the cluster APIServer config

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -194,6 +194,12 @@ function(params) {
       },
       {
         apiGroups: ['config.openshift.io'],
+        resources: ['apiservers'],
+        resourceNames: ['cluster'],
+        verbs: ['get', 'list', 'watch'],
+      },
+      {
+        apiGroups: ['config.openshift.io'],
         resources: ['proxies'],
         verbs: ['get'],
       },

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -117,6 +117,16 @@ rules:
   - watch
 - apiGroups:
   - config.openshift.io
+  resourceNames:
+  - cluster
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
   resources:
   - proxies
   verbs:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -174,6 +174,29 @@ func (c *Client) InfrastructureListWatchForResource(ctx context.Context, resourc
 	}
 }
 
+func (c *Client) ApiServersListWatchForResource(ctx context.Context, resource string) *cache.ListWatch {
+	apiServerInterface := c.oscclient.ConfigV1().APIServers()
+
+	return &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return apiServerInterface.List(
+				ctx,
+				metav1.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector("metadata.name", resource).String(),
+				},
+			)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return apiServerInterface.Watch(
+				ctx,
+				metav1.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector("metadata.name", resource).String(),
+				},
+			)
+		},
+	}
+}
+
 func (c *Client) AssurePrometheusOperatorCRsExist(ctx context.Context) error {
 	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		_, err := c.mclient.MonitoringV1().Prometheuses(c.namespace).List(ctx, metav1.ListOptions{})
@@ -274,6 +297,10 @@ func (c *Client) GetProxy(ctx context.Context, name string) (*configv1.Proxy, er
 
 func (c *Client) GetInfrastructure(ctx context.Context, name string) (*configv1.Infrastructure, error) {
 	return c.oscclient.ConfigV1().Infrastructures().Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) GetAPIServerConfig(ctx context.Context, name string) (*configv1.APIServer, error) {
+	return c.oscclient.ConfigV1().APIServers().Get(ctx, name, metav1.GetOptions{})
 }
 
 func (c *Client) GetConfigmap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {

--- a/pkg/manifests/apiserver_config.go
+++ b/pkg/manifests/apiserver_config.go
@@ -25,7 +25,7 @@ func NewAPIServerConfig(config *configv1.APIServer) *APIServerConfig {
 // TLS security profile defined in the APIServerConfig.
 func (c *APIServerConfig) GetTLSCiphers() []string {
 	profile := c.getTLSProfile()
-	if profile.Ciphers == nil || len(profile.Ciphers) == 0 {
+	if len(profile.Ciphers) == 0 {
 		return APIServerDefaultTLSCiphers
 	}
 	return profile.Ciphers

--- a/pkg/manifests/apiserver_config.go
+++ b/pkg/manifests/apiserver_config.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package manifests
 
 import configv1 "github.com/openshift/api/config/v1"

--- a/pkg/manifests/apiserver_config.go
+++ b/pkg/manifests/apiserver_config.go
@@ -1,0 +1,63 @@
+package manifests
+
+import configv1 "github.com/openshift/api/config/v1"
+
+var (
+	// APIServerDefaultTLSCiphers are the default TLS ciphers for API servers
+	APIServerDefaultTLSCiphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers
+	// APIServerDefaultMinTLSVersion is the default minimum TLS version for API servers
+	APIServerDefaultMinTLSVersion = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion
+)
+
+// APIServerConfig is the cluster-wide configuration for all API servers.
+type APIServerConfig struct {
+	*configv1.APIServer
+}
+
+// NewAPIServerConfig creates a new APIServerConfig
+func NewAPIServerConfig(config *configv1.APIServer) *APIServerConfig {
+	return &APIServerConfig{
+		config,
+	}
+}
+
+// GetTLSCiphers returns the TLS ciphers for the
+// TLS security profile defined in the APIServerConfig.
+func (c *APIServerConfig) GetTLSCiphers() []string {
+	profile := c.getTLSProfile()
+	if profile.Ciphers == nil || len(profile.Ciphers) == 0 {
+		return APIServerDefaultTLSCiphers
+	}
+	return profile.Ciphers
+}
+
+// GetMinTLSVersion returns the minimum TLS version for the
+// TLS security profile defined in the APIServerConfig.
+func (c *APIServerConfig) GetMinTLSVersion() configv1.TLSProtocolVersion {
+	profile := c.getTLSProfile()
+	if profile.MinTLSVersion == "" {
+		return APIServerDefaultMinTLSVersion
+	}
+	return profile.MinTLSVersion
+}
+
+func (c *APIServerConfig) getTLSProfile() configv1.TLSProfileSpec {
+	defaultProfile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	if c == nil || c.APIServer == nil || c.Spec.TLSSecurityProfile == nil {
+		return defaultProfile
+	}
+
+	profile := c.Spec.TLSSecurityProfile
+	if profile.Type != configv1.TLSProfileCustomType {
+		if tlsConfig, ok := configv1.TLSProfiles[profile.Type]; ok {
+			return *tlsConfig
+		}
+		return defaultProfile
+	}
+
+	if profile.Custom != nil {
+		return profile.Custom.TLSProfileSpec
+	}
+
+	return defaultProfile
+}

--- a/pkg/manifests/apiserver_config_test.go
+++ b/pkg/manifests/apiserver_config_test.go
@@ -1,0 +1,136 @@
+package manifests_test
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGetTLSCiphers(t *testing.T) {
+	defaultCiphers := manifests.APIServerDefaultTLSCiphers
+	defaultTLSVersion := manifests.APIServerDefaultMinTLSVersion
+
+	testCases := []struct {
+		name                  string
+		config                *manifests.APIServerConfig
+		expectedCiphers       []string
+		expectedMinTLSVersion configv1.TLSProtocolVersion
+	}{
+		{
+			name:                  "nil config",
+			config:                nil,
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
+			name:                  "nil config",
+			config:                manifests.NewAPIServerConfig(nil),
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
+			name:                  "nil profile",
+			config:                newApiserverConfig(nil),
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
+			name: "empty profile",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: "",
+			}),
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
+			name: "invalid profile",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: "invalid-profile",
+			}),
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
+			name: "old profile",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			}),
+			expectedCiphers:       configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers,
+			expectedMinTLSVersion: configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion,
+		},
+		{
+			name: "intermediate profile",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			}),
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
+			name: "modern profile",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			expectedCiphers:       configv1.TLSProfiles[configv1.TLSProfileModernType].Ciphers,
+			expectedMinTLSVersion: configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion,
+		},
+		{
+			name: "custom profile without TLS configuration",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			}),
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
+			name: "custom profile without ciphers and min tls version",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{},
+			}),
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
+			name: "custom profile with ciphers and min tls version",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"cipher-1", "cipher-2"},
+						MinTLSVersion: configv1.VersionTLS11,
+					},
+				},
+			}),
+			expectedCiphers:       []string{"cipher-1", "cipher-2"},
+			expectedMinTLSVersion: configv1.VersionTLS11,
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actualCiphers := tt.config.GetTLSCiphers()
+			if !reflect.DeepEqual(tt.expectedCiphers, actualCiphers) {
+				t.Fatalf("invalid ciphers, got %s, want %s", strings.Join(actualCiphers, ", "), strings.Join(tt.expectedCiphers, ", "))
+			}
+
+			actualTLSVersion := tt.config.GetMinTLSVersion()
+			if tt.expectedMinTLSVersion != actualTLSVersion {
+				t.Fatalf("invalid min TLS version, got %s, want %s", actualTLSVersion, tt.expectedMinTLSVersion)
+			}
+		})
+	}
+}
+
+func newApiserverConfig(profile *configv1.TLSSecurityProfile) *manifests.APIServerConfig {
+	config := manifests.NewAPIServerConfig(&configv1.APIServer{
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: profile,
+		},
+	})
+
+	return config
+}

--- a/pkg/manifests/apiserver_config_test.go
+++ b/pkg/manifests/apiserver_config_test.go
@@ -96,7 +96,7 @@ func TestGetTLSCiphers(t *testing.T) {
 		{
 			name: "custom profile nil ciphers and empty min tls version",
 			config: newApiserverConfig(&configv1.TLSSecurityProfile{
-				Type:   configv1.TLSProfileCustomType,
+				Type: configv1.TLSProfileCustomType,
 				Custom: &configv1.CustomTLSProfile{
 					TLSProfileSpec: configv1.TLSProfileSpec{
 						Ciphers:       nil,

--- a/pkg/manifests/apiserver_config_test.go
+++ b/pkg/manifests/apiserver_config_test.go
@@ -94,6 +94,20 @@ func TestGetTLSCiphers(t *testing.T) {
 			expectedMinTLSVersion: defaultTLSVersion,
 		},
 		{
+			name: "custom profile nil ciphers and empty min tls version",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       nil,
+						MinTLSVersion: "",
+					},
+				},
+			}),
+			expectedCiphers:       defaultCiphers,
+			expectedMinTLSVersion: defaultTLSVersion,
+		},
+		{
 			name: "custom profile with ciphers and min tls version",
 			config: newApiserverConfig(&configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileCustomType,

--- a/pkg/manifests/apiserver_config_test.go
+++ b/pkg/manifests/apiserver_config_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package manifests_test
 
 import (

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2089,20 +2089,20 @@ func setTLSSecurityConfiguration(args []string, config *APIServerConfig) []strin
 }
 
 func setArg(args []string, argName string, argValue string) []string {
-	flagFound := false
-	for i := range args {
-		if strings.HasPrefix(args[i], argName) {
-			args[i] = fmt.Sprintf("%s%s", argName, argValue)
-			flagFound = true
-		}
+	argsMap := make(map[string]string)
+	for _, arg := range args {
+		parts := strings.SplitAfter(arg, "=")
+		argsMap[parts[0]] = parts[1]
 	}
 
-	if !flagFound {
-		arg := fmt.Sprintf("%s%s", argName, argValue)
-		args = append(args, arg)
+	argsMap[argName] = argValue
+
+	resultArgs := make([]string, 0, len(args))
+	for k, v := range argsMap {
+		resultArgs = append(resultArgs, k+v)
 	}
 
-	return args
+	return resultArgs
 }
 
 func (f *Factory) PrometheusRuleValidatingWebhook() (*admissionv1.ValidatingWebhookConfiguration, error) {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/library-go/pkg/crypto"
 	"hash/fnv"
 	"io"
 	"net"
@@ -245,6 +246,8 @@ var (
 	PrometheusConfigReloaderFlag                         = "--prometheus-config-reloader="
 	PrometheusOperatorPrometheusInstanceNamespacesFlag   = "--prometheus-instance-namespaces="
 	PrometheusOperatorAlertmanagerInstanceNamespacesFlag = "--alertmanager-instance-namespaces="
+	PrometheusOperatorWebTLSCipherSuitesFlag             = "--web.tls-cipher-suites="
+	PrometheusOperatorWebTLSMinTLSVersionFlag            = "--web.tls-min-version="
 
 	AuthProxyExternalURLFlag  = "-external-url="
 	AuthProxyCookieDomainFlag = "-cookie-domain="
@@ -1979,7 +1982,7 @@ func (f *Factory) PrometheusOperatorUserWorkloadServiceAccount() (*v1.ServiceAcc
 	return s, nil
 }
 
-func (f *Factory) PrometheusOperatorDeployment() (*appsv1.Deployment, error) {
+func (f *Factory) PrometheusOperatorDeployment(config *APIServerConfig) (*appsv1.Deployment, error) {
 	d, err := f.NewDeployment(f.assets.MustNewAssetReader(PrometheusOperatorDeployment))
 	if err != nil {
 		return nil, err
@@ -2018,6 +2021,8 @@ func (f *Factory) PrometheusOperatorDeployment() (*appsv1.Deployment, error) {
 			if f.config.ClusterMonitoringConfiguration.PrometheusOperatorConfig.LogLevel != "" {
 				args = append(args, fmt.Sprintf("--log-level=%s", f.config.ClusterMonitoringConfiguration.PrometheusOperatorConfig.LogLevel))
 			}
+
+			args = setTLSSecurityConfiguration(f.namespace, args, config)
 			d.Spec.Template.Spec.Containers[i].Args = args
 		}
 	}
@@ -2026,7 +2031,7 @@ func (f *Factory) PrometheusOperatorDeployment() (*appsv1.Deployment, error) {
 	return d, nil
 }
 
-func (f *Factory) PrometheusOperatorUserWorkloadDeployment() (*appsv1.Deployment, error) {
+func (f *Factory) PrometheusOperatorUserWorkloadDeployment(config *APIServerConfig) (*appsv1.Deployment, error) {
 	d, err := f.NewDeployment(f.assets.MustNewAssetReader(PrometheusOperatorUserWorkloadDeployment))
 	if err != nil {
 		return nil, err
@@ -2064,12 +2069,40 @@ func (f *Factory) PrometheusOperatorUserWorkloadDeployment() (*appsv1.Deployment
 			if f.config.UserWorkloadConfiguration.PrometheusOperator.LogLevel != "" {
 				args = append(args, fmt.Sprintf("--log-level=%s", f.config.UserWorkloadConfiguration.PrometheusOperator.LogLevel))
 			}
+			args = setTLSSecurityConfiguration(f.namespace, args, config)
 			d.Spec.Template.Spec.Containers[i].Args = args
 		}
 	}
 	d.Namespace = f.namespaceUserWorkload
 
 	return d, nil
+}
+
+func setTLSSecurityConfiguration(namespace string, args []string, config *APIServerConfig) []string {
+	cipherSuites := strings.Join(crypto.OpenSSLToIANACipherSuites(config.GetTLSCiphers()), ",")
+	args = setArg(namespace, args, PrometheusOperatorWebTLSCipherSuitesFlag, cipherSuites)
+
+	minTLSVersion := config.GetMinTLSVersion()
+	args = setArg(namespace, args, PrometheusOperatorWebTLSMinTLSVersionFlag, string(minTLSVersion))
+
+	return args
+}
+
+func setArg(namespace string, args []string, argName string, argValue string) []string {
+	flagFound := false
+	for i := range args {
+		if strings.HasPrefix(args[i], argName) && namespace != "" {
+			args[i] = fmt.Sprintf("%s%s", argName, argValue)
+			flagFound = true
+		}
+	}
+
+	if !flagFound {
+		arg := fmt.Sprintf("%s%s", argName, argValue)
+		args = append(args, arg)
+	}
+
+	return args
 }
 
 func (f *Factory) PrometheusRuleValidatingWebhook() (*admissionv1.ValidatingWebhookConfiguration, error) {
@@ -3479,7 +3512,7 @@ func (f *Factory) mountThanosRulerAlertmanagerSecrets(t *monv1.ThanosRuler) {
 	}
 
 	t.Spec.Volumes = append(t.Spec.Volumes, volumes...)
-	for i, _ := range t.Spec.Containers {
+	for i := range t.Spec.Containers {
 		containerName := t.Spec.Containers[i].Name
 		if containerName == "thanos-ruler" {
 			t.Spec.Containers[i].VolumeMounts = append(t.Spec.Containers[i].VolumeMounts, volumeMounts...)
@@ -3494,7 +3527,7 @@ func (f *Factory) injectThanosRulerAlertmanagerDigest(t *monv1.ThanosRuler, aler
 	}
 	digestBytes := md5.Sum([]byte(alertmanagerConfig.StringData["alertmanagers.yaml"]))
 	digest = fmt.Sprintf("%x", digestBytes)
-	for i, _ := range t.Spec.Containers {
+	for i := range t.Spec.Containers {
 		containerName := t.Spec.Containers[i].Name
 		if containerName == "thanos-ruler" {
 			// Thanos ruler does not refresh its config when the alertmanagers secret changes.

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -15,6 +15,8 @@
 package manifests
 
 import (
+	"fmt"
+	"github.com/openshift/library-go/pkg/crypto"
 	"net/url"
 	"reflect"
 	"sort"
@@ -569,7 +571,7 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.PrometheusOperatorDeployment()
+	_, err = f.PrometheusOperatorDeployment(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -743,7 +745,7 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 	}
 
 	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath))
-	d, err := f.PrometheusOperatorDeployment()
+	d, err := f.PrometheusOperatorDeployment(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -763,15 +765,39 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 	}
 
 	prometheusReloaderFound := false
+	prometheusWebTLSCipherSuitesArg := ""
+	prometheusWebTLSVersionArg := ""
 	for i := range d.Spec.Template.Spec.Containers[0].Args {
 		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusConfigReloaderFlag+"docker.io/openshift/origin-prometheus-config-reloader:latest") {
 			prometheusReloaderFound = true
+		}
+
+		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusOperatorWebTLSCipherSuitesFlag) {
+			prometheusWebTLSCipherSuitesArg = d.Spec.Template.Spec.Containers[0].Args[i]
+		}
+
+		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusOperatorWebTLSMinTLSVersionFlag) {
+			prometheusWebTLSVersionArg = d.Spec.Template.Spec.Containers[0].Args[i]
 		}
 	}
 
 	if !prometheusReloaderFound {
 		t.Fatal("Configuring the Prometheus Config reloader image failed")
 	}
+
+	expectedPrometheusWebTLSCipherSuitesArg := fmt.Sprintf("%s%s",
+		PrometheusOperatorWebTLSCipherSuitesFlag,
+		strings.Join(crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), ","))
+	if expectedPrometheusWebTLSCipherSuitesArg != prometheusWebTLSCipherSuitesArg {
+		t.Fatalf("incorrect TLS ciphers, \n got %s, \nwant %s", prometheusWebTLSCipherSuitesArg, expectedPrometheusWebTLSCipherSuitesArg)
+	}
+
+	expectedPrometheusWebTLSVersionArg := fmt.Sprintf("%s%s",
+		PrometheusOperatorWebTLSMinTLSVersionFlag, APIServerDefaultMinTLSVersion)
+	if expectedPrometheusWebTLSVersionArg != prometheusWebTLSVersionArg {
+		t.Fatalf("incorrect TLS version \n got %s, \nwant %s", prometheusWebTLSVersionArg, expectedPrometheusWebTLSVersionArg)
+	}
+
 }
 
 func TestPrometheusK8sRemoteWrite(t *testing.T) {
@@ -2211,6 +2237,58 @@ func TestPodDisruptionBudget(t *testing.T) {
 		}
 	}
 
+}
+
+func TestPrometheusOperatorUserWorkloadConfiguration(t *testing.T) {
+	c, err := NewConfigFromString(`
+enableUserWorkload: true
+`)
+
+	c.SetImages(map[string]string{
+		"prometheus-operator":        "docker.io/openshift/origin-prometheus-operator:latest",
+		"prometheus-config-reloader": "docker.io/openshift/origin-prometheus-config-reloader:latest",
+		"configmap-reloader":         "docker.io/openshift/origin-configmap-reloader:latest",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath))
+	d, err := f.PrometheusOperatorUserWorkloadDeployment(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPromOpImage := "docker.io/openshift/origin-prometheus-operator:latest"
+	resPromOpImage := d.Spec.Template.Spec.Containers[0].Image
+	if resPromOpImage != expectedPromOpImage {
+		t.Fatalf("Configuring the Prometheus Operator image failed, expected: %v, got %v", expectedPromOpImage, resPromOpImage)
+	}
+
+	prometheusReloaderFound := false
+	prometheusWebTLSCipherSuitesArg := ""
+	for i := range d.Spec.Template.Spec.Containers[0].Args {
+		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusConfigReloaderFlag+"docker.io/openshift/origin-prometheus-config-reloader:latest") {
+			prometheusReloaderFound = true
+		}
+
+		if strings.HasPrefix(d.Spec.Template.Spec.Containers[0].Args[i], PrometheusOperatorWebTLSCipherSuitesFlag) {
+			prometheusWebTLSCipherSuitesArg = d.Spec.Template.Spec.Containers[0].Args[i]
+		}
+	}
+
+	if !prometheusReloaderFound {
+		t.Fatal("Configuring the Prometheus Config reloader image failed")
+	}
+
+	expectedPrometheusWebTLSCipherSuitesArg := fmt.Sprintf("%s%s",
+		PrometheusOperatorWebTLSCipherSuitesFlag,
+		strings.Join(crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), ","),
+	)
+	if expectedPrometheusWebTLSCipherSuitesArg != prometheusWebTLSCipherSuitesArg {
+		t.Fatalf("incorrect TLS ciphers, \n got %s, \nwant %s", prometheusWebTLSCipherSuitesArg, expectedPrometheusWebTLSCipherSuitesArg)
+	}
 }
 
 func trustedCABundleVolumeConfigured(volumes []v1.Volume, volumeName string) bool {

--- a/pkg/tasks/prometheusoperator.go
+++ b/pkg/tasks/prometheusoperator.go
@@ -86,7 +86,7 @@ func (t *PrometheusOperatorTask) Run(ctx context.Context) error {
 
 	config, err := t.client.GetAPIServerConfig(ctx, "cluster")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get API server configuration")
 	}
 	apiserverConfig := manifests.NewAPIServerConfig(config)
 	d, err := t.factory.PrometheusOperatorDeployment(apiserverConfig)

--- a/pkg/tasks/prometheusoperator.go
+++ b/pkg/tasks/prometheusoperator.go
@@ -84,7 +84,12 @@ func (t *PrometheusOperatorTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Prometheus Operator Service failed")
 	}
 
-	d, err := t.factory.PrometheusOperatorDeployment()
+	config, err := t.client.GetAPIServerConfig(ctx, "cluster")
+	if err != nil {
+		return err
+	}
+	apiserverConfig := manifests.NewAPIServerConfig(config)
+	d, err := t.factory.PrometheusOperatorDeployment(apiserverConfig)
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus Operator Deployment failed")
 	}

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -87,7 +87,7 @@ func (t *PrometheusOperatorUserWorkloadTask) create(ctx context.Context) error {
 
 	config, err := t.client.GetAPIServerConfig(ctx, "cluster")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get API server configuration")
 	}
 	apiserverConfig := manifests.NewAPIServerConfig(config)
 	d, err := t.factory.PrometheusOperatorUserWorkloadDeployment(apiserverConfig)

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -85,7 +85,12 @@ func (t *PrometheusOperatorUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator Service failed")
 	}
 
-	d, err := t.factory.PrometheusOperatorUserWorkloadDeployment()
+	config, err := t.client.GetAPIServerConfig(ctx, "cluster")
+	if err != nil {
+		return err
+	}
+	apiserverConfig := manifests.NewAPIServerConfig(config)
+	d, err := t.factory.PrometheusOperatorUserWorkloadDeployment(apiserverConfig)
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator Deployment failed")
 	}
@@ -127,7 +132,7 @@ func (t *PrometheusOperatorUserWorkloadTask) create(ctx context.Context) error {
 }
 
 func (t *PrometheusOperatorUserWorkloadTask) destroy(ctx context.Context) error {
-	dep, err := t.factory.PrometheusOperatorUserWorkloadDeployment()
+	dep, err := t.factory.PrometheusOperatorUserWorkloadDeployment(nil)
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator Deployment failed")
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	openshiftconfigclientset "github.com/openshift/client-go/config/clientset/versioned"
 	"net/http"
 	"net/url"
 	"os/exec"
@@ -58,18 +59,19 @@ const (
 )
 
 type Framework struct {
-	RestConfig          *rest.Config
-	OperatorClient       *client.Client
-	OpenShiftRouteClient *routev1.RouteV1Client
-	KubeClient           kubernetes.Interface
-	ThanosQuerierClient  *PrometheusClient
-	PrometheusK8sClient  *PrometheusClient
-	AlertmanagerClient   *PrometheusClient
-	APIServicesClient    *apiservicesclient.Clientset
-	AdmissionClient      *admissionclient.AdmissionregistrationV1Client
-	MetricsClient        *metricsclient.Clientset
-	SchedulingClient     *schedulingv1client.SchedulingV1Client
-	kubeConfigPath       string
+	RestConfig            *rest.Config
+	OperatorClient        *client.Client
+	OpenShiftConfigClient *openshiftconfigclientset.Clientset
+	OpenShiftRouteClient  *routev1.RouteV1Client
+	KubeClient            kubernetes.Interface
+	ThanosQuerierClient   *PrometheusClient
+	PrometheusK8sClient   *PrometheusClient
+	AlertmanagerClient    *PrometheusClient
+	APIServicesClient     *apiservicesclient.Clientset
+	AdmissionClient       *admissionclient.AdmissionregistrationV1Client
+	MetricsClient         *metricsclient.Clientset
+	SchedulingClient      *schedulingv1client.SchedulingV1Client
+	kubeConfigPath        string
 
 	MonitoringClient             *monClient.MonitoringV1Client
 	Ns, UserWorkloadMonitoringNs string
@@ -125,9 +127,15 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		return nil, nil, errors.Wrap(err, "creating scheduling v1 client failed")
 	}
 
+	openshiftConfigClient, err := openshiftconfigclientset.NewForConfig(config)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating openshift config v1 client failed")
+	}
+
 	f := &Framework{
 		RestConfig:               config,
 		OperatorClient:           operatorClient,
+		OpenShiftConfigClient:    openshiftConfigClient,
 		OpenShiftRouteClient:     openshiftRouteClient,
 		KubeClient:               kubeClient,
 		APIServicesClient:        apiServicesClient,

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -1,0 +1,158 @@
+// Copyright 2021 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
+	"github.com/openshift/library-go/pkg/crypto"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTLSSecurityProfileConfiguration(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		profile               *configv1.TLSSecurityProfile
+		expectedCipherSuite   []string
+		expectedMinTLSVersion string
+	}{
+		{
+			name:                  "no profile",
+			profile:               nil,
+			expectedCipherSuite:   manifests.APIServerDefaultTLSCiphers,
+			expectedMinTLSVersion: "VersionTLS12",
+		},
+		{
+			name: "old profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+				Old:  &configv1.OldTLSProfile{},
+			},
+			expectedCipherSuite:   configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers,
+			expectedMinTLSVersion: "VersionTLS10",
+		},
+		{
+			name: "intermediate profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type:         configv1.TLSProfileIntermediateType,
+				Intermediate: &configv1.IntermediateTLSProfile{},
+			},
+			expectedCipherSuite:   configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers,
+			expectedMinTLSVersion: "VersionTLS12",
+		},
+		{
+			name: "custom profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers: []string{
+							"TLS_AES_128_GCM_SHA256",
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"DHE-RSA-AES256-GCM-SHA384",
+						},
+						MinTLSVersion: "VersionTLS10",
+					},
+				},
+			},
+			expectedCipherSuite: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"ECDHE-ECDSA-AES128-GCM-SHA256",
+				"DHE-RSA-AES256-GCM-SHA384",
+			},
+			expectedMinTLSVersion: "VersionTLS10",
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			setTlsSecurityProfile(t, tt.profile)
+			assertCorrectTLSConfiguration(t, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
+		})
+	}
+}
+
+func assertCorrectTLSConfiguration(t *testing.T, ciphers []string, tlsVersion string) {
+	ctx := context.Background()
+	if err := framework.Poll(5*time.Second, 5*time.Minute, func() (err error) {
+		d, err := f.KubeClient.AppsV1().Deployments("openshift-monitoring").Get(ctx, "prometheus-operator", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		isCipherSuiteArgCorrect := correctCipherSuiteArg(ciphers, d)
+		if !isCipherSuiteArgCorrect {
+			return fmt.Errorf("invalid cipher suite set for prometheus-operator in openshift-monitoring namespace")
+		}
+
+		validTLSVersion := correctMinTLSVersion(tlsVersion, d)
+		if !validTLSVersion {
+			return fmt.Errorf("invalid tls version set for prometheus-operator in openshift-monitoring namespace")
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func correctCipherSuiteArg(ciphers []string, d *appsv1.Deployment) bool {
+	expectedCiphersArg := fmt.Sprintf(
+		"%s%s",
+		manifests.PrometheusOperatorWebTLSCipherSuitesFlag,
+		strings.Join(crypto.OpenSSLToIANACipherSuites(ciphers), ","),
+	)
+
+	for _, c := range d.Spec.Template.Spec.Containers {
+		for _, arg := range c.Args {
+			if arg == expectedCiphersArg {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func correctMinTLSVersion(tlsVersion string, d *appsv1.Deployment) bool {
+	expectedVersionArg := fmt.Sprintf("%s%s", manifests.PrometheusOperatorWebTLSMinTLSVersionFlag, tlsVersion)
+	for _, c := range d.Spec.Template.Spec.Containers {
+		for _, arg := range c.Args {
+			if arg == expectedVersionArg {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func setTlsSecurityProfile(t *testing.T, tlsSecurityProfile *configv1.TLSSecurityProfile) {
+	ctx := context.Background()
+	apiserverConfig, err := f.OpenShiftConfigClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiserverConfig.Spec.TLSSecurityProfile = tlsSecurityProfile
+	if _, err := f.OpenShiftConfigClient.ConfigV1().APIServers().Update(ctx, apiserverConfig, metav1.UpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -66,18 +66,16 @@ func TestTLSSecurityProfileConfiguration(t *testing.T) {
 				Custom: &configv1.CustomTLSProfile{
 					TLSProfileSpec: configv1.TLSProfileSpec{
 						Ciphers: []string{
-							"TLS_AES_128_GCM_SHA256",
-							"ECDHE-ECDSA-AES128-GCM-SHA256",
-							"DHE-RSA-AES256-GCM-SHA384",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"ECDHE-ECDSA-AES256-GCM-SHA384",
 						},
 						MinTLSVersion: "VersionTLS10",
 					},
 				},
 			},
 			expectedCipherSuite: []string{
-				"TLS_AES_128_GCM_SHA256",
-				"ECDHE-ECDSA-AES128-GCM-SHA256",
-				"DHE-RSA-AES256-GCM-SHA384",
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"ECDHE-ECDSA-AES256-GCM-SHA384",
 			},
 			expectedMinTLSVersion: "VersionTLS10",
 		},


### PR DESCRIPTION
OpenShift exposes a cluster-scoped resource called APIServer which
admins can use to configure TLS security settings for all openshift
components. Admins can choose from three predefined profiles, old,
intermediate and modern, or define custom TLS settings themselves.

This commit implements logic in CMO to apply the TLS settings defined in
the APIServer resource to the PM and UWM prometheus-operator.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
