### PR TITLE
Update KSM version to match what we deploy

### DIFF
--- a/assets/kube-state-metrics/cluster-role-binding.yaml
+++ b/assets/kube-state-metrics/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/kube-state-metrics/cluster-role.yaml
+++ b/assets/kube-state-metrics/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
   namespace: openshift-monitoring
 spec:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.1.1
     spec:
       containers:
       - args:
@@ -47,7 +47,7 @@ spec:
           kube_pod_container_status_running,
           kube_pod_completion_time,
           kube_pod_status_scheduled
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.1
         name: kube-state-metrics
         resources:
           requests:

--- a/assets/kube-state-metrics/prometheus-rule.yaml
+++ b/assets/kube-state-metrics/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/assets/kube-state-metrics/service-account.yaml
+++ b/assets/kube-state-metrics/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
   namespace: openshift-monitoring

--- a/assets/kube-state-metrics/service-monitor.yaml
+++ b/assets/kube-state-metrics/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
   namespace: openshift-monitoring
 spec:

--- a/assets/kube-state-metrics/service.yaml
+++ b/assets/kube-state-metrics/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -17,7 +17,7 @@ versions:
   alertmanager: 0.22.2
   grafana: 7.5.5
   kubeRbacProxy: 0.11.0
-  kubeStateMetrics: 2.0.0
+  kubeStateMetrics: 2.1.1
   nodeExporter: 1.1.2
   promLabelProxy: 0.3.0
   prometheus: 2.29.2


### PR DESCRIPTION
The versions check was broken in the CI until recently and operand
versions in jsonnet/versions.yaml were not validated properly. Now that
the CI job is fixed, all version checks are starting to fail for newly
created PRs.
    
This commit regenerates the versions to make sure they are correct.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
