### PR TITLE
Remove extraneous file commited during rebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ tmp/
 # purpose is to track the last target execution time to evaluate, whether the
 # container needs to be rebuilt
 .hack-*-image
+
+# This file gets generated as part of `make run-local`
+operator.log


### PR DESCRIPTION
Duriing one of the many rebases of https://github.com/openshift/cluster-monitoring-operator/pull/1280 I seem to have accidentally committed an empty stray file
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
