### PR TITLE
Bug 2004051: changing the condition for error in daemon set creation

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -998,8 +998,10 @@ func (c *Client) WaitForDaemonSetRollout(ctx context.Context, ds *appsv1.DaemonS
 				}
 			}
 		}
-
-		if d.Status.NumberAvailable != nodeReadyCount {
+		// It has been noticed that the number of available pods can be greater than
+		// the node ready count. This is because a node can be reported as not ready
+		// but the daemon set status states that all required pods are running.
+		if d.Status.NumberAvailable < nodeReadyCount {
 			lastErr = errors.Errorf("expected %d ready pods for %q daemonset, got %d ",
 				nodeReadyCount, d.GetName(), d.Status.NumberAvailable)
 			return false, nil


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
