### PR TITLE
static auth changes for osm

### DIFF
--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - --upstream=http://127.0.0.1:8081/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
+        - --config-file=/etc/kube-rbac-policy/config.yaml
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy-main
         ports:
@@ -43,6 +44,9 @@ spec:
         - mountPath: /etc/tls/private
           name: openshift-state-metrics-tls
           readOnly: false
+        - mountPath: /etc/kube-rbac-policy
+          name: openshift-state-metrics-kube-rbac-proxy-config
+          readOnly: true
       - args:
         - --logtostderr
         - --secure-listen-address=:9443
@@ -50,6 +54,7 @@ spec:
         - --upstream=http://127.0.0.1:8082/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
+        - --config-file=/etc/kube-rbac-policy/config.yaml
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy-self
         ports:
@@ -63,6 +68,9 @@ spec:
         - mountPath: /etc/tls/private
           name: openshift-state-metrics-tls
           readOnly: false
+        - mountPath: /etc/kube-rbac-policy
+          name: openshift-state-metrics-kube-rbac-proxy-config
+          readOnly: true
       - args:
         - --host=127.0.0.1
         - --port=8081
@@ -82,3 +90,6 @@ spec:
       - name: openshift-state-metrics-tls
         secret:
           secretName: openshift-state-metrics-tls
+      - name: openshift-state-metrics-kube-rbac-proxy-config
+        secret:
+          secretName: openshift-state-metrics-kube-rbac-proxy-config

--- a/assets/openshift-state-metrics/kube-rbac-proxy-secret.yaml
+++ b/assets/openshift-state-metrics/kube-rbac-proxy-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: openshift-state-metrics-kube-rbac-proxy-config
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -75,12 +75,13 @@ var (
 	KubeStateMetricsPrometheusRule      = "kube-state-metrics/prometheus-rule.yaml"
 	KubeStateMetricsKubeRbacProxySecret = "kube-state-metrics/kube-rbac-proxy-secret.yaml"
 
-	OpenShiftStateMetricsClusterRoleBinding = "openshift-state-metrics/cluster-role-binding.yaml"
-	OpenShiftStateMetricsClusterRole        = "openshift-state-metrics/cluster-role.yaml"
-	OpenShiftStateMetricsDeployment         = "openshift-state-metrics/deployment.yaml"
-	OpenShiftStateMetricsServiceAccount     = "openshift-state-metrics/service-account.yaml"
-	OpenShiftStateMetricsService            = "openshift-state-metrics/service.yaml"
-	OpenShiftStateMetricsServiceMonitor     = "openshift-state-metrics/service-monitor.yaml"
+	OpenShiftStateMetricsClusterRoleBinding  = "openshift-state-metrics/cluster-role-binding.yaml"
+	OpenShiftStateMetricsClusterRole         = "openshift-state-metrics/cluster-role.yaml"
+	OpenShiftStateMetricsDeployment          = "openshift-state-metrics/deployment.yaml"
+	OpenShiftStateMetricsServiceAccount      = "openshift-state-metrics/service-account.yaml"
+	OpenShiftStateMetricsService             = "openshift-state-metrics/service.yaml"
+	OpenShiftStateMetricsServiceMonitor      = "openshift-state-metrics/service-monitor.yaml"
+	OpenShiftStateMetricsKubeRbacProxySecret = "openshift-state-metrics/kube-rbac-proxy-secret.yaml"
 
 	NodeExporterDaemonSet                  = "node-exporter/daemonset.yaml"
 	NodeExporterService                    = "node-exporter/service.yaml"
@@ -664,6 +665,17 @@ func (f *Factory) OpenShiftStateMetricsServiceAccount() (*v1.ServiceAccount, err
 
 func (f *Factory) OpenShiftStateMetricsService() (*v1.Service, error) {
 	s, err := f.NewService(f.assets.MustNewAssetReader(OpenShiftStateMetricsService))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespace
+
+	return s, nil
+}
+
+func (f *Factory) OpenShiftStateMetricsRBACProxySecret() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetReader(OpenShiftStateMetricsKubeRbacProxySecret))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tasks/openshiftstatemetrics.go
+++ b/pkg/tasks/openshiftstatemetrics.go
@@ -74,6 +74,16 @@ func (t *OpenShiftStateMetricsTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling openshift-state-metrics Service failed")
 	}
 
+	rs, err := t.factory.OpenShiftStateMetricsRBACProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing openshift-state-metrics RBAC proxy Secret failed")
+	}
+
+	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	if err != nil {
+		return errors.Wrap(err, "creating openshift-state-metrics RBAC proxy Secret failed")
+	}
+
 	dep, err := t.factory.OpenShiftStateMetricsDeployment()
 	if err != nil {
 		return errors.Wrap(err, "initializing openshift-state-metrics Deployment failed")


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
