### PR TITLE
test:e2e: Fixes assertion logic for missing secret

### DIFF
--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -996,7 +996,7 @@ func assertSecretDoesNotExist(name string, namespace string) func(*testing.T) {
 	return func(t *testing.T) {
 		if err := framework.Poll(5*time.Second, 10*time.Minute, func() error {
 			_, err := f.OperatorClient.GetSecret(ctx, namespace, name)
-			if err == nil || apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return nil
 			}
 


### PR DESCRIPTION
EDIT - we were expecting this test to fail since the code prior to the change looked like a no-op but we should merge this fix regardless.
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
