### PR TITLE
static auth changes for node-exporter

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -65,6 +65,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
+        - --config-file=/etc/kube-rbac-policy/config.yaml
         env:
         - name: IP
           valueFrom:
@@ -92,6 +93,9 @@ spec:
         - mountPath: /etc/tls/client
           name: metrics-client-ca
           readOnly: false
+        - mountPath: /etc/kube-rbac-policy
+          name: node-exporter-kube-rbac-proxy-config
+          readOnly: true
       hostNetwork: true
       hostPID: true
       initContainers:
@@ -147,6 +151,9 @@ spec:
       - configMap:
           name: metrics-client-ca
         name: metrics-client-ca
+      - name: node-exporter-kube-rbac-proxy-config
+        secret:
+          secretName: node-exporter-kube-rbac-proxy-config
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/assets/node-exporter/kube-rbac-proxy-secret.yaml
+++ b/assets/node-exporter/kube-rbac-proxy-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: node-exporter-kube-rbac-proxy-config
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -91,6 +91,7 @@ var (
 	NodeExporterSecurityContextConstraints = "node-exporter/security-context-constraints.yaml"
 	NodeExporterServiceMonitor             = "node-exporter/service-monitor.yaml"
 	NodeExporterPrometheusRule             = "node-exporter/prometheus-rule.yaml"
+	NodeExporterKubeRbacProxySecret        = "node-exporter/kube-rbac-proxy-secret.yaml"
 
 	PrometheusK8sClusterRoleBinding          = "prometheus-k8s/cluster-role-binding.yaml"
 	PrometheusK8sRoleBindingConfig           = "prometheus-k8s/role-binding-config.yaml"
@@ -772,6 +773,17 @@ func (f *Factory) NodeExporterClusterRole() (*rbacv1.ClusterRole, error) {
 
 func (f *Factory) NodeExporterPrometheusRule() (*monv1.PrometheusRule, error) {
 	return f.NewPrometheusRule(f.assets.MustNewAssetReader(NodeExporterPrometheusRule))
+}
+
+func (f *Factory) NodeExporterRBACProxySecret() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetReader(NodeExporterKubeRbacProxySecret))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespace
+
+	return s, nil
 }
 
 func (f *Factory) PrometheusK8sClusterRoleBinding() (*rbacv1.ClusterRoleBinding, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -703,6 +703,11 @@ func TestUnconfiguredManifests(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	_, err = f.NodeExporterRBACProxySecret()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestSharingConfig(t *testing.T) {

--- a/pkg/tasks/nodeexporter.go
+++ b/pkg/tasks/nodeexporter.go
@@ -74,6 +74,15 @@ func (t *NodeExporterTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling node-exporter ClusterRoleBinding failed")
 	}
 
+	nes, err := t.factory.NodeExporterRBACProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "intializing node-exporter rbac proxy secret failed")
+	}
+
+	err = t.client.CreateIfNotExistSecret(ctx, nes)
+	if err != nil {
+		return errors.Wrap(err, "creating node-exporter rbac proxy secret failed")
+	}
 	svc, err := t.factory.NodeExporterService()
 	if err != nil {
 		return errors.Wrap(err, "initializing node-exporter Service failed")


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
