### PR TITLE
chore: update versions according to downstream latest

### DIFF
--- a/assets/kube-state-metrics/cluster-role-binding.yaml
+++ b/assets/kube-state-metrics/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/kube-state-metrics/cluster-role.yaml
+++ b/assets/kube-state-metrics/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
   namespace: openshift-monitoring
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.1.1
     spec:
       containers:
       - args:
@@ -48,7 +48,7 @@ spec:
           kube_pod_container_status_running,
           kube_pod_completion_time,
           kube_pod_status_scheduled
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.1
         name: kube-state-metrics
         resources:
           requests:

--- a/assets/kube-state-metrics/prometheus-rule.yaml
+++ b/assets/kube-state-metrics/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/assets/kube-state-metrics/service-account.yaml
+++ b/assets/kube-state-metrics/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
   namespace: openshift-monitoring

--- a/assets/kube-state-metrics/service-monitor.yaml
+++ b/assets/kube-state-metrics/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
   namespace: openshift-monitoring
 spec:

--- a/assets/kube-state-metrics/service.yaml
+++ b/assets/kube-state-metrics/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.0.0
+    app.kubernetes.io/version: 2.1.1
   name: kube-state-metrics
   namespace: openshift-monitoring
 spec:

--- a/assets/node-exporter/cluster-role-binding.yaml
+++ b/assets/node-exporter/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 1.1.2
+    app.kubernetes.io/version: 1.2.2
   name: node-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/node-exporter/cluster-role.yaml
+++ b/assets/node-exporter/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 1.1.2
+    app.kubernetes.io/version: 1.2.2
   name: node-exporter
 rules:
 - apiGroups:

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 1.1.2
+    app.kubernetes.io/version: 1.2.2
   name: node-exporter
   namespace: openshift-monitoring
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: node-exporter
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 1.1.2
+        app.kubernetes.io/version: 1.2.2
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
         - --no-collector.cpufreq
-        image: quay.io/prometheus/node-exporter:v1.1.2
+        image: quay.io/prometheus/node-exporter:v1.2.2
         name: node-exporter
         resources:
           requests:
@@ -107,7 +107,7 @@ spec:
         env:
         - name: TMPDIR
           value: /tmp
-        image: quay.io/prometheus/node-exporter:v1.1.2
+        image: quay.io/prometheus/node-exporter:v1.2.2
         name: init-textfile
         resources:
           requests:

--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 1.1.2
+    app.kubernetes.io/version: 1.2.2
     prometheus: k8s
     role: alert-rules
   name: node-exporter-rules

--- a/assets/node-exporter/service-account.yaml
+++ b/assets/node-exporter/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 1.1.2
+    app.kubernetes.io/version: 1.2.2
   name: node-exporter
   namespace: openshift-monitoring

--- a/assets/node-exporter/service-monitor.yaml
+++ b/assets/node-exporter/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 1.1.2
+    app.kubernetes.io/version: 1.2.2
   name: node-exporter
   namespace: openshift-monitoring
 spec:

--- a/assets/node-exporter/service.yaml
+++ b/assets/node-exporter/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 1.1.2
+    app.kubernetes.io/version: 1.2.2
   name: node-exporter
   namespace: openshift-monitoring
 spec:

--- a/assets/prometheus-k8s/cluster-role-binding.yaml
+++ b/assets/prometheus-k8s/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-k8s/cluster-role.yaml
+++ b/assets/prometheus-k8s/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-k8s
 rules:
 - apiGroups:

--- a/assets/prometheus-k8s/prometheus-rule-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/prometheus-rule-thanos-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: k8s
     role: alert-rules
   name: prometheus-k8s-thanos-sidecar-rules

--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: k8s
     role: alert-rules
   name: prometheus-k8s-prometheus-rules

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: k8s
   name: k8s
   namespace: openshift-monitoring
@@ -161,7 +161,7 @@ spec:
         memory: 10Mi
   enableFeatures: []
   externalLabels: {}
-  image: quay.io/prometheus/prometheus:v2.29.2
+  image: quay.io/prometheus/prometheus:v2.30.0
   listenLocal: true
   nodeSelector:
     kubernetes.io/os: linux
@@ -172,7 +172,7 @@ spec:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
   podMonitorNamespaceSelector:
     matchLabels:
       openshift.io/cluster-monitoring: "true"
@@ -214,4 +214,4 @@ spec:
         cpu: 1m
         memory: 100Mi
     version: 0.22.0
-  version: 2.29.2
+  version: 2.30.0

--- a/assets/prometheus-k8s/role-binding-config.yaml
+++ b/assets/prometheus-k8s/role-binding-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-k8s-config
   namespace: openshift-monitoring
 roleRef:

--- a/assets/prometheus-k8s/role-binding-specific-namespaces.yaml
+++ b/assets/prometheus-k8s/role-binding-specific-namespaces.yaml
@@ -7,7 +7,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: default
   roleRef:
@@ -25,7 +25,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: kube-system
   roleRef:
@@ -43,7 +43,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: openshift-monitoring
   roleRef:
@@ -61,7 +61,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: openshift-etcd
   roleRef:
@@ -79,7 +79,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: openshift-user-workload-monitoring
   roleRef:

--- a/assets/prometheus-k8s/role-config.yaml
+++ b/assets/prometheus-k8s/role-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-k8s-config
   namespace: openshift-monitoring
 rules:

--- a/assets/prometheus-k8s/role-specific-namespaces.yaml
+++ b/assets/prometheus-k8s/role-specific-namespaces.yaml
@@ -7,7 +7,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: default
   rules:
@@ -44,7 +44,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: kube-system
   rules:
@@ -81,7 +81,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: openshift-monitoring
   rules:
@@ -118,7 +118,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: openshift-etcd
   rules:
@@ -155,7 +155,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-k8s
     namespace: openshift-user-workload-monitoring
   rules:

--- a/assets/prometheus-k8s/service-account.yaml
+++ b/assets/prometheus-k8s/service-account.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-k8s
   namespace: openshift-monitoring

--- a/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: thanos-sidecar
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: k8s
   name: thanos-sidecar
   namespace: openshift-monitoring

--- a/assets/prometheus-k8s/service-monitor.yaml
+++ b/assets/prometheus-k8s/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-k8s
   namespace: openshift-monitoring
 spec:

--- a/assets/prometheus-k8s/service-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-thanos-sidecar.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: thanos-sidecar
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: k8s
   name: prometheus-k8s-thanos-sidecar
   namespace: openshift-monitoring

--- a/assets/prometheus-k8s/service.yaml
+++ b/assets/prometheus-k8s/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: k8s
   name: prometheus-k8s
   namespace: openshift-monitoring

--- a/assets/prometheus-user-workload/cluster-role-binding.yaml
+++ b/assets/prometheus-user-workload/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-user-workload
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-user-workload/cluster-role.yaml
+++ b/assets/prometheus-user-workload/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-user-workload
 rules:
 - apiGroups:

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: user-workload
   name: user-workload
   namespace: openshift-user-workload-monitoring
@@ -111,7 +111,7 @@ spec:
   enforcedNamespaceLabel: namespace
   externalLabels: {}
   ignoreNamespaceSelectors: true
-  image: quay.io/prometheus/prometheus:v2.29.2
+  image: quay.io/prometheus/prometheus:v2.30.0
   listenLocal: true
   nodeSelector:
     kubernetes.io/os: linux
@@ -124,7 +124,7 @@ spec:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
   podMonitorNamespaceSelector:
     matchExpressions:
     - key: openshift.io/cluster-monitoring
@@ -192,4 +192,4 @@ spec:
         cpu: 1m
         memory: 100Mi
     version: 0.22.0
-  version: 2.29.2
+  version: 2.30.0

--- a/assets/prometheus-user-workload/role-binding-config.yaml
+++ b/assets/prometheus-user-workload/role-binding-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-user-workload-config
   namespace: openshift-user-workload-monitoring
 roleRef:

--- a/assets/prometheus-user-workload/role-binding-specific-namespaces.yaml
+++ b/assets/prometheus-user-workload/role-binding-specific-namespaces.yaml
@@ -7,7 +7,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-user-workload
     namespace: openshift-user-workload-monitoring
   roleRef:

--- a/assets/prometheus-user-workload/role-config.yaml
+++ b/assets/prometheus-user-workload/role-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-user-workload-config
   namespace: openshift-user-workload-monitoring
 rules:

--- a/assets/prometheus-user-workload/role-specific-namespaces.yaml
+++ b/assets/prometheus-user-workload/role-specific-namespaces.yaml
@@ -7,7 +7,7 @@ items:
       app.kubernetes.io/component: prometheus
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 2.29.2
+      app.kubernetes.io/version: 2.30.0
     name: prometheus-user-workload
     namespace: openshift-user-workload-monitoring
   rules:

--- a/assets/prometheus-user-workload/service-account.yaml
+++ b/assets/prometheus-user-workload/service-account.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-user-workload
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: thanos-sidecar
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: user-workload
   name: thanos-sidecar
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-user-workload/service-monitor.yaml
+++ b/assets/prometheus-user-workload/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
   name: prometheus-user-workload
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/prometheus-user-workload/service-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-thanos-sidecar.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: thanos-sidecar
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: user-workload
   name: prometheus-user-workload-thanos-sidecar
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-user-workload/service.yaml
+++ b/assets/prometheus-user-workload/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 2.29.2
+    app.kubernetes.io/version: 2.30.0
     prometheus: user-workload
   name: prometheus-user-workload
   namespace: openshift-user-workload-monitoring

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -17,10 +17,10 @@ versions:
   alertmanager: 0.22.2
   grafana: 7.5.5
   kubeRbacProxy: 0.11.0
-  kubeStateMetrics: 2.0.0
-  nodeExporter: 1.1.2
+  kubeStateMetrics: 2.1.1
+  nodeExporter: 1.2.2
   promLabelProxy: 0.3.0
-  prometheus: 2.29.2
+  prometheus: 2.30.0
   prometheusAdapter: 0.9.0
   prometheusOperator: 0.50.0
   thanos: 0.22.0


### PR DESCRIPTION
Following component versions are updated.,

kubeStateMetrics: 2.1.1
nodeExporter: 1.2.2
prometheus: 2.30.0

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
