### PR TITLE
un-drop cadvisor metrics

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -72,11 +72,6 @@ spec:
       - pod
       - namespace
     - action: drop
-      regex: (container_fs_.*|container_blkio_device_usage_total);.+
-      sourceLabels:
-      - __name__
-      - container
-    - action: drop
       regex: container_memory_failures_total
       sourceLabels:
       - __name__


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
