### PR TITLE
Bug 1808240: prom-label-proxy: set --error-on-replace

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -93,6 +93,7 @@ spec:
     - --insecure-listen-address=127.0.0.1:9096
     - --upstream=http://127.0.0.1:9093
     - --label=namespace
+    - --error-on-replace
     image: quay.io/prometheuscommunity/prom-label-proxy:v0.4.0
     name: prom-label-proxy
     resources:

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -93,7 +93,7 @@ spec:
     - --insecure-listen-address=127.0.0.1:9096
     - --upstream=http://127.0.0.1:9093
     - --label=namespace
-    image: quay.io/prometheuscommunity/prom-label-proxy:v0.3.0
+    image: quay.io/prometheuscommunity/prom-label-proxy:v0.4.0
     name: prom-label-proxy
     resources:
       requests:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -161,7 +161,7 @@ spec:
         - --upstream=http://127.0.0.1:9090
         - --label=namespace
         - --enable-label-apis
-        image: quay.io/prometheuscommunity/prom-label-proxy:v0.3.0
+        image: quay.io/prometheuscommunity/prom-label-proxy:v0.4.0
         name: prom-label-proxy
         resources:
           requests:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -161,6 +161,7 @@ spec:
         - --upstream=http://127.0.0.1:9090
         - --label=namespace
         - --enable-label-apis
+        - --error-on-replace
         image: quay.io/prometheuscommunity/prom-label-proxy:v0.4.0
         name: prom-label-proxy
         resources:

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -328,6 +328,7 @@ function(params)
               '--insecure-listen-address=127.0.0.1:9096',
               '--upstream=http://127.0.0.1:9093',
               '--label=namespace',
+              '--error-on-replace',
             ],
             resources: {
               requests: {

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -506,6 +506,7 @@ function(params)
                   '--upstream=http://127.0.0.1:9090',
                   '--label=namespace',
                   '--enable-label-apis',
+                  '--error-on-replace',
                 ],
                 resources: {
                   requests: {

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -19,7 +19,7 @@ versions:
   kubeRbacProxy: 0.11.0
   kubeStateMetrics: 2.1.1
   nodeExporter: 1.2.2
-  promLabelProxy: 0.3.0
+  promLabelProxy: 0.4.0
   prometheus: 2.30.3
   prometheusAdapter: 0.9.0
   prometheusOperator: 0.51.2

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -151,6 +151,10 @@ func (qp *QueryParameterInjector) WrapTransport(rt http.RoundTripper) http.Round
 // PrometheusQuery runs an HTTP GET request against the Prometheus query API and returns
 // the response body.
 func (c *PrometheusClient) PrometheusQuery(query string) ([]byte, error) {
+	return c.PrometheusQueryWithStatus(query, http.StatusOK)
+}
+
+func (c *PrometheusClient) PrometheusQueryWithStatus(query string, status int) ([]byte, error) {
 	resp, err := c.Do("GET", fmt.Sprintf("/api/v1/query?query=%s", url.QueryEscape(query)), nil)
 	if err != nil {
 		return nil, err
@@ -162,8 +166,8 @@ func (c *PrometheusClient) PrometheusQuery(query string) ([]byte, error) {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code response, want %d, got %d (%q)", http.StatusOK, resp.StatusCode, ClampMax(body))
+	if resp.StatusCode != status {
+		return nil, fmt.Errorf("unexpected status code response, want %d, got %d (%q)", status, resp.StatusCode, ClampMax(body))
 	}
 
 	return body, nil


### PR DESCRIPTION
This commit enables the new prom-label-proxy flag in order to return an
error in case a label would have been silently replaced. Before the user
would simply see a result that would not respond to the query. Returning
an error follows the principle of least surprise.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
