### PR TITLE
Bug 2007677: Adjust dropped cAdvisor metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.10
 
 - [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose expose /api/v1/labels endpoint for Thanos query.
+- [#1402](https://github.com/openshift/cluster-monitoring-operator/pull/1402) Drop pod-centric cAdvisor metrics that are available at slice level.
 
 ## 4.9
 

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -72,7 +72,7 @@ spec:
       - pod
       - namespace
     - action: drop
-      regex: (container_fs_.*|container_blkio_device_usage_total);.+
+      regex: (container_blkio_device_usage_total);.+
       sourceLabels:
       - __name__
       - container

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -80,6 +80,11 @@ spec:
       regex: container_memory_failures_total
       sourceLabels:
       - __name__
+    - action: drop
+      regex: (container_fs_.*);.+
+      sourceLabels:
+      - __name__
+      - container
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -88,6 +88,12 @@ function(params)
                       action: 'drop',
                       regex: 'container_memory_failures_total',
                     },
+                    {
+                      // these metrics are available at the slice level
+                      sourceLabels: ['__name__', 'container'],
+                      action: 'drop',
+                      regex: '(container_fs_.*);.+',
+                    },
                   ],
                 }
               else

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -121,8 +121,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "211e758dfeae14ac1eb018599d0b141b3b2c3d9c",
-      "sum": "7Y2gI0uyUCeEpjdhPIOxLs9vHu6cnOUu311HNSN1BiE="
+      "version": "a2eee1803a074fb40cad109d690732c22f0130cf",
+      "sum": "kqVnoNBux2YF1s03m+O3w/5jreAnjXx2/NjvNP1Hoy4="
     },
     {
       "source": {


### PR DESCRIPTION
This change drops pod-centric metrics that have a non empty `container` label.  For context it is best to look at the detailed discussion on https://github.com/prometheus-operator/kube-prometheus/pull/1402 and the issues it links to
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
