### PR TITLE
Bug 2008120: Adjust dropped cAdvisor metrics

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -66,11 +66,16 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: (container_fs_.*|container_spec_.*|container_blkio_device_usage_total|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      regex: (container_spec_.*|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
       sourceLabels:
       - __name__
       - pod
       - namespace
+    - action: drop
+      regex: (container_blkio_device_usage_total);.+
+      sourceLabels:
+      - __name__
+      - container
     - action: drop
       regex: container_memory_failures_total
       sourceLabels:

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -80,6 +80,11 @@ spec:
       regex: container_memory_failures_total
       sourceLabels:
       - __name__
+    - action: drop
+      regex: (container_fs_.*);.+
+      sourceLabels:
+      - __name__
+      - container
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -88,6 +88,12 @@ function(params)
                       action: 'drop',
                       regex: 'container_memory_failures_total',
                     },
+                    {
+                      // these metrics are available at the slice level
+                      sourceLabels: ['__name__', 'container'],
+                      action: 'drop',
+                      regex: '(container_fs_.*);.+',
+                    },
                   ],
                 }
               else

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -121,8 +121,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "9ead6ebc539e463a45d9e04a9168ff91ba4dc7c4",
-      "sum": "amTJvacjyfzql3YWkeOV92B3lvSRGsk/7SqXGcDdCw0="
+      "version": "c1fc78c979072cb8e09ec06687401062d60902db",
+      "sum": "IDP95BakTCLnW4hdLoJTYSp7LOQDiCGlZlf1zzVCzY0="
     },
     {
       "source": {


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-monitoring-operator/pull/1402

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
