### PR TITLE
static auth changes for telemeter client

### DIFF
--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -84,6 +84,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --config-file=/etc/kube-rbac-policy/config.yaml
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:
@@ -97,6 +98,9 @@ spec:
         - mountPath: /etc/tls/private
           name: telemeter-client-tls
           readOnly: false
+        - mountPath: /etc/kube-rbac-policy
+          name: telemeter-client-kube-rbac-proxy-config
+          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
@@ -111,3 +115,6 @@ spec:
       - name: telemeter-client-tls
         secret:
           secretName: telemeter-client-tls
+      - name: telemeter-client-kube-rbac-proxy-config
+        secret:
+          secretName: telemeter-client-kube-rbac-proxy-config

--- a/assets/telemeter-client/kube-rbac-proxy-secret.yaml
+++ b/assets/telemeter-client/kube-rbac-proxy-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: telemeter-client-kube-rbac-proxy-config
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -203,6 +203,7 @@ var (
 	TelemeterClientServiceAccount         = "telemeter-client/service-account.yaml"
 	TelemeterClientServiceMonitor         = "telemeter-client/service-monitor.yaml"
 	TelemeterClientServingCertsCABundle   = "telemeter-client/serving-certs-ca-bundle.yaml"
+	TelemeterClientKubeRbacProxySecret    = "telemeter-client/kube-rbac-proxy-secret.yaml"
 
 	ThanosQuerierDeployment           = "thanos-querier/deployment.yaml"
 	ThanosQuerierPodDisruptionBudget  = "thanos-querier/pod-disruption-budget.yaml"
@@ -3194,6 +3195,16 @@ func (f *Factory) TelemeterClientServiceMonitor() (*monv1.ServiceMonitor, error)
 	sm.Namespace = f.namespace
 
 	return sm, nil
+}
+
+func (f *Factory) TelemeterClientKubeRbacProxySecret() (*v1.Secret, error) {
+	secret, err := f.NewSecret(f.assets.MustNewAssetReader(TelemeterClientKubeRbacProxySecret))
+	if err != nil {
+		return nil, err
+	}
+
+	secret.Namespace = f.namespace
+	return secret, nil
 }
 
 // TelemeterClientDeployment generates a new Deployment for Telemeter client.

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -710,6 +710,11 @@ func TestUnconfiguredManifests(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	_, err = f.TelemeterClientKubeRbacProxySecret()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestSharingConfig(t *testing.T) {

--- a/pkg/tasks/telemeter.go
+++ b/pkg/tasks/telemeter.go
@@ -122,6 +122,16 @@ func (t *TelemeterClientTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Telemeter client Secret failed")
 	}
 
+	krs, err := t.factory.TelemeterClientKubeRbacProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing Telemeter client kube rbac proxy secret failed")
+	}
+
+	err = t.client.CreateOrUpdateSecret(ctx, krs)
+	if err != nil {
+		return errors.Wrap(err, "reconciling Telemeter client kube rbac proxy secret failed")
+	}
+
 	{
 		// Create trusted CA bundle ConfigMap.
 		trustedCA, err := t.factory.TelemeterTrustedCABundle()
@@ -193,6 +203,16 @@ func (t *TelemeterClientTask) destroy(ctx context.Context) error {
 	err = t.client.DeleteSecret(ctx, s)
 	if err != nil {
 		return errors.Wrap(err, "deleting Telemeter client Secret failed")
+	}
+
+	krs, err := t.factory.TelemeterClientKubeRbacProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing Telemeter client kube rbac proxy secrent failed")
+	}
+
+	err = t.client.DeleteSecret(ctx, krs)
+	if err != nil {
+		return errors.Wrap(err, "deleting Telemeter client kube rbac proxy secret failed")
 	}
 
 	svc, err := t.factory.TelemeterClientService()


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
