### PR TITLE
Adjust prometheus-adapter queries intervals

### DIFF
--- a/assets/prometheus-adapter/config-map.yaml
+++ b/assets/prometheus-adapter/config-map.yaml
@@ -7,13 +7,13 @@ data:
         "containerQuery": |
           sum by (<<.GroupBy>>) (
             irate (
-                container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[4m]
+                container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[120s]
             )
           )
         "nodeQuery": |
           sum by (<<.GroupBy>>) (
             1 - irate(
-              node_cpu_seconds_total{mode="idle"}[4m]
+              node_cpu_seconds_total{mode="idle"}[60s]
             )
             * on(namespace, pod) group_left(node) (
               node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}
@@ -21,7 +21,7 @@ data:
           )
           or sum by (<<.GroupBy>>) (
             1 - irate(
-              windows_cpu_time_total{mode="idle", job="windows-exporter",<<.LabelMatchers>>}[4m]
+              windows_cpu_time_total{mode="idle", job="windows-exporter",<<.LabelMatchers>>}[120s]
             )
           )
         "resources":


### PR DESCRIPTION
Readjust the intervals used in prometheus-adapter queries to take into
account the scrape interval of kubelet, node-exporter and
windows-exporter.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
