### PR TITLE
Change kube-rbac-proxy authentication for UWM Prometheus

### DIFF
--- a/assets/prometheus-user-workload/cluster-role.yaml
+++ b/assets/prometheus-user-workload/cluster-role.yaml
@@ -19,18 +19,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
   - ""
   resources:
   - namespaces

--- a/assets/prometheus-user-workload/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-user-workload/kube-rbac-proxy-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: kube-rbac-proxy
+  namespace: openshift-user-workload-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -39,14 +39,17 @@ spec:
     deny: true
   configMaps:
   - serving-certs-ca-bundle
+  - metrics-client-ca
   containers:
   - args:
     - --secure-listen-address=0.0.0.0:9091
     - --upstream=http://127.0.0.1:9090
+    - --allow-paths=/metrics
+    - --config-file=/etc/kube-rbac-proxy/config.yaml
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key
+    - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    - --allow-paths=/metrics
     image: quay.io/brancz/kube-rbac-proxy:v0.11.0
     name: kube-rbac-proxy
     ports:
@@ -60,13 +63,20 @@ spec:
     volumeMounts:
     - mountPath: /etc/tls/private
       name: secret-prometheus-user-workload-tls
+    - mountPath: /etc/tls/client
+      name: configmap-metrics-client-ca
+      readOnly: true
+    - mountPath: /etc/kube-rbac-proxy
+      name: secret-kube-rbac-proxy
   - args:
     - --secure-listen-address=[$(POD_IP)]:10902
     - --upstream=http://127.0.0.1:10902
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key
+    - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --allow-paths=/metrics
+    - --config-file=/etc/kube-rbac-proxy/config.yaml
     - --logtostderr=true
     env:
     - name: POD_IP
@@ -86,6 +96,11 @@ spec:
     volumeMounts:
     - mountPath: /etc/tls/private
       name: secret-prometheus-user-workload-thanos-sidecar-tls
+    - mountPath: /etc/tls/client
+      name: configmap-metrics-client-ca
+      readOnly: true
+    - mountPath: /etc/kube-rbac-proxy
+      name: secret-kube-rbac-proxy
   - args:
     - sidecar
     - --prometheus.url=http://localhost:9090/
@@ -169,6 +184,7 @@ spec:
   secrets:
   - prometheus-user-workload-tls
   - prometheus-user-workload-thanos-sidecar-tls
+  - kube-rbac-proxy
   securityContext:
     fsGroup: 65534
     runAsNonRoot: true

--- a/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
@@ -11,12 +11,13 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     port: thanos-proxy
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: prometheus-user-workload-thanos-sidecar
   selector:
     matchLabels:

--- a/assets/prometheus-user-workload/service-monitor.yaml
+++ b/assets/prometheus-user-workload/service-monitor.yaml
@@ -10,12 +10,13 @@ metadata:
   namespace: openshift-user-workload-monitoring
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     port: metrics
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: prometheus-user-workload
   selector:
     matchLabels:

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -1,3 +1,4 @@
+local generateSecret = import '../utils/generate-secret.libsonnet';
 local prometheus = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/components/prometheus.libsonnet';
 
 function(params)
@@ -81,16 +82,6 @@ function(params)
     clusterRole+: {
       rules+: [
         {
-          apiGroups: ['authentication.k8s.io'],
-          resources: ['tokenreviews'],
-          verbs: ['create'],
-        },
-        {
-          apiGroups: ['authorization.k8s.io'],
-          resources: ['subjectaccessreviews'],
-          verbs: ['create'],
-        },
-        {
           apiGroups: [''],
           resources: ['namespaces'],
           verbs: ['get'],
@@ -147,10 +138,11 @@ function(params)
             interval: '30s',
             scheme: 'https',
             tlsConfig: {
-              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
               serverName: 'prometheus-user-workload',
+              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
             },
-            bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
           },
         ],
       },
@@ -180,14 +172,17 @@ function(params)
             interval: '30s',
             scheme: 'https',
             tlsConfig: {
-              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
               serverName: 'prometheus-user-workload-thanos-sidecar',
+              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
             },
-            bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
           },
         ],
       },
     },
+
+    kubeRbacProxySecret: generateSecret.staticAuthSecret(cfg.namespace, cfg.commonLabels, 'kube-rbac-proxy'),
 
     prometheus+: {
       spec+: {
@@ -237,8 +232,9 @@ function(params)
         secrets: [
           'prometheus-user-workload-tls',
           'prometheus-user-workload-thanos-sidecar-tls',
+          $.kubeRbacProxySecret.metadata.name,
         ],
-        configMaps: ['serving-certs-ca-bundle'],
+        configMaps: ['serving-certs-ca-bundle', 'metrics-client-ca'],
         probeNamespaceSelector: cfg.namespaceSelector,
         podMonitorNamespaceSelector: cfg.namespaceSelector,
         serviceMonitorSelector: {},
@@ -265,16 +261,27 @@ function(params)
             args: [
               '--secure-listen-address=0.0.0.0:9091',
               '--upstream=http://127.0.0.1:9090',
+              '--allow-paths=/metrics',
+              '--config-file=/etc/kube-rbac-proxy/config.yaml',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',
+              '--client-ca-file=/etc/tls/client/client-ca.crt',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
-              '--allow-paths=/metrics',
             ],
             terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',
                 name: 'secret-prometheus-user-workload-tls',
+              },
+              {
+                mountPath: '/etc/tls/client',
+                name: 'configmap-metrics-client-ca',
+                readOnly: true,
+              },
+              {
+                mountPath: '/etc/kube-rbac-proxy',
+                name: 'secret-' + $.kubeRbacProxySecret.metadata.name,
               },
             ],
           },
@@ -306,8 +313,10 @@ function(params)
               '--upstream=http://127.0.0.1:10902',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',
+              '--client-ca-file=/etc/tls/client/client-ca.crt',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
               '--allow-paths=/metrics',
+              '--config-file=/etc/kube-rbac-proxy/config.yaml',
               '--logtostderr=true',
             ],
             terminationMessagePolicy: 'FallbackToLogsOnError',
@@ -315,6 +324,15 @@ function(params)
               {
                 mountPath: '/etc/tls/private',
                 name: 'secret-prometheus-user-workload-thanos-sidecar-tls',
+              },
+              {
+                mountPath: '/etc/tls/client',
+                name: 'configmap-metrics-client-ca',
+                readOnly: true,
+              },
+              {
+                mountPath: '/etc/kube-rbac-proxy',
+                name: 'secret-' + $.kubeRbacProxySecret.metadata.name,
               },
             ],
           },

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -108,6 +108,7 @@ var (
 	PrometheusK8sServiceThanosSidecar        = "prometheus-k8s/service-thanos-sidecar.yaml"
 	PrometheusK8sProxySecret                 = "prometheus-k8s/proxy-secret.yaml"
 	PrometheusRBACProxySecret                = "prometheus-k8s/kube-rbac-proxy-secret.yaml"
+	PrometheusUserWorkloadRBACProxySecret    = "prometheus-user-workload/kube-rbac-proxy-secret.yaml"
 	PrometheusK8sRoute                       = "prometheus-k8s/route.yaml"
 	PrometheusK8sHtpasswd                    = "prometheus-k8s/htpasswd-secret.yaml"
 	PrometheusK8sServingCertsCABundle        = "prometheus-k8s/serving-certs-ca-bundle.yaml"
@@ -1135,6 +1136,17 @@ func (f *Factory) PrometheusRBACProxySecret() (*v1.Secret, error) {
 	}
 
 	s.Namespace = f.namespace
+
+	return s, nil
+}
+
+func (f *Factory) PrometheusUserWorkloadRBACProxySecret() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetReader(PrometheusUserWorkloadRBACProxySecret))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespaceUserWorkload
 
 	return s, nil
 }

--- a/pkg/manifests/tls.go
+++ b/pkg/manifests/tls.go
@@ -87,6 +87,17 @@ func (f *Factory) MetricsClientCACM(apiAuthConfigmap *v1.ConfigMap) (*v1.ConfigM
 	return cm, nil
 }
 
+func (f *Factory) UserWorkloadMetricsClientCACM(apiAuthConfigmap *v1.ConfigMap) (*v1.ConfigMap, error) {
+	cm, err := f.MetricsClientCACM(apiAuthConfigmap)
+	if err != nil {
+		return nil, err
+	}
+
+	cm.Namespace = f.namespaceUserWorkload
+
+	return cm, nil
+}
+
 // RotateGRPCSecret rotates key material for Thanos GRPC TLS based communication.
 //
 // If no key material is present, it creates it.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -513,7 +513,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		// update prometheus-operator before anything else because it is responsible for managing many other resources (e.g. Prometheus, Alertmanager, Thanos Ruler, ...).
 		tasks.NewTaskGroup(
 			[]*tasks.TaskSpec{
-				tasks.NewTaskSpec("Updating metrics scraping client CA", tasks.NewMetricsClientCATask(o.client, factory)),
+				tasks.NewTaskSpec("Updating metrics scraping client CA", tasks.NewMetricsClientCATask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Prometheus Operator", tasks.NewPrometheusOperatorTask(o.client, factory)),
 			}),
 		tasks.NewTaskGroup(

--- a/pkg/tasks/metrics_client_ca.go
+++ b/pkg/tasks/metrics_client_ca.go
@@ -5,21 +5,24 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 )
 
 type MetricsClientCATask struct {
 	client  *client.Client
 	factory *manifests.Factory
+	config  *manifests.Config
 }
 
 // NewMetricsClientCATask returns and instance of MetricsClientCATask which creates
 // and updates the client-CA ConfigMap that is required by our deployments of the
 // kube-rbac-proxy in order to be able to authenticate client-cert authenticated
 // metrics requests
-func NewMetricsClientCATask(client *client.Client, factory *manifests.Factory) *MetricsClientCATask {
+func NewMetricsClientCATask(client *client.Client, factory *manifests.Factory, config *manifests.Config) *MetricsClientCATask {
 	return &MetricsClientCATask{
 		client:  client,
 		factory: factory,
+		config:  config,
 	}
 }
 
@@ -39,5 +42,18 @@ func (t *MetricsClientCATask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Metrics Client CA ConfigMap failed")
 	}
 
-	return nil
+	return t.reconcileUWMConfigMap(ctx, apiAuthConfigmap)
+}
+
+func (t *MetricsClientCATask) reconcileUWMConfigMap(ctx context.Context, apiAuthConfigmap *v1.ConfigMap) error {
+	cm, err := t.factory.UserWorkloadMetricsClientCACM(apiAuthConfigmap)
+	if err != nil {
+		return err
+	}
+
+	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
+		return t.client.CreateOrUpdateConfigMap(ctx, cm)
+	}
+
+	return t.client.DeleteConfigMap(ctx, cm)
 }

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -188,6 +188,16 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "error creating UserWorkload Prometheus Client GRPC TLS secret")
 	}
 
+	rs, err := t.factory.PrometheusUserWorkloadRBACProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload Prometheus RBAC proxy Secret failed")
+	}
+
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
+	if err != nil {
+		return errors.Wrap(err, "creating or updating UserWorkload Prometheus RBAC proxy Secret failed")
+	}
+
 	secret, err := t.factory.PrometheusUserWorkloadAdditionalAlertManagerConfigsSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus additionalAlertmanagerConfigs secret failed")
@@ -403,6 +413,16 @@ func (t *PrometheusUserWorkloadTask) destroy(ctx context.Context) error {
 	cacm, err := t.factory.PrometheusUserWorkloadServingCertsCABundle()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload serving certs CA Bundle ConfigMap failed")
+	}
+
+	rs, err := t.factory.PrometheusUserWorkloadRBACProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload Prometheus RBAC proxy Secret failed")
+	}
+
+	err = t.client.DeleteSecret(ctx, rs)
+	if err != nil {
+		return errors.Wrap(err, "deleting or updating UserWorkload Prometheus RBAC proxy Secret failed")
 	}
 
 	amsSecret, err := t.factory.PrometheusUserWorkloadAdditionalAlertManagerConfigsSecret()


### PR DESCRIPTION
The UWM Prometheus kube-rbac-proxy currently works with subject access
reviews to verify whether the caller is allowed to access Prometheus endpoints.
    
This commit changes the authentication method to a static one based on
the CN in the certificate of the caller.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
