### PR TITLE
podsecurity: enforce privileged for openshift-monitoring namespace

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
@@ -12,6 +12,9 @@ metadata:
     openshift.io/cluster-monitoring: "true"
     name: openshift-monitoring
     network.openshift.io/policy-group: monitoring
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-monitoring` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @stlaz 

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
