### PR TITLE
MON-1666: CMO deployment: pass enabled-remote-write

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -63,6 +63,7 @@ spec:
         - -images=prom-label-proxy=quay.io/openshift/origin-prom-label-proxy:latest
         - -images=k8s-prometheus-adapter=quay.io/openshift/origin-k8s-prometheus-adapter:latest
         - -images=thanos=quay.io/openshift/origin-thanos:latest
+        - -enabled-remote-write
         env:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -92,6 +92,7 @@ spec:
         - "-images=prom-label-proxy=quay.io/openshift/origin-prom-label-proxy:latest"
         - "-images=k8s-prometheus-adapter=quay.io/openshift/origin-k8s-prometheus-adapter:latest"
         - "-images=thanos=quay.io/openshift/origin-thanos:latest"
+        - "-enabled-remote-write"
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1370,6 +1370,9 @@ func (f *Factory) PrometheusK8s(host string, grpcTLS *v1.Secret, trustedCABundle
 					Replacement:  "alerts",
 				},
 			},
+			MetadataConfig: &monv1.MetadataConfig{
+				Send: false,
+			},
 		}
 
 		p.Spec.RemoteWrite = []monv1.RemoteWriteSpec{spec}


### PR DESCRIPTION
in order to switch telemeter over to Prometheus remote write.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
