### PR TITLE
MON-1949: changes for prometheus adapter to use thanos-querier instead of prome…

### DIFF
--- a/assets/prometheus-adapter/configmap-prometheus.yaml
+++ b/assets/prometheus-adapter/configmap-prometheus.yaml
@@ -5,18 +5,18 @@ data:
     clusters:
     - cluster:
         certificate-authority: /etc/ssl/certs/service-ca.crt
-        server: https://prometheus-k8s.openshift-monitoring.svc:9091
-      name: prometheus-k8s
+        server: https://thanos-querier.openshift-monitoring.svc:9091
+      name: thanos-querier
     contexts:
     - context:
-        cluster: prometheus-k8s
-        user: prometheus-k8s
-      name: prometheus-k8s
-    current-context: prometheus-k8s
+        cluster: thanos-querier
+        user: thanos-querier
+      name: thanos-querier
+    current-context: thanos-querier
     kind: Config
     preferences: {}
     users:
-    - name: prometheus-k8s
+    - name: thanos-querier
       user:
         tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 kind: ConfigMap

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --logtostderr=true
         - --metrics-relist-interval=1m
-        - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc:9091
+        - --prometheus-url=https://thanos-querier.openshift-monitoring.svc:9091
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         image: directxman12/k8s-prometheus-adapter:v0.9.0

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -201,17 +201,17 @@ function(params)
           - cluster:
               certificate-authority: %s
               server: %s
-            name: prometheus-k8s
+            name: thanos-querier
           contexts:
           - context:
-              cluster: prometheus-k8s
-              user: prometheus-k8s
-            name: prometheus-k8s
-          current-context: prometheus-k8s
+              cluster: thanos-querier
+              user: thanos-querier
+            name: thanos-querier
+          current-context: thanos-querier
           kind: Config
           preferences: {}
           users:
-          - name: prometheus-k8s
+          - name: thanos-querier
             user:
               tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
         ||| % [

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -258,7 +258,7 @@ local inCluster =
         namespace: $.values.common.namespace,
         version: $.values.common.versions.prometheusAdapter,
         image: $.values.common.images.prometheusAdapter,
-        prometheusURL: 'https://prometheus-' + $.values.prometheus.name + '.' + $.values.common.namespace + '.svc:9091',
+        prometheusURL: 'https://thanos-querier' + '.' + $.values.common.namespace + '.svc:9091',
         commonLabels+: $.values.common.commonLabels,
         tlsCipherSuites: $.values.common.tlsCipherSuites,
       },


### PR DESCRIPTION
Change to PA config to use thanos querier instead of prometheus for its queries.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
