### PR TITLE
Bug 2011698: Allow namespace label in metric allow list

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         - --metric-denylist=kube_secret_labels
-        - --metric-labels-allowlist=pods=[*],nodes=[*]
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*]
         - |
           --metric-denylist=
           kube_.+_created,

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -134,7 +134,7 @@ function(params)
                     c {
                       args+: [
                         '--metric-denylist=kube_secret_labels',
-                        '--metric-labels-allowlist=pods=[*],nodes=[*]',
+                        '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
Customer need this label for custom alerting which was available in previous OCP versions which went away with KSM v2 update. Adding it back by allowing in metric label allow list


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
