### PR TITLE
Bug 2012915: add kube_persistentvolumeclaim_labels and kube_persistentvolume_labels

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         - --metric-denylist=kube_secret_labels,kube_*_annotations
-        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*]
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*]
         - |
           --metric-denylist=
           kube_.+_created,

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -134,7 +134,7 @@ function(params)
                     c {
                       args+: [
                         '--metric-denylist=kube_secret_labels,kube_*_annotations',
-                        '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*]',
+                        '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
This PR adds `kube_persistentvolumeclaim_labels` and `kube_persistentvolume_labels` to the `metric-labels-allowlist`. The cost-management-metrics-operator utilizes these metrics.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
