### PR TITLE
KSM: add kube_*_annotations to --metric-denylist arg

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        - --metric-denylist=kube_secret_labels
+        - --metric-denylist=kube_secret_labels,kube_*_annotations
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*]
         - |
           --metric-denylist=

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -133,7 +133,7 @@ function(params)
                   else
                     c {
                       args+: [
-                        '--metric-denylist=kube_secret_labels',
+                        '--metric-denylist=kube_secret_labels,kube_*_annotations',
                         '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*]',
                       ],
                       securityContext: {},


### PR DESCRIPTION
These metrics were added in
https://github.com/kubernetes/kube-state-metrics/pull/1468/ but for us
don't add any valuable information.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
