### PR TITLE
KSM: use new --use-apiserver-cache argument

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         - --telemetry-port=8082
         - --metric-denylist=kube_secret_labels,kube_*_annotations
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*]
+        - --use-apiserver-cache
         - |
           --metric-denylist=
           kube_.+_created,

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -135,6 +135,7 @@ function(params)
                       args+: [
                         '--metric-denylist=kube_secret_labels,kube_*_annotations',
                         '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*]',
+                        '--use-apiserver-cache',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
This cli arg was added in
https://github.com/kubernetes/kube-state-metrics/pull/1548 and is
available since KSM v2.2.0.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
