### PR TITLE
add E2E test checking image registry is well replaced for containers.

### DIFF
--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -73,6 +73,25 @@ func (f *Framework) MustGetStatefulSet(t *testing.T, name, namespace string) *ap
 	return statefulSet
 }
 
+// MustGetPods return all pods from `namespace` within 5 minutes or fail
+func (f *Framework) MustGetPods(t *testing.T, namespace string) *v1.PodList {
+	t.Helper()
+	var pods *v1.PodList
+	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+		pl, err := f.KubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		pods = pl
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to get pods in namespace %s - %s", namespace, err.Error())
+	}
+	return pods
+}
+
 func ensureCreatedByTestLabel(obj metav1.Object) {
 	// only add the label if it doesn't exist yet, leave existing values
 	// untouched

--- a/test/e2e/image_registry_test.go
+++ b/test/e2e/image_registry_test.go
@@ -1,0 +1,99 @@
+package e2e
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestImageRegistryPods(t *testing.T) {
+	var pods *v1.PodList
+
+	// Get all pods in openshift-monitoring namespace.
+	var urlRegistry string
+	pods = f.MustGetPods(t, f.Ns)
+
+	// use CMO image's registry as a reference for all other containers
+	for _, pod := range pods.Items {
+		if strings.Contains(pod.Name, "cluster-monitoring-operator") {
+			imageUrl, err := url.Parse("stubheader://" + pod.Spec.Containers[0].Image)
+			if err != nil {
+				t.Fatalf("Fail to decode host: %v", err)
+			}
+			urlRegistry = imageUrl.Host
+			break
+		}
+	}
+
+	if urlRegistry == "" {
+		t.Fatalf("CMO pod not found")
+	}
+
+	for _, pod := range pods.Items {
+
+		for _, container := range pod.Spec.Containers {
+
+			// We consider the hostname part of image URL be the image registry
+			imageUrl, err := url.Parse("stubheader://" + container.Image)
+			if err != nil {
+				t.Fatalf("Fail to decode host: %v", err)
+			}
+
+			if imageUrl.Host != urlRegistry {
+				t.Fatalf("Pod %s Container %s registry %s differs from CMO registry %s", pod.Name, container.Name, imageUrl.Host, urlRegistry)
+			}
+		}
+
+	}
+
+	setupUserWorkloadAssetsWithTeardownHook(t, f)
+	uwmCM := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userWorkloadMonitorConfigMapName,
+			Namespace: f.UserWorkloadMonitoringNs,
+			Labels: map[string]string{
+				framework.E2eTestLabelName: framework.E2eTestLabelValue,
+			},
+		},
+		Data: map[string]string{
+			"config.yaml": `prometheus:
+  enforcedTargetLimit: 10
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 2Gi
+`,
+		},
+	}
+
+	f.MustCreateOrUpdateConfigMap(t, uwmCM)
+	defer f.MustDeleteConfigMap(t, uwmCM)
+
+	f.AssertStatefulSetExistsAndRollout("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
+	setupUserApplication(t, f)
+
+	pods = f.MustGetPods(t, f.UserWorkloadMonitoringNs)
+
+	for _, pod := range pods.Items {
+
+		for _, container := range pod.Spec.Containers {
+
+			// We consider the hostname part of image URL be the image registry
+			imageUrl, err := url.Parse("stubheader://" + container.Image)
+			if err != nil {
+				t.Fatalf("Fail to decode host: %v", err)
+			}
+
+			if imageUrl.Host != urlRegistry {
+				t.Fatalf("UWM Pod %s Container %s registry %s differs from CMO registry %s", pod.Name, container.Name, imageUrl.Host, urlRegistry)
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR adds a test to verify image registry of each container is the same as cluster-monitoring-operator has. 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
