### PR TITLE
pkg: remove dead code

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1609,7 +1609,6 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		p.Spec.EnforcedTargetLimit = f.config.UserWorkloadConfiguration.Prometheus.EnforcedTargetLimit
 	}
 
-	// end removal
 	if f.config.Images.Thanos != "" {
 		p.Spec.Thanos.Image = &f.config.Images.Thanos
 	}

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -36,13 +36,6 @@ func NewControlPlaneTask(client *client.Client, factory *manifests.Factory, conf
 }
 
 func (t *ControlPlaneTask) Run(ctx context.Context) error {
-	// TODO: remove in 4.10
-	// This was needed when etcd rule was moved to cluster-etcd-operator.
-	err := t.client.DeletePrometheusRuleByNamespaceAndName(ctx, "openshift-monitoring", "etcd-prometheus-rules")
-	if err != nil {
-		return errors.Wrap(err, "deleting etcd rules PrometheusRule failed")
-	}
-
 	pr, err := t.factory.ControlPlanePrometheusRule()
 	if err != nil {
 		return errors.Wrap(err, "initializing kubernetes mixin rules PrometheusRule failed")

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -219,12 +219,6 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Prometheus config RoleBinding failed")
 	}
 
-	// TODO(paulfantom): Can be removed after OpenShift 4.7 and earlier are no longer supported
-	err = t.client.DeletePrometheusRuleByNamespaceAndName(ctx, t.client.Namespace(), "prometheus-k8s-rules")
-	if err != nil {
-		return errors.Wrap(err, "removing old Prometheus rules PrometheusRule failed")
-	}
-
 	pm, err := t.factory.PrometheusK8sPrometheusRule()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus rules PrometheusRule failed")
@@ -381,22 +375,5 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Prometheus Thanos sidecar ServiceMonitor failed")
 	}
 
-	// Clean up the service monitors previously managed by the cluster monitoring operator.
-	// TODO(bison): Verify these are no longer needed and remove them after 4.8 release.
-	deprecatedServiceMonitors := []string{
-		"cluster-version-operator",
-		"kube-apiserver",
-		"kube-controller-manager",
-		"kube-scheduler",
-		"openshift-apiserver",
-		"prometheus", // Bug 1952744: Renamed to "prometheus-k8s" in #1044.
-	}
-
-	for _, name := range deprecatedServiceMonitors {
-		err := t.client.DeleteServiceMonitorByNamespaceAndName(ctx, t.client.Namespace(), name)
-		if err != nil {
-			return errors.Wrapf(err, "deleting Prometheus %s ServiceMonitor failed", name)
-		}
-	}
 	return nil
 }

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -226,11 +226,6 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus ServiceMonitor failed")
 	}
 
-	err = t.deleteDeprecatedServiceMonitors(ctx)
-	if err != nil {
-		return errors.Wrap(err, "deleting deprecated UserWorkload Prometheus ServiceMonitor failed")
-	}
-
 	smt, err := t.factory.PrometheusUserWorkloadThanosSidecarServiceMonitor()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Thanos sidecar ServiceMonitor failed")
@@ -263,11 +258,6 @@ func (t *PrometheusUserWorkloadTask) destroy(ctx context.Context) error {
 	err = t.client.DeleteServiceMonitor(ctx, smp)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Prometheus ServiceMonitor failed")
-	}
-
-	err = t.deleteDeprecatedServiceMonitors(ctx)
-	if err != nil {
-		return errors.Wrap(err, "deleting deprecated UserWorkload Prometheus ServiceMonitor failed")
 	}
 
 	grpcTLS, err := t.factory.GRPCSecret()
@@ -416,23 +406,4 @@ func (t *PrometheusUserWorkloadTask) destroy(ctx context.Context) error {
 
 	err = t.client.DeleteConfigMap(ctx, cacm)
 	return errors.Wrap(err, "deleting UserWorkload serving certs CA Bundle ConfigMap failed")
-}
-
-func (t *PrometheusUserWorkloadTask) deleteDeprecatedServiceMonitors(ctx context.Context) error {
-	// TODO(bison): This can be removed after the 4.8 release.  The "prometheus"
-	// ServiceMonitor was renamed to "prometheus-user-workload" recently. See:
-	//
-	//   https://github.com/openshift/cluster-monitoring-operator/pull/1044
-	//   https://bugzilla.redhat.com/show_bug.cgi?id=1959278
-	//
-	deprecatedServiceMonitors := []string{"prometheus"}
-
-	for _, name := range deprecatedServiceMonitors {
-		err := t.client.DeleteServiceMonitorByNamespaceAndName(ctx, t.client.UserWorkloadNamespace(), name)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
This change removes code that was needed to delete service monitors and
Prometheus rules that don't exist anymore in 4.10.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
