### PR TITLE
Switch hosted control plane check to controlPlaneTopology

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"crypto/x509/pkix"
 	"fmt"
-	cmostr "github.com/openshift/cluster-monitoring-operator/pkg/strings"
 	"time"
+
+	cmostr "github.com/openshift/cluster-monitoring-operator/pkg/strings"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -66,7 +67,7 @@ func NewInfrastructureConfig(i *configv1.Infrastructure) *InfrastructureConfig {
 	if i.Status.InfrastructureTopology == configv1.SingleReplicaTopologyMode {
 		ic.highlyAvailableInfrastructure = false
 	}
-	if i.Status.Platform == configv1.IBMCloudPlatformType {
+	if i.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
 		ic.hostedControlPlane = true
 	}
 

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -35,10 +35,10 @@ func TestNewInfrastructureConfig(t *testing.T) {
 			haInfrastructure:   true,
 		},
 		{
-			name: "IBM infrastructure",
+			name: "External control plane",
 			infrastructure: configv1.Infrastructure{
 				Status: configv1.InfrastructureStatus{
-					Platform: configv1.IBMCloudPlatformType,
+					ControlPlaneTopology: configv1.ExternalTopologyMode,
 				},
 			},
 			hostedControlPlane: true,


### PR DESCRIPTION
Before 4.9, the only platform that had an external/hosted control plane
was IBM cloud. However, starting in 4.10, IBM cloud will also be
available with a self-hosted control plane, and other platforms will
also support an external control plane via Hypershift. This changes the
hosted control plane check to use the
Infrastructure.Status.ControlPlaneTopology field instead of the
platform to match the latest state.

* [x] No user facing changes, so no entry in CHANGELOG was needed.
