### PR TITLE
Bug 2013617: Update KubePodCrashLooping alert

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -14,13 +14,11 @@ spec:
     rules:
     - alert: KubePodCrashLooping
       annotations:
-        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
-          }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.
+        description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+          }}) is in waiting state (reason: "CrashLoopBackOff").'
         summary: Pod is crash looping.
       expr: |
-        increase(kube_pod_container_status_restarts_total{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[10m]) > 0
-        and
-        kube_pod_container_status_waiting{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} == 1
+        max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}[5m]) >= 1
       for: 15m
       labels:
         severity: warning

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -59,8 +59,8 @@
           "subdir": ""
         }
       },
-      "version": "1163ea85e45e1f7edf6d4f83758d44c6fef1f2fa",
-      "sum": "4H2pzHd6A47rQIZcQ3B0o+nFMeNgLE9dGYJv7ZP7m2s="
+      "version": "10bb7c344cea4c9bf5dcf3d4d562aef55b77c49c",
+      "sum": "IuBmSSNjmazPgFW7w1BJGv4YifK9pxUIzNPJ0TCkWK8="
     },
     {
       "source": {


### PR DESCRIPTION
This change pulls in the fix for https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/645 via https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/678
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
