### PR TITLE
static auth changes for uwm prometheus operator

### DIFF
--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
+        - --config-file=/etc/kube-rbac-policy/config.yaml
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:
@@ -67,6 +68,9 @@ spec:
         - mountPath: /etc/tls/private
           name: prometheus-operator-user-workload-tls
           readOnly: false
+        - mountPath: /etc/kube-rbac-policy
+          name: prometheus-operator-uwm-kube-rbac-proxy-config
+          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
@@ -81,3 +85,6 @@ spec:
       - name: prometheus-operator-user-workload-tls
         secret:
           secretName: prometheus-operator-user-workload-tls
+      - name: prometheus-operator-uwm-kube-rbac-proxy-config
+        secret:
+          secretName: prometheus-operator-uwm-kube-rbac-proxy-config

--- a/assets/prometheus-operator-user-workload/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-operator-user-workload/kube-rbac-proxy-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: prometheus-operator-uwm-kube-rbac-proxy-config
+  namespace: openshift-user-workload-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -162,12 +162,13 @@ var (
 	PrometheusOperatorRuleValidatingWebhook = "prometheus-operator/prometheus-rule-validating-webhook.yaml"
 	PrometheusOperatorPrometheusRule        = "prometheus-operator/prometheus-rule.yaml"
 
-	PrometheusOperatorUserWorkloadServiceAccount     = "prometheus-operator-user-workload/service-account.yaml"
-	PrometheusOperatorUserWorkloadClusterRole        = "prometheus-operator-user-workload/cluster-role.yaml"
-	PrometheusOperatorUserWorkloadClusterRoleBinding = "prometheus-operator-user-workload/cluster-role-binding.yaml"
-	PrometheusOperatorUserWorkloadService            = "prometheus-operator-user-workload/service.yaml"
-	PrometheusOperatorUserWorkloadDeployment         = "prometheus-operator-user-workload/deployment.yaml"
-	PrometheusOperatorUserWorkloadServiceMonitor     = "prometheus-operator-user-workload/service-monitor.yaml"
+	PrometheusOperatorUserWorkloadServiceAccount      = "prometheus-operator-user-workload/service-account.yaml"
+	PrometheusOperatorUserWorkloadClusterRole         = "prometheus-operator-user-workload/cluster-role.yaml"
+	PrometheusOperatorUserWorkloadClusterRoleBinding  = "prometheus-operator-user-workload/cluster-role-binding.yaml"
+	PrometheusOperatorUserWorkloadService             = "prometheus-operator-user-workload/service.yaml"
+	PrometheusOperatorUserWorkloadDeployment          = "prometheus-operator-user-workload/deployment.yaml"
+	PrometheusOperatorUserWorkloadServiceMonitor      = "prometheus-operator-user-workload/service-monitor.yaml"
+	PrometheusOperatorUserWorkloadKubeRbacProxySecret = "prometheus-operator-user-workload/kube-rbac-proxy-secret.yaml"
 
 	GrafanaClusterRoleBinding    = "grafana/cluster-role-binding.yaml"
 	GrafanaClusterRole           = "grafana/cluster-role.yaml"
@@ -2013,6 +2014,17 @@ func (f *Factory) PrometheusOperatorUserWorkloadClusterRoleBinding() (*rbacv1.Cl
 	crb.Subjects[0].Namespace = f.namespaceUserWorkload
 
 	return crb, nil
+}
+
+func (f *Factory) PrometheusOperatorUserWorkloadCRBACProxySecret() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetReader(PrometheusOperatorUserWorkloadKubeRbacProxySecret))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespaceUserWorkload
+
+	return s, nil
 }
 
 func (f *Factory) PrometheusOperatorClusterRole() (*rbacv1.ClusterRole, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -706,6 +706,11 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = f.PrometheusOperatorUserWorkloadCRBACProxySecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = f.NodeExporterRBACProxySecret()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -85,6 +85,16 @@ func (t *PrometheusOperatorUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator Service failed")
 	}
 
+	rpc, err := t.factory.PrometheusOperatorUserWorkloadCRBACProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator RBAC proxy secret failed")
+	}
+
+	err = t.client.CreateOrUpdateSecret(ctx, rpc)
+	if err != nil {
+		return errors.Wrap(err, "reconciling UserWorkload Prometheus Operator RBAC proxy secret failed")
+	}
+
 	config, err := t.client.GetAPIServerConfig(ctx, "cluster")
 	if err != nil {
 		return errors.Wrap(err, "failed to get API server configuration")
@@ -180,6 +190,16 @@ func (t *PrometheusOperatorUserWorkloadTask) destroy(ctx context.Context) error 
 	err = t.client.DeleteRoleBinding(ctx, arb)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload Alertmanager Role Binding failed")
+	}
+
+	rpc, err := t.factory.PrometheusOperatorUserWorkloadCRBACProxySecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload Prometheus Operator RBAC proxy secret failed")
+	}
+
+	err = t.client.DeleteSecret(ctx, rpc)
+	if err != nil {
+		return errors.Wrap(err, "deleting UserWorkload Prometheus Operator RBAC proxy secret failed")
 	}
 
 	cr, err := t.factory.PrometheusOperatorUserWorkloadClusterRole()


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
