### PR TITLE
pkg: add tlsSecurityProfile to kube-rbac-proxy in KSM

### DIFF
--- a/pkg/tasks/kubestatemetrics.go
+++ b/pkg/tasks/kubestatemetrics.go
@@ -16,6 +16,7 @@ package tasks
 
 import (
 	"context"
+
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"


### PR DESCRIPTION
This PR only covers kube-rbac-proxy in KSM since we wanted to break it down the changes in smaller chunks

This PR implements TLS security profile for kube-rbac-proxy in kube-state-metrics

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

[MON-1651](https://issues.redhat.com/browse/MON-1651)

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
