### PR TITLE
Bug 2019992: Bump jsonnet dependencies to latest

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -143,6 +143,7 @@ spec:
     annotations:
       target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
+      alertmanager: main
       app.kubernetes.io/component: alert-router
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/alertmanager/service-monitor.yaml
+++ b/assets/alertmanager/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.22.2
-  name: alertmanager
+  name: alertmanager-main
   namespace: openshift-monitoring
 spec:
   endpoints:

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -143,8 +143,9 @@ spec:
         severity: warning
     - alert: KubeContainerWaiting
       annotations:
-        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}}
-          has been in waiting state for longer than 1 hour.
+        description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }} on
+          container {{ $labels.container}} has been in waiting state for longer than
+          1 hour.
         summary: Pod container waiting longer than 1 hour
       expr: |
         sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}) > 0

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kubelet
+    app.kubernetes.io/part-of: openshift-monitoring
     k8s-app: kubelet
   name: kubelet
   namespace: openshift-monitoring

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -2017,7 +2017,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(rate(grpc_server_started_total{job=\"$cluster\",grpc_type=\"unary\"}[5m]))",
+                                  "expr": "sum(rate(grpc_server_started_total{job=\"$cluster\",grpc_type=\"unary\"}[$__rate_interval]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "RPC Rate",
@@ -2026,7 +2026,7 @@ items:
                                   "step": 2
                               },
                               {
-                                  "expr": "sum(rate(grpc_server_handled_total{job=\"$cluster\",grpc_type=\"unary\",grpc_code=~\"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded\"}[5m]))",
+                                  "expr": "sum(rate(grpc_server_handled_total{job=\"$cluster\",grpc_type=\"unary\",grpc_code=~\"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded\"}[$__rate_interval]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "RPC Failed Rate",
@@ -2307,7 +2307,7 @@ items:
                           "steppedLine": true,
                           "targets": [
                               {
-                                  "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=\"$cluster\"}[5m])) by (instance, le))",
+                                  "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=\"$cluster\"}[$__rate_interval])) by (instance, le))",
                                   "hide": false,
                                   "intervalFactor": 2,
                                   "legendFormat": "{{instance}} WAL fsync",
@@ -2316,7 +2316,7 @@ items:
                                   "step": 4
                               },
                               {
-                                  "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job=\"$cluster\"}[5m])) by (instance, le))",
+                                  "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job=\"$cluster\"}[$__rate_interval])) by (instance, le))",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{instance}} DB fsync",
                                   "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
@@ -2494,7 +2494,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "rate(etcd_network_client_grpc_received_bytes_total{job=\"$cluster\"}[5m])",
+                                  "expr": "rate(etcd_network_client_grpc_received_bytes_total{job=\"$cluster\"}[$__rate_interval])",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{instance}} Client Traffic In",
                                   "metric": "etcd_network_client_grpc_received_bytes_total",
@@ -2580,7 +2580,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "rate(etcd_network_client_grpc_sent_bytes_total{job=\"$cluster\"}[5m])",
+                                  "expr": "rate(etcd_network_client_grpc_sent_bytes_total{job=\"$cluster\"}[$__rate_interval])",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{instance}} Client Traffic Out",
                                   "metric": "etcd_network_client_grpc_sent_bytes_total",
@@ -2666,7 +2666,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(rate(etcd_network_peer_received_bytes_total{job=\"$cluster\"}[5m])) by (instance)",
+                                  "expr": "sum(rate(etcd_network_peer_received_bytes_total{job=\"$cluster\"}[$__rate_interval])) by (instance)",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{instance}} Peer Traffic In",
                                   "metric": "etcd_network_peer_received_bytes_total",
@@ -2755,7 +2755,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(rate(etcd_network_peer_sent_bytes_total{job=\"$cluster\"}[5m])) by (instance)",
+                                  "expr": "sum(rate(etcd_network_peer_sent_bytes_total{job=\"$cluster\"}[$__rate_interval])) by (instance)",
                                   "hide": false,
                                   "interval": "",
                                   "intervalFactor": 2,
@@ -2849,7 +2849,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(rate(etcd_server_proposals_failed_total{job=\"$cluster\"}[5m]))",
+                                  "expr": "sum(rate(etcd_server_proposals_failed_total{job=\"$cluster\"}[$__rate_interval]))",
                                   "intervalFactor": 2,
                                   "legendFormat": "Proposal Failure Rate",
                                   "metric": "etcd_server_proposals_failed_total",
@@ -2865,7 +2865,7 @@ items:
                                   "step": 2
                               },
                               {
-                                  "expr": "sum(rate(etcd_server_proposals_committed_total{job=\"$cluster\"}[5m]))",
+                                  "expr": "sum(rate(etcd_server_proposals_committed_total{job=\"$cluster\"}[$__rate_interval]))",
                                   "intervalFactor": 2,
                                   "legendFormat": "Proposal Commit Rate",
                                   "metric": "etcd_server_proposals_committed_total",
@@ -2873,7 +2873,7 @@ items:
                                   "step": 2
                               },
                               {
-                                  "expr": "sum(rate(etcd_server_proposals_applied_total{job=\"$cluster\"}[5m]))",
+                                  "expr": "sum(rate(etcd_server_proposals_applied_total{job=\"$cluster\"}[$__rate_interval]))",
                                   "intervalFactor": 2,
                                   "legendFormat": "Proposal Apply Rate",
                                   "refId": "D",
@@ -3074,7 +3074,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"$cluster\"}[5m])))",
+                                  "expr": "histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"$cluster\"}[$__rate_interval])))",
                                   "interval": "",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{instance}} Peer round trip time",
@@ -3152,7 +3152,7 @@ items:
                           "value": "Prometheus"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -3301,7 +3301,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "1 - avg(rate(node_cpu_seconds_total{mode=~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval]))",
+                                  "expr": "1 - sum(avg by (mode) (rate(node_cpu_seconds_total{mode=~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval])))",
                                   "format": "time_series",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -3314,7 +3314,7 @@ items:
                           "title": "CPU Utilisation",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -3398,7 +3398,7 @@ items:
                           "title": "CPU Requests Commitment",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -3482,7 +3482,7 @@ items:
                           "title": "CPU Limits Commitment",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -3566,7 +3566,7 @@ items:
                           "title": "Memory Utilisation",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -3650,7 +3650,7 @@ items:
                           "title": "Memory Requests Commitment",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -3734,7 +3734,7 @@ items:
                           "title": "Memory Limits Commitment",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -3832,7 +3832,7 @@ items:
                           "title": "CPU Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -4160,7 +4160,7 @@ items:
                           "title": "CPU Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -4259,7 +4259,7 @@ items:
                           "title": "Memory Usage (w/o cache)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -4587,7 +4587,7 @@ items:
                           "title": "Requests by Namespace",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -4889,7 +4889,7 @@ items:
                           "title": "Current Network Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -4988,7 +4988,7 @@ items:
                           "title": "Receive Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5074,7 +5074,7 @@ items:
                           "title": "Transmit Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5172,7 +5172,7 @@ items:
                           "title": "Average Container Bandwidth by Namespace: Received",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5258,7 +5258,7 @@ items:
                           "title": "Average Container Bandwidth by Namespace: Transmitted",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5356,7 +5356,7 @@ items:
                           "title": "Rate of Received Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5442,7 +5442,7 @@ items:
                           "title": "Rate of Transmitted Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5540,7 +5540,7 @@ items:
                           "title": "Rate of Received Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5626,7 +5626,7 @@ items:
                           "title": "Rate of Transmitted Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5725,7 +5725,7 @@ items:
                           "title": "IOPS(Reads+Writes)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -5811,7 +5811,7 @@ items:
                           "title": "ThroughPut(Read+Write)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -6115,7 +6115,7 @@ items:
                           "title": "Current Storage IO",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -6170,7 +6170,7 @@ items:
                           "value": "default"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -6330,7 +6330,7 @@ items:
                           "title": "CPU Utilisation (from requests)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -6414,7 +6414,7 @@ items:
                           "title": "CPU Utilisation (from limits)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -6498,7 +6498,7 @@ items:
                           "title": "Memory Utilisation (from requests)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -6582,7 +6582,7 @@ items:
                           "title": "Memory Utilisation (from limits)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "singlestat",
@@ -6717,7 +6717,7 @@ items:
                           "title": "CPU Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -6989,7 +6989,7 @@ items:
                           "title": "CPU Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -7125,7 +7125,7 @@ items:
                           "title": "Memory Usage (w/o cache)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -7481,7 +7481,7 @@ items:
                           "title": "Memory Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -7783,7 +7783,7 @@ items:
                           "title": "Current Network Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -7882,7 +7882,7 @@ items:
                           "title": "Receive Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -7968,7 +7968,7 @@ items:
                           "title": "Transmit Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -8066,7 +8066,7 @@ items:
                           "title": "Rate of Received Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -8152,7 +8152,7 @@ items:
                           "title": "Rate of Transmitted Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -8250,7 +8250,7 @@ items:
                           "title": "Rate of Received Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -8336,7 +8336,7 @@ items:
                           "title": "Rate of Transmitted Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -8435,7 +8435,7 @@ items:
                           "title": "IOPS(Reads+Writes)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -8521,7 +8521,7 @@ items:
                           "title": "ThroughPut(Read+Write)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -8825,7 +8825,7 @@ items:
                           "title": "Current Storage IO",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -8880,7 +8880,7 @@ items:
                           "value": "default"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -8905,7 +8905,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -8932,7 +8932,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                      "query": "label_values(kube_namespace_created{cluster=\"$cluster\"}, namespace)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -9069,7 +9069,7 @@ items:
                           "title": "CPU Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -9341,7 +9341,7 @@ items:
                           "title": "CPU Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -9440,7 +9440,7 @@ items:
                           "title": "Memory Usage (w/o cache)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -9796,7 +9796,7 @@ items:
                           "title": "Memory Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -9851,7 +9851,7 @@ items:
                           "value": "default"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -9876,7 +9876,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -9903,7 +9903,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, node)",
+                      "query": "label_values(kube_node_info{cluster=\"$cluster\"}, node)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -10073,7 +10073,7 @@ items:
                           "title": "CPU Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -10178,7 +10178,7 @@ items:
                           "title": "CPU Throttling",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -10450,7 +10450,7 @@ items:
                           "title": "CPU Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -10584,7 +10584,7 @@ items:
                           "title": "Memory Usage (WSS)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -10940,7 +10940,7 @@ items:
                           "title": "Memory Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -11040,7 +11040,7 @@ items:
                           "title": "Receive Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11127,7 +11127,7 @@ items:
                           "title": "Transmit Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11226,7 +11226,7 @@ items:
                           "title": "Rate of Received Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11313,7 +11313,7 @@ items:
                           "title": "Rate of Transmitted Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11412,7 +11412,7 @@ items:
                           "title": "Rate of Received Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11499,7 +11499,7 @@ items:
                           "title": "Rate of Transmitted Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11606,7 +11606,7 @@ items:
                           "title": "IOPS",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11700,7 +11700,7 @@ items:
                           "title": "ThroughPut",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11799,7 +11799,7 @@ items:
                           "title": "IOPS(Reads+Writes)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -11885,7 +11885,7 @@ items:
                           "title": "ThroughPut(Read+Write)",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -12189,7 +12189,7 @@ items:
                           "title": "Current Storage IO",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -12244,7 +12244,7 @@ items:
                           "value": "default"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -12269,7 +12269,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -12296,7 +12296,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                      "query": "label_values(kube_namespace_created{cluster=\"$cluster\"}, namespace)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -12460,7 +12460,7 @@ items:
                           "title": "CPU Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -12732,7 +12732,7 @@ items:
                           "title": "CPU Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -12831,7 +12831,7 @@ items:
                           "title": "Memory Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -13103,7 +13103,7 @@ items:
                           "title": "Memory Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -13405,7 +13405,7 @@ items:
                           "title": "Current Network Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -13504,7 +13504,7 @@ items:
                           "title": "Receive Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -13590,7 +13590,7 @@ items:
                           "title": "Transmit Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -13688,7 +13688,7 @@ items:
                           "title": "Average Container Bandwidth by Pod: Received",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -13774,7 +13774,7 @@ items:
                           "title": "Average Container Bandwidth by Pod: Transmitted",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -13872,7 +13872,7 @@ items:
                           "title": "Rate of Received Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -13958,7 +13958,7 @@ items:
                           "title": "Rate of Transmitted Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -14056,7 +14056,7 @@ items:
                           "title": "Rate of Received Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -14142,7 +14142,7 @@ items:
                           "title": "Rate of Transmitted Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -14196,7 +14196,7 @@ items:
                           "value": "default"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -14221,7 +14221,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -14248,7 +14248,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                      "query": "label_values(kube_namespace_created{cluster=\"$cluster\"}, namespace)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -14476,7 +14476,7 @@ items:
                           "title": "CPU Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -14795,7 +14795,7 @@ items:
                           "title": "CPU Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -14931,7 +14931,7 @@ items:
                           "title": "Memory Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -15250,7 +15250,7 @@ items:
                           "title": "Memory Quota",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -15571,7 +15571,7 @@ items:
                           "title": "Current Network Usage",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -15670,7 +15670,7 @@ items:
                           "title": "Receive Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -15756,7 +15756,7 @@ items:
                           "title": "Transmit Bandwidth",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -15854,7 +15854,7 @@ items:
                           "title": "Average Container Bandwidth by Workload: Received",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -15940,7 +15940,7 @@ items:
                           "title": "Average Container Bandwidth by Workload: Transmitted",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -16038,7 +16038,7 @@ items:
                           "title": "Rate of Received Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -16124,7 +16124,7 @@ items:
                           "title": "Rate of Transmitted Packets",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -16222,7 +16222,7 @@ items:
                           "title": "Rate of Received Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -16308,7 +16308,7 @@ items:
                           "title": "Rate of Transmitted Packets Dropped",
                           "tooltip": {
                               "shared": false,
-                              "sort": 0,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -16362,7 +16362,7 @@ items:
                           "value": "default"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -16387,7 +16387,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,
@@ -18935,7 +18935,7 @@ items:
                           "value": "Prometheus"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -19991,7 +19991,7 @@ items:
                           "value": "Prometheus"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 
@@ -21526,8 +21526,8 @@ items:
                           "timeShift": null,
                           "title": "Prometheus Stats",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "transform": "table",
@@ -21625,8 +21625,8 @@ items:
                           "timeShift": null,
                           "title": "Target Sync",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -21711,8 +21711,8 @@ items:
                           "timeShift": null,
                           "title": "Targets",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -21809,8 +21809,8 @@ items:
                           "timeShift": null,
                           "title": "Average Scrape Interval Duration",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -21927,8 +21927,8 @@ items:
                           "timeShift": null,
                           "title": "Scrape failures",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -22013,8 +22013,8 @@ items:
                           "timeShift": null,
                           "title": "Appended Samples",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -22111,8 +22111,8 @@ items:
                           "timeShift": null,
                           "title": "Head Series",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -22197,8 +22197,8 @@ items:
                           "timeShift": null,
                           "title": "Head Chunks",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -22295,8 +22295,8 @@ items:
                           "timeShift": null,
                           "title": "Query Rate",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -22381,8 +22381,8 @@ items:
                           "timeShift": null,
                           "title": "Stage Duration",
                           "tooltip": {
-                              "shared": false,
-                              "sort": 0,
+                              "shared": true,
+                              "sort": 2,
                               "value_type": "individual"
                           },
                           "type": "graph",
@@ -22436,7 +22436,7 @@ items:
                           "value": "default"
                       },
                       "hide": 0,
-                      "label": null,
+                      "label": "Data Source",
                       "name": "datasource",
                       "options": [
 

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - args:
         - -config=/etc/grafana/grafana.ini
         env: []
-        image: grafana/grafana:7.5.11
+        image: grafana/grafana:v7.5.11
         name: grafana
         ports:
         - containerPort: 3001

--- a/assets/grafana/service-account.yaml
+++ b/assets/grafana/service-account.yaml
@@ -3,5 +3,10 @@ kind: ServiceAccount
 metadata:
   annotations:
     serviceaccounts.openshift.io/oauth-redirectreference.grafana: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana"}}'
+  labels:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 7.5.11
   name: grafana
   namespace: openshift-monitoring

--- a/assets/node-exporter/cluster-role-binding.yaml
+++ b/assets/node-exporter/cluster-role-binding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.2.2
   name: node-exporter
+  namespace: openshift-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/assets/node-exporter/cluster-role.yaml
+++ b/assets/node-exporter/cluster-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 1.2.2
   name: node-exporter
+  namespace: openshift-monitoring
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: node-exporter
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter

--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -269,8 +269,8 @@ spec:
         )
       record: instance:node_num_cpu:sum
     - expr: |
-        1 - avg without (cpu, mode) (
-          rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[1m])
+        1 - avg without (cpu) (
+          sum without (mode) (rate(node_cpu_seconds_total{job="node-exporter", mode=~"idle|iowait|steal"}[1m]))
         )
       record: instance:node_cpu_utilisation:rate1m
     - expr: |
@@ -282,16 +282,18 @@ spec:
       record: instance:node_load1_per_cpu:ratio
     - expr: |
         1 - (
-          node_memory_MemAvailable_bytes{job="node-exporter"}
-          or
           (
-            node_memory_Buffers_bytes{job="node-exporter"}
-            +
-            node_memory_Cached_bytes{job="node-exporter"}
-            +
-            node_memory_MemFree_bytes{job="node-exporter"}
-            +
-            node_memory_Slab_bytes{job="node-exporter"}
+            node_memory_MemAvailable_bytes{job="node-exporter"}
+            or
+            (
+              node_memory_Buffers_bytes{job="node-exporter"}
+              +
+              node_memory_Cached_bytes{job="node-exporter"}
+              +
+              node_memory_MemFree_bytes{job="node-exporter"}
+              +
+              node_memory_Slab_bytes{job="node-exporter"}
+            )
           )
         /
           node_memory_MemTotal_bytes{job="node-exporter"}

--- a/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
+++ b/assets/prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml
@@ -11,6 +11,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: system:aggregated-metrics-reader
+  namespace: openshift-monitoring
 rules:
 - apiGroups:
   - metrics.k8s.io

--- a/assets/prometheus-adapter/cluster-role-binding-delegator.yaml
+++ b/assets/prometheus-adapter/cluster-role-binding-delegator.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.9.0
   name: resource-metrics:system:auth-delegator
+  namespace: openshift-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/assets/prometheus-adapter/cluster-role-binding.yaml
+++ b/assets/prometheus-adapter/cluster-role-binding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
+  namespace: openshift-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/assets/prometheus-adapter/cluster-role-server-resources.yaml
+++ b/assets/prometheus-adapter/cluster-role-server-resources.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.9.0
   name: resource-metrics-server-resources
+  namespace: openshift-monitoring
 rules:
 - apiGroups:
   - metrics.k8s.io

--- a/assets/prometheus-adapter/cluster-role.yaml
+++ b/assets/prometheus-adapter/cluster-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 0.9.0
   name: prometheus-adapter
+  namespace: openshift-monitoring
 rules:
 - apiGroups:
   - ""

--- a/assets/prometheus-k8s/cluster-role-binding.yaml
+++ b/assets/prometheus-k8s/cluster-role-binding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.30.3
   name: prometheus-k8s
+  namespace: openshift-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/assets/prometheus-k8s/cluster-role.yaml
+++ b/assets/prometheus-k8s/cluster-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.30.3
   name: prometheus-k8s
+  namespace: openshift-monitoring
 rules:
 - apiGroups:
   - ""

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -172,6 +172,7 @@ spec:
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.30.3
+      prometheus: k8s
   podMonitorNamespaceSelector:
     matchLabels:
       openshift.io/cluster-monitoring: "true"

--- a/assets/prometheus-user-workload/cluster-role-binding.yaml
+++ b/assets/prometheus-user-workload/cluster-role-binding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.30.3
   name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/assets/prometheus-user-workload/cluster-role.yaml
+++ b/assets/prometheus-user-workload/cluster-role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 2.30.3
   name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
 rules:
 - apiGroups:
   - ""

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -140,6 +140,7 @@ spec:
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 2.30.3
+      prometheus: user-workload
   podMonitorNamespaceSelector:
     matchExpressions:
     - key: openshift.io/cluster-monitoring

--- a/assets/telemeter-client/serving-certs-ca-bundle.yaml
+++ b/assets/telemeter-client/serving-certs-ca-bundle.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
-data:
-  service-ca.crt: ""
+data: {}
 kind: ConfigMap
 metadata:
   annotations:
-    service.alpha.openshift.io/inject-cabundle: "true"
+    service.beta.openshift.io/inject-cabundle: "true"
   name: telemeter-client-serving-certs-ca-bundle
   namespace: openshift-monitoring

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana"
         }
       },
-      "version": "c3b14b24b83cfe9abf1064649d19e2d679f033fb",
-      "sum": "YrE4DNQsWgYWs6h0j/FjQETt8xDXdYdsslb1WK7xQEk="
+      "version": "199e363523104ff8b3a12483a4e3eca86372b078",
+      "sum": "/jDHzVAjHB4AOLkJHw1GyATX5ogZ1iMdcJXZAgaG3+g="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "3df272774672366beb02c5447782805ab5fec957",
-      "sum": "5XhYOigrKipOWDbIn9hlrz7JcbelzvJnormxSaup9JI="
+      "version": "15b0820e2fced98c4e648e0ab01c6a095c189379",
+      "sum": "cdKL5kPYfpWSpTCu4qctmh+gWQqL+4YWom6rw9qLYJU="
     },
     {
       "source": {
@@ -28,7 +28,7 @@
           "subdir": "grafonnet"
         }
       },
-      "version": "19b27b272abf4263af1365ec485784c49815a332",
+      "version": "3626fc4dc2326931c530861ac5bebe39444f6cbf",
       "sum": "gF8foHByYcB25jcUOBqP6jxk0OPifQMjPvKY0HaCk6w="
     },
     {
@@ -38,8 +38,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "b7eae75972a369bf8ebfb03dcb0d4c14464ef85a",
-      "sum": "GRf2GvwEU4jhXV+JOonXSZ4wdDv8mnHBPCQ6TUVd+g8="
+      "version": "488418661ae974de085d858d4b5f91d9ae25a91b",
+      "sum": "U34Nd1ViO2LZ3D8IzygPPRfUcy6zOgCnTMVHZ+9O/QE="
     },
     {
       "source": {
@@ -59,8 +59,8 @@
           "subdir": ""
         }
       },
-      "version": "6c72589035f4f49674a56cf97a3ec1a02f14671a",
-      "sum": "9T4XbN7fM8PkCe+5UuN9DhWqz8E0aWHxy02s4H3ih4s="
+      "version": "53d2bb3899bd249a16d81175d4f298361beb359b",
+      "sum": "U3X88YoEavKFnoLPWA9Pw8+qauiAEaWMnJDo+TAa1hQ="
     },
     {
       "source": {
@@ -69,7 +69,7 @@
           "subdir": "lib/promgrafonnet"
         }
       },
-      "version": "ff4641bcd83314c955150bea6b147df9ca335c4a",
+      "version": "53d2bb3899bd249a16d81175d4f298361beb359b",
       "sum": "zv7hXGui6BfHzE9wPatHI/AGZa4A2WKo6pq7ZdqBsps="
     },
     {
@@ -79,8 +79,8 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "8dab6f7472c26987ab7f8899a4a2f753fed8e8a8",
-      "sum": "S5qI+PJUdNeYOv76jH5nxwYS9N6U7CRxvyuB1wI4cTE="
+      "version": "261dbadfa7b3933487b9c37504a567eb3c1cbb95",
+      "sum": "U1wzIpTAtOvC1yj43Y8PfvT0JfvnAcMfNH12Wi+ab0Y="
     },
     {
       "source": {
@@ -89,7 +89,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "8dab6f7472c26987ab7f8899a4a2f753fed8e8a8",
+      "version": "261dbadfa7b3933487b9c37504a567eb3c1cbb95",
       "sum": "u8gaydJoxEjzizQ8jY8xSjYgWooPmxw+wIWdDxifMAk="
     },
     {
@@ -99,7 +99,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "0dd6085d7d4c00d70f874794dab93bdc64e6774a",
+      "version": "2dcf523061502a5fff2b13829c74b3f266e1776c",
       "sum": "YbabTSgCAw6v0rzfxU59vWkoJy2RNDC5WQdbDGuZo0U=",
       "name": "openshift-state-metrics"
     },
@@ -110,8 +110,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "1e97dddbde49e13867733cbf3219f6505d3b083a",
-      "sum": "Sm209vnPf0l7otdQvWS2rX376AqnhaIrlWqCpopMPCM=",
+      "version": "91bff806c60507a1f806b9dc48bd64b83c2d9cb6",
+      "sum": "k4Tv/+U6SM/5pEIYCrFtlNa+tbsrl3rR5Iw5rIH5olQ=",
       "name": "telemeter-client"
     },
     {
@@ -121,8 +121,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "d0464b2bde9c0ce581b7fdf541baa23700529e15",
-      "sum": "FO+x63rzVy6weEPyVzCoACnG1pgxAN2Jr3Dk8Tr6QAM="
+      "version": "310a74abd22479c83f331f82fffcbc6bfa046d95",
+      "sum": "MLuJgZKnHZ4UGgC7gaj+Mt/yRnZkBp65C2JpnZYb9g4="
     },
     {
       "source": {
@@ -131,7 +131,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "d8584e51dc23929ab1863ac866b53ab9de8e60c1",
+      "version": "d866500b016256147c0933c59cbc22e08e7cf680",
       "sum": "qZ4WgiweaE6eeKtFK60QUjLO8sf2L9Q8fgafWvDcyfY=",
       "name": "prometheus-operator-mixin"
     },
@@ -152,7 +152,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "e35efbddb66a73fd8723be5334477e76f21fbd19",
+      "version": "5b825e22a4645840f7074a8f97e9ff809ea1f076",
       "sum": "pep+dHzfIjh2SU5pEkwilMCAT/NoL6YYflV4x8cr7vU=",
       "name": "alertmanager"
     },
@@ -163,8 +163,8 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "0e6b23c338e98809c9872c70a2f5dfa8d6d370d4",
-      "sum": "MnfAA4+l2BkgJncnYfV8uHC7CxHZut8+ap8KkEqyB5Y="
+      "version": "fda358a1ec010a59f37988a6c7d36bc180caa454",
+      "sum": "MlWDAKGZ+JArozRKdKEvewHeWn8j2DNBzesJfLVd0dk="
     },
     {
       "source": {
@@ -173,8 +173,8 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "fdbc40a9efcc8197a94f23f0e479b0b56e52d424",
-      "sum": "m4VHwft4fUcxzL4+52lLZG/V5aH5ZEdjaweb88vISL0=",
+      "version": "1ed94142fc6293f396f77708438c11c3d5b0ca5d",
+      "sum": "n5Zdr/7YeRb8Y9FsXnul5K+hprHOzuSXsYdkapEhPts=",
       "name": "prometheus"
     },
     {
@@ -184,8 +184,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "1fe5b3bda19294b7beab0f0e2902e0d65c4b8cb6",
-      "sum": "NZ8WoqtNu3Xyn9wJemVHnEo5vaG4S9IBms3rNlVRNkk="
+      "version": "fdba356cad426f24dedaed3c29b22b2dc44e2cde",
+      "sum": "AULYhjhp9+cczRq/s1/Cege/7/Su+v6O47T7CJQi2wE="
     },
     {
       "source": {
@@ -194,7 +194,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "360b39e1c6ab3ac8dcefa225a6205142f9362c68",
+      "version": "12ce53622cec9c2722df0ad77c6ee0412341d91d",
       "sum": "Og+wEHfgzXBvBLAeeQvGNoiCw3FY4LQHlJdpsG/owj8="
     }
   ],

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -11,6 +11,9 @@ local excludedRuleGroups = [
   'kube-apiserver.rules',
   'kube-apiserver-burnrate.rules',
   'kube-apiserver-histogram.rules',
+  // Availability of kube-proxy depends on the selected CNO plugin hence the
+  // rules should be managed by CNO directly.
+  'kubernetes-system-kube-proxy',
 ];
 
 local excludedRules = [

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -2018,7 +2018,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(grpc_server_started_total{job=\"$cluster\",grpc_type=\"unary\"}[5m]))",
+                                "expr": "sum(rate(grpc_server_started_total{job=\"$cluster\",grpc_type=\"unary\"}[$__rate_interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "RPC Rate",
@@ -2027,7 +2027,7 @@ data:
                                 "step": 2
                             },
                             {
-                                "expr": "sum(rate(grpc_server_handled_total{job=\"$cluster\",grpc_type=\"unary\",grpc_code=~\"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded\"}[5m]))",
+                                "expr": "sum(rate(grpc_server_handled_total{job=\"$cluster\",grpc_type=\"unary\",grpc_code=~\"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded\"}[$__rate_interval]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "RPC Failed Rate",
@@ -2308,7 +2308,7 @@ data:
                         "steppedLine": true,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=\"$cluster\"}[5m])) by (instance, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=\"$cluster\"}[$__rate_interval])) by (instance, le))",
                                 "hide": false,
                                 "intervalFactor": 2,
                                 "legendFormat": "{{instance}} WAL fsync",
@@ -2317,7 +2317,7 @@ data:
                                 "step": 4
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job=\"$cluster\"}[5m])) by (instance, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job=\"$cluster\"}[$__rate_interval])) by (instance, le))",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{instance}} DB fsync",
                                 "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
@@ -2495,7 +2495,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "rate(etcd_network_client_grpc_received_bytes_total{job=\"$cluster\"}[5m])",
+                                "expr": "rate(etcd_network_client_grpc_received_bytes_total{job=\"$cluster\"}[$__rate_interval])",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{instance}} Client Traffic In",
                                 "metric": "etcd_network_client_grpc_received_bytes_total",
@@ -2581,7 +2581,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "rate(etcd_network_client_grpc_sent_bytes_total{job=\"$cluster\"}[5m])",
+                                "expr": "rate(etcd_network_client_grpc_sent_bytes_total{job=\"$cluster\"}[$__rate_interval])",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{instance}} Client Traffic Out",
                                 "metric": "etcd_network_client_grpc_sent_bytes_total",
@@ -2667,7 +2667,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(etcd_network_peer_received_bytes_total{job=\"$cluster\"}[5m])) by (instance)",
+                                "expr": "sum(rate(etcd_network_peer_received_bytes_total{job=\"$cluster\"}[$__rate_interval])) by (instance)",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{instance}} Peer Traffic In",
                                 "metric": "etcd_network_peer_received_bytes_total",
@@ -2756,7 +2756,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(etcd_network_peer_sent_bytes_total{job=\"$cluster\"}[5m])) by (instance)",
+                                "expr": "sum(rate(etcd_network_peer_sent_bytes_total{job=\"$cluster\"}[$__rate_interval])) by (instance)",
                                 "hide": false,
                                 "interval": "",
                                 "intervalFactor": 2,
@@ -2850,7 +2850,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(etcd_server_proposals_failed_total{job=\"$cluster\"}[5m]))",
+                                "expr": "sum(rate(etcd_server_proposals_failed_total{job=\"$cluster\"}[$__rate_interval]))",
                                 "intervalFactor": 2,
                                 "legendFormat": "Proposal Failure Rate",
                                 "metric": "etcd_server_proposals_failed_total",
@@ -2866,7 +2866,7 @@ data:
                                 "step": 2
                             },
                             {
-                                "expr": "sum(rate(etcd_server_proposals_committed_total{job=\"$cluster\"}[5m]))",
+                                "expr": "sum(rate(etcd_server_proposals_committed_total{job=\"$cluster\"}[$__rate_interval]))",
                                 "intervalFactor": 2,
                                 "legendFormat": "Proposal Commit Rate",
                                 "metric": "etcd_server_proposals_committed_total",
@@ -2874,7 +2874,7 @@ data:
                                 "step": 2
                             },
                             {
-                                "expr": "sum(rate(etcd_server_proposals_applied_total{job=\"$cluster\"}[5m]))",
+                                "expr": "sum(rate(etcd_server_proposals_applied_total{job=\"$cluster\"}[$__rate_interval]))",
                                 "intervalFactor": 2,
                                 "legendFormat": "Proposal Apply Rate",
                                 "refId": "D",
@@ -3075,7 +3075,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"$cluster\"}[5m])))",
+                                "expr": "histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"$cluster\"}[$__rate_interval])))",
                                 "interval": "",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{instance}} Peer round trip time",
@@ -3153,7 +3153,7 @@ data:
                         "value": "Prometheus"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -3304,7 +3304,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "1 - avg(rate(node_cpu_seconds_total{mode=~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval]))",
+                                "expr": "1 - sum(avg by (mode) (rate(node_cpu_seconds_total{mode=~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval])))",
                                 "format": "time_series",
                                 "instant": true,
                                 "intervalFactor": 2,
@@ -3317,7 +3317,7 @@ data:
                         "title": "CPU Utilisation",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -3401,7 +3401,7 @@ data:
                         "title": "CPU Requests Commitment",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -3485,7 +3485,7 @@ data:
                         "title": "CPU Limits Commitment",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -3569,7 +3569,7 @@ data:
                         "title": "Memory Utilisation",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -3653,7 +3653,7 @@ data:
                         "title": "Memory Requests Commitment",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -3737,7 +3737,7 @@ data:
                         "title": "Memory Limits Commitment",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -3835,7 +3835,7 @@ data:
                         "title": "CPU Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -4163,7 +4163,7 @@ data:
                         "title": "CPU Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -4262,7 +4262,7 @@ data:
                         "title": "Memory Usage (w/o cache)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -4590,7 +4590,7 @@ data:
                         "title": "Requests by Namespace",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -4892,7 +4892,7 @@ data:
                         "title": "Current Network Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -4991,7 +4991,7 @@ data:
                         "title": "Receive Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5077,7 +5077,7 @@ data:
                         "title": "Transmit Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5175,7 +5175,7 @@ data:
                         "title": "Average Container Bandwidth by Namespace: Received",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5261,7 +5261,7 @@ data:
                         "title": "Average Container Bandwidth by Namespace: Transmitted",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5359,7 +5359,7 @@ data:
                         "title": "Rate of Received Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5445,7 +5445,7 @@ data:
                         "title": "Rate of Transmitted Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5543,7 +5543,7 @@ data:
                         "title": "Rate of Received Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5629,7 +5629,7 @@ data:
                         "title": "Rate of Transmitted Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5728,7 +5728,7 @@ data:
                         "title": "IOPS(Reads+Writes)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -5814,7 +5814,7 @@ data:
                         "title": "ThroughPut(Read+Write)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -6118,7 +6118,7 @@ data:
                         "title": "Current Storage IO",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -6173,7 +6173,7 @@ data:
                         "value": "default"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -6335,7 +6335,7 @@ data:
                         "title": "CPU Utilisation (from requests)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -6419,7 +6419,7 @@ data:
                         "title": "CPU Utilisation (from limits)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -6503,7 +6503,7 @@ data:
                         "title": "Memory Utilisation (from requests)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -6587,7 +6587,7 @@ data:
                         "title": "Memory Utilisation (from limits)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "singlestat",
@@ -6722,7 +6722,7 @@ data:
                         "title": "CPU Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -6994,7 +6994,7 @@ data:
                         "title": "CPU Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -7130,7 +7130,7 @@ data:
                         "title": "Memory Usage (w/o cache)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -7486,7 +7486,7 @@ data:
                         "title": "Memory Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -7788,7 +7788,7 @@ data:
                         "title": "Current Network Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -7887,7 +7887,7 @@ data:
                         "title": "Receive Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -7973,7 +7973,7 @@ data:
                         "title": "Transmit Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -8071,7 +8071,7 @@ data:
                         "title": "Rate of Received Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -8157,7 +8157,7 @@ data:
                         "title": "Rate of Transmitted Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -8255,7 +8255,7 @@ data:
                         "title": "Rate of Received Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -8341,7 +8341,7 @@ data:
                         "title": "Rate of Transmitted Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -8440,7 +8440,7 @@ data:
                         "title": "IOPS(Reads+Writes)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -8526,7 +8526,7 @@ data:
                         "title": "ThroughPut(Read+Write)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -8830,7 +8830,7 @@ data:
                         "title": "Current Storage IO",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -8885,7 +8885,7 @@ data:
                         "value": "default"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -8910,7 +8910,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info, cluster)",
+                    "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -8937,7 +8937,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                    "query": "label_values(kube_namespace_created{cluster=\"$cluster\"}, namespace)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -9077,7 +9077,7 @@ data:
                         "title": "CPU Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -9349,7 +9349,7 @@ data:
                         "title": "CPU Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -9448,7 +9448,7 @@ data:
                         "title": "Memory Usage (w/o cache)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -9804,7 +9804,7 @@ data:
                         "title": "Memory Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -9859,7 +9859,7 @@ data:
                         "value": "default"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -9884,7 +9884,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info, cluster)",
+                    "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -9911,7 +9911,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, node)",
+                    "query": "label_values(kube_node_info{cluster=\"$cluster\"}, node)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -10083,7 +10083,7 @@ data:
                         "title": "CPU Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -10188,7 +10188,7 @@ data:
                         "title": "CPU Throttling",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -10460,7 +10460,7 @@ data:
                         "title": "CPU Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -10594,7 +10594,7 @@ data:
                         "title": "Memory Usage (WSS)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -10950,7 +10950,7 @@ data:
                         "title": "Memory Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -11050,7 +11050,7 @@ data:
                         "title": "Receive Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11137,7 +11137,7 @@ data:
                         "title": "Transmit Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11236,7 +11236,7 @@ data:
                         "title": "Rate of Received Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11323,7 +11323,7 @@ data:
                         "title": "Rate of Transmitted Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11422,7 +11422,7 @@ data:
                         "title": "Rate of Received Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11509,7 +11509,7 @@ data:
                         "title": "Rate of Transmitted Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11616,7 +11616,7 @@ data:
                         "title": "IOPS",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11710,7 +11710,7 @@ data:
                         "title": "ThroughPut",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11809,7 +11809,7 @@ data:
                         "title": "IOPS(Reads+Writes)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -11895,7 +11895,7 @@ data:
                         "title": "ThroughPut(Read+Write)",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -12199,7 +12199,7 @@ data:
                         "title": "Current Storage IO",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -12254,7 +12254,7 @@ data:
                         "value": "default"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -12279,7 +12279,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info, cluster)",
+                    "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -12306,7 +12306,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                    "query": "label_values(kube_namespace_created{cluster=\"$cluster\"}, namespace)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -12473,7 +12473,7 @@ data:
                         "title": "CPU Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -12745,7 +12745,7 @@ data:
                         "title": "CPU Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -12844,7 +12844,7 @@ data:
                         "title": "Memory Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -13116,7 +13116,7 @@ data:
                         "title": "Memory Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -13418,7 +13418,7 @@ data:
                         "title": "Current Network Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -13517,7 +13517,7 @@ data:
                         "title": "Receive Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -13603,7 +13603,7 @@ data:
                         "title": "Transmit Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -13701,7 +13701,7 @@ data:
                         "title": "Average Container Bandwidth by Pod: Received",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -13787,7 +13787,7 @@ data:
                         "title": "Average Container Bandwidth by Pod: Transmitted",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -13885,7 +13885,7 @@ data:
                         "title": "Rate of Received Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -13971,7 +13971,7 @@ data:
                         "title": "Rate of Transmitted Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -14069,7 +14069,7 @@ data:
                         "title": "Rate of Received Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -14155,7 +14155,7 @@ data:
                         "title": "Rate of Transmitted Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -14209,7 +14209,7 @@ data:
                         "value": "default"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -14234,7 +14234,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info, cluster)",
+                    "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -14261,7 +14261,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                    "query": "label_values(kube_namespace_created{cluster=\"$cluster\"}, namespace)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -14492,7 +14492,7 @@ data:
                         "title": "CPU Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -14811,7 +14811,7 @@ data:
                         "title": "CPU Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -14947,7 +14947,7 @@ data:
                         "title": "Memory Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -15266,7 +15266,7 @@ data:
                         "title": "Memory Quota",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -15587,7 +15587,7 @@ data:
                         "title": "Current Network Usage",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -15686,7 +15686,7 @@ data:
                         "title": "Receive Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -15772,7 +15772,7 @@ data:
                         "title": "Transmit Bandwidth",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -15870,7 +15870,7 @@ data:
                         "title": "Average Container Bandwidth by Workload: Received",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -15956,7 +15956,7 @@ data:
                         "title": "Average Container Bandwidth by Workload: Transmitted",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -16054,7 +16054,7 @@ data:
                         "title": "Rate of Received Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -16140,7 +16140,7 @@ data:
                         "title": "Rate of Transmitted Packets",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -16238,7 +16238,7 @@ data:
                         "title": "Rate of Received Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -16324,7 +16324,7 @@ data:
                         "title": "Rate of Transmitted Packets Dropped",
                         "tooltip": {
                             "shared": false,
-                            "sort": 0,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -16378,7 +16378,7 @@ data:
                         "value": "default"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -16403,7 +16403,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_pod_info, cluster)",
+                    "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -18956,7 +18956,7 @@ data:
                         "value": "Prometheus"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -20014,7 +20014,7 @@ data:
                         "value": "Prometheus"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 
@@ -21553,8 +21553,8 @@ data:
                         "timeShift": null,
                         "title": "Prometheus Stats",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "transform": "table",
@@ -21652,8 +21652,8 @@ data:
                         "timeShift": null,
                         "title": "Target Sync",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -21738,8 +21738,8 @@ data:
                         "timeShift": null,
                         "title": "Targets",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -21836,8 +21836,8 @@ data:
                         "timeShift": null,
                         "title": "Average Scrape Interval Duration",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -21954,8 +21954,8 @@ data:
                         "timeShift": null,
                         "title": "Scrape failures",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -22040,8 +22040,8 @@ data:
                         "timeShift": null,
                         "title": "Appended Samples",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -22138,8 +22138,8 @@ data:
                         "timeShift": null,
                         "title": "Head Series",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -22224,8 +22224,8 @@ data:
                         "timeShift": null,
                         "title": "Head Chunks",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -22322,8 +22322,8 @@ data:
                         "timeShift": null,
                         "title": "Query Rate",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -22408,8 +22408,8 @@ data:
                         "timeShift": null,
                         "title": "Stage Duration",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -22463,7 +22463,7 @@ data:
                         "value": "default"
                     },
                     "hide": 0,
-                    "label": null,
+                    "label": "Data Source",
                     "name": "datasource",
                     "options": [
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -271,6 +271,7 @@ var (
 
 	TrustedCABundleKey = "ca-bundle.crt"
 
+	AlertmanagerLegacyServiceMonitorName                = "alertmanager"
 	AdditionalAlertmanagerConfigSecretKey               = "alertmanager-configs.yaml"
 	PrometheusK8sAdditionalAlertmanagerConfigSecretName = "prometheus-k8s-additional-alertmanager-configs"
 	PrometheusUWAdditionalAlertmanagerConfigSecretName  = "prometheus-user-workload-additional-alertmanager-configs"

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -189,6 +189,14 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Alertmanager ServiceMonitor failed")
 	}
 
+	// Alertmanager ServiceMonitor has been renamed from alertmanager to alertmanager-${config}.
+	// This deletion ensures that the previous ServiceMonitor will be always removed after a CMO upgrade.
+	// Refer https://github.com/prometheus-operator/kube-prometheus/pull/1471 for more info.
+	t.client.DeleteServiceMonitorByNamespaceAndName(ctx, smam.Namespace, manifests.AlertmanagerLegacyServiceMonitorName)
+	if err != nil {
+		return errors.Wrap(err, "deleting legacy Alertmanager ServiceMonitor failed")
+	}
+
 	err = t.client.CreateOrUpdateServiceMonitor(ctx, smam)
 	return errors.Wrap(err, "reconciling Alertmanager ServiceMonitor failed")
 }

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -368,7 +368,8 @@ func TestAlertmanagerDisabling(t *testing.T) {
 		{name: "assert clusterrolebinding alertmanager-main does not exist", assertion: f.AssertClusterRoleBindingDoesNotExist("alertmanager-main")},
 		{name: "assert trusted-ca-bundle does not exist", assertion: f.AssertConfigmapDoesNotExist("alertmanager-trusted-ca-bundle", f.Ns)},
 		{name: "assert prometheus rule does not exist", assertion: f.AssertPrometheusRuleDoesNotExist("alertmanager-main-rules", f.Ns)},
-		{name: "assert service monitor does not exist", assertion: f.AssertServiceMonitorDoesNotExist("alertmanager", f.Ns)},
+		{name: "assert service monitor does not exist", assertion: f.AssertServiceMonitorDoesNotExist("alertmanager-main", f.Ns)},
+		{name: "assert old service monitor does not exists", assertion: f.AssertServiceMonitorDoesNotExist("alertmanager", f.Ns)},
 		{name: "alertmanager public URL is unset", assertion: f.AssertValueInConfigMapEquals(
 			"monitoring-shared-config", "openshift-config-managed", "alertmanagerPublicURL", "")},
 		{name: "assert operator not degraded", assertion: f.AssertOperatorCondition(statusv1.OperatorDegraded, statusv1.ConditionFalse)},
@@ -402,7 +403,8 @@ func TestAlertmanagerDisabling(t *testing.T) {
 		{name: "assert clusterrolebinding alertmanager-main exists", assertion: f.AssertClusterRoleBindingExists("alertmanager-main")},
 		{name: "assert trusted-ca-bundle exists", assertion: f.AssertConfigmapExists("alertmanager-trusted-ca-bundle", f.Ns)},
 		{name: "assert prometheus rule exists", assertion: f.AssertPrometheusRuleExists("alertmanager-main-rules", f.Ns)},
-		{name: "assert service monitor exists", assertion: f.AssertServiceMonitorExists("alertmanager", f.Ns)},
+		{name: "assert service monitor exists", assertion: f.AssertServiceMonitorExists("alertmanager-main", f.Ns)},
+		{name: "assert old service monitor does not exists", assertion: f.AssertServiceMonitorDoesNotExist("alertmanager", f.Ns)},
 		{name: "alertmanager public URL properly set", assertion: f.AssertValueInConfigMapNotEquals(
 			"monitoring-shared-config", "openshift-config-managed", "alertmanagerPublicURL", "")},
 		{name: "assert operator not degraded", assertion: f.AssertOperatorCondition(statusv1.OperatorDegraded, statusv1.ConditionFalse)},


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

This PR bumps jsonnet dependencies to latest which also fixes Bug 2013920 and Bug 2019992.

Removal of kube-proxy alerts shall be found in https://github.com/openshift/cluster-monitoring-operator/pull/1444/files#r732821044

Alertmanager SM has been renamed from alertmanager to alertmanager-main.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
