### PR TITLE
Bug 2018431: [4.8] add kube_persistentvolumeclaim_labels and kube_persistentvolume_labels

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         - --metric-denylist=kube_secret_labels
-        - --metric-labels-allowlist=pods=[*],node=[*],namespaces=[*]
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*]
         - |
           --metric-denylist=
           kube_.+_created,

--- a/jsonnet/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics.libsonnet
@@ -110,7 +110,7 @@ function(params)
                     c {
                       args+: [
                         '--metric-denylist=kube_secret_labels',
-                        '--metric-labels-allowlist=pods=[*],node=[*],namespaces=[*]',
+                        '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
Signed-off-by: Michael Skarbek <mskarbek@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->
- Cherry pick https://github.com/openshift/cluster-monitoring-operator/pull/1457
- node => nodes in allow label list argument, change is meant for consistency, shouldn't really affect functionality!

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
