### PR TITLE
Bug 2015418: Keep container_fs_usage_bytes metric

### DIFF
--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -80,11 +80,19 @@ spec:
       regex: container_memory_failures_total
       sourceLabels:
       - __name__
-    - action: drop
-      regex: (container_fs_.*);.+
+    - regex: container_fs_usage_bytes
+      replacement: "true"
       sourceLabels:
       - __name__
+      targetLabel: __tmp_keep_metric
+    - action: drop
+      regex: ;(container_fs_.*);.+
+      sourceLabels:
+      - __tmp_keep_metric
+      - __name__
       - container
+    - action: labeldrop
+      regex: __tmp_keep_metric
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -88,11 +88,23 @@ function(params)
                       action: 'drop',
                       regex: 'container_memory_failures_total',
                     },
+                    // stash 'container_fs_usage_bytes' because we don't want to include it in the drop set
+                    {
+                      sourceLabels: ['__name__'],
+                      regex: 'container_fs_usage_bytes',
+                      targetLabel: '__tmp_keep_metric',
+                      replacement: 'true',
+                    },
                     {
                       // these metrics are available at the slice level
-                      sourceLabels: ['__name__', 'container'],
+                      sourceLabels: ['__tmp_keep_metric', '__name__', 'container'],
                       action: 'drop',
-                      regex: '(container_fs_.*);.+',
+                      regex: ';(container_fs_.*);.+',
+                    },
+                    // drop the temporarily stashed metrics
+                    {
+                      action: 'labeldrop',
+                      regex: '__tmp_keep_metric',
                     },
                   ],
                 }


### PR DESCRIPTION
This change ensures we keep `container_fs_usage_bytes` since some of the dashboards depend on it and the metric is not being aggregated at the pod level.

Fixes the issue with utilisation dashboards not displaying


<img width="1609" alt="util" src="https://user-images.githubusercontent.com/5781491/139432179-c4405e8d-5e15-4cab-a282-92cb2dcc9003.png">


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
