### PR TITLE
pkg: add tlsSecurityProfile to kube-rbac-proxy in OSM

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -663,10 +663,9 @@ func (f *Factory) OpenShiftStateMetricsDeployment() (*appsv1.Deployment, error) 
 
 	for i, container := range d.Spec.Template.Spec.Containers {
 		switch container.Name {
-		case "kube-rbac-proxy-main":
+		case "kube-rbac-proxy-main", "kube-rbac-proxy-self":
 			d.Spec.Template.Spec.Containers[i].Image = f.config.Images.KubeRbacProxy
-		case "kube-rbac-proxy-self":
-			d.Spec.Template.Spec.Containers[i].Image = f.config.Images.KubeRbacProxy
+			d.Spec.Template.Spec.Containers[i].Args = f.setTLSSecurityConfiguration(container.Args, KubeRbacProxyTLSCipherSuitesFlag, KubeRbacProxyMinTLSVersionFlag)
 		case "openshift-state-metrics":
 			d.Spec.Template.Spec.Containers[i].Image = f.config.Images.OpenShiftStateMetrics
 		}

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -89,11 +89,13 @@ func TestTLSSecurityProfileConfiguration(t *testing.T) {
 			assertCorrectTLSConfiguration(t, "prometheus-operator",
 				manifests.PrometheusOperatorWebTLSCipherSuitesFlag,
 				manifests.PrometheusOperatorWebTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
-
 			assertCorrectTLSConfiguration(t, "prometheus-adapter",
 				manifests.PrometheusAdapterTLSCipherSuitesFlag,
 				manifests.PrometheusAdapterTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
 			assertCorrectTLSConfiguration(t, "kube-state-metrics",
+				manifests.KubeRbacProxyTLSCipherSuitesFlag,
+				manifests.KubeRbacProxyMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
+			assertCorrectTLSConfiguration(t, "openshift-state-metrics",
 				manifests.KubeRbacProxyTLSCipherSuitesFlag,
 				manifests.KubeRbacProxyMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
 		})


### PR DESCRIPTION
This PR only covers kube-rbac-proxy in OSM since we wanted to break it down the changes in smaller chunks

test: Add tests for osm-rbacproxy tlssecurityprofile

This commit implements TLS security profile for kube-rbac-proxy in openshift-state-metrics

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

[MON-1651](https://issues.redhat.com/browse/MON-1651)

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
