### PR TITLE
run-local: harden -images switch retrieval

### DIFF
--- a/hack/local-cmo.sh
+++ b/hack/local-cmo.sh
@@ -75,7 +75,7 @@ __EOF
 }
 
 images_from_deployment() {
-  kc get deployment cluster-monitoring-operator -o yaml | grep -o '\-images.*'
+  kc get deployment cluster-monitoring-operator -o json | jq -r '.spec.template.spec.containers[] | select(.name=="cluster-monitoring-operator") | .args[] | select(.|test("\\-images.*"))'
 }
 
 run() {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

The existing local dev flow makes uses of `-images` flag from existing deployment. However retrieval of `-images` flag produces erroneous argument when I apply local manifests for testing(see below). This commit hardens the retrieval process by using jq.

```
$ kc get deployment cluster-monitoring-operator -o yaml | grep -o '\-images.*'
-images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest","-images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest","-images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest","-images=prometheus=quay.io/openshift/origin-prometheus:latest","-images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest","-images=grafana=quay.io/openshift/origin-grafana:latest","-images=oauth-proxy=quay.io/openshift/origin-oauth-proxy:latest","-images=node-exporter=quay.io/openshift/origin-prometheus-node-exporter:latest","-images=kube-state-metrics=quay.io/openshift/origin-kube-state-metrics:latest","-images=openshift-state-metrics=quay.io/openshift/origin-openshift-state-metrics:latest","-images=kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:latest","-images=telemeter-client=quay.io/openshift/origin-telemeter:latest","-images=prom-label-proxy=quay.io/openshift/origin-prom-label-proxy:latest","-images=k8s-prometheus-adapter=quay.io/openshift/origin-k8s-prometheus-adapter:latest","-images=thanos=quay.io/openshift/origin-thanos:latest"],"env":[{"name":"RELEASE_VERSION","value":"0.0.1-snapshot"}],"image":"quay.io/openshift/origin-cluster-monitoring-operator:latest","name":"cluster-monitoring-operator","resources":{"requests":{"cpu":"10m","memory":"75Mi"}},"terminationMessagePolicy":"FallbackToLogsOnError","volumeMounts":[{"mountPath":"/etc/cluster-monitoring-operator/telemetry","name":"telemetry-config"}]}],"nodeSelector":{"kubernetes.io/os":"linux","node-role.kubernetes.io/master":""},"priorityClassName":"system-cluster-critical","serviceAccountName":"cluster-monitoring-operator","tolerations":[{"effect":"NoSchedule","key":"node.kubernetes.io/memory-pressure","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":120},{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":120}],"volumes":[{"configMap":{"name":"telemetry-config"},"name":"telemetry-config"},{"name":"cluster-monitoring-operator-tls","secret":{"secretName":"cluster-monitoring-operator-tls"}}]}}}}
-images=prometheus-operator=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:0b22af5e982b5b645f71b3ec1006e9b675a82c76ae8a109691e1cf4f7afe33de
-images=prometheus-config-reloader=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:23b1c603d2d321aa12efdbf129283dcac82cb036690461e19f597170aa9380cf
-images=configmap-reloader=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:877bc48aa3a690d2b63933ac908051719e9138c74c8372d138883b5cd1651f6e
-images=prometheus=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:1b6388fe6428c19b42cb12926da440a831b477b79299ce629ab301b726c8898e
-images=alertmanager=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:eb4bcc9502e26f3d9ed5d2415e81c384fbdd82048611f1f3e77bc24d01c9cdca
-images=grafana=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:27ec4203f48cfd2c2d947880fdd4e03ab52bcb0c03ecd0e5215f3bcc6af34ef6
-images=oauth-proxy=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:3b3a6aa6409e8510b412ec492d658644a9262897b7be2c40ae202162f01f9849
-images=node-exporter=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:5fc9a72702a1c5cf7481d5bbb8e11ac50397eb6d91a791f9e6ded8faf741c461
-images=kube-state-metrics=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:ce58675352fb7d30f8ea9a15d7146157b0f6d074403df452d473f906b2947c7a
-images=openshift-state-metrics=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:ad0d6370f9a5cf492a65d9eeb269b3fd6be6458aff3ec57046e60b5854be0051
-images=kube-rbac-proxy=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:5562d8692d5532b0f2a888adb58c325d81ae2ff04bfa82f7c512fb0650062b9d
-images=telemeter-client=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:6c1145cbeb10f9703ba77bacf342c7a1de9db9bbd06d9749f86fe4389950e1f9
-images=prom-label-proxy=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:f2f47cf432896d52a8c641148a2bc40a25fa9ea38f7d5678faeb9a9065cbb24e
-images=k8s-prometheus-adapter=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:bcb7f65ab6cce35e69b698941d339c139e7ee4c684701d520b8161072a85f526
-images=thanos=registry.ci.openshift.org/ocp/4.10-2021-10-28-162412@sha256:0190ddbe0ee5acb4625667f7217ec2b1483b29c8f665bf0056e70764137f7dca
```

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
