### PR TITLE
Add bodysize limit for metric scraping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#1630](https://github.com/openshift/cluster-monitoring-operator/pull/1630) Expose retention size settings for UWM Prometheus
 - [#1640](https://github.com/openshift/cluster-monitoring-operator/pull/1640) Deploy standalone admission webhook for HA.
 - [#1651](https://github.com/openshift/cluster-monitoring-operator/pull/1651) Allow retention to be configurable for Thanos-Ruler in UWM
+- [#1467](https://github.com/openshift/cluster-monitoring-operator/pull/1467) Add bodysize limit for metric scraping
 
 ## 4.10
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1524,6 +1524,24 @@ func (c *Client) DeleteRole(ctx context.Context, role *rbacv1.Role) error {
 	return err
 }
 
+func (c *Client) PodCapacity(ctx context.Context) (int, error) {
+	nodes, err := c.kclient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	var podCapacityTotal int64
+	for _, node := range nodes.Items {
+		podsCount, succeeded := node.Status.Capacity.Pods().AsInt64()
+		if !succeeded {
+			klog.Warningf("Cannot get pod capacity from node: %s. Error: %v", node.Name, err)
+			continue
+		}
+		podCapacityTotal += podsCount
+	}
+
+	return int(podCapacityTotal), nil
+}
+
 // mergeMetadata merges labels and annotations from `existing` map into `required` one where `required` has precedence
 // over `existing` keys and values. Additionally function performs filtering of labels and annotations from `exiting` map
 // where keys starting from string defined in `metadataPrefix` are deleted. This prevents issues with preserving stale

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1674,6 +1674,10 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 		p.Spec.Secrets = append(p.Spec.Secrets, getAdditionalAlertmanagerSecrets(f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs)...)
 	}
 
+	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.EnforcedBodySizeLimit != "" {
+		p.Spec.EnforcedBodySizeLimit = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.EnforcedBodySizeLimit
+	}
+
 	return p, nil
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -829,6 +829,12 @@ func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, e
 	}
 	o.userWorkloadEnabled = *c.ClusterMonitoringConfiguration.UserWorkloadEnabled
 
+	err = c.LoadEnforcedBodySizeLimit(o.client, ctx)
+	if err != nil {
+		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.EnforcedBodySizeLimit = ""
+		klog.Warningf("Error loading enforced body size limit, no body size limit will be enforced: %v", err)
+	}
+
 	// Only fetch the token and cluster ID if they have not been specified in the config.
 	if c.ClusterMonitoringConfiguration.TelemeterClientConfig.ClusterID == "" || c.ClusterMonitoringConfiguration.TelemeterClientConfig.Token == "" {
 		err := c.LoadClusterID(func() (*configv1.ClusterVersion, error) {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [X] I added CHANGELOG entry for this change.
* [ ] No user-facing changes, so no entry in CHANGELOG was needed.

This PR adds an option to CMO config map to activate bodysize limit on metrics scraping, which can prevent potential OOM problems when scraping metric endpoints responding with an oversized HTTP body.

The dependency upgrade PR is PR #1468 . This functionality requires Prometheus-Operator 0.51+. So I upgrade it to 0.52.

Here is the [JIRA ticket](https://issues.redhat.com/browse/MON-1838).

FIeld prometheusK8s.enforcedBodySizeLimit to CMO ConfigMap, accepting the size format from Prometheus:
 - Empty value and 0 mean no limit 
 - string "automatic" for automatically set the limit according the cluster pod capacity.
 -  [0-9]+[A-Z][a-z]*B for a customized size.