### PR TITLE
MON-1261: exposing topology spread constraints through config

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -168,17 +168,18 @@ type RemoteWriteSpec struct {
 }
 
 type PrometheusK8sConfig struct {
-	LogLevel            string                               `json:"logLevel"`
-	Retention           string                               `json:"retention"`
-	NodeSelector        map[string]string                    `json:"nodeSelector"`
-	Tolerations         []v1.Toleration                      `json:"tolerations"`
-	Resources           *v1.ResourceRequirements             `json:"resources"`
-	ExternalLabels      map[string]string                    `json:"externalLabels"`
-	VolumeClaimTemplate *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
-	RemoteWrite         []RemoteWriteSpec                    `json:"remoteWrite"`
-	TelemetryMatches    []string                             `json:"-"`
-	AlertmanagerConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
-	QueryLogFile        string                               `json:"queryLogFile"`
+	LogLevel                  string                               `json:"logLevel"`
+	Retention                 string                               `json:"retention"`
+	NodeSelector              map[string]string                    `json:"nodeSelector"`
+	Tolerations               []v1.Toleration                      `json:"tolerations"`
+	Resources                 *v1.ResourceRequirements             `json:"resources"`
+	ExternalLabels            map[string]string                    `json:"externalLabels"`
+	VolumeClaimTemplate       *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+	RemoteWrite               []RemoteWriteSpec                    `json:"remoteWrite"`
+	TelemetryMatches          []string                             `json:"-"`
+	AlertmanagerConfigs       []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
+	QueryLogFile              string                               `json:"queryLogFile"`
+	TopologySpreadConstraints []v1.TopologySpreadConstraint        `json:"topologySpreadConstraints"`
 }
 
 type AdditionalAlertmanagerConfig struct {
@@ -213,12 +214,13 @@ type TLSConfig struct {
 }
 
 type AlertmanagerMainConfig struct {
-	Enabled             *bool                                `json:"enabled"`
-	LogLevel            string                               `json:"logLevel"`
-	NodeSelector        map[string]string                    `json:"nodeSelector"`
-	Tolerations         []v1.Toleration                      `json:"tolerations"`
-	Resources           *v1.ResourceRequirements             `json:"resources"`
-	VolumeClaimTemplate *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+	Enabled                   *bool                                `json:"enabled"`
+	LogLevel                  string                               `json:"logLevel"`
+	NodeSelector              map[string]string                    `json:"nodeSelector"`
+	Tolerations               []v1.Toleration                      `json:"tolerations"`
+	Resources                 *v1.ResourceRequirements             `json:"resources"`
+	VolumeClaimTemplate       *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+	TopologySpreadConstraints []v1.TopologySpreadConstraint        `json:"topologySpreadConstraints"`
 }
 
 func (a AlertmanagerMainConfig) IsEnabled() bool {
@@ -226,12 +228,13 @@ func (a AlertmanagerMainConfig) IsEnabled() bool {
 }
 
 type ThanosRulerConfig struct {
-	LogLevel             string                               `json:"logLevel"`
-	NodeSelector         map[string]string                    `json:"nodeSelector"`
-	Tolerations          []v1.Toleration                      `json:"tolerations"`
-	Resources            *v1.ResourceRequirements             `json:"resources"`
-	VolumeClaimTemplate  *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
-	AlertmanagersConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
+	LogLevel                  string                               `json:"logLevel"`
+	NodeSelector              map[string]string                    `json:"nodeSelector"`
+	Tolerations               []v1.Toleration                      `json:"tolerations"`
+	Resources                 *v1.ResourceRequirements             `json:"resources"`
+	VolumeClaimTemplate       *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+	AlertmanagersConfigs      []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
+	TopologySpreadConstraints []v1.TopologySpreadConstraint        `json:"topologySpreadConstraints"`
 }
 
 type ThanosQuerierConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -473,6 +473,11 @@ func (f *Factory) AlertmanagerMain(host string, trustedCABundleCM *v1.ConfigMap)
 		a.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Tolerations
 	}
 
+	if len(f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.TopologySpreadConstraints) > 0 {
+		a.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.TopologySpreadConstraints
+	}
+
 	for i, c := range a.Spec.Containers {
 		switch c.Name {
 		case "alertmanager-proxy":
@@ -1367,6 +1372,11 @@ func (f *Factory) PrometheusK8s(host string, grpcTLS *v1.Secret, trustedCABundle
 
 	if len(f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Tolerations) > 0 {
 		p.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Tolerations
+	}
+
+	if len(f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.TopologySpreadConstraints) > 0 {
+		p.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.TopologySpreadConstraints
 	}
 
 	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels != nil {
@@ -3625,6 +3635,10 @@ func (f *Factory) ThanosRulerCustomResource(
 
 	if f.config.UserWorkloadConfiguration.ThanosRuler.NodeSelector != nil {
 		t.Spec.NodeSelector = f.config.UserWorkloadConfiguration.ThanosRuler.NodeSelector
+	}
+
+	if f.config.UserWorkloadConfiguration.ThanosRuler.TopologySpreadConstraints != nil {
+		t.Spec.TopologySpreadConstraints = f.config.UserWorkloadConfiguration.ThanosRuler.TopologySpreadConstraints
 	}
 
 	if len(f.config.UserWorkloadConfiguration.ThanosRuler.Tolerations) > 0 {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1024,6 +1024,13 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
       resources:
         requests:
           storage: 15Gi
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar
   resources:
     limits:
       cpu: 200m
@@ -1150,6 +1157,14 @@ ingress:
 	}
 	if p.Spec.Tolerations[0].Operator != "Exists" {
 		t.Fatal("Prometheus toleration effect not configured correctly")
+	}
+
+	if p.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Prometheus topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if p.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Prometheus topology spread contraints WhenUnsatisfiable not configured correctly")
 	}
 
 	if p.Spec.ExternalLabels["datacenter"] != "eu-west" {
@@ -1846,6 +1861,13 @@ func TestAlertmanagerMainConfiguration(t *testing.T) {
   tolerations:
   - effect: PreferNoSchedule
     operator: Exists
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar
   resources:
     limits:
       cpu: 20m
@@ -1915,6 +1937,14 @@ ingress:
 	}
 	if a.Spec.Tolerations[0].Operator != "Exists" {
 		t.Fatal("Prometheus toleration effect not configured correctly")
+	}
+
+	if a.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Alertmanager main topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if a.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Alertmanager main topology spread contraints WhenUnsatisfiable not configured correctly")
 	}
 
 	storageRequest := a.Spec.Storage.VolumeClaimTemplate.Spec.Resources.Requests[v1.ResourceStorage]
@@ -2429,6 +2459,16 @@ func TestTelemeterConfiguration(t *testing.T) {
 
 func TestThanosRulerConfiguration(t *testing.T) {
 	c, err := NewConfigFromString(``)
+	uwc, err := NewUserConfigFromString(`thanosRuler:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar`)
+
+	c.UserWorkloadConfiguration = uwc
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2454,6 +2494,14 @@ func TestThanosRulerConfiguration(t *testing.T) {
 			}
 		}
 	}
+	if tr.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Thanos ruler topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if tr.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Thanos ruler topology spread contraints WhenUnsatisfiable not configured correctly")
+	}
+
 }
 
 func TestNonHighlyAvailableInfrastructure(t *testing.T) {


### PR DESCRIPTION
This PR exposes the [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) through the CMO config. 

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
