### PR TITLE
MON-1872: Use kube-thanos jsonnet libs for thanos ruler

### DIFF
--- a/assets/thanos-ruler/service-account.yaml
+++ b/assets/thanos-ruler/service-account.yaml
@@ -3,5 +3,11 @@ kind: ServiceAccount
 metadata:
   annotations:
     serviceaccounts.openshift.io/oauth-redirectreference.thanos-ruler: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"thanos-ruler"}}'
+  labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: thanos-ruler
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.22.0
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring

--- a/assets/thanos-ruler/service-monitor.yaml
+++ b/assets/thanos-ruler/service-monitor.yaml
@@ -2,7 +2,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/name: thanos-ruler
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: thanos-ruler
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.22.0
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:
@@ -18,4 +22,7 @@ spec:
       serverName: server-name-replaced-at-runtime
   selector:
     matchLabels:
-      app.kubernetes.io/name: user-workload
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: thanos-ruler
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/thanos-ruler/service.yaml
+++ b/assets/thanos-ruler/service.yaml
@@ -4,7 +4,11 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: thanos-ruler-tls
   labels:
-    app.kubernetes.io/name: user-workload
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: thanos-ruler
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.22.0
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -1,495 +1,485 @@
-// TODO(paulfantom): This should use upstream kube-thanos project.
 local generateCertInjection = import '../utils/generate-certificate-injection.libsonnet';
+local ruler = import 'github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-rule.libsonnet';
 
-function(params) {
-  local cfg = params,
+local defaults = {
+  volumeClaimTemplate: {},
+  serviceMonitor: true,
+};
 
-  mixin:: (import 'github.com/thanos-io/thanos/mixin/alerts/rule.libsonnet') {
-    targetGroups: {},
-    rule+:: {
-      selector: 'job="thanos-ruler"',
-    },
-  },
+function(params)
+  local cfg = defaults + params;
+  local tr = ruler(cfg);
 
-  thanosRulerPrometheusRule: {
-    apiVersion: 'monitoring.coreos.com/v1',
-    kind: 'PrometheusRule',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-    },
-    spec: $.mixin.prometheusAlerts,
-  },
-
-  trustedCaBundle: generateCertInjection.trustedCNOCaBundleCM(cfg.namespace, 'thanos-ruler-trusted-ca-bundle'),
-
-  route: {
-    apiVersion: 'v1',
-    kind: 'Route',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-    },
-    spec: {
-      to: {
-        kind: 'Service',
-        name: 'thanos-ruler',
-      },
-      port: {
-        targetPort: 'web',
-      },
-      tls: {
-        termination: 'Reencrypt',
-        insecureEdgeTerminationPolicy: 'Redirect',
+  tr {
+    mixin:: (import 'github.com/thanos-io/thanos/mixin/alerts/rule.libsonnet') {
+      targetGroups: {},
+      rule+:: {
+        selector: 'job="thanos-ruler"',
       },
     },
-  },
 
-  clusterRole: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'ClusterRole',
-    metadata: {
-      name: 'thanos-ruler',
+    thanosRulerPrometheusRule: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'PrometheusRule',
+      metadata: {
+        name: tr.config.name,
+        namespace: tr.config.namespace,
+      },
+      spec: $.mixin.prometheusAlerts,
     },
-    rules: [
-      {
-        apiGroups: ['authentication.k8s.io'],
-        resources: ['tokenreviews'],
-        verbs: ['create'],
-      },
-      {
-        apiGroups: ['authorization.k8s.io'],
-        resources: ['subjectaccessreviews'],
-        verbs: ['create'],
-      },
-      {
-        apiGroups: ['security.openshift.io'],
-        resourceNames: ['nonroot'],
-        resources: ['securitycontextconstraints'],
-        verbs: ['use'],
-      },
-    ],
-  },
 
-  clusterRoleBinding: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'ClusterRoleBinding',
-    metadata: {
-      name: 'thanos-ruler',
+    trustedCaBundle: generateCertInjection.trustedCNOCaBundleCM(cfg.namespace, 'thanos-ruler-trusted-ca-bundle'),
+
+    route: {
+      apiVersion: 'v1',
+      kind: 'Route',
+      metadata: {
+        name: tr.config.name,
+        namespace: tr.config.namespace,
+      },
+      spec: {
+        to: {
+          kind: 'Service',
+          name: tr.config.name,
+        },
+        port: {
+          targetPort: 'web',
+        },
+        tls: {
+          termination: 'Reencrypt',
+          insecureEdgeTerminationPolicy: 'Redirect',
+        },
+      },
     },
-    roleRef: {
-      apiGroup: 'rbac.authorization.k8s.io',
+
+    clusterRole: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
       kind: 'ClusterRole',
-      name: 'thanos-ruler',
+      metadata: {
+        name: tr.config.name,
+      },
+      rules: [
+        {
+          apiGroups: ['authentication.k8s.io'],
+          resources: ['tokenreviews'],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['authorization.k8s.io'],
+          resources: ['subjectaccessreviews'],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['security.openshift.io'],
+          resourceNames: ['nonroot'],
+          resources: ['securitycontextconstraints'],
+          verbs: ['use'],
+        },
+      ],
     },
-    subjects: [{
-      kind: 'ServiceAccount',
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-    }],
-  },
 
-  clusterRoleBindingMonitoring: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'ClusterRoleBinding',
-    metadata: {
-      name: 'thanos-ruler-monitoring',
+    clusterRoleBinding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: tr.config.name,
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: tr.config.name,
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: tr.config.name,
+        namespace: cfg.namespace,
+      }],
     },
-    roleRef: {
-      apiGroup: 'rbac.authorization.k8s.io',
-      kind: 'ClusterRole',
-      name: 'cluster-monitoring-view',
-    },
-    subjects: [{
-      kind: 'ServiceAccount',
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-    }],
-  },
 
-  alertmanagerRoleBinding: {
-    apiVersion: 'rbac.authorization.k8s.io/v1',
-    kind: 'RoleBinding',
-    metadata: {
-      name: 'alertmanager-thanos-ruler',
-      namespace: 'openshift-monitoring',
+    clusterRoleBindingMonitoring: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: 'thanos-ruler-monitoring',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'cluster-monitoring-view',
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: tr.config.name,
+        namespace: tr.config.namespace,
+      }],
     },
-    roleRef: {
-      apiGroup: 'rbac.authorization.k8s.io',
-      kind: 'Role',
-      name: 'monitoring-alertmanager-edit',
-    },
-    subjects: [{
-      kind: 'ServiceAccount',
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-    }],
-  },
 
-  grpcTlsSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-grpc-tls',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
+    alertmanagerRoleBinding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'RoleBinding',
+      metadata: {
+        name: 'alertmanager-thanos-ruler',
+        namespace: 'openshift-monitoring',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'monitoring-alertmanager-edit',
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: tr.config.name,
+        namespace: tr.config.namespace,
+      }],
+    },
+
+    grpcTlsSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-grpc-tls',
+        namespace: tr.config.namespace,
+        labels: {
+          'app.kubernetes.io/name': tr.config.name,
+        },
+      },
+      type: 'Opaque',
+      data: {},
+    },
+
+    // holds the secret which is used encrypt/decrypt cookies
+    // issued by the oauth proxy.
+    oauthCookieSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-oauth-cookie',
+        namespace: tr.config.namespace,
+        labels: {
+          'app.kubernetes.io/name': tr.config.name,
+        },
+      },
+      type: 'Opaque',
+      data: {},
+    },
+
+    // holds the htpasswd configuration
+    // which includes a static secret used to authenticate/authorize
+    // requests originating from grafana.
+    oauthHtpasswdSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-oauth-htpasswd',
+        namespace: tr.config.namespace,
+        labels: {
+          'app.kubernetes.io/name': tr.config.name,
+        },
+      },
+      type: 'Opaque',
+      data: {},
+    },
+
+    // alertmanager config holds the http configuration
+    // for communication between thanos ruler and alertmanager.
+    alertmanagersConfigSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-alertmanagers-config',
+        namespace: tr.config.namespace,
+        labels: {
+          'app.kubernetes.io/name': tr.config.name,
+        },
+      },
+      type: 'Opaque',
+      data: {},
+      stringData: {
+        'alertmanagers.yaml': std.manifestYamlDoc({
+          alertmanagers: [{
+            http_config: {
+              bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+              tls_config: {
+                ca_file: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+                server_name: 'alertmanager-main.openshift-monitoring.svc',
+              },
+            },
+            static_configs: ['dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc'],
+            scheme: 'https',
+            api_version: 'v2',
+          }],
+        }),
       },
     },
-    type: 'Opaque',
-    data: {},
-  },
 
-  // holds the secret which is used encrypt/decrypt cookies
-  // issued by the oauth proxy.
-  oauthCookieSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-oauth-cookie',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
+    // query config which holds http configuration
+    // for communication between thanos ruler and thanos querier.
+    queryConfigSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'thanos-ruler-query-config',
+        namespace: tr.config.namespace,
+        labels: {
+          'app.kubernetes.io/name': tr.config.name,
+        },
       },
-    },
-    type: 'Opaque',
-    data: {},
-  },
-
-  // holds the htpasswd configuration
-  // which includes a static secret used to authenticate/authorize
-  // requests originating from grafana.
-  oauthHtpasswdSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-oauth-htpasswd',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
-      },
-    },
-    type: 'Opaque',
-    data: {},
-  },
-
-  // alertmanager config holds the http configuration
-  // for communication between thanos ruler and alertmanager.
-  alertmanagersConfigSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-alertmanagers-config',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
-      },
-    },
-    type: 'Opaque',
-    data: {},
-    stringData: {
-      'alertmanagers.yaml': std.manifestYamlDoc({
-        alertmanagers: [{
+      type: 'Opaque',
+      data: {},
+      stringData: {
+        'query.yaml': std.manifestYamlDoc([{
           http_config: {
             bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
             tls_config: {
               ca_file: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-              server_name: 'alertmanager-main.openshift-monitoring.svc',
+              server_name: 'thanos-querier.openshift-monitoring.svc',
             },
           },
-          static_configs: ['dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc'],
+          static_configs: ['thanos-querier.openshift-monitoring.svc:9091'],
           scheme: 'https',
-          api_version: 'v2',
+        }]),
+      },
+    },
+
+    serviceAccount+: {
+      metadata+: {
+        annotations: {
+          'serviceaccounts.openshift.io/oauth-redirectreference.thanos-ruler': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"thanos-ruler"}}',
+        },
+      },
+    },
+
+    service+: {
+      metadata+: {
+        annotations: {
+          'service.beta.openshift.io/serving-cert-secret-name': 'thanos-ruler-tls',
+        },
+      },
+      spec+: {
+        ports: [{
+          name: 'web',
+          port: 9091,
+          targetPort: 'web',
+        }, {
+          name: 'grpc',
+          port: 10901,
+          targetPort: 'grpc',
         }],
-      }),
-    },
-  },
-
-  // query config which holds http configuration
-  // for communication between thanos ruler and thanos querier.
-  queryConfigSecret: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      name: 'thanos-ruler-query-config',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
-      },
-    },
-    type: 'Opaque',
-    data: {},
-    stringData: {
-      'query.yaml': std.manifestYamlDoc([{
-        http_config: {
-          bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-          tls_config: {
-            ca_file: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-            server_name: 'thanos-querier.openshift-monitoring.svc',
-          },
+        selector: {
+          'app.kubernetes.io/name': tr.config.name,
+          'thanos-ruler': 'user-workload',
         },
-        static_configs: ['thanos-querier.openshift-monitoring.svc:9091'],
-        scheme: 'https',
-      }]),
+        sessionAffinity: 'ClientIP',
+        type: 'ClusterIP',
+        clusterIP:: {},
+      },
     },
-  },
 
-  serviceAccount: {
-    apiVersion: 'v1',
-    kind: 'ServiceAccount',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-      annotations: {
-        'serviceaccounts.openshift.io/oauth-redirectreference.thanos-ruler': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"thanos-ruler"}}',
-      },
-    },
-  },
-
-  service: {
-    apiVersion: 'v1',
-    kind: 'Service',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-      annotations: {
-        'service.beta.openshift.io/serving-cert-secret-name': 'thanos-ruler-tls',
-      },
-      labels: cfg.labels,
-    },
-    spec: {
-      ports: [{
-        name: 'web',
-        port: 9091,
-        targetPort: 'web',
-      }, {
-        name: 'grpc',
-        port: 10901,
-        targetPort: 'grpc',
-      }],
-      selector: cfg.selectorLabels,
-      sessionAffinity: 'ClientIP',
-      type: 'ClusterIP',
-    },
-  },
-
-  serviceMonitor: {
-    apiVersion: 'monitoring.coreos.com/v1',
-    kind: 'ServiceMonitor',
-    metadata: {
-      name: 'thanos-ruler',
-      namespace: cfg.namespace,
-      labels: {
-        'app.kubernetes.io/name': 'thanos-ruler',
-      },
-    },
-    spec: {
-      selector: {
-        matchLabels: cfg.labels,
-      },
-      endpoints: [
-        {
-          port: 'web',
-          interval: '30s',
-          scheme: 'https',
-          tlsConfig: {
-            caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-            serverName: 'server-name-replaced-at-runtime',
-            certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
-            keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
-          },
-          bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-        },
-      ],
-    },
-  },
-
-  thanosRuler: {
-    apiVersion: 'monitoring.coreos.com/v1',
-    kind: 'ThanosRuler',
-    metadata: {
-      name: cfg.name,
-      namespace: cfg.namespace,
-      labels: {
-        thanosRulerName: cfg.name,
-      },
-    },
-    spec: {
-      affinity: {
-        podAntiAffinity: {
-          requiredDuringSchedulingIgnoredDuringExecution: [{
-            labelSelector: {
-              matchLabels: cfg.selectorLabels,
-            },
-            namespaces: [cfg.namespace],
-            topologyKey: 'kubernetes.io/hostname',
-          }],
-        },
-      },
-      securityContext: {
-        fsGroup: 65534,
-        runAsNonRoot: true,
-        runAsUser: 65534,
-      },
-      replicas: cfg.replicas,
-      resources: {
-        requests: {
-          memory: '21Mi',
-          cpu: '1m',
-        },
-      },
-      image: cfg.image,
-      grpcServerTlsConfig: {
-        certFile: '/etc/tls/grpc/server.crt',
-        keyFile: '/etc/tls/grpc/server.key',
-        caFile: '/etc/tls/grpc/ca.crt',
-      },
-      alertmanagersConfig: {
-        key: 'alertmanagers.yaml',
-        name: 'thanos-ruler-alertmanagers-config',
-      },
-      queryConfig: {
-        key: 'query.yaml',
-        name: 'thanos-ruler-query-config',
-      },
-      enforcedNamespaceLabel: 'namespace',
-      listenLocal: true,
-      ruleSelector: {
-        matchExpressions:
-          [
+    serviceMonitor+:
+      {
+        spec+: {
+          endpoints: [
             {
-              key: 'openshift.io/prometheus-rule-evaluation-scope',
-              operator: 'NotIn',
-              values: ['leaf-prometheus'],
-            },
-          ],
-      },
-      ruleNamespaceSelector: cfg.namespaceSelector,
-      volumes: [
-        generateCertInjection.SCOCaBundleVolume('serving-certs-ca-bundle'),
-        {
-          name: 'secret-thanos-ruler-tls',
-          secret: {
-            secretName: 'thanos-ruler-tls',
-          },
-        },
-        {
-          name: 'secret-thanos-ruler-oauth-cookie',
-          secret: {
-            secretName: $.oauthCookieSecret.metadata.name,
-          },
-        },
-        {
-          name: 'secret-thanos-ruler-oauth-htpasswd',
-          secret: {
-            secretName: $.oauthHtpasswdSecret.metadata.name,
-          },
-        },
-      ],
-      serviceAccountName: 'thanos-ruler',
-      priorityClassName: 'openshift-user-critical',
-      containers: [
-        {
-          // Note: this is performing strategic-merge-patch for thanos-ruler container.
-          // Remainder of the container configuration is managed by prometheus-operator based on $.thanosRuler.spec
-          name: 'thanos-ruler',
-          terminationMessagePolicy: 'FallbackToLogsOnError',
-          volumeMounts: [
-            {
-              mountPath: '/etc/tls/private',
-              name: 'secret-thanos-ruler-tls',
-            },
-            {
-              mountPath: '/etc/tls/grpc',
-              name: 'secret-grpc-tls',
-            },
-            {
-              mountPath: '/etc/prometheus/configmaps/serving-certs-ca-bundle',
-              name: 'serving-certs-ca-bundle',
+              port: 'web',
+              interval: '30s',
+              scheme: 'https',
+              tlsConfig: {
+                caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+                serverName: 'server-name-replaced-at-runtime',
+                certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+                keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
+              },
+              bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
             },
           ],
         },
-        {
-          name: 'thanos-ruler-proxy',
-          image: 'quay.io/openshift/oauth-proxy:latest',  //FIXME(paulfantom)
-          ports: [{
-            containerPort: $.service.spec.ports[0].port,
-            name: 'web',
-          }],
-          env: [
-            { name: 'HTTP_PROXY', value: '' },
-            { name: 'HTTPS_PROXY', value: '' },
-            { name: 'NO_PROXY', value: '' },
-          ],
-          args: [
-            '-provider=openshift',
-            '-https-address=:9091',
-            '-http-address=',
-            '-email-domain=*',
-            '-upstream=http://localhost:10902',
-            '-openshift-sar={"resource": "namespaces", "verb": "get"}',
-            '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}',
-            '-tls-cert=/etc/tls/private/tls.crt',
-            '-tls-key=/etc/tls/private/tls.key',
-            '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token',
-            '-cookie-secret-file=/etc/proxy/secrets/session_secret',
-            '-openshift-service-account=thanos-ruler',
-            '-openshift-ca=/etc/pki/tls/cert.pem',
-            '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-          ],
-          terminationMessagePolicy: 'FallbackToLogsOnError',
-          resources: {
-            requests: {
-              cpu: '1m',
-              memory: '12Mi',
-            },
-          },
-          volumeMounts: [
-            {
-              mountPath: '/etc/tls/private',
-              name: 'secret-thanos-ruler-tls',
-            },
-            {
-              mountPath: '/etc/proxy/secrets',
-              name: 'secret-thanos-ruler-oauth-cookie',
-            },
-          ],
+      },
+
+
+    thanosRuler: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ThanosRuler',
+      metadata: {
+        name: cfg.crName,
+        namespace: tr.config.namespace,
+        labels: {
+          thanosRulerName: cfg.crName,
         },
-        {
-          // Note: this is performing strategic-merge-patch for config-reloader container.
-          // Remainder of the container configuration is managed by prometheus-operator based on $.thanosRuler.spec
-          name: 'config-reloader',
-          resources: {
-            requests: {
-              cpu: '1m',
-              memory: '10Mi',
-            },
+      },
+      spec: {
+        affinity: {
+          podAntiAffinity: {
+            requiredDuringSchedulingIgnoredDuringExecution: [{
+              labelSelector: {
+                matchLabels: cfg.selectorLabels,
+              },
+              namespaces: [cfg.namespace],
+              topologyKey: 'kubernetes.io/hostname',
+            }],
           },
         },
-      ],
-    },
-  },
-
-  podDisruptionBudget: {
-    apiVersion: 'policy/v1',
-    kind: 'PodDisruptionBudget',
-    metadata: {
-      name: 'thanos-ruler-' + cfg.name,
-      namespace: cfg.namespace,
-      labels: {
-        thanosRulerName: cfg.name,
+        securityContext: {
+          fsGroup: 65534,
+          runAsNonRoot: true,
+          runAsUser: 65534,
+        },
+        replicas: cfg.replicas,
+        resources: {
+          requests: {
+            memory: '21Mi',
+            cpu: '1m',
+          },
+        },
+        image: cfg.image,
+        grpcServerTlsConfig: {
+          certFile: '/etc/tls/grpc/server.crt',
+          keyFile: '/etc/tls/grpc/server.key',
+          caFile: '/etc/tls/grpc/ca.crt',
+        },
+        alertmanagersConfig: {
+          key: 'alertmanagers.yaml',
+          name: 'thanos-ruler-alertmanagers-config',
+        },
+        queryConfig: {
+          key: 'query.yaml',
+          name: 'thanos-ruler-query-config',
+        },
+        enforcedNamespaceLabel: 'namespace',
+        listenLocal: true,
+        ruleSelector: {
+          matchExpressions:
+            [
+              {
+                key: 'openshift.io/prometheus-rule-evaluation-scope',
+                operator: 'NotIn',
+                values: ['leaf-prometheus'],
+              },
+            ],
+        },
+        ruleNamespaceSelector: cfg.namespaceSelector,
+        volumes: [
+          generateCertInjection.SCOCaBundleVolume('serving-certs-ca-bundle'),
+          {
+            name: 'secret-thanos-ruler-tls',
+            secret: {
+              secretName: 'thanos-ruler-tls',
+            },
+          },
+          {
+            name: 'secret-thanos-ruler-oauth-cookie',
+            secret: {
+              secretName: $.oauthCookieSecret.metadata.name,
+            },
+          },
+          {
+            name: 'secret-thanos-ruler-oauth-htpasswd',
+            secret: {
+              secretName: $.oauthHtpasswdSecret.metadata.name,
+            },
+          },
+        ],
+        serviceAccountName: tr.config.name,
+        priorityClassName: 'openshift-user-critical',
+        containers: [
+          {
+            // Note: this is performing strategic-merge-patch for thanos-ruler container.
+            // Remainder of the container configuration is managed by prometheus-operator based on $.thanosRuler.spec
+            name: tr.config.name,
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+            volumeMounts: [
+              {
+                mountPath: '/etc/tls/private',
+                name: 'secret-thanos-ruler-tls',
+              },
+              {
+                mountPath: '/etc/tls/grpc',
+                name: 'secret-grpc-tls',
+              },
+              {
+                mountPath: '/etc/prometheus/configmaps/serving-certs-ca-bundle',
+                name: 'serving-certs-ca-bundle',
+              },
+            ],
+          },
+          {
+            name: 'thanos-ruler-proxy',
+            image: 'quay.io/openshift/oauth-proxy:latest',  //FIXME(paulfantom)
+            ports: [{
+              containerPort: $.service.spec.ports[0].port,
+              name: 'web',
+            }],
+            env: [
+              { name: 'HTTP_PROXY', value: '' },
+              { name: 'HTTPS_PROXY', value: '' },
+              { name: 'NO_PROXY', value: '' },
+            ],
+            args: [
+              '-provider=openshift',
+              '-https-address=:9091',
+              '-http-address=',
+              '-email-domain=*',
+              '-upstream=http://localhost:10902',
+              '-openshift-sar={"resource": "namespaces", "verb": "get"}',
+              '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}',
+              '-tls-cert=/etc/tls/private/tls.crt',
+              '-tls-key=/etc/tls/private/tls.key',
+              '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token',
+              '-cookie-secret-file=/etc/proxy/secrets/session_secret',
+              '-openshift-service-account=thanos-ruler',
+              '-openshift-ca=/etc/pki/tls/cert.pem',
+              '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+            ],
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+            resources: {
+              requests: {
+                cpu: '1m',
+                memory: '12Mi',
+              },
+            },
+            volumeMounts: [
+              {
+                mountPath: '/etc/tls/private',
+                name: 'secret-thanos-ruler-tls',
+              },
+              {
+                mountPath: '/etc/proxy/secrets',
+                name: 'secret-thanos-ruler-oauth-cookie',
+              },
+            ],
+          },
+          {
+            // Note: this is performing strategic-merge-patch for config-reloader container.
+            // Remainder of the container configuration is managed by prometheus-operator based on $.thanosRuler.spec
+            name: 'config-reloader',
+            resources: {
+              requests: {
+                cpu: '1m',
+                memory: '10Mi',
+              },
+            },
+          },
+        ],
       },
     },
-    spec: {
-      minAvailable: 1,
-      selector: {
-        matchLabels: cfg.selectorLabels,
+
+    podDisruptionBudget: {
+      apiVersion: 'policy/v1',
+      kind: 'PodDisruptionBudget',
+      metadata: {
+        name: 'thanos-ruler-' + cfg.crName,
+        namespace: cfg.namespace,
+        labels: {
+          thanosRulerName: cfg.crName,
+        },
+      },
+      spec: {
+        minAvailable: 1,
+        selector: {
+          matchLabels: cfg.selectorLabels,
+        },
       },
     },
-  },
 
-  // statefulSet from kube-thanos is not needed because thanosruler custom resource
-  // is used instead.
-  //statefulSet:: {},
+    statefulSet:: {},
 
-}
+  }

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -284,17 +284,16 @@ local inCluster =
         version: $.values.common.versions.thanos,
       },
       thanosRuler: $.values.thanos {
-        name: 'user-workload',
+        name: 'thanos-ruler',
+        crName: 'user-workload',
         namespace: $.values.common.namespaceUserWorkload,
         replicas: 2,
-        labels: {
-          'app.kubernetes.io/name': 'user-workload',
-        },
         selectorLabels: {
           'app.kubernetes.io/name': 'thanos-ruler',
           'thanos-ruler': 'user-workload',
         },
         namespaceSelector: $.values.common.userWorkloadMonitoringNamespaceSelector,
+        commonLabels+: $.values.common.commonLabels,
       },
       thanosQuerier: $.values.thanos {
         name: 'thanos-querier',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
