### PR TITLE
Fix TestUserWorkloadMonitoringAlerting for Prometheus Operator v0.52

### DIFF
--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -804,7 +804,6 @@ func assertTenancyForRules(t *testing.T) {
 		}
 
 		type testData struct {
-			file      string
 			ruleType  string
 			name      string
 			namespace string
@@ -812,19 +811,16 @@ func assertTenancyForRules(t *testing.T) {
 
 		expected := []testData{
 			{
-				file:      "/etc/prometheus/rules/prometheus-user-workload-rulefiles-0/user-workload-test-prometheus-example-rule-leaf.yaml",
 				ruleType:  "recording",
 				name:      "version:blah:leaf:count",
 				namespace: "user-workload-test",
 			},
 			{
-				file:      "/etc/thanos/rules/thanos-ruler-user-workload-rulefiles-0/user-workload-test-prometheus-example-rule.yaml",
 				ruleType:  "alerting",
 				name:      "VersionAlert",
 				namespace: "user-workload-test",
 			},
 			{
-				file:      "/etc/thanos/rules/thanos-ruler-user-workload-rulefiles-0/user-workload-test-prometheus-example-rule.yaml",
 				ruleType:  "recording",
 				name:      "version:blah:count",
 				namespace: "user-workload-test",
@@ -846,7 +842,6 @@ func assertTenancyForRules(t *testing.T) {
 				}
 
 				got = append(got, testData{
-					file:      group.Path("file").Data().(string),
 					ruleType:  rule.Path("type").Data().(string),
 					name:      rule.Path("name").Data().(string),
 					namespace: labels["namespace"].Data().(string),


### PR DESCRIPTION
Prometheus Operator version 0.52 has a new feature to append a postfix to the rule file name to avoid name collision. This breaks the E2E test [TestUserWorkloadMonitoringAlerting ](https://github.com/openshift/cluster-monitoring-operator/blob/4ecf1715bf3f572edb1c424cf3185f37719521fe/test/e2e/user_workload_monitoring_test.go#L733)which assumes rule file without this postfix.

This PR update that test so it can pass after upgrading Prometheus Operator to version 0.52.

rule file name before 0.52: ` /etc/prometheus/rules/prometheus-user-workload-rulefiles-0/user-workload-test-prometheus-example-rule-leaf.yaml`
rule file name after 0.52: `/etc/prometheus/rules/prometheus-user-workload-rulefiles-0/user-workload-test-prometheus-example-rule-leaf-f4c6359f-9510-4c1d-9b44-5aa014b3aacd.yaml`

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
