### PR TITLE
test/e2e: fix assertTenancyForLabels test

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -209,7 +209,7 @@ func TestAlertmanagerKubeRbacProxy(t *testing.T) {
 	t.Cleanup(func() {
 		resp, err := clients["editor"].Do("DELETE", fmt.Sprintf("/api/v2/silence/%s", silID), sil)
 		if err != nil || resp.Status != "200" {
-			t.Logf("failed to delete silence HTTP: %q err: %q", resp.Status, err)
+			t.Logf("failed to delete silence HTTP: %q err: %v", resp.Status, err)
 		}
 	})
 

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -575,13 +575,19 @@ func assertUserWorkloadRules(t *testing.T) {
 func assertTenancyForMetrics(t *testing.T) {
 	const testAccount = "test-metrics"
 
-	_, err := f.CreateServiceAccount(userWorkloadTestNs, testAccount)
+	err := framework.Poll(2*time.Second, 10*time.Second, func() error {
+		_, err := f.CreateServiceAccount(userWorkloadTestNs, testAccount)
+		return err
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Grant enough permissions to the account so it can read metrics.
-	_, err = f.CreateRoleBindingFromClusterRole(userWorkloadTestNs, testAccount, "admin")
+	err = framework.Poll(2*time.Second, 10*time.Second, func() error {
+		_, err = f.CreateRoleBindingFromClusterRole(userWorkloadTestNs, testAccount, "admin")
+		return err
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -893,50 +899,51 @@ func assertTenancyForRules(t *testing.T) {
 func assertTenancyForLabels(t *testing.T) {
 	const testAccount = "test-labels"
 
-	_, err := f.CreateServiceAccount(userWorkloadTestNs, testAccount)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Grant enough permissions to read labels.
-	_, err = f.CreateRoleBindingFromClusterRole(userWorkloadTestNs, testAccount, "admin")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var token string
-	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		token, err = f.GetServiceAccountToken(userWorkloadTestNs, testAccount)
-		if err != nil {
-			return err
-		}
-		return nil
+	err := framework.Poll(2*time.Second, 10*time.Second, func() error {
+		_, err := f.CreateServiceAccount(userWorkloadTestNs, testAccount)
+		return err
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// The tenancy port (9092) is only exposed in-cluster so we need to use
-	// port forwarding to access kube-rbac-proxy.
-	host, cleanUp, err := f.ForwardPort(t, "thanos-querier", 9092)
+	// Grant enough permissions to read labels.
+	err = framework.Poll(2*time.Second, 10*time.Second, func() error {
+		_, err = f.CreateRoleBindingFromClusterRole(userWorkloadTestNs, testAccount, "admin")
+		return err
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cleanUp()
 
-	client := framework.NewPrometheusClient(
-		host,
-		token,
-		&framework.QueryParameterInjector{
-			Name:  "namespace",
-			Value: userWorkloadTestNs,
-		},
-	)
-
-	t.Logf("Checking all labels")
+	var token string
+	err = framework.Poll(5*time.Second, time.Minute, func() error {
+		token, err = f.GetServiceAccountToken(userWorkloadTestNs, testAccount)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// check /api/v1/labels endpoint
 	err = framework.Poll(5*time.Second, time.Minute, func() error {
+		// The tenancy port (9092) is only exposed in-cluster so we need to use
+		// port forwarding to access kube-rbac-proxy.
+		host, cleanUp, err := f.ForwardPort(t, "thanos-querier", 9092)
+		if err != nil {
+			return err
+		}
+		defer cleanUp()
+
+		client := framework.NewPrometheusClient(
+			host,
+			token,
+			&framework.QueryParameterInjector{
+				Name:  "namespace",
+				Value: userWorkloadTestNs,
+			},
+		)
+
 		resp, err := client.Do("GET", "/api/v1/labels", nil)
 		if err != nil {
 			return err
@@ -962,31 +969,23 @@ func assertTenancyForLabels(t *testing.T) {
 			return err
 		}
 
-		for _, label := range labels {
-			t.Logf("label %q", label.Data().(string))
-		}
-
 		if len(labels) == 0 {
-			return errors.Errorf("expecting a label list with at least one item.")
+			return errors.Errorf("expecting a label list with at least one item, got zero")
 		}
 
 		return nil
-
 	})
 	if err != nil {
 		t.Fatalf("failed to query labels from Thanos querier: %v", err)
 	}
 
-	// check /api/v1/label/namespace/values has a single value
-	t.Logf("Checking Label namespace having a single value")
-	const label = "namespace"
-
+	// Check that /api/v1/label/namespace/values returns a single value.
 	err = framework.Poll(5*time.Second, time.Minute, func() error {
 		// The tenancy port (9092) is only exposed in-cluster so we need to use
 		// port forwarding to access kube-rbac-proxy.
 		host, cleanUp, err := f.ForwardPort(t, "thanos-querier", 9092)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
 		defer cleanUp()
 
@@ -999,7 +998,7 @@ func assertTenancyForLabels(t *testing.T) {
 			},
 		)
 
-		b, err := client.PrometheusLabel(label)
+		b, err := client.PrometheusLabel("namespace")
 		if err != nil {
 			return err
 		}
@@ -1015,16 +1014,18 @@ func assertTenancyForLabels(t *testing.T) {
 		}
 
 		if len(values) != 1 {
-			return errors.Errorf("expecting for label %q value list with exact one item.", label)
+			return errors.Errorf("expecting only 1 value for the 'namespace' label but got %d", len(values))
 		}
 
 		if values[0].Data().(string) != userWorkloadTestNs {
-			return errors.Errorf("expecting for label %q having value %q, but got %q .", label, userWorkloadTestNs, values[0].Data().(string))
+			return errors.Errorf("expecting 'namespace' label value to be %q but got %q .", userWorkloadTestNs, values[0].Data().(string))
 		}
 
 		return nil
 	})
-
+	if err != nil {
+		t.Fatalf("failed to query namespace label from Thanos querier: %v", err)
+	}
 }
 
 func assertGRPCTLSRotation(t *testing.T) {


### PR DESCRIPTION
The test didn't check the last returned error.


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
