### PR TITLE
Bug 2016435: Removing one of the AlertmanagerClusterFailedToSendAlerts alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1446](https://github.com/openshift/cluster-monitoring-operator/pull/1446) Bump Grafana version to 7.5.11
 - [#1439](https://github.com/openshift/cluster-monitoring-operator/pull/1439) Expose PodDisruptionBudget labels from kube-state-metrics metrics.
 - [#1377](https://github.com/openshift/cluster-monitoring-operator/pull/1377) Allow OpenShift users to configure audit logs for prometheus-adapter
+- [#1481](https://github.com/openshift/cluster-monitoring-operator/pull/1481) Removing one of the AlertmanagerClusterFailedToSendAlerts alerts
 
 ## 4.9
 

--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -75,23 +75,6 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: AlertmanagerClusterFailedToSendAlerts
-      annotations:
-        description: The minimum notification failure rate to {{ $labels.integration
-          }} sent from any instance in the {{$labels.job}} cluster is {{ $value |
-          humanizePercentage }}.
-        summary: All Alertmanager instances in a cluster failed to send notifications
-          to a non-critical integration.
-      expr: |
-        min by (namespace,service, integration) (
-          rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="openshift-monitoring", integration!~`.*`}[5m])
-        /
-          rate(alertmanager_notifications_total{job="alertmanager-main",namespace="openshift-monitoring", integration!~`.*`}[5m])
-        )
-        > 0.01
-      for: 5m
-      labels:
-        severity: warning
     - alert: AlertmanagerConfigInconsistent
       annotations:
         description: Alertmanager instances within the {{$labels.job}} cluster have

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -21,6 +21,7 @@ local excludedRules = [
     name: 'alertmanager.rules',
     rules: [
       { alert: 'AlertmanagerClusterCrashlooping' },
+      { alert: 'AlertmanagerClusterFailedToSendAlerts', severity: 'warning' },
     ],
   },
   {
@@ -368,6 +369,8 @@ local removeRunbookUrl(rule) = rule {
 local patchOrExcludeRule(rule, ruleSet, operation) =
   if std.length(ruleSet) == 0 then
     [rule]
+  else if ('severity' in ruleSet[0] && !std.startsWith(rule.labels.severity, ruleSet[0].severity)) then
+    [] + patchOrExcludeRule(rule, ruleSet[1:], operation)
   else if (('alert' in rule && 'alert' in ruleSet[0]) && std.startsWith(rule.alert, ruleSet[0].alert)) ||
           (('record' in rule && 'record' in ruleSet[0]) && std.startsWith(rule.record, ruleSet[0].record)) then
     if operation == 'patch' then


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
