### PR TITLE
MON-1659: adding relatedObjects to cluster operator manifest

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_06-clusteroperator.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_06-clusteroperator.yaml
@@ -11,3 +11,31 @@ status:
   versions:
   - name: operator
     version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: ''
+      name: openshift-monitoring
+      resource: namespaces
+    - group: ''
+      name: openshift-user-workload-monitoring
+      resource: namespaces
+    - group: monitoring.coreos.com
+      name: ''
+      resource: servicemonitors
+    - group: monitoring.coreos.com
+      name: ''
+      resource: podmonitors
+    - group: monitoring.coreos.com
+      name: ''
+      resource: prometheusrules
+    - group: monitoring.coreos.com
+      name: ''
+      resource: alertmanagers
+    - group: monitoring.coreos.com
+      name: ''
+      resource: prometheuses
+    - group: monitoring.coreos.com
+      name: ''
+      resource: thanosrulers
+    - group: monitoring.coreos.com
+      name: ''
+      resource: alertmanagerconfigs


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
