### PR TITLE
Bug 1955489: enable hard-anti affinity and PDB for Alertmanager

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -23,17 +23,6 @@ spec:
         - openshift-monitoring
         topologyKey: kubernetes.io/hostname
   containers:
-  - name: alertmanager
-    startupProbe:
-      exec:
-        command:
-        - sh
-        - -c
-        - exec curl http://localhost:9093/-/ready
-      initialDelaySeconds: 20
-      periodSeconds: 1
-      successThreshold: 1
-      timeoutSeconds: 3
   - args:
     - -provider=openshift
     - -https-address=:9095

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -12,19 +12,28 @@ metadata:
 spec:
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: alert-router
-              app.kubernetes.io/instance: main
-              app.kubernetes.io/name: alertmanager
-              app.kubernetes.io/part-of: openshift-monitoring
-          namespaces:
-          - openshift-monitoring
-          topologyKey: kubernetes.io/hostname
-        weight: 100
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: alert-router
+            app.kubernetes.io/instance: main
+            app.kubernetes.io/name: alertmanager
+            app.kubernetes.io/part-of: openshift-monitoring
+        namespaces:
+        - openshift-monitoring
+        topologyKey: kubernetes.io/hostname
   containers:
+  - name: alertmanager
+    startupProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - exec curl http://localhost:9093/-/ready
+      initialDelaySeconds: 20
+      periodSeconds: 1
+      successThreshold: 1
+      timeoutSeconds: 3
   - args:
     - -provider=openshift
     - -https-address=:9095
@@ -150,7 +159,7 @@ spec:
       app.kubernetes.io/part-of: openshift-monitoring
       app.kubernetes.io/version: 0.22.2
   priorityClassName: system-cluster-critical
-  replicas: 3
+  replicas: 2
   resources:
     requests:
       cpu: 4m

--- a/assets/alertmanager/pod-disruption-budget.yaml
+++ b/assets/alertmanager/pod-disruption-budget.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.22.2
+  name: alertmanager-main
+  namespace: openshift-monitoring
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -230,30 +230,6 @@ function(params)
         },
         containers: [
           {
-            name: 'alertmanager',
-            // Configure a startup probe to ensure that the Alertmanager
-            // container has time to replicate data from other peers before
-            // declaring itself as ready. This allows silences and
-            // notifications to be preserved on roll-outs even if persistent
-            // storage isn't configured.
-            // We assume that 20 seconds is enough for a full synchronization
-            // (this is twice the time Alertmanager waits before declaring that
-            // it can start sending notfications).
-            startupProbe: {
-              exec: {
-                command: [
-                  'sh',
-                  '-c',
-                  'exec curl http://localhost:9093/-/ready',
-                ],
-              },
-              timeoutSeconds: 3,
-              periodSeconds: 1,
-              successThreshold: 1,
-              initialDelaySeconds: 20,
-            },
-          },
-          {
             name: 'alertmanager-proxy',
             image: 'quay.io/openshift/oauth-proxy:latest',  //FIXME(paulfantom)
             ports: [

--- a/jsonnet/utils/anti-affinity.libsonnet
+++ b/jsonnet/utils/anti-affinity.libsonnet
@@ -2,6 +2,9 @@ local addon = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kub
 
 addon {
   values+:: {
+    alertmanager+:: {
+      podAntiAffinity: 'hard',
+    },
     prometheus+: {
       podAntiAffinity: 'hard',
     },

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -464,6 +464,34 @@ func (f *Factory) AlertmanagerMain(host string, trustedCABundleCM *v1.ConfigMap)
 		a.Spec.Storage = &monv1.StorageSpec{
 			VolumeClaimTemplate: *f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.VolumeClaimTemplate,
 		}
+	} else if f.infrastructure.HighlyAvailableInfrastructure() {
+		// When no persistent storage is configured, add a startup probe to
+		// ensure that the Alertmanager container has time to replicate data
+		// from other peers before declaring itself as ready. This allows
+		// silences and notifications to be preserved on roll-outs. We assume
+		// that 20 seconds is enough for a full synchronization (this is twice
+		// the time Alertmanager waits before declaring that it can start
+		// sending notfications).
+		a.Spec.Containers = append(a.Spec.Containers,
+			v1.Container{
+				Name: "alertmanager",
+				StartupProbe: &v1.Probe{
+					Handler: v1.Handler{
+						Exec: &v1.ExecAction{
+							Command: []string{
+								"sh",
+								"-c",
+								"exec curl http://localhost:9093/-/ready",
+							},
+						},
+					},
+					InitialDelaySeconds: 20,
+					PeriodSeconds:       1,
+					SuccessThreshold:    1,
+					TimeoutSeconds:      3,
+				},
+			},
+		)
 	}
 
 	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.NodeSelector != nil {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -69,6 +69,7 @@ var (
 	AlertmanagerServiceMonitor        = "alertmanager/service-monitor.yaml"
 	AlertmanagerTrustedCABundle       = "alertmanager/trusted-ca-bundle.yaml"
 	AlertmanagerPrometheusRule        = "alertmanager/prometheus-rule.yaml"
+	AlertmanagerPodDisruptionBudget   = "alertmanager/pod-disruption-budget.yaml"
 
 	KubeStateMetricsClusterRoleBinding  = "kube-state-metrics/cluster-role-binding.yaml"
 	KubeStateMetricsClusterRole         = "kube-state-metrics/cluster-role.yaml"
@@ -553,6 +554,10 @@ func (f *Factory) KubeStateMetricsClusterRoleBinding() (*rbacv1.ClusterRoleBindi
 	crb.Subjects[0].Namespace = f.namespace
 
 	return crb, nil
+}
+
+func (f *Factory) AlertmanagerPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {
+	return f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(AlertmanagerPodDisruptionBudget))
 }
 
 func (f *Factory) KubeStateMetricsClusterRole() (*rbacv1.ClusterRole, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2590,6 +2590,20 @@ func TestPodDisruptionBudget(t *testing.T) {
 			ha: false,
 		},
 		{
+			name: "Alertmanager HA",
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
+				return f.AlertmanagerPodDisruptionBudget()
+			},
+			ha: true,
+		},
+		{
+			name: "Alertmanager non-HA",
+			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
+				return f.AlertmanagerPodDisruptionBudget()
+			},
+			ha: false,
+		},
+		{
 			name: "PrometheusAdapter HA",
 			getPDB: func(f *Factory) (*policyv1.PodDisruptionBudget, error) {
 				return f.PrometheusAdapterPodDisruptionBudget()

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -74,6 +74,18 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "creating Alertmanager configuration Secret failed")
 	}
 
+	pdb, err := t.factory.AlertmanagerPodDisruptionBudget()
+	if err != nil {
+		return errors.Wrap(err, "initializing Alertmanager PodDisruptionBudget object failed")
+	}
+
+	if pdb != nil {
+		err = t.client.CreateOrUpdatePodDisruptionBudget(ctx, pdb)
+		if err != nil {
+			return errors.Wrap(err, "reconciling Alertmanager PodDisruptionBudget object failed")
+		}
+	}
+
 	rs, err := t.factory.AlertmanagerRBACProxySecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing Alertmanager RBAC proxy Secret failed")
@@ -290,6 +302,18 @@ func (t *AlertmanagerTask) destroy(ctx context.Context) error {
 	err = t.client.DeleteService(ctx, svc)
 	if err != nil {
 		return errors.Wrap(err, "deleting Alertmanager Service failed")
+	}
+
+	pdb, err := t.factory.AlertmanagerPodDisruptionBudget()
+	if err != nil {
+		return errors.Wrap(err, "initializing Alertmanager PodDisruptionBudget object failed")
+	}
+
+	if pdb != nil {
+		err = t.client.DeletePodDisruptionBudget(ctx, pdb)
+		if err != nil {
+			return errors.Wrap(err, "deleting Alertmanager PodDisruptionBudget object failed")
+		}
 	}
 
 	{

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -272,9 +272,9 @@ func TestUserWorkloadMonitoringWithAdditionalAlertmanagerConfigs(t *testing.T) {
 	f.AssertStatefulSetExistsAndRollout("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
 
 	scenarios := []scenario{
-		{"assert 5 alertmanagers are discovered (3 built-in and 2 from the additional configs)", assertAlertmanagerInstancesDiscovered(5)},
+		{"assert 4 alertmanagers are discovered (2 built-in and 2 from the additional configs)", assertAlertmanagerInstancesDiscovered(4)},
 		{"disable additional alertmanagers", disableAdditionalAlertmanagerConfigs},
-		{"assert 3 alertmanagers are discovered", assertAlertmanagerInstancesDiscovered(3)},
+		{"assert 2 alertmanagers are discovered", assertAlertmanagerInstancesDiscovered(2)},
 	}
 
 	for _, scenario := range scenarios {

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -483,7 +483,7 @@ func assertUserWorkloadMetrics(t *testing.T) {
 	}
 
 	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		body, err := f.AlertmanagerClient.AlertmanagerQueryAlerts(
+		body, err := f.AlertmanagerClient.GetAlertmanagerAlerts(
 			"filter", `alertname="VersionAlert"`,
 			"active", "true",
 		)


### PR DESCRIPTION
This change introduces hard pod anti-affinity rules and pod disruption
budgets for Alertmanager to ensure the maximum availability for the
Alertmanager cluster in the event of nodes going down (either due to
upgrades or unexpected outages). The cluster monitoring operator updates
the `Upgradeable` condition to false when it detects that the pods
aren't correctly spread to ensure that an upgrade only happens in safe
configurations.

The change also decreases the number of Alertmanager replicas from 3 to
2 to be consistent with the other monitoring components as well as the
  HA conventions stating that in general OpenShift component should run
with a replica count of 2 [1]. In addition with 3 replicas, it is
impossible to enable hard anti-affinity on nodes since 2 worker nodes is
a supported deployment for OCP.

The initial idea of running 3 replicas was to guarantee the replication
of data (silences + notifications) during pod roll-outs even if the user
didn't configure persistent storage. However given that no pod
disruption budget were defined, there was no guarantee that Kubernetes
would always keep one Alertmanager pod running.  With hard anti-affinity
and PDB, we are now sure that at least one Alertmanager pod is kept
running. And we are also setting up a startup probe that waits for at
least 20 seconds meaning that Kubernetes should wait for about 20
seconds after a new Alertmanager pod is running before considering
rolling out the next one. This interval of time should be more than
enough for the new Alertmanager to synchronize its data from the older
peer.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
