### PR TITLE
Mon 1858: Enable silence KubePersistentVolumeFillingUp via PVC label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1373](https://github.com/openshift/cluster-monitoring-operator/pull/1373) Enable admins to toggle the [query_log_file](https://prometheus.io/docs/guides/query-log/#enable-the-query-log) setting for Prometheus.
 - [#1491](https://github.com/openshift/cluster-monitoring-operator/pull/1491) Rename alerts `AggregatedAPIErrors to KubeAggregatedAPIErrors` and `AggregatedAPIDown to KubeAggregatedAPIDown`.
 - [#1488](https://github.com/openshift/cluster-monitoring-operator/pull/1488) Removing the alert HighlyAvailableWorkloadIncorrectlySpread.
+- [#1858](https://github.com/openshift/cluster-monitoring-operator/pull/1858) Allow suppression of storage alerts via PersistentVolumeClaim label
 
 ## 4.9
 

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -340,7 +340,7 @@ spec:
         unless on(namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
         unless on(namespace, persistentvolumeclaim)
-        kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_excluded_from_alerts="true"} == 1
+        kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
       for: 1m
       labels:
         severity: critical
@@ -365,7 +365,7 @@ spec:
         unless on(namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
         unless on(namespace, persistentvolumeclaim)
-        kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_excluded_from_alerts="true"} == 1
+        kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
       for: 1h
       labels:
         severity: warning

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -333,6 +333,7 @@ local inCluster =
             namespaceSelector: $.values.common.mixinNamespaceSelector,
             cpuThrottlingSelector: $.values.common.mixinNamespaceSelector,
             kubeletPodLimit: 250,
+            pvExcludedSelector: 'label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"',
           },
         },
       },


### PR DESCRIPTION
https://issues.redhat.com/browse/MON-1858


This change allows an admin to add a label to a PVC to prevent `KubePersistentVolumeFillingUp` firing for certain workloads that consume an entire volume by default.

Pulls in https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/711


    This change allows us to ignore the KubePersistentVolumeFillingUp
    storage alerts by adding the label "alerts.k8s.io/KubePersistentVolumeFillingUp: disabled"
    to a PVC.

    The use case for this is that some workloads (kubevirt) request
    a PV that will by default be the exact size of the file (disk image),
    causing the alerts to fire, when the realtiy is, that the size
    of the data will never grow and the alert is obsolete.

    An operator can label accordingly in advance for these use cases.
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
