### PR TITLE
client: check all OwnerRefs on a service

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1127,7 +1127,7 @@ func (c *Client) CreateOrUpdateSecret(ctx context.Context, s *v1.Secret) error {
 	// name as the value.
 	// This means that service-ca-operator controls and populates the two
 	// data fields tls.crt and tls.key. We want to retain those on updates
-	// if they existing and are not empty.
+	// if they exist and are not empty.
 	if c.maybeHasServiceCAData(ctx, required) {
 		if v, ok := existing.Data["tls.crt"]; ok && len(v) > 0 {
 			required.Data["tls.crt"] = v
@@ -1150,7 +1150,7 @@ func (c *Client) maybeHasServiceCAData(ctx context.Context, s *v1.Secret) bool {
 		sclient := c.kclient.CoreV1().Services(s.GetNamespace())
 		svc, err := sclient.Get(ctx, owner.Name, metav1.GetOptions{})
 		if err != nil {
-			return false
+			continue
 		}
 		if secName, ok := svc.Annotations["service.beta.openshift.io/serving-cert-secret-name"]; ok && secName == s.Name {
 			return true


### PR DESCRIPTION
In maybeHasServiceCAData we shouldn't return false if a particular
owning Service can't be retrieved, but rather continue to loop throught
the OwnerReferences. There could be a valid one and if not the function
still returns false.

Followup to #1495 fixing one unlikely but potential bug and one comment typo.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>


* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
