### PR TITLE
fix test go-fmt for go 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ GOPROXY?=http://proxy.golang.org
 export GO111MODULE
 export GOPROXY
 
-PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test|/examples')
+# go pakages for unit tests, excluding e2e tests
+PKGS=$(shell go list ./... | grep -v /test/e2e)
 GOLANG_FILES:=$(shell find . -name \*.go -print)
 # NOTE: grep -v %.yaml is needed  because "%s-policy.yaml" is used
 # in manifest.go and that isn't a valid asset.
@@ -144,7 +145,7 @@ format: go-fmt shellcheck jsonnet-fmt check-rules
 
 .PHONY: go-fmt
 go-fmt:
-	go fmt $(PKGS)
+	go fmt ./...
 
 .PHONY: jsonnet-fmt
 jsonnet-fmt: $(JSONNETFMT_BIN)

--- a/hack/telemeter_query.go
+++ b/hack/telemeter_query.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 package main


### PR DESCRIPTION
This PR fix a failling test `ci/prow/go-fmt` caused by  `hack/telemeter_query.go:12` . Please refer to [this test log](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-monitoring-operator/1354/pull-ci-openshift-cluster-monitoring-operator-master-go-fmt/1465606982751752192) for an example.


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
