### PR TITLE
hack/local-cmo.sh: fix CVO override

### DIFF
--- a/hack/local-cmo.sh
+++ b/hack/local-cmo.sh
@@ -54,7 +54,7 @@ disable_managed_cmo(){
         "overrides": [
           [ .spec | .? | .overrides[] | .? | select(.name != "cluster-monitoring-operator")] +
           [{
-            "group": "apps/v1",
+            "group": "apps",
             "kind": "Deployment",
             "name": "cluster-monitoring-operator",
             "namespace": "openshift-monitoring",


### PR DESCRIPTION
Since [1] got merged, CVO checks that the manifest's group matches with
the override definition hence the `/v1` needs to be removed.

[1] https://github.com/openshift/cluster-version-operator/pull/689

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
