### PR TITLE
MON-1656: removing all the check tasks from other targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ update: $(JB_BIN)
 	cd jsonnet && $(JB_BIN) update $(COMPONENTS)
 
 .PHONY: generate
-generate: build-jsonnet docs check-assets check-runbooks
+generate: build-jsonnet docs
 
 .PHONY: verify
 verify: check-assets check-rules check-runbooks
@@ -140,7 +140,7 @@ Documentation/telemetry/telemeter_query: manifests/0000_50_cluster-monitoring-op
 ##############
 
 .PHONY: format
-format: go-fmt shellcheck jsonnet-fmt check-rules
+format: go-fmt shellcheck jsonnet-fmt
 
 .PHONY: go-fmt
 go-fmt:


### PR DESCRIPTION
[PR](https://github.com/openshift/cluster-monitoring-operator/pull/1492)  created a new target named verify in the MakeFile. which runs all the check tasks. It is now running as a part of every PR build. 

This PR removes the check tasks that were spread across multiple targets.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
