### PR TITLE
jsonnet: Add external labels to platform Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1481](https://github.com/openshift/cluster-monitoring-operator/pull/1481) Removing one of the AlertmanagerClusterFailedToSendAlerts alerts
 - [#1373](https://github.com/openshift/cluster-monitoring-operator/pull/1373) Enable admins to toggle the [query_log_file](https://prometheus.io/docs/guides/query-log/#enable-the-query-log) setting for Prometheus.
 - [#1491](https://github.com/openshift/cluster-monitoring-operator/pull/1491) Rename alerts `AggregatedAPIErrors to KubeAggregatedAPIErrors` and `AggregatedAPIDown to KubeAggregatedAPIDown`.
+- [#1505](https://github.com/openshift/cluster-monitoring-operator/pull/1505) Add external label `'openshift_io_alert_source': 'platform'` to platform Prometheus.
 
 ## 4.9
 

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -157,7 +157,8 @@ spec:
         cpu: 1m
         memory: 10Mi
   enableFeatures: []
-  externalLabels: {}
+  externalLabels:
+    openshift_io_alert_source: platform
   image: quay.io/prometheus/prometheus:v2.30.3
   listenLocal: true
   nodeSelector:

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -302,6 +302,7 @@ function(params)
         ruleNamespaceSelector: cfg.namespaceSelector,
         listenLocal: true,
         priorityClassName: 'system-cluster-critical',
+        externalLabels: cfg.externalLabels,
         containers: [
           {
             name: 'prometheus-proxy',

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -255,6 +255,9 @@ local inCluster =
         tlsCipherSuites: $.values.common.tlsCipherSuites,
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
         promLabelProxyImage: $.values.common.images.promLabelProxy,
+        externalLabels: {
+          openshift_io_alert_source: 'platform',
+        },
       },
       prometheusAdapter: {
         namespace: $.values.common.namespace,


### PR DESCRIPTION
See https://issues.redhat.com/browse/MON-2089

In order to effectively support multi-tenant, self-service alerting,
it is useful to allow identifying the source of the alert,
(i.e., platform vs UWM).

This change adds the external label 'openshift_io_alert_source': 'platform'
to platform monitoring Prometheus.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
