### PR TITLE
Bug 2027272: Humanize bytes value for KubeMemoryOvercommit

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -247,7 +247,7 @@ spec:
     - alert: KubeMemoryOvercommit
       annotations:
         description: Cluster has overcommitted memory resource requests for Pods by
-          {{ $value }} bytes and cannot tolerate node failure.
+          {{ $value | humanize }} bytes and cannot tolerate node failure.
         summary: Cluster has overcommitted memory resource requests.
       expr: |
         sum(namespace_memory:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -9165,13 +9165,31 @@ items:
                           "points": false,
                           "renderer": "flot",
                           "seriesOverrides": [
-
+                              {
+                                  "alias": "max capacity",
+                                  "color": "#F2495C",
+                                  "dashes": true,
+                                  "fill": 0,
+                                  "hiddenSeries": true,
+                                  "hideTooltip": true,
+                                  "legend": true,
+                                  "linewidth": 2,
+                                  "stack": false
+                              }
                           ],
                           "spaceLength": 10,
                           "span": 12,
                           "stack": true,
                           "steppedLine": false,
                           "targets": [
+                              {
+                                  "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
+                                  "format": "time_series",
+                                  "intervalFactor": 2,
+                                  "legendFormat": "max capacity",
+                                  "legendLink": null,
+                                  "step": 10
+                              },
                               {
                                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "time_series",
@@ -9542,13 +9560,31 @@ items:
                           "points": false,
                           "renderer": "flot",
                           "seriesOverrides": [
-
+                              {
+                                  "alias": "max capacity",
+                                  "color": "#F2495C",
+                                  "dashes": true,
+                                  "fill": 0,
+                                  "hiddenSeries": true,
+                                  "hideTooltip": true,
+                                  "legend": true,
+                                  "linewidth": 2,
+                                  "stack": false
+                              }
                           ],
                           "spaceLength": 10,
                           "span": 12,
                           "stack": true,
                           "steppedLine": false,
                           "targets": [
+                              {
+                                  "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"})",
+                                  "format": "time_series",
+                                  "intervalFactor": 2,
+                                  "legendFormat": "max capacity",
+                                  "legendLink": null,
+                                  "step": 10
+                              },
                               {
                                   "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
                                   "format": "time_series",

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -59,8 +59,8 @@
           "subdir": ""
         }
       },
-      "version": "ee732bc30e1a5bc8b45e436508b7685bb1109a28",
-      "sum": "TCe4Sctkv+i5/UzDy10Vda5s1Slt6EGzEES9Mi5kTko="
+      "version": "9821d07e94e9a9916575a234fb699ae3331fa939",
+      "sum": "xubNXyvDwUw9GZzi9BRb6ob3bYzfoMr5F5zCVn2d7ag="
     },
     {
       "source": {
@@ -121,8 +121,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "431b6626022416be1bf857b8fac2dde28706625a",
-      "sum": "tOVN46rCkCc580BrjBQq14UHWHn262Rh4TO/ZPr77v0="
+      "version": "6d013d4e4f980ba99cfdafa9432819d484e2f829",
+      "sum": "xaZABcBZUc4ci5mi3KtpSBLeUAxDDu8nqdAqxKxEsaM="
     },
     {
       "source": {

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -9173,13 +9173,31 @@ data:
                         "points": false,
                         "renderer": "flot",
                         "seriesOverrides": [
-
+                            {
+                                "alias": "max capacity",
+                                "color": "#F2495C",
+                                "dashes": true,
+                                "fill": 0,
+                                "hiddenSeries": true,
+                                "hideTooltip": true,
+                                "legend": true,
+                                "linewidth": 2,
+                                "stack": false
+                            }
                         ],
                         "spaceLength": 10,
                         "span": 12,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
+                            {
+                                "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "max capacity",
+                                "legendLink": null,
+                                "step": 10
+                            },
                             {
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "time_series",
@@ -9550,13 +9568,31 @@ data:
                         "points": false,
                         "renderer": "flot",
                         "seriesOverrides": [
-
+                            {
+                                "alias": "max capacity",
+                                "color": "#F2495C",
+                                "dashes": true,
+                                "fill": 0,
+                                "hiddenSeries": true,
+                                "hideTooltip": true,
+                                "legend": true,
+                                "linewidth": 2,
+                                "stack": false
+                            }
                         ],
                         "spaceLength": 10,
                         "span": 12,
                         "stack": true,
                         "steppedLine": false,
                         "targets": [
+                            {
+                                "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "max capacity",
+                                "legendLink": null,
+                                "step": 10
+                            },
                             {
                                 "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
                                 "format": "time_series",


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
