### PR TITLE
test/e2e/framework: retry configmap actions

### DIFF
--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -22,7 +22,10 @@ const (
 func (f *Framework) MustCreateOrUpdateConfigMap(t *testing.T, cm *v1.ConfigMap) {
 	t.Helper()
 	ensureCreatedByTestLabel(cm)
-	if err := f.OperatorClient.CreateOrUpdateConfigMap(ctx, cm); err != nil {
+	err := Poll(time.Second, 10*time.Second, func() error {
+		return f.OperatorClient.CreateOrUpdateConfigMap(ctx, cm)
+	})
+	if err != nil {
 		t.Fatalf("failed to create/update configmap - %s", err.Error())
 	}
 }
@@ -30,8 +33,11 @@ func (f *Framework) MustCreateOrUpdateConfigMap(t *testing.T, cm *v1.ConfigMap) 
 // MustDeleteConfigMap or fail the test
 func (f *Framework) MustDeleteConfigMap(t *testing.T, cm *v1.ConfigMap) {
 	t.Helper()
-	if err := f.OperatorClient.DeleteConfigMap(ctx, cm); err != nil {
-		t.Fatalf("failed to configmap configmap - %s", err.Error())
+	err := Poll(time.Second, 10*time.Second, func() error {
+		return f.OperatorClient.DeleteConfigMap(ctx, cm)
+	})
+	if err != nil {
+		t.Fatalf("failed to delete configmap - %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
