### PR TITLE
MON-2089: Ensure we can identify the source of alerts from Platform Prometheus

### DIFF
--- a/assets/prometheus-k8s/additional-alert-manager-relabelling-secret.yaml
+++ b/assets/prometheus-k8s/additional-alert-manager-relabelling-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: alert-relabel-configs
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    - "action": "replace"
+      "replacement": "platform"
+      "target_label": "openshift_io_alert_source"
+type: Opaque

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -10,6 +10,9 @@ metadata:
   name: k8s
   namespace: openshift-monitoring
 spec:
+  additionalAlertRelabelConfigs:
+    key: config.yaml
+    name: alert-relabel-configs
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -325,6 +325,7 @@ function(params)
         ruleNamespaceSelector: cfg.namespaceSelector,
         listenLocal: true,
         priorityClassName: 'system-cluster-critical',
+        additionalAlertRelabelConfigs: cfg.additionalRelabelConfigs,
         containers: [
           {
             name: 'prometheus-proxy',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -190,6 +190,29 @@ function(params)
 
     kubeRbacProxySecret: generateSecret.staticAuthSecret(cfg.namespace, cfg.commonLabels, 'kube-rbac-proxy'),
 
+    // this secret allows us to identify alerts that
+    // are coming from platform monitoring
+    additionalAlertManagerRelabellingSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'alert-relabel-configs',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
+      },
+      type: 'Opaque',
+      data: {},
+      stringData: {
+        'config.yaml': std.manifestYamlDoc([
+          {
+            target_label: 'openshift_io_alert_source',
+            action: 'replace',
+            replacement: 'platform',
+          },
+        ],),
+      },
+    },
+
     // This changes the Prometheuses to be scraped with TLS, authN and
     // authZ, which are not present in kube-prometheus.
 

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -255,6 +255,10 @@ local inCluster =
         tlsCipherSuites: $.values.common.tlsCipherSuites,
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
         promLabelProxyImage: $.values.common.images.promLabelProxy,
+        additionalRelabelConfigs: {
+          name: 'alert-relabel-configs',
+          key: 'config.yaml',
+        },
       },
       prometheusAdapter: {
         namespace: $.values.common.namespace,

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -98,31 +98,32 @@ var (
 	NodeExporterPrometheusRule             = "node-exporter/prometheus-rule.yaml"
 	NodeExporterKubeRbacProxySecret        = "node-exporter/kube-rbac-proxy-secret.yaml"
 
-	PrometheusK8sClusterRoleBinding          = "prometheus-k8s/cluster-role-binding.yaml"
-	PrometheusK8sRoleBindingConfig           = "prometheus-k8s/role-binding-config.yaml"
-	PrometheusK8sRoleBindingList             = "prometheus-k8s/role-binding-specific-namespaces.yaml"
-	PrometheusK8sClusterRole                 = "prometheus-k8s/cluster-role.yaml"
-	PrometheusK8sRoleConfig                  = "prometheus-k8s/role-config.yaml"
-	PrometheusK8sRoleList                    = "prometheus-k8s/role-specific-namespaces.yaml"
-	PrometheusK8sPrometheusRule              = "prometheus-k8s/prometheus-rule.yaml"
-	PrometheusK8sThanosSidecarPrometheusRule = "prometheus-k8s/prometheus-rule-thanos-sidecar.yaml"
-	PrometheusK8sServiceAccount              = "prometheus-k8s/service-account.yaml"
-	PrometheusK8s                            = "prometheus-k8s/prometheus.yaml"
-	PrometheusK8sPrometheusServiceMonitor    = "prometheus-k8s/service-monitor.yaml"
-	PrometheusK8sService                     = "prometheus-k8s/service.yaml"
-	PrometheusK8sServiceThanosSidecar        = "prometheus-k8s/service-thanos-sidecar.yaml"
-	PrometheusK8sProxySecret                 = "prometheus-k8s/proxy-secret.yaml"
-	PrometheusRBACProxySecret                = "prometheus-k8s/kube-rbac-proxy-secret.yaml"
-	PrometheusUserWorkloadRBACProxySecret    = "prometheus-user-workload/kube-rbac-proxy-secret.yaml"
-	PrometheusK8sRoute                       = "prometheus-k8s/route.yaml"
-	PrometheusK8sHtpasswd                    = "prometheus-k8s/htpasswd-secret.yaml"
-	PrometheusK8sServingCertsCABundle        = "prometheus-k8s/serving-certs-ca-bundle.yaml"
-	PrometheusK8sKubeletServingCABundle      = "prometheus-k8s/kubelet-serving-ca-bundle.yaml"
-	PrometheusK8sGrpcTLSSecret               = "prometheus-k8s/grpc-tls-secret.yaml"
-	PrometheusK8sTrustedCABundle             = "prometheus-k8s/trusted-ca-bundle.yaml"
-	PrometheusK8sThanosSidecarServiceMonitor = "prometheus-k8s/service-monitor-thanos-sidecar.yaml"
-	PrometheusK8sTAlertmanagerRoleBinding    = "prometheus-k8s/alertmanager-role-binding.yaml"
-	PrometheusK8sPodDisruptionBudget         = "prometheus-k8s/pod-disruption-budget.yaml"
+	PrometheusK8sClusterRoleBinding                   = "prometheus-k8s/cluster-role-binding.yaml"
+	PrometheusK8sRoleBindingConfig                    = "prometheus-k8s/role-binding-config.yaml"
+	PrometheusK8sRoleBindingList                      = "prometheus-k8s/role-binding-specific-namespaces.yaml"
+	PrometheusK8sClusterRole                          = "prometheus-k8s/cluster-role.yaml"
+	PrometheusK8sRoleConfig                           = "prometheus-k8s/role-config.yaml"
+	PrometheusK8sRoleList                             = "prometheus-k8s/role-specific-namespaces.yaml"
+	PrometheusK8sPrometheusRule                       = "prometheus-k8s/prometheus-rule.yaml"
+	PrometheusK8sThanosSidecarPrometheusRule          = "prometheus-k8s/prometheus-rule-thanos-sidecar.yaml"
+	PrometheusK8sServiceAccount                       = "prometheus-k8s/service-account.yaml"
+	PrometheusK8s                                     = "prometheus-k8s/prometheus.yaml"
+	PrometheusK8sPrometheusServiceMonitor             = "prometheus-k8s/service-monitor.yaml"
+	PrometheusK8sService                              = "prometheus-k8s/service.yaml"
+	PrometheusK8sServiceThanosSidecar                 = "prometheus-k8s/service-thanos-sidecar.yaml"
+	PrometheusK8sProxySecret                          = "prometheus-k8s/proxy-secret.yaml"
+	PrometheusRBACProxySecret                         = "prometheus-k8s/kube-rbac-proxy-secret.yaml"
+	PrometheusUserWorkloadRBACProxySecret             = "prometheus-user-workload/kube-rbac-proxy-secret.yaml"
+	PrometheusK8sRoute                                = "prometheus-k8s/route.yaml"
+	PrometheusK8sHtpasswd                             = "prometheus-k8s/htpasswd-secret.yaml"
+	PrometheusK8sServingCertsCABundle                 = "prometheus-k8s/serving-certs-ca-bundle.yaml"
+	PrometheusK8sKubeletServingCABundle               = "prometheus-k8s/kubelet-serving-ca-bundle.yaml"
+	PrometheusK8sGrpcTLSSecret                        = "prometheus-k8s/grpc-tls-secret.yaml"
+	PrometheusK8sTrustedCABundle                      = "prometheus-k8s/trusted-ca-bundle.yaml"
+	PrometheusK8sThanosSidecarServiceMonitor          = "prometheus-k8s/service-monitor-thanos-sidecar.yaml"
+	PrometheusK8sTAlertmanagerRoleBinding             = "prometheus-k8s/alertmanager-role-binding.yaml"
+	PrometheusK8sPodDisruptionBudget                  = "prometheus-k8s/pod-disruption-budget.yaml"
+	PrometheusK8sAdditionalAlertManagerRelabelConfigs = "prometheus-k8s/additional-alert-manager-relabelling-secret.yaml"
 
 	PrometheusUserWorkloadServingCertsCABundle        = "prometheus-user-workload/serving-certs-ca-bundle.yaml"
 	PrometheusUserWorkloadServiceAccount              = "prometheus-user-workload/service-account.yaml"
@@ -2353,6 +2354,16 @@ func (f *Factory) PrometheusK8sServiceThanosSidecar() (*v1.Service, error) {
 
 func (f *Factory) PrometheusK8sPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {
 	return f.NewPodDisruptionBudget(f.assets.MustNewAssetReader(PrometheusK8sPodDisruptionBudget))
+}
+
+func (f *Factory) PrometheusK8sAdditionalAlertRelabelConfigs() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetReader(PrometheusK8sAdditionalAlertManagerRelabelConfigs))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespace
+	return s, nil
 }
 
 func (f *Factory) PrometheusUserWorkloadPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -324,6 +324,20 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 	}
 
 	{
+		relabelConfigSecret, err := t.factory.PrometheusK8sAdditionalAlertRelabelConfigs()
+		if err != nil {
+			return errors.Wrap(err, "initializing Prometheus AdditionalAlertRelabelConfigs secret failed")
+		}
+
+		if relabelConfigSecret != nil {
+			err = t.client.CreateOrUpdateSecret(ctx, relabelConfigSecret)
+			if err != nil {
+				return errors.Wrap(err, "reconciling Prometheus AdditionalAlertRelabelConfigs secret failed")
+			}
+		}
+	}
+
+	{
 		// Create trusted CA bundle ConfigMap.
 		trustedCA, err := t.factory.PrometheusK8sTrustedCABundle()
 		if err != nil {


### PR DESCRIPTION
See https://issues.redhat.com/browse/MON-2089

In order to effectively support multi-tenant, self-service alerting,
it is useful to allow identifying the source of the alert,
(i.e., platform vs UWM).

This change adds the external label 'openshift_io_alert_source': 'platform'
to platform monitoring Prometheus.
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
