### PR TITLE
[MON-1950] Remove UI access from the Thanos routes

### DIFF
--- a/assets/thanos-querier/route.yaml
+++ b/assets/thanos-querier/route.yaml
@@ -10,6 +10,7 @@ metadata:
   name: thanos-querier
   namespace: openshift-monitoring
 spec:
+  path: /api
   port:
     targetPort: web
   tls:

--- a/assets/thanos-ruler/route.yaml
+++ b/assets/thanos-ruler/route.yaml
@@ -4,6 +4,7 @@ metadata:
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:
+  path: /api
   port:
     targetPort: web
   tls:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -37,6 +37,7 @@ function(params)
         labels: tq.config.commonLabels,
       },
       spec: {
+        path: '/api',
         to: {
           kind: 'Service',
           name: 'thanos-querier',

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -40,6 +40,9 @@ function(params)
         namespace: tr.config.namespace,
       },
       spec: {
+        // restrict to Thanos Rule API endpoint only
+        // ref: https://github.com/thanos-io/thanos/blob/v0.24.0/cmd/thanos/rule.go#L657
+        path: '/api',
         to: {
           kind: 'Service',
           name: tr.config.name,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
