### PR TITLE
manifests: Support thanos query requst logging via CM

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -235,10 +235,11 @@ type ThanosRulerConfig struct {
 }
 
 type ThanosQuerierConfig struct {
-	LogLevel     string                   `json:"logLevel"`
-	NodeSelector map[string]string        `json:"nodeSelector"`
-	Tolerations  []v1.Toleration          `json:"tolerations"`
-	Resources    *v1.ResourceRequirements `json:"resources"`
+	LogLevel             string                   `json:"logLevel"`
+	NodeSelector         map[string]string        `json:"nodeSelector"`
+	Tolerations          []v1.Toleration          `json:"tolerations"`
+	Resources            *v1.ResourceRequirements `json:"resources"`
+	EnableRequestLogging bool                     `json:"enableRequestLogging"`
 }
 
 type GrafanaConfig struct {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

This change allows an admin to configure request logging (in an opinionated fashion) for Thanos Querier via the `cluster-monitoring-config` CM. Using the following block:

```yaml
thanosQuerier:
  enableRequestLogging: true
```

The request logging config for Thanos is largely undocumented. There is a WIP PR [here](https://github.com/thanos-io/thanos/pull/4934)

Enabling this in CMO, by default will cause Thanos to emit logs at error level only. This can be tweaked via the preexisting `logLevel` flag for great verbosity:

```yaml
thanosQuerier:
  enableRequestLogging: true
  logLevel: debug
```


* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
