### PR TITLE
Bug 2015386: Enable PDB label metric

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         - --metric-denylist=kube_secret_labels,kube_*_annotations
-        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]
         - |
           --metric-denylist=
           kube_.+_created,

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -139,7 +139,8 @@ function(params)
                     c {
                       args+: [
                         '--metric-denylist=kube_secret_labels,kube_*_annotations',
-                        '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]',
+                        // TODO: Remove "poddisruptionbudget" once upstream KSM addresses a typo in PDB label metrics allowlist key.
+                        '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
Though PDB labels are already enabled, however it is not working yet due to a
typo bug in upstream KSM[2]. Usually allowlist resource name should be in
plural form, but incase of PDB KSM is using singular form of resource name
which is incorrect.

This commit is a workaround to enable PDB by passing singular form of
PDB resource name. This commit should be reverted once the upstream KSM
fixes the typo.

[1] https://github.com/openshift/cluster-monitoring-operator/pull/1439
[2] https://github.com/syncbot-io/kube-state-metrics/blob/b5e78331cc2bfb6896d20d077b7ba79c3f3e7f2d/internal/store/builder.go#L328

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
