### PR TITLE
Enable the /api/v1/series endpoint on the Thanos tenancy port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 4.10
 
 - [#1509](https://github.com/openshift/cluster-monitoring-operator/pull/1509) add NLB usage metrics for network edge
-- [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose expose /api/v1/labels endpoint for Thanos query.
+- [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose /api/v1/labels and /api/v1/labels/*/values endpoint on the Thanos query tenancy port.
+- [#1529](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose /api/v1/series endpoint on the Thanos query tenancy port.
 - [#1402](https://github.com/openshift/cluster-monitoring-operator/pull/1402) Drop pod-centric cAdvisor metrics that are available at slice level.
 - [#1399](https://github.com/openshift/cluster-monitoring-operator/pull/1399) Rename ThanosSidecarUnhealthy to ThanosSidecarNoConnectionToStartedPrometheus and make it resilient to WAL replays.
 - [#1446](https://github.com/openshift/cluster-monitoring-operator/pull/1446) Bump Grafana version to 7.5.11

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -141,7 +141,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
-        - --allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values
+        - --allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values,/api/v1/series
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -504,7 +504,13 @@ function(params)
                   '--tls-private-key-file=/etc/tls/private/tls.key',
                   '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                   '--logtostderr=true',
-                  '--allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values',
+                  '--allow-paths=' + std.join(',', [
+                    '/api/v1/query',
+                    '/api/v1/query_range',
+                    '/api/v1/labels',
+                    '/api/v1/label/*/values',
+                    '/api/v1/series',
+                  ]),
                 ],
                 terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -216,7 +216,7 @@ func (c *PrometheusClient) PrometheusRules() ([]byte, error) {
 	return body, nil
 }
 
-// PrometheusRules runs an HTTP GET request against the Prometheus label API and returns
+// PrometheusLabel runs an HTTP GET request against the Prometheus label API and returns
 // the response body.
 func (c *PrometheusClient) PrometheusLabel(label string) ([]byte, error) {
 	resp, err := c.Do("GET", fmt.Sprintf("/api/v1/label/%s/values", url.QueryEscape(label)), nil)


### PR DESCRIPTION
Follow-up of #1299
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
