### PR TITLE
Bug 2012426: Add namespace label for all thanos alerts

### DIFF
--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -15,42 +15,42 @@ spec:
     rules:
     - alert: ThanosQueryHttpRequestQueryErrorRateHigh
       annotations:
-        description: Thanos Query {{$labels.job}} is failing to handle {{$value |
-          humanize}}% of "query" requests.
+        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is failing
+          to handle {{$value | humanize}}% of "query" requests.
         summary: Thanos Query is failing to handle requests.
       expr: |
         (
-          sum by (job, namespace) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query"}[5m]))
+          sum by (namespace, job) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query"}[5m]))
         /
-          sum by (job, namespace) (rate(http_requests_total{job="thanos-querier", handler="query"}[5m]))
+          sum by (namespace, job) (rate(http_requests_total{job="thanos-querier", handler="query"}[5m]))
         ) * 100 > 5
       for: 1h
       labels:
         severity: warning
     - alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
       annotations:
-        description: Thanos Query {{$labels.job}} is failing to handle {{$value |
-          humanize}}% of "query_range" requests.
+        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is failing
+          to handle {{$value | humanize}}% of "query_range" requests.
         summary: Thanos Query is failing to handle requests.
       expr: |
         (
-          sum by (job, namespace) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query_range"}[5m]))
+          sum by (namespace, job) (rate(http_requests_total{code=~"5..", job="thanos-querier", handler="query_range"}[5m]))
         /
-          sum by (job, namespace) (rate(http_requests_total{job="thanos-querier", handler="query_range"}[5m]))
+          sum by (namespace, job) (rate(http_requests_total{job="thanos-querier", handler="query_range"}[5m]))
         ) * 100 > 5
       for: 1h
       labels:
         severity: warning
     - alert: ThanosQueryGrpcServerErrorRate
       annotations:
-        description: Thanos Query {{$labels.job}} is failing to handle {{$value |
-          humanize}}% of requests.
+        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is failing
+          to handle {{$value | humanize}}% of requests.
         summary: Thanos Query is failing to handle requests.
       expr: |
         (
-          sum by (job, namespace) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job="thanos-querier"}[5m]))
+          sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job="thanos-querier"}[5m]))
         /
-          sum by (job, namespace) (rate(grpc_server_started_total{job="thanos-querier"}[5m]))
+          sum by (namespace, job) (rate(grpc_server_started_total{job="thanos-querier"}[5m]))
         * 100 > 5
         )
       for: 1h
@@ -58,28 +58,28 @@ spec:
         severity: warning
     - alert: ThanosQueryGrpcClientErrorRate
       annotations:
-        description: Thanos Query {{$labels.job}} is failing to send {{$value | humanize}}%
-          of requests.
+        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} is failing
+          to send {{$value | humanize}}% of requests.
         summary: Thanos Query is failing to send requests.
       expr: |
         (
-          sum by (job, namespace) (rate(grpc_client_handled_total{grpc_code!="OK", job="thanos-querier"}[5m]))
+          sum by (namespace, job) (rate(grpc_client_handled_total{grpc_code!="OK", job="thanos-querier"}[5m]))
         /
-          sum by (job, namespace) (rate(grpc_client_started_total{job="thanos-querier"}[5m]))
+          sum by (namespace, job) (rate(grpc_client_started_total{job="thanos-querier"}[5m]))
         ) * 100 > 5
       for: 1h
       labels:
         severity: warning
     - alert: ThanosQueryHighDNSFailures
       annotations:
-        description: Thanos Query {{$labels.job}} have {{$value | humanize}}% of failing
-          DNS queries for store endpoints.
+        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} have {{$value
+          | humanize}}% of failing DNS queries for store endpoints.
         summary: Thanos Query is having high number of DNS failures.
       expr: |
         (
-          sum by (job, namespace) (rate(thanos_query_store_apis_dns_failures_total{job="thanos-querier"}[5m]))
+          sum by (namespace, job) (rate(thanos_query_store_apis_dns_failures_total{job="thanos-querier"}[5m]))
         /
-          sum by (job, namespace) (rate(thanos_query_store_apis_dns_lookups_total{job="thanos-querier"}[5m]))
+          sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{job="thanos-querier"}[5m]))
         ) * 100 > 1
       for: 1h
       labels:

--- a/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
+++ b/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
@@ -9,33 +9,35 @@ spec:
     rules:
     - alert: ThanosRuleQueueIsDroppingAlerts
       annotations:
-        description: Thanos Rule {{$labels.instance}} is failing to queue alerts.
+        description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}} is
+          failing to queue alerts.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ThanosRuleQueueIsDroppingAlerts.md
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0
       for: 5m
       labels:
         severity: critical
     - alert: ThanosRuleSenderIsFailingAlerts
       annotations:
-        description: Thanos Rule {{$labels.instance}} is failing to send alerts to
-          alertmanager.
+        description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}} is
+          failing to send alerts to alertmanager.
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job="thanos-ruler"}[5m])) > 0
       for: 5m
       labels:
         severity: warning
     - alert: ThanosRuleHighRuleEvaluationFailures
       annotations:
-        description: Thanos Rule {{$labels.instance}} is failing to evaluate rules.
+        description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}} is
+          failing to evaluate rules.
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (job, instance) (rate(prometheus_rule_evaluation_failures_total{job="thanos-ruler"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job="thanos-ruler"}[5m]))
         /
-          sum by (job, instance) (rate(prometheus_rule_evaluations_total{job="thanos-ruler"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job="thanos-ruler"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -43,38 +45,38 @@ spec:
         severity: warning
     - alert: ThanosRuleHighRuleEvaluationWarnings
       annotations:
-        description: Thanos Rule {{$labels.instance}} has high number of evaluation
-          warnings.
+        description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}} has
+          high number of evaluation warnings.
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job="thanos-ruler"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job="thanos-ruler"}[5m])) > 0
       for: 15m
       labels:
         severity: info
     - alert: ThanosRuleRuleEvaluationLatencyHigh
       annotations:
-        description: Thanos Rule {{$labels.instance}} has higher evaluation latency
-          than interval for {{$labels.rule_group}}.
+        description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}} has
+          higher evaluation latency than interval for {{$labels.rule_group}}.
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job="thanos-ruler"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job="thanos-ruler"})
         >
-          sum by (job, instance, rule_group) (prometheus_rule_group_interval_seconds{job="thanos-ruler"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job="thanos-ruler"})
         )
       for: 5m
       labels:
         severity: warning
     - alert: ThanosRuleGrpcErrorRate
       annotations:
-        description: Thanos Rule {{$labels.job}} is failing to handle {{$value | humanize}}%
-          of requests.
+        description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} is failing
+          to handle {{$value | humanize}}% of requests.
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job="thanos-ruler"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job="thanos-ruler"}[5m]))
         /
-          sum by (job, instance) (rate(grpc_server_started_total{job="thanos-ruler"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job="thanos-ruler"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -82,23 +84,24 @@ spec:
         severity: warning
     - alert: ThanosRuleConfigReloadFailure
       annotations:
-        description: Thanos Rule {{$labels.job}} has not been able to reload its configuration.
+        description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not
+          been able to reload its configuration.
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (job, instance) (thanos_rule_config_last_reload_successful{job="thanos-ruler"})
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job="thanos-ruler"})
         != 1
       for: 5m
       labels:
         severity: info
     - alert: ThanosRuleQueryHighDNSFailures
       annotations:
-        description: Thanos Rule {{$labels.job}} has {{$value | humanize}}% of failing
-          DNS queries for query endpoints.
+        description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has {{$value
+          | humanize}}% of failing DNS queries for query endpoints.
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job="thanos-ruler"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job="thanos-ruler"}[5m]))
         /
-          sum by (job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job="thanos-ruler"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job="thanos-ruler"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -106,14 +109,14 @@ spec:
         severity: warning
     - alert: ThanosRuleAlertmanagerHighDNSFailures
       annotations:
-        description: Thanos Rule {{$labels.instance}} has {{$value | humanize}}% of
-          failing DNS queries for Alertmanager endpoints.
+        description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}} has
+          {{$value | humanize}}% of failing DNS queries for Alertmanager endpoints.
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job="thanos-ruler"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job="thanos-ruler"}[5m]))
         /
-          sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job="thanos-ruler"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job="thanos-ruler"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -121,25 +124,26 @@ spec:
         severity: warning
     - alert: ThanosRuleNoEvaluationFor10Intervals
       annotations:
-        description: Thanos Rule {{$labels.job}} has {{$value | humanize}}% rule groups
-          that did not evaluate for at least 10x of their expected interval.
+        description: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has {{$value
+          | humanize}}% rule groups that did not evaluate for at least 10x of their
+          expected interval.
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job="thanos-ruler"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job="thanos-ruler"})
         >
-        10 * max by (job, instance, group) (prometheus_rule_group_interval_seconds{job="thanos-ruler"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job="thanos-ruler"})
       for: 5m
       labels:
         severity: info
     - alert: ThanosNoRuleEvaluations
       annotations:
-        description: Thanos Rule {{$labels.instance}} did not perform any rule evaluations
-          in the past 10 minutes.
+        description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}} did
+          not perform any rule evaluations in the past 10 minutes.
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (job, instance) (rate(prometheus_rule_evaluations_total{job="thanos-ruler"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job="thanos-ruler"}[5m])) <= 0
           and
-        sum by (job, instance) (thanos_rule_loaded_rules{job="thanos-ruler"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job="thanos-ruler"}) > 0
       for: 5m
       labels:
         severity: warning

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -7,12 +7,11 @@ function(params)
   local tq = querier(cfg);
   tq {
     mixin:: (import 'github.com/thanos-io/thanos/mixin/alerts/query.libsonnet') {
-      targetGroups: {},
+      targetGroups: {
+        namespace: cfg.namespace,
+      },
       query+:: {
         selector: 'job="thanos-querier"',
-        // All OpenShift alerts should include a namespace label.
-        // See: https://issues.redhat.com/browse/MON-939
-        dimensions: 'job, namespace',
       },
     },
 

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -12,7 +12,9 @@ function(params)
 
   tr {
     mixin:: (import 'github.com/thanos-io/thanos/mixin/alerts/rule.libsonnet') {
-      targetGroups: {},
+      targetGroups: {
+        namespace: tr.config.namespace,
+      },
       rule+:: {
         selector: 'job="thanos-ruler"',
       },


### PR DESCRIPTION
This PR adds namespace label through thanos `targetGroup` config
variable[1].

[1] https://github.com/thanos-io/thanos/blob/d1acaea2a11a3e4db6bb435c98dea63c517e3530/mixin/config.libsonnet#L7-L26

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.