### PR TITLE
Bug 2035046: Recover Platform CPU by Reducing the Kubelet ServiceMonitor Scrape Interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#1377](https://github.com/openshift/cluster-monitoring-operator/pull/1377) Allow OpenShift users to configure audit logs for prometheus-adapter
 - [#1481](https://github.com/openshift/cluster-monitoring-operator/pull/1481) Removing one of the AlertmanagerClusterFailedToSendAlerts alerts
 - [#1373](https://github.com/openshift/cluster-monitoring-operator/pull/1373) Enable admins to toggle the [query_log_file](https://prometheus.io/docs/guides/query-log/#enable-the-query-log) setting for Prometheus.
+- [#1528](https://github.com/openshift/cluster-monitoring-operator/pull/1528) Reduce Kubelet ServiceMonitor scrape interval via relabelling
 
 ## 4.9
 

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -94,6 +94,11 @@ spec:
       - container
     - action: labeldrop
       regex: __tmp_keep_metric
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+      - __meta_kubernetes_service_annotation_openshift_io_scrape_interval
+      targetLabel: __scrape_interval__
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -106,6 +106,13 @@ function(params)
                       action: 'labeldrop',
                       regex: '__tmp_keep_metric',
                     },
+                    // allow kubelet to dynamically change its scrape interval during runtime
+                    {
+                      action: 'replace',
+                      regex: '(.+)',
+                      sourceLabels: ['__meta_kubernetes_service_annotation_openshift_io_scrape_interval'],
+                      targetLabel: '__scrape_interval__'
+                    }
                   ],
                 }
               else


### PR DESCRIPTION
The change is required for core reduction in SNOs. 

Currently kubelet servicemonitor scrape interval is hard coded to 30 secs [here](https://github.com/openshift/cluster-monitoring-operator/blob/master/assets/control-plane/service-monitor-kubelet.yaml). With new Prometheus [feature](https://promlabs.com/blog/2021/09/14/whats-new-in-prometheus-2-30#controlling-scrape-intervals-and-timeouts-via-relabeling) we should able to change the value dynamically (preferably to 60 secs) and in-turn reduce CPU usage. Jira [link](https://issues.redhat.com/browse/CNF-2893)
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

- [x] I added CHANGELOG entry for this change.
- [ ] No user facing changes, so no entry in CHANGELOG was needed.