### PR TITLE
[MON-1630] Remove UI access to AlertManager

### DIFF
--- a/assets/alertmanager/route.yaml
+++ b/assets/alertmanager/route.yaml
@@ -4,6 +4,7 @@ metadata:
   name: alertmanager-main
   namespace: openshift-monitoring
 spec:
+  path: /api/v2
   port:
     targetPort: web
   tls:

--- a/assets/alertmanager/route.yaml
+++ b/assets/alertmanager/route.yaml
@@ -4,7 +4,7 @@ metadata:
   name: alertmanager-main
   namespace: openshift-monitoring
 spec:
-  path: /api/v2
+  path: /api
   port:
     targetPort: web
   tls:

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -22,6 +22,7 @@ function(params)
         namespace: cfg.namespace,
       },
       spec: {
+        path: '/api/v2',
         to: {
           kind: 'Service',
           name: 'alertmanager-main',

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -22,7 +22,7 @@ function(params)
         namespace: cfg.namespace,
       },
       spec: {
-        path: '/api/v2',
+        path: '/api',
         to: {
           kind: 'Service',
           name: 'alertmanager-main',

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -194,6 +194,11 @@ function(params) {
         verbs: ['get', 'update', 'create'],
       },
       {
+        apiGroups: ['config.openshift.io'],
+        resources: ['consoles'],
+        verbs: ['get', 'list', 'watch'],
+      },
+      {
         apiGroups: ['certificates.k8s.io'],
         resources: ['certificatesigningrequests'],
         verbs: ['create', 'get', 'list', 'watch', 'update', 'delete'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -105,6 +105,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - consoles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - certificates.k8s.io
   resources:
   - certificatesigningrequests

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -258,6 +258,19 @@ func (c *Client) ApiServersListWatchForResource(ctx context.Context, resource st
 	}
 }
 
+func (c *Client) ConsoleListWatch(ctx context.Context) *cache.ListWatch {
+	consoleInterface := c.oscclient.ConfigV1().Consoles()
+
+	return &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return consoleInterface.List(ctx, metav1.ListOptions{})
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return consoleInterface.Watch(ctx, options)
+		},
+	}
+}
+
 func (c *Client) AssurePrometheusOperatorCRsExist(ctx context.Context) error {
 	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		_, err := c.mclient.MonitoringV1().Prometheuses(c.namespace).List(ctx, metav1.ListOptions{})
@@ -370,6 +383,10 @@ func (c *Client) GetInfrastructure(ctx context.Context, name string) (*configv1.
 
 func (c *Client) GetAPIServerConfig(ctx context.Context, name string) (*configv1.APIServer, error) {
 	return c.oscclient.ConfigV1().APIServers().Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) GetConsoleConfig(ctx context.Context, name string) (*configv1.Console, error) {
+	return c.oscclient.ConfigV1().Consoles().Get(ctx, name, metav1.GetOptions{})
 }
 
 func (c *Client) GetConfigmap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/crypto"
 
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/cluster-monitoring-operator/pkg/promqlgen"
@@ -294,6 +295,7 @@ type Factory struct {
 	proxy                 ProxyReader
 	assets                *Assets
 	APIServerConfig       *APIServerConfig
+	consoleConfig         *configv1.Console
 }
 
 // InfrastructureReader has methods to describe the cluster infrastructure.
@@ -309,7 +311,7 @@ type ProxyReader interface {
 	NoProxy() string
 }
 
-func NewFactory(namespace, namespaceUserWorkload string, c *Config, infrastructure InfrastructureReader, proxy ProxyReader, a *Assets, apiServerConfig *APIServerConfig) *Factory {
+func NewFactory(namespace, namespaceUserWorkload string, c *Config, infrastructure InfrastructureReader, proxy ProxyReader, a *Assets, apiServerConfig *APIServerConfig, consoleConfig *configv1.Console) *Factory {
 	return &Factory{
 		namespace:             namespace,
 		namespaceUserWorkload: namespaceUserWorkload,
@@ -318,6 +320,7 @@ func NewFactory(namespace, namespaceUserWorkload string, c *Config, infrastructu
 		proxy:                 proxy,
 		assets:                a,
 		APIServerConfig:       apiServerConfig,
+		consoleConfig:         consoleConfig,
 	}
 }
 
@@ -443,7 +446,7 @@ func (f *Factory) injectProxyVariables(container *v1.Container) {
 	}
 }
 
-func (f *Factory) AlertmanagerMain(host string, trustedCABundleCM *v1.ConfigMap) (*monv1.Alertmanager, error) {
+func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Alertmanager, error) {
 	a, err := f.NewAlertmanager(f.assets.MustNewAssetReader(AlertmanagerMain))
 	if err != nil {
 		return nil, err
@@ -451,7 +454,9 @@ func (f *Factory) AlertmanagerMain(host string, trustedCABundleCM *v1.ConfigMap)
 
 	a.Spec.Image = &f.config.Images.Alertmanager
 
-	a.Spec.ExternalURL = f.AlertmanagerExternalURL(host).String()
+	if f.consoleConfig != nil {
+		a.Spec.ExternalURL = f.consoleConfig.Status.ConsoleURL + "/monitoring"
+	}
 
 	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.LogLevel != "" {
 		a.Spec.LogLevel = f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.LogLevel

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/crypto"
 
+	configv1 "github.com/openshift/api/config/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -133,7 +134,7 @@ func TestHashSecret(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 			s, err := f.HashSecret(tt.given, tt.data...)
 			if got := err != nil; got != tt.errExpected {
 				t.Errorf("expected error %t, got %t, err %v", tt.errExpected, got, err)
@@ -148,7 +149,7 @@ func TestHashSecret(t *testing.T) {
 }
 
 func TestUnconfiguredManifests(t *testing.T) {
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	_, err := f.AlertmanagerConfig()
 	if err != nil {
 		t.Fatal(err)
@@ -244,7 +245,7 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.AlertmanagerMain("alertmanager-main.openshift-monitoring.svc", nil)
+	_, err = f.AlertmanagerMain(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -730,7 +731,7 @@ func TestUnconfiguredManifests(t *testing.T) {
 }
 
 func TestSharingConfig(t *testing.T) {
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	u, err := url.Parse("http://example.com/")
 	if err != nil {
 		t.Fatal(err)
@@ -767,7 +768,7 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	d, err := f.PrometheusOperatorDeployment()
 	if err != nil {
 		t.Fatal(err)
@@ -987,7 +988,7 @@ func TestPrometheusK8sRemoteWrite(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := tc.config()
 
-			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 			p, err := f.PrometheusK8s(
 				"prometheus-k8s.openshift-monitoring.svc",
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
@@ -1050,7 +1051,7 @@ ingress:
 		"prom-label-proxy": "docker.io/openshift/origin-prom-label-proxy:latest",
 	})
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	p, err := f.PrometheusK8s(
 		"prometheus-k8s.openshift-monitoring.svc",
 		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
@@ -1229,7 +1230,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			config: `prometheusK8s:
   additionalAlertmanagerConfigs:
   - apiVersion: v2
-    scheme: https    
+    scheme: https
     bearerToken:
       name: alertmanager1-bearer-token
       key: token
@@ -1252,7 +1253,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			config: `prometheusK8s:
   additionalAlertmanagerConfigs:
   - apiVersion: v2
-    scheme: https    
+    scheme: https
     tlsConfig:
       ca:
         name: alertmanager-tls
@@ -1286,7 +1287,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			config: `prometheusK8s:
   additionalAlertmanagerConfigs:
   - apiVersion: v2
-    scheme: https    
+    scheme: https
     tlsConfig:
       ca:
         name: alertmanager-ca-tls
@@ -1365,7 +1366,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 			p, err := f.PrometheusK8s(
 				"prometheus-k8s.openshift-monitoring.svc",
@@ -1666,7 +1667,7 @@ alertmanagerMain:
 				t.Fatal(err)
 			}
 			c.UserWorkloadConfiguration = uwc
-			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 			s, err := f.ThanosRulerAlertmanagerConfigSecret()
 			if err != nil {
@@ -1762,7 +1763,7 @@ k8sPrometheusAdapter:
 
 			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring",
 				c, defaultInfrastructureReader(), &fakeProxyReader{},
-				NewAssets(assetsPath), &APIServerConfig{})
+				NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 			d, err := f.PrometheusAdapterDeployment("foo", map[string]string{
 				"requestheader-allowed-names":        "",
@@ -1817,7 +1818,7 @@ k8sPrometheusAdapter:
 		"k8s-prometheus-adapter": "docker.io/openshift/origin-k8s-prometheus-adapter:latest",
 	})
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	d, err := f.PrometheusAdapterDeployment("foo", map[string]string{
 		"requestheader-allowed-names":        "",
 		"requestheader-extra-headers-prefix": "",
@@ -1874,9 +1875,8 @@ func TestAlertmanagerMainStartupProbe(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, tc.infrastructure, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, tc.infrastructure, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 			a, err := f.AlertmanagerMain(
-				"alertmanager-main.openshift-monitoring.svc",
 				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			)
 			if err != nil {
@@ -1938,9 +1938,8 @@ ingress:
 		"alertmanager": "docker.io/openshift/origin-prometheus-alertmanager:latest",
 	})
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	a, err := f.AlertmanagerMain(
-		"alertmanager-main.openshift-monitoring.svc",
 		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 	)
 	if err != nil {
@@ -2036,7 +2035,7 @@ func TestNodeExporter(t *testing.T) {
 		"kube-rbac-proxy": "docker.io/openshift/origin-kube-rbac-proxy:latest",
 	})
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 	ds, err := f.NodeExporterDaemonSet()
 	if err != nil {
@@ -2095,7 +2094,7 @@ func TestKubeStateMetrics(t *testing.T) {
 		"kube-rbac-proxy":    "docker.io/openshift/origin-kube-rbac-proxy:latest",
 	})
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 	d, err := f.KubeStateMetricsDeployment()
 	if err != nil {
@@ -2154,7 +2153,7 @@ func TestOpenShiftStateMetrics(t *testing.T) {
 		"kube-rbac-proxy":         "docker.io/openshift/origin-kube-rbac-proxy:latest",
 	})
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 	d, err := f.OpenShiftStateMetricsDeployment()
 	if err != nil {
@@ -2231,7 +2230,7 @@ func TestPrometheusK8sControlPlaneRulesFiltered(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), tc.infrastructure, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), tc.infrastructure, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 		r, err := f.ControlPlanePrometheusRule()
 		if err != nil {
 			t.Fatal(err)
@@ -2251,7 +2250,7 @@ func TestEtcdGrafanaDashboardFiltered(t *testing.T) {
 	enabled := false
 	c := NewDefaultConfig()
 	c.ClusterMonitoringConfiguration.EtcdConfig.Enabled = &enabled
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 	cms, err := f.GrafanaDashboardDefinitions()
 	if err != nil {
@@ -2269,7 +2268,7 @@ func TestEtcdGrafanaDashboard(t *testing.T) {
 	enabled := true
 	c := NewDefaultConfig()
 	c.ClusterMonitoringConfiguration.EtcdConfig.Enabled = &enabled
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 	cms, err := f.GrafanaDashboardDefinitions()
 	if err != nil {
@@ -2307,7 +2306,7 @@ func TestThanosQuerierConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	d, err := f.ThanosQuerierDeployment(
 		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 		false,
@@ -2415,7 +2414,7 @@ func TestGrafanaConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	d, err := f.GrafanaDeployment(&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
 	if err != nil {
 		t.Fatal(err)
@@ -2458,7 +2457,7 @@ func TestTelemeterConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	d, err := f.TelemeterClientDeployment(&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
 	if err != nil {
 		t.Fatal(err)
@@ -2502,7 +2501,7 @@ func TestThanosRulerConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	tr, err := f.ThanosRulerCustomResource(
 		"",
 		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
@@ -2554,7 +2553,6 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 			name: "Alertmanager",
 			getSpec: func(f *Factory) (spec, error) {
 				a, err := f.AlertmanagerMain(
-					"alertmanager-main.openshift-monitoring.svc",
 					&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				)
 				if err != nil {
@@ -2623,7 +2621,7 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), &fakeInfrastructureReader{highlyAvailableInfrastructure: false}, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), &fakeInfrastructureReader{highlyAvailableInfrastructure: false}, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 		spec, err := tc.getSpec(f)
 		if err != nil {
 			t.Error(err)
@@ -2732,7 +2730,7 @@ func TestPodDisruptionBudget(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), &fakeInfrastructureReader{highlyAvailableInfrastructure: tc.ha}, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), &fakeInfrastructureReader{highlyAvailableInfrastructure: tc.ha}, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 		pdb, err := tc.getPDB(f)
 		if err != nil {
 			t.Error(err)
@@ -2763,7 +2761,7 @@ enableUserWorkload: true
 		t.Fatal(err)
 	}
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	d, err := f.PrometheusOperatorUserWorkloadDeployment()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/manifests/tls_test.go
+++ b/pkg/manifests/tls_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 	v1 "k8s.io/api/core/v1"
 )
@@ -94,7 +95,7 @@ func TestNeedsNewCert(t *testing.T) {
 }
 
 func TestRotateGrpcTLSSecret(t *testing.T) {
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 	for _, tc := range []struct {
 		name  string
@@ -212,7 +213,7 @@ func TestRotateGrpcTLSSecret(t *testing.T) {
 }
 
 func TestUnconfiguredGRPCManifests(t *testing.T) {
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	_, err := f.AlertmanagerConfig()
 	if err != nil {
 		t.Fatal(err)
@@ -225,7 +226,7 @@ func TestUnconfiguredGRPCManifests(t *testing.T) {
 }
 
 func TestCrossSigningAfterRotation(t *testing.T) {
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", NewDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 	for _, tc := range []struct {
 		name string

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -59,7 +59,7 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "creating Alertmanager Route failed")
 	}
 
-	host, err := t.client.WaitForRouteReady(ctx, r)
+	_, err = t.client.WaitForRouteReady(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Alertmanager Route to become ready failed")
 	}
@@ -173,7 +173,7 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 			return errors.Wrap(err, "syncing Thanos Querier trusted CA bundle ConfigMap failed")
 		}
 
-		a, err := t.factory.AlertmanagerMain(host, trustedCA)
+		a, err := t.factory.AlertmanagerMain(trustedCA)
 		if err != nil {
 			return errors.Wrap(err, "initializing Alertmanager object failed")
 		}
@@ -328,7 +328,7 @@ func (t *AlertmanagerTask) destroy(ctx context.Context) error {
 
 		}
 
-		a, err := t.factory.AlertmanagerMain("", trustedCA)
+		a, err := t.factory.AlertmanagerMain(trustedCA)
 		if err != nil {
 			return errors.Wrap(err, "initializing Alertmanager object failed")
 		}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/Jeffail/gabs/v2"
+	configv1 "github.com/openshift/api/config/v1"
 	statusv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
@@ -35,7 +36,7 @@ import (
 
 func TestAlertmanagerTrustedCA(t *testing.T) {
 	var (
-		factory = manifests.NewFactory("openshift-monitoring", "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{})
+		factory = manifests.NewFactory("openshift-monitoring", "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{}, &configv1.Console{})
 		newCM   *v1.ConfigMap
 		lastErr error
 	)

--- a/test/e2e/prometheusadapter_test.go
+++ b/test/e2e/prometheusadapter_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -241,7 +242,7 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	factory := manifests.NewFactory(f.Ns, "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{})
+	factory := manifests.NewFactory(f.Ns, "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{}, &configv1.Console{})
 	adapterSecret, err := factory.PrometheusAdapterSecret(tls, apiAuth)
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/thanos_querier_test.go
+++ b/test/e2e/thanos_querier_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	"github.com/pkg/errors"
@@ -30,7 +31,7 @@ import (
 func TestThanosQuerierTrustedCA(t *testing.T) {
 	ctx := context.Background()
 	var (
-		factory = manifests.NewFactory("openshift-monitoring", "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{})
+		factory = manifests.NewFactory("openshift-monitoring", "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{}, &configv1.Console{})
 		newCM   *v1.ConfigMap
 		lastErr error
 	)


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
