### PR TITLE
[MON-1941]: Add runbooks for FailedToSendAlerts

### DIFF
--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -48,6 +48,7 @@ spec:
         description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
           to send {{ $value | humanizePercentage }} of notifications to {{ $labels.integration
           }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/AlertmanagerFailedToSendAlerts.md
         summary: An Alertmanager instance failed to send notifications.
       expr: |
         (
@@ -64,6 +65,7 @@ spec:
         description: The minimum notification failure rate to {{ $labels.integration
           }} sent from any instance in the {{$labels.job}} cluster is {{ $value |
           humanizePercentage }}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/AlertmanagerClusterFailedToSendAlerts.md
         summary: All Alertmanager instances in a cluster failed to send notifications
           to a critical integration.
       expr: |

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -334,6 +334,8 @@ local openShiftRunbookCMO(runbook) =
 
 local includeRunbooks = {
   AlertmanagerFailedReload: openShiftRunbookCMO('AlertmanagerFailedReload.md'),
+  AlertmanagerFailedToSendAlerts: openShiftRunbookCMO('AlertmanagerFailedToSendAlerts.md'),
+  AlertmanagerClusterFailedToSendAlerts: openShiftRunbookCMO('AlertmanagerClusterFailedToSendAlerts.md'),
   ClusterOperatorDegraded: openShiftRunbookCMO('ClusterOperatorDegraded.md'),
   ClusterOperatorDown: openShiftRunbookCMO('ClusterOperatorDown.md'),
   KubeAPIDown: openShiftRunbookCMO('KubeAPIDown.md'),


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

Please also see: https://github.com/openshift/runbooks/pull/34 
