### PR TITLE
MON-1631: prometheus: remove ui access

### DIFF
--- a/assets/prometheus-k8s/api-route.yaml
+++ b/assets/prometheus-k8s/api-route.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Route
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+spec:
+  path: /api
+  port:
+    targetPort: web
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: Reencrypt
+  to:
+    kind: Service
+    name: prometheus-k8s

--- a/assets/prometheus-k8s/federate-route.yaml
+++ b/assets/prometheus-k8s/federate-route.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
 kind: Route
 metadata:
-  name: prometheus-k8s
+  name: prometheus-k8s-federate
   namespace: openshift-monitoring
 spec:
+  path: /federate
   port:
     targetPort: web
   tls:

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -161,6 +161,7 @@ spec:
         memory: 10Mi
   enableFeatures: []
   externalLabels: {}
+  externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091
   image: quay.io/prometheus/prometheus:v2.32.1
   listenLocal: true
   nodeSelector:

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -22,8 +22,8 @@ function(params)
       data: {},
     },
 
-    // OpenShift route to access the Prometheus UI.
-    route: {
+    // OpenShift route to access the Prometheus api.
+    apiRoute: {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
@@ -35,6 +35,31 @@ function(params)
           kind: 'Service',
           name: 'prometheus-k8s',
         },
+        path: '/api',
+        port: {
+          targetPort: 'web',
+        },
+        tls: {
+          termination: 'Reencrypt',
+          insecureEdgeTerminationPolicy: 'Redirect',
+        },
+      },
+    },
+
+    // OpenShift route to access the Prometheus federate endpoint.
+    federateRoute: {
+      apiVersion: 'v1',
+      kind: 'Route',
+      metadata: {
+        name: 'prometheus-k8s-federate',
+        namespace: cfg.namespace,
+      },
+      spec: {
+        to: {
+          kind: 'Service',
+          name: 'prometheus-k8s',
+        },
+        path: '/federate',
         port: {
           targetPort: 'web',
         },
@@ -316,6 +341,7 @@ function(params)
           'kube-rbac-proxy',
           'metrics-client-certs',
         ],
+        externalURL: 'https://prometheus-k8s.openshift-monitoring.svc:9091',
         configMaps: ['serving-certs-ca-bundle', 'kubelet-serving-ca-bundle', 'metrics-client-ca'],
         probeNamespaceSelector: cfg.namespaceSelector,
         podMonitorNamespaceSelector: cfg.namespaceSelector,

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -375,7 +375,7 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.PrometheusK8s("prometheus-k8s.openshift-monitoring.svc", &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}, nil)
+	_, err = f.PrometheusK8s(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1005,7 +1005,6 @@ func TestPrometheusK8sRemoteWrite(t *testing.T) {
 
 			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 			p, err := f.PrometheusK8s(
-				"prometheus-k8s.openshift-monitoring.svc",
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			)
@@ -1068,7 +1067,6 @@ ingress:
 
 	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 	p, err := f.PrometheusK8s(
-		"prometheus-k8s.openshift-monitoring.svc",
 		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 	)
@@ -1384,7 +1382,6 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 			p, err := f.PrometheusK8s(
-				"prometheus-k8s.openshift-monitoring.svc",
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			)
@@ -2640,7 +2637,6 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 			name: "Prometheus",
 			getSpec: func(f *Factory) (spec, error) {
 				p, err := f.PrometheusK8s(
-					"prometheus-k8s.openshift-monitoring.svc",
 					&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 					&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				)

--- a/pkg/tasks/configsharing.go
+++ b/pkg/tasks/configsharing.go
@@ -38,7 +38,7 @@ func NewConfigSharingTask(client *client.Client, factory *manifests.Factory, con
 }
 
 func (t *ConfigSharingTask) Run(ctx context.Context) error {
-	promRoute, err := t.factory.PrometheusK8sRoute()
+	promRoute, err := t.factory.PrometheusK8sAPIRoute()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus Route failed")
 	}


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
