### PR TITLE
Bug 2037891: Changing the grafana data source secret to be updatable. 

### DIFF
--- a/pkg/tasks/grafana.go
+++ b/pkg/tasks/grafana.go
@@ -115,7 +115,7 @@ func (t *GrafanaTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Grafana Datasources Secret failed")
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, sds)
+	err = t.client.CreateOrUpdateSecret(ctx, sds)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Grafana Datasources Secret failed")
 	}


### PR DESCRIPTION


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
