### PR TITLE
Bug 2037891: Reverting the secureJsonData change for the grafana password

### DIFF
--- a/assets/grafana/dashboard-datasources.yaml
+++ b/assets/grafana/dashboard-datasources.yaml
@@ -16,6 +16,7 @@ stringData:
             {
                 "access": "proxy",
                 "basicAuth": true,
+                "basicAuthPassword": "",
                 "basicAuthUser": "internal",
                 "editable": false,
                 "jsonData": {
@@ -23,9 +24,6 @@ stringData:
                 },
                 "name": "prometheus",
                 "orgId": 1,
-                "secureJsonData": {
-                    "basicAuthPassword": ""
-                },
                 "type": "prometheus",
                 "url": "https://prometheus-k8s.openshift-monitoring.svc:9091",
                 "version": 1

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         checksum/grafana-config: 0303a6f0d3f67044635dd2aa97083486
         checksum/grafana-dashboardproviders: a5f80a0329e7003f13e17e230353e9f2
-        checksum/grafana-datasources: a71f9b7f7c844843b143c9432eb464be
+        checksum/grafana-datasources: 026372726b2a5b921ffa60e63482bb79
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -150,9 +150,7 @@ local inCluster =
           editable: false,
           basicAuth: true,
           basicAuthUser: 'internal',
-          secureJsonData: {
-            basicAuthPassword: '',
-          },
+          basicAuthPassword: '',
           jsonData: {
             tlsSkipVerify: true,
           },

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2453,22 +2453,18 @@ type GrafanaDatasources struct {
 	Datasources []*GrafanaDatasource `json:"datasources"`
 }
 
-type SecureJSONData struct {
-	BasicAuthPassword string `json:"basicAuthPassword"`
-}
-
 type GrafanaDatasource struct {
-	Access         string           `json:"access"`
-	BasicAuth      bool             `json:"basicAuth"`
-	SecureJSONData SecureJSONData   `json:"secureJsonData"`
-	BasicAuthUser  string           `json:"basicAuthUser"`
-	Editable       bool             `json:"editable"`
-	JsonData       *GrafanaJsonData `json:"jsonData"`
-	Name           string           `json:"name"`
-	OrgId          int              `json:"orgId"`
-	Type           string           `json:"type"`
-	Url            string           `json:"url"`
-	Version        int              `json:"version"`
+	Access            string           `json:"access"`
+	BasicAuth         bool             `json:"basicAuth"`
+	BasicAuthPassword string           `json:"basicAuthPassword"`
+	BasicAuthUser     string           `json:"basicAuthUser"`
+	Editable          bool             `json:"editable"`
+	JsonData          *GrafanaJsonData `json:"jsonData"`
+	Name              string           `json:"name"`
+	OrgId             int              `json:"orgId"`
+	Type              string           `json:"type"`
+	Url               string           `json:"url"`
+	Version           int              `json:"version"`
 }
 
 type GrafanaJsonData struct {
@@ -2486,7 +2482,7 @@ func (f *Factory) GrafanaDatasources() (*v1.Secret, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.Datasources[0].SecureJSONData.BasicAuthPassword, err = GeneratePassword(255)
+	d.Datasources[0].BasicAuthPassword, err = GeneratePassword(255)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tasks/grafana.go
+++ b/pkg/tasks/grafana.go
@@ -115,7 +115,7 @@ func (t *GrafanaTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Grafana Datasources Secret failed")
 	}
 
-	err = t.client.CreateOrUpdateSecret(ctx, sds)
+	err = t.client.CreateIfNotExistSecret(ctx, sds)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Grafana Datasources Secret failed")
 	}

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -107,7 +107,7 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 			return errors.Wrap(err, "unmarshalling grafana datasource failed")
 		}
 
-		basicAuthPassword := d.Datasources[0].SecureJSONData.BasicAuthPassword
+		basicAuthPassword := d.Datasources[0].BasicAuthPassword
 
 		htpasswdSecret, err := t.factory.PrometheusK8sHtpasswdSecret(basicAuthPassword)
 		if err != nil {

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -91,7 +91,7 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 			return errors.Wrap(err, "unmarshalling grafana datasource failed")
 		}
 
-		basicAuthPassword := d.Datasources[0].SecureJSONData.BasicAuthPassword
+		basicAuthPassword := d.Datasources[0].BasicAuthPassword
 
 		htpasswdSecret, err := t.factory.ThanosQuerierHtpasswdSecret(basicAuthPassword)
 		if err != nil {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
