### PR TITLE
Bug 2026489: Add runbook url for ThanosRuleRuleEvaluationLatencyHigh alert

### DIFF
--- a/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
+++ b/assets/thanos-ruler/thanos-ruler-prometheus-rule.yaml
@@ -57,6 +57,7 @@ spec:
       annotations:
         description: Thanos Rule {{$labels.instance}} in {{$labels.namespace}} has
           higher evaluation latency than interval for {{$labels.rule_group}}.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ThanosRuleRuleEvaluationLatencyHigh.md
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -351,6 +351,7 @@ local includeRunbooks = {
   NodeRAIDDegraded: openShiftRunbookCMO('NodeRAIDDegraded.md'),
   PrometheusTargetSyncFailure: openShiftRunbookCMO('PrometheusTargetSyncFailure.md'),
   ThanosRuleQueueIsDroppingAlerts: openShiftRunbookCMO('ThanosRuleQueueIsDroppingAlerts.md'),
+  ThanosRuleRuleEvaluationLatencyHigh: openShiftRunbookCMO('ThanosRuleRuleEvaluationLatencyHigh.md'),
 };
 
 local addRunbookUrl(rule) = rule {


### PR DESCRIPTION
Runbook PR: 

https://github.com/openshift/runbooks/pull/35
https://github.com/openshift/runbooks/pull/37

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
