### PR TITLE
Bug 2038419: Bump Grafana to 8.3.4 and handle datasource migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#1488](https://github.com/openshift/cluster-monitoring-operator/pull/1488) Removing the alert HighlyAvailableWorkloadIncorrectlySpread.
 - [#1858](https://github.com/openshift/cluster-monitoring-operator/pull/1858) Allow suppression of storage alerts via PersistentVolumeClaim label
 - [#1527](https://github.com/openshift/cluster-monitoring-operator/pull/1527) Enable user alerts via AlertManagerConfig to be forwarded to the existing Platform Alertmanager
+-[#1543](https://github.com/openshift/cluster-monitoring-operator/pull/1543) Bump Grafana version to v8.3.4
 
 ## 4.9
 

--- a/assets/grafana/config.yaml
+++ b/assets/grafana/config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
   name: grafana-config
   namespace: openshift-monitoring
 stringData:

--- a/assets/grafana/dashboard-datasources.yaml
+++ b/assets/grafana/dashboard-datasources.yaml
@@ -16,7 +16,6 @@ stringData:
             {
                 "access": "proxy",
                 "basicAuth": true,
-                "basicAuthPassword": "",
                 "basicAuthUser": "internal",
                 "editable": false,
                 "jsonData": {
@@ -24,6 +23,9 @@ stringData:
                 },
                 "name": "prometheus",
                 "orgId": 1,
+                "secureJsonData": {
+                    "basicAuthPassword": ""
+                },
                 "type": "prometheus",
                 "url": "https://prometheus-k8s.openshift-monitoring.svc:9091",
                 "version": 1

--- a/assets/grafana/dashboard-datasources.yaml
+++ b/assets/grafana/dashboard-datasources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
   name: grafana-datasources
   namespace: openshift-monitoring
 stringData:

--- a/assets/grafana/dashboard-datasources.yaml
+++ b/assets/grafana/dashboard-datasources.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
     app.kubernetes.io/version: 8.3.4
-  name: grafana-datasources
+  name: grafana-datasources-v2
   namespace: openshift-monitoring
 stringData:
   datasources.yaml: |-

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -1872,7 +1872,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-cluster-total
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -3236,7 +3236,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-etcd
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -6317,7 +6317,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-k8s-resources-cluster
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -9107,7 +9107,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-k8s-resources-namespace
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -10126,7 +10126,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-k8s-resources-node
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -12588,7 +12588,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-k8s-resources-pod
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -14605,7 +14605,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-k8s-resources-workload
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -16787,7 +16787,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-k8s-resources-workloads-namespace
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -18244,7 +18244,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-namespace-by-pod
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -19300,7 +19300,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-node-cluster-rsrc-use
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -20382,7 +20382,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-node-rsrc-use
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -21603,7 +21603,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-pod-total
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -22831,7 +22831,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.11
+      app.kubernetes.io/version: 8.3.4
     name: grafana-dashboard-prometheus
     namespace: openshift-monitoring
 kind: ConfigMapList

--- a/assets/grafana/dashboard-sources.yaml
+++ b/assets/grafana/dashboard-sources.yaml
@@ -22,6 +22,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
   name: grafana-dashboards
   namespace: openshift-monitoring

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         checksum/grafana-config: 28b9b36ac4d235c1c5f2f9ca81714d1c
         checksum/grafana-dashboardproviders: 9ac0e8fe144a3a59f7ab62b4e733f22d
-        checksum/grafana-datasources: 0817debaf3d8ef0b64e766cefc9f8d84
+        checksum/grafana-datasources: 58dfbb3df9951f2ac8acf4c625c7173c
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana
@@ -178,7 +178,7 @@ spec:
         name: grafana-storage
       - name: grafana-datasources
         secret:
-          secretName: grafana-datasources
+          secretName: grafana-datasources-v2
       - configMap:
           name: grafana-dashboards
         name: grafana-dashboards

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
   name: grafana
   namespace: openshift-monitoring
 spec:
@@ -19,22 +19,22 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/grafana-config: 0303a6f0d3f67044635dd2aa97083486
-        checksum/grafana-dashboardproviders: a5f80a0329e7003f13e17e230353e9f2
-        checksum/grafana-datasources: 026372726b2a5b921ffa60e63482bb79
+        checksum/grafana-config: 28b9b36ac4d235c1c5f2f9ca81714d1c
+        checksum/grafana-dashboardproviders: 9ac0e8fe144a3a59f7ab62b4e733f22d
+        checksum/grafana-datasources: 6a4111aa0ba640da939e8bbc8a2c8fad
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 7.5.11
+        app.kubernetes.io/version: 8.3.4
     spec:
       containers:
       - args:
         - -config=/etc/grafana/grafana.ini
         env: []
-        image: grafana/grafana:v7.5.11
+        image: grafana/grafana:v8.3.4
         name: grafana
         ports:
         - containerPort: 3001

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         checksum/grafana-config: 28b9b36ac4d235c1c5f2f9ca81714d1c
         checksum/grafana-dashboardproviders: 9ac0e8fe144a3a59f7ab62b4e733f22d
-        checksum/grafana-datasources: 6a4111aa0ba640da939e8bbc8a2c8fad
+        checksum/grafana-datasources: 0817debaf3d8ef0b64e766cefc9f8d84
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana

--- a/assets/grafana/service-account.yaml
+++ b/assets/grafana/service-account.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
   name: grafana
   namespace: openshift-monitoring

--- a/assets/grafana/service-monitor.yaml
+++ b/assets/grafana/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
   name: grafana
   namespace: openshift-monitoring
 spec:

--- a/assets/grafana/service.yaml
+++ b/assets/grafana/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
   name: grafana
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/components/grafana.libsonnet
+++ b/jsonnet/components/grafana.libsonnet
@@ -184,6 +184,11 @@ function(params)
       }],
     },
 
+    dashboardDatasources+: {
+      metadata+: {
+        name: 'grafana-datasources-v2',
+      },
+    },
     // These patches inject the oauth proxy as a sidecar and configures it with
     // TLS.
 

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -150,7 +150,9 @@ local inCluster =
           editable: false,
           basicAuth: true,
           basicAuthUser: 'internal',
-          basicAuthPassword: '',
+          secureJsonData: {
+            basicAuthPassword: '',
+          },
           jsonData: {
             tlsSkipVerify: true,
           },

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -15,7 +15,7 @@ repos:
   thanos: openshift/thanos
 versions:
   alertmanager: 0.23.0
-  grafana: 7.5.11
+  grafana: 8.3.4
   kubeRbacProxy: 0.11.0
   kubeStateMetrics: 2.3.0
   nodeExporter: 1.3.1

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1871,7 +1871,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-cluster-total
   namespace: openshift-config-managed
@@ -3237,7 +3237,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-etcd
   namespace: openshift-config-managed
@@ -6320,7 +6320,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-cluster
   namespace: openshift-config-managed
@@ -9112,7 +9112,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-namespace
@@ -10134,7 +10134,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-node
   namespace: openshift-config-managed
@@ -12598,7 +12598,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-pod
@@ -14618,7 +14618,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-workload
@@ -16803,7 +16803,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-workloads-namespace
@@ -18263,7 +18263,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-namespace-by-pod
   namespace: openshift-config-managed
@@ -19321,7 +19321,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-node-cluster-rsrc-use
   namespace: openshift-config-managed
@@ -20405,7 +20405,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-node-rsrc-use
   namespace: openshift-config-managed
@@ -21628,7 +21628,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-pod-total
   namespace: openshift-config-managed
@@ -22858,7 +22858,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.11
+    app.kubernetes.io/version: 8.3.4
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-prometheus
   namespace: openshift-config-managed

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2453,18 +2453,22 @@ type GrafanaDatasources struct {
 	Datasources []*GrafanaDatasource `json:"datasources"`
 }
 
+type SecureJSONData struct {
+	BasicAuthPassword string `json:"basicAuthPassword"`
+}
+
 type GrafanaDatasource struct {
-	Access            string           `json:"access"`
-	BasicAuth         bool             `json:"basicAuth"`
-	BasicAuthPassword string           `json:"basicAuthPassword"`
-	BasicAuthUser     string           `json:"basicAuthUser"`
-	Editable          bool             `json:"editable"`
-	JsonData          *GrafanaJsonData `json:"jsonData"`
-	Name              string           `json:"name"`
-	OrgId             int              `json:"orgId"`
-	Type              string           `json:"type"`
-	Url               string           `json:"url"`
-	Version           int              `json:"version"`
+	Access         string           `json:"access"`
+	BasicAuth      bool             `json:"basicAuth"`
+	SecureJSONData SecureJSONData   `json:"secureJsonData"`
+	BasicAuthUser  string           `json:"basicAuthUser"`
+	Editable       bool             `json:"editable"`
+	JsonData       *GrafanaJsonData `json:"jsonData"`
+	Name           string           `json:"name"`
+	OrgId          int              `json:"orgId"`
+	Type           string           `json:"type"`
+	Url            string           `json:"url"`
+	Version        int              `json:"version"`
 }
 
 type GrafanaJsonData struct {
@@ -2482,7 +2486,7 @@ func (f *Factory) GrafanaDatasources() (*v1.Secret, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.Datasources[0].BasicAuthPassword, err = GeneratePassword(255)
+	d.Datasources[0].SecureJSONData.BasicAuthPassword, err = GeneratePassword(255)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tasks/grafana.go
+++ b/pkg/tasks/grafana.go
@@ -115,7 +115,7 @@ func (t *GrafanaTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Grafana Datasources Secret failed")
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, sds)
+	err = t.client.CreateOrUpdateSecret(ctx, sds)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Grafana Datasources Secret failed")
 	}

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -107,7 +107,7 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 			return errors.Wrap(err, "unmarshalling grafana datasource failed")
 		}
 
-		basicAuthPassword := d.Datasources[0].BasicAuthPassword
+		basicAuthPassword := d.Datasources[0].SecureJSONData.BasicAuthPassword
 
 		htpasswdSecret, err := t.factory.PrometheusK8sHtpasswdSecret(basicAuthPassword)
 		if err != nil {

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -91,7 +91,7 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 			return errors.Wrap(err, "unmarshalling grafana datasource failed")
 		}
 
-		basicAuthPassword := d.Datasources[0].BasicAuthPassword
+		basicAuthPassword := d.Datasources[0].SecureJSONData.BasicAuthPassword
 
 		htpasswdSecret, err := t.factory.ThanosQuerierHtpasswdSecret(basicAuthPassword)
 		if err != nil {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->
Newer version of grafana(e.g v8.3.3) seem to be supporting basic auth
only through `secureJsonData.basicAuthPassword`. This PR ensures the
creation of new datasources secret with `secureJsonData.basicAuthPassword` field and removes old secret during upgrade.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
