### PR TITLE
Bug 2030347: kube-state-metrics exposes metrics about resource annotations

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        - --metric-denylist=kube_secret_labels,kube_*_annotations
+        - --metric-denylist=kube_secret_labels,kube_.*_annotations
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]
         - |
           --metric-denylist=

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -138,7 +138,7 @@ function(params)
                   else
                     c {
                       args+: [
-                        '--metric-denylist=kube_secret_labels,kube_*_annotations',
+                        '--metric-denylist=kube_secret_labels,kube_.*_annotations',
                         // TODO: Remove "poddisruptionbudget" once upstream KSM addresses a typo in PDB label metrics allowlist key.
                         '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]',
                       ],

--- a/test/e2e/kube_state_metrics_test.go
+++ b/test/e2e/kube_state_metrics_test.go
@@ -1,0 +1,67 @@
+// Copyright 2019 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/Jeffail/gabs/v2"
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
+	"github.com/pkg/errors"
+)
+
+func TestKSMMetricsSuppression(t *testing.T) {
+
+	suppressedPattern, _ := regexp.Compile("kube_.*_annotations")
+
+	err := framework.Poll(5*time.Second, time.Minute, func() error {
+
+		client := f.PrometheusK8sClient
+
+		b, err := client.PrometheusLabel("__name__")
+		if err != nil {
+			return err
+		}
+
+		response, err := gabs.ParseJSON(b)
+		if err != nil {
+			return err
+		}
+
+		status, ok := response.Path("status").Data().(string)
+		if !ok {
+			return errors.New("status not found")
+		}
+
+		if status != "success" {
+			t.Errorf("Prometheus returned unexpected status: %s", status)
+		}
+
+		for _, name := range response.Search("data").Children() {
+			metricName := name.Data().(string)
+			if suppressedPattern.Match([]byte(metricName)) {
+				t.Errorf("Metric should be suppressed: %s", metricName)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Errorf("failed to query Prometheus: %v", err)
+	}
+
+}


### PR DESCRIPTION
 Fix typo in kube-state-metric's arg --metric-denylist.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
