### PR TITLE
Mon 2172: Add clusterrole for editing alertmanagerconfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - [#1488](https://github.com/openshift/cluster-monitoring-operator/pull/1488) Removing the alert HighlyAvailableWorkloadIncorrectlySpread.
 - [#1858](https://github.com/openshift/cluster-monitoring-operator/pull/1858) Allow suppression of storage alerts via PersistentVolumeClaim label
 - [#1527](https://github.com/openshift/cluster-monitoring-operator/pull/1527) Enable user alerts via AlertManagerConfig to be forwarded to the existing Platform Alertmanager
--[#1543](https://github.com/openshift/cluster-monitoring-operator/pull/1543) Bump Grafana version to v8.3.4
+- [#1543](https://github.com/openshift/cluster-monitoring-operator/pull/1543) Bump Grafana version to v8.3.4
+- [#1545](https://github.com/openshift/cluster-monitoring-operator/pull/1545) Add ClusterRole to allow editing of AlertManagerConfig
 
 ## 4.9
 

--- a/assets/cluster-monitoring-operator/alerting-edit-cluster-role.yaml
+++ b/assets/cluster-monitoring-operator/alerting-edit-cluster-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alert-routing-edit
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagerconfigs
+  verbs:
+  - '*'

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -342,4 +342,17 @@ function(params) {
       verbs: ['*'],
     }],
   },
+
+  alertingEditClusterRole: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'ClusterRole',
+    metadata: {
+      name: 'alert-routing-edit',
+    },
+    rules: [{
+      apiGroups: ['monitoring.coreos.com'],
+      resources: ['alertmanagerconfigs'],
+      verbs: ['*'],
+    }],
+  },
 }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -199,6 +199,7 @@ var (
 	ClusterMonitoringRulesEditClusterRole       = "cluster-monitoring-operator/monitoring-rules-edit-cluster-role.yaml"
 	ClusterMonitoringRulesViewClusterRole       = "cluster-monitoring-operator/monitoring-rules-view-cluster-role.yaml"
 	ClusterMonitoringEditClusterRole            = "cluster-monitoring-operator/monitoring-edit-cluster-role.yaml"
+	ClusterMonitoringEditAlertingClusterRole    = "cluster-monitoring-operator/alerting-edit-cluster-role.yaml"
 	ClusterMonitoringEditUserWorkloadConfigRole = "cluster-monitoring-operator/user-workload-config-edit-role.yaml"
 	ClusterMonitoringGrpcTLSSecret              = "cluster-monitoring-operator/grpc-tls-secret.yaml"
 	ClusterMonitoringOperatorPrometheusRule     = "cluster-monitoring-operator/prometheus-rule.yaml"
@@ -2711,6 +2712,15 @@ func (f *Factory) ClusterMonitoringRulesViewClusterRole() (*rbacv1.ClusterRole, 
 
 func (f *Factory) ClusterMonitoringEditClusterRole() (*rbacv1.ClusterRole, error) {
 	cr, err := f.NewClusterRole(f.assets.MustNewAssetReader(ClusterMonitoringEditClusterRole))
+	if err != nil {
+		return nil, err
+	}
+
+	return cr, nil
+}
+
+func (f *Factory) ClusterMonitoringAlertingEditClusterRole() (*rbacv1.ClusterRole, error) {
+	cr, err := f.NewClusterRole(f.assets.MustNewAssetReader(ClusterMonitoringEditAlertingClusterRole))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -668,6 +668,11 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = f.ClusterMonitoringAlertingEditClusterRole()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = f.ClusterMonitoringEditUserWorkloadConfigRole()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/tasks/clustermonitoringoperator.go
+++ b/pkg/tasks/clustermonitoringoperator.go
@@ -49,6 +49,7 @@ func (t *ClusterMonitoringOperatorTask) Run(ctx context.Context) error {
 		"monitoring-rules-edit":   t.factory.ClusterMonitoringRulesEditClusterRole,
 		"monitoring-rules-view":   t.factory.ClusterMonitoringRulesViewClusterRole,
 		"monitoring-edit":         t.factory.ClusterMonitoringEditClusterRole,
+		"alert-routing-edit":      t.factory.ClusterMonitoringAlertingEditClusterRole,
 	} {
 		cr, err := crf()
 		if err != nil {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Create role to allow end users to manage alerting CR's

See https://issues.redhat.com/browse/MON-2172 

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
