### PR TITLE
Bug 2043518: Better ClusterOperator status message when Promethues pods fail

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -707,6 +708,60 @@ func (c *Client) DeleteSecret(ctx context.Context, s *v1.Secret) error {
 	return err
 }
 
+func (c *Client) validatePromethuesPodState(ctx context.Context, p *monv1.Prometheus) error {
+
+	status, _, err := prometheusoperator.Status(ctx, c.kclient.(*kubernetes.Clientset), p)
+	// supress but log if we are unable to obtain the status
+	if err != nil {
+		klog.V(4).ErrorS(err, "validatePrometheusPodState: failed to get Prometheus status")
+		return nil
+	}
+
+	// return early if the state seems okay
+	expected := *p.Spec.Replicas
+	if status.UpdatedReplicas == expected || status.AvailableReplicas >= expected {
+		return nil
+	}
+
+	// look for unavailable pods
+	// the state of the pods do not match the expectation; figure out why
+
+	// TODO(sthaha) fix prometheusoperator.Status which currently does not return
+	// pods that are not running (e.g. in PodPending state) although it  match
+	// the ListOption, thus we have to iterate all pods again
+
+	// FIXME(sthaha): this assumes that the p.Spec.Shard is nil
+	pods, err := c.kclient.CoreV1().Pods(p.Namespace).List(ctx, prometheusoperator.ListOptions(p.Name))
+	if err != nil {
+		return errors.Wrap(err, "failed to list prometheus pods")
+	}
+
+	for _, pod := range pods.Items {
+		nsName := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+
+		switch pod.Status.Phase {
+		// ignore those in running state
+		case v1.PodRunning:
+			continue
+
+		case v1.PodFailed, v1.PodSucceeded:
+			// we expect pods to be running all the time
+			return errors.Errorf("prometheus pod %s ran to completion", nsName)
+
+		case v1.PodPending:
+			for _, cond := range pod.Status.Conditions {
+				if cond.Status != v1.ConditionFalse {
+					continue
+				}
+				return errors.Errorf("prometheus pod %s is %s: %s", nsName, cond.Reason, cond.Message)
+			}
+		}
+	}
+	// catch all error; probably those pods in Unknown State
+	return errors.Errorf("expected %d replicas, got %d replicas",
+		*p.Spec.Replicas, status.AvailableReplicas)
+}
+
 func (c *Client) WaitForPrometheus(ctx context.Context, p *monv1.Prometheus) error {
 	var lastErr error
 	if err := wait.Poll(time.Second*10, time.Minute*5, func() (bool, error) {
@@ -716,22 +771,9 @@ func (c *Client) WaitForPrometheus(ctx context.Context, p *monv1.Prometheus) err
 			klog.V(4).ErrorS(err, "WaitForPrometheus: failed to get Prometheus object")
 			return false, nil
 		}
-		status, _, err := prometheusoperator.Status(ctx, c.kclient.(*kubernetes.Clientset), p)
-		if err != nil {
-			lastErr = err
-			klog.V(4).ErrorS(err, "WaitForPrometheus: failed to get Prometheus status")
-			return false, nil
-		}
 
-		expectedReplicas := *p.Spec.Replicas
-		if expectedReplicas != status.UpdatedReplicas {
-			lastErr = errors.Errorf("expected %d replicas, got %d updated replicas",
-				expectedReplicas, status.UpdatedReplicas)
-			return false, nil
-		}
-		if status.AvailableReplicas < expectedReplicas {
-			lastErr = errors.Errorf("expected %d replicas, got %d available replicas",
-				expectedReplicas, status.AvailableReplicas)
+		if err := c.validatePromethuesPodState(ctx, p); err != nil {
+			lastErr = err
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
This patch surfaces pod failure message to cluster-operator status
message by inspecting each prometheus pod that isn't running and
surfacing the failure messages to monitoring cluster-operator.

For example, given the following monitoring config which uses a
non-existent PVC

```yaml
    prometheusK8s:
      volumeClaimTemplate:
        metadata:
          name: prometheus-db
        spec:
          storageClassName: foo
          resources:
            requests:
              storage: 100Mi
```
ClusterOperator status showed the following message for `Degraded`
condition (formatted for readability)
>  Failed to rollout the stack.
>  Error
>   : updating prometheus-k8s
>   : waiting for Prometheus object changes failed
>   : waiting for Prometheus openshift-monitoring/k8s
>   : expected 2 replicas, got 0 updated replicas"
>

Which now shows
> Failed to rollout the stack.
> Error
>  : updating prometheus-k8s
>  : waiting for Prometheus object changes failed
>  : waiting for Prometheus openshift-monitoring/k8s
>  : prometheus pod prometheus-k8s-0 is pending state Unschedulable
>  : 0/1 nodes are available
>  : 1 pod has unbound immediate PersistentVolumeClaims.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>


* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
