### PR TITLE
Bug 2059470: Unable to connect external Grafana with Openshift Monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.10
 
 - [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose expose /api/v1/labels endpoint for Thanos query.
+
 ## 4.9
 
 - [#1312](https://github.com/openshift/cluster-monitoring-operator/pull/1312) Support label to exclude namespaces from user-workload monitoring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
-## 4.10
-
-- [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose expose /api/v1/labels endpoint for Thanos query.
-
 ## 4.9
 
 - [#1312](https://github.com/openshift/cluster-monitoring-operator/pull/1312) Support label to exclude namespaces from user-workload monitoring.
@@ -17,6 +13,8 @@
 - [#1310](https://github.com/openshift/cluster-monitoring-operator/pull/1310) Update Alert Configs, fewer critical alerts with more accurate triggering condition.
 - [#1324](https://github.com/openshift/cluster-monitoring-operator/pull/1324) Allow filtering by job in 'Prometheus/Overview' dashboard.
 - [#1404](https://github.com/openshift/cluster-monitoring-operator/pull/1404) Drop pod-centric cAdvisor metrics that are available at slice level.
+- [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose expose /api/v1/labels endpoint for Thanos query.
+- [#1529](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose /api/v1/series endpoint on the Thanos query tenancy port.
 
 ## 4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.10
+
+- [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose expose /api/v1/labels endpoint for Thanos query.
 ## 4.9
 
 - [#1312](https://github.com/openshift/cluster-monitoring-operator/pull/1312) Support label to exclude namespaces from user-workload monitoring.

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
-        - --allow-paths=/api/v1/query,/api/v1/query_range
+        - --allow-paths="/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values"
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:
@@ -155,6 +155,7 @@ spec:
         - --insecure-listen-address=127.0.0.1:9095
         - --upstream=http://127.0.0.1:9090
         - --label=namespace
+        - --enable-label-apis
         image: quay.io/prometheuscommunity/prom-label-proxy:v0.3.0
         name: prom-label-proxy
         resources:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
-        - --allow-paths="/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values"
+        - --allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
-        - --allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values
+        - --allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values,/api/v1/series
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -479,7 +479,7 @@ function(params)
                   '--tls-private-key-file=/etc/tls/private/tls.key',
                   '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                   '--logtostderr=true',
-                  '--allow-paths="/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values"',
+                  '--allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values',
                 ],
                 terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -479,7 +479,13 @@ function(params)
                   '--tls-private-key-file=/etc/tls/private/tls.key',
                   '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                   '--logtostderr=true',
-                  '--allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values',
+                  '--allow-paths=' + std.join(',', [
+                    '/api/v1/query',
+                    '/api/v1/query_range',
+                    '/api/v1/labels',
+                    '/api/v1/label/*/values',
+                    '/api/v1/series',
+                  ]),
                 ],
                 terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -479,7 +479,7 @@ function(params)
                   '--tls-private-key-file=/etc/tls/private/tls.key',
                   '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                   '--logtostderr=true',
-                  '--allow-paths=/api/v1/query,/api/v1/query_range',
+                  '--allow-paths="/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values"',
                 ],
                 terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [
@@ -500,6 +500,7 @@ function(params)
                   '--insecure-listen-address=127.0.0.1:9095',
                   '--upstream=http://127.0.0.1:9090',
                   '--label=namespace',
+                  '--enable-label-apis',
                 ],
                 resources: {
                   requests: {

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -211,6 +211,27 @@ func (c *PrometheusClient) PrometheusRules() ([]byte, error) {
 	return body, nil
 }
 
+// PrometheusRules runs an HTTP GET request against the Prometheus label API and returns
+// the response body.
+func (c *PrometheusClient) PrometheusLabel(label string) ([]byte, error) {
+	resp, err := c.Do("GET", fmt.Sprintf("/api/v1/label/%s/values", url.QueryEscape(label)), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code response, want %d, got %d (%q)", http.StatusOK, resp.StatusCode, ClampMax(body))
+	}
+
+	return body, nil
+}
+
 // AlertmanagerQueryAlerts runs an HTTP GET request against the Alertmanager
 // /api/v2/alerts endpoint and returns the response body.
 func (c *PrometheusClient) AlertmanagerQueryAlerts(kvs ...string) ([]byte, error) {

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -211,7 +211,7 @@ func (c *PrometheusClient) PrometheusRules() ([]byte, error) {
 	return body, nil
 }
 
-// PrometheusRules runs an HTTP GET request against the Prometheus label API and returns
+// PrometheusLabel runs an HTTP GET request against the Prometheus label API and returns
 // the response body.
 func (c *PrometheusClient) PrometheusLabel(label string) ([]byte, error) {
 	resp, err := c.Do("GET", fmt.Sprintf("/api/v1/label/%s/values", url.QueryEscape(label)), nil)

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -101,7 +101,7 @@ func TestUserWorkloadMonitoringWithStorage(t *testing.T) {
 		{"assert user workload metrics", assertUserWorkloadMetrics},
 		{"assert user workload rules", assertUserWorkloadRules},
 		{"assert tenancy model is enforced for metrics", assertTenancyForMetrics},
-		{"assert tenancy model is enforced for labels", assertTenancyForLabels},
+		{"assert tenancy model is enforced for series metadata", assertTenancyForSeriesMetadata},
 		{"assert tenancy model is enforced for rules", assertTenancyForRules},
 		{"assert prometheus and alertmanager is not deployed in user namespace", assertPrometheusAlertmanagerInUserNamespace},
 		{"assert grpc tls rotation", assertGRPCTLSRotation},
@@ -1011,7 +1011,7 @@ func assertPrometheusAlertmanagerInUserNamespace(t *testing.T) {
 	}
 }
 
-func assertTenancyForLabels(t *testing.T) {
+func assertTenancyForSeriesMetadata(t *testing.T) {
 	const testAccount = "test-labels"
 
 	_, err := f.CreateServiceAccount(userWorkloadTestNs, testAccount)
@@ -1098,7 +1098,61 @@ func assertTenancyForLabels(t *testing.T) {
 		t.Fatalf("failed to query labels from Thanos querier: %v", err)
 	}
 
-	// check /api/v1/label/namespace/values has a single value
+	// Check the /api/v1/series endpoint.
+	err = framework.Poll(5*time.Second, time.Minute, func() error {
+		// The tenancy port (9092) is only exposed in-cluster so we need to use
+		// port forwarding to access kube-rbac-proxy.
+		host, cleanUp, err := f.ForwardPort(t, "thanos-querier", 9092)
+		if err != nil {
+			return err
+		}
+		defer cleanUp()
+
+		client := framework.NewPrometheusClient(
+			host,
+			token,
+			&framework.QueryParameterInjector{
+				Name:  "namespace",
+				Value: userWorkloadTestNs,
+			},
+		)
+
+		resp, err := client.Do("GET", "/api/v1/series?match[]=up", nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
+		}
+
+		res, err := gabs.ParseJSON(b)
+		if err != nil {
+			return err
+		}
+
+		series, err := res.Path("data").Children()
+		if err != nil {
+			return err
+		}
+
+		if len(series) != 1 {
+			return errors.Errorf("expecting a series list with one item, got %d (%s)", len(series), framework.ClampMax(b))
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to query series from Thanos querier: %v", err)
+	}
+
+	// Check that /api/v1/label/{namespace}/values returns a single value.
 	t.Logf("Checking Label namespace having a single value")
 	const label = "namespace"
 

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -101,6 +101,7 @@ func TestUserWorkloadMonitoringWithStorage(t *testing.T) {
 		{"assert user workload metrics", assertUserWorkloadMetrics},
 		{"assert user workload rules", assertUserWorkloadRules},
 		{"assert tenancy model is enforced for metrics", assertTenancyForMetrics},
+		{"assert tenancy model is enforced for labels", assertTenancyForLabels},
 		{"assert tenancy model is enforced for rules", assertTenancyForRules},
 		{"assert prometheus and alertmanager is not deployed in user namespace", assertPrometheusAlertmanagerInUserNamespace},
 		{"assert grpc tls rotation", assertGRPCTLSRotation},
@@ -147,13 +148,13 @@ func TestUserWorkloadMonitoringWithAdditionalAlertmanagerConfigs(t *testing.T) {
     timeout: "30s"
     apiVersion: v1
     tlsConfig:
-      key: 
+      key:
         name: alertmanager-tls
         key: tls.key
-      cert: 
+      cert:
         name: alertmanager-tls
         key: tls.crt
-      ca: 
+      ca:
         name: alertmanager-tls
         key: tls.ca
     staticConfigs: ["127.0.0.1", "127.0.0.2"]
@@ -1008,6 +1009,143 @@ func assertPrometheusAlertmanagerInUserNamespace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected no Alertmanager statefulset to be deployed, but found one")
 	}
+}
+
+func assertTenancyForLabels(t *testing.T) {
+	const testAccount = "test-labels"
+
+	_, err := f.CreateServiceAccount(userWorkloadTestNs, testAccount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Grant enough permissions to read labels.
+	_, err = f.CreateRoleBindingFromClusterRole(userWorkloadTestNs, testAccount, "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var token string
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
+		token, err = f.GetServiceAccountToken(userWorkloadTestNs, testAccount)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The tenancy port (9092) is only exposed in-cluster so we need to use
+	// port forwarding to access kube-rbac-proxy.
+	host, cleanUp, err := f.ForwardPort(t, "thanos-querier", 9092)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanUp()
+
+	client := framework.NewPrometheusClient(
+		host,
+		token,
+		&framework.QueryParameterInjector{
+			Name:  "namespace",
+			Value: userWorkloadTestNs,
+		},
+	)
+
+	t.Logf("Checking all labels")
+
+	// check /api/v1/labels endpoint
+	err = framework.Poll(5*time.Second, time.Minute, func() error {
+		resp, err := client.Do("GET", "/api/v1/labels", nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
+		}
+
+		res, err := gabs.ParseJSON(b)
+		if err != nil {
+			return err
+		}
+
+		labels, err := res.Path("data").Children()
+		if err != nil {
+			return err
+		}
+
+		for _, label := range labels {
+			t.Logf("label %q", label.Data().(string))
+		}
+
+		if len(labels) == 0 {
+			return errors.Errorf("expecting a label list with at least one item.")
+		}
+
+		return nil
+
+	})
+	if err != nil {
+		t.Fatalf("failed to query labels from Thanos querier: %v", err)
+	}
+
+	// check /api/v1/label/namespace/values has a single value
+	t.Logf("Checking Label namespace having a single value")
+	const label = "namespace"
+
+	err = framework.Poll(5*time.Second, time.Minute, func() error {
+		// The tenancy port (9092) is only exposed in-cluster so we need to use
+		// port forwarding to access kube-rbac-proxy.
+		host, cleanUp, err := f.ForwardPort(t, "thanos-querier", 9092)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanUp()
+
+		client := framework.NewPrometheusClient(
+			host,
+			token,
+			&framework.QueryParameterInjector{
+				Name:  "namespace",
+				Value: userWorkloadTestNs,
+			},
+		)
+
+		b, err := client.PrometheusLabel(label)
+		if err != nil {
+			return err
+		}
+
+		res, err := gabs.ParseJSON(b)
+		if err != nil {
+			return err
+		}
+
+		values, err := res.Path("data").Children()
+		if err != nil {
+			return err
+		}
+
+		if len(values) != 1 {
+			return errors.Errorf("expecting for label %q value list with exact one item.", label)
+		}
+
+		if values[0].Data().(string) != userWorkloadTestNs {
+			return errors.Errorf("expecting for label %q having value %q, but got %q .", label, userWorkloadTestNs, values[0].Data().(string))
+		}
+
+		return nil
+	})
+
 }
 
 func assertGRPCTLSRotation(t *testing.T) {


### PR DESCRIPTION
Executed the following API calls as described in https://grafana.com/docs/grafana/latest/datasources/prometheus/#query-variable.

```
$ curl -X GET -kG 'https://localhost:9092/api/v1/query?query=up&namespace=ns1'  -H "Authorization: Bearer $TOKEN"
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","endpoint":"web","instance":"10.128.2.14:8080","job":"prometheus-example-app","namespace":"ns1","pod":"prometheus-example-app-d748cfb54-fss5h","prometheus":"openshift-user-workload-monitoring/user-workload","service":"prometheus-example-app"},"value":[1643640318.046,"1"]},{"metric":{"__name__":"up","endpoint":"web","instance":"10.129.2.14:8080","job":"prometheus-example-app","namespace":"ns1","pod":"prometheus-example-app-d748cfb54-z2xh6","prometheus":"openshift-user-workload-monitoring/user-workload","service":"prometheus-example-app"},"value":[1643640318.046,"1"]}]}}


$ curl -X GET -kG 'https://localhost:9092/api/v1/labels?namespace=ns1'  -H "Authorization: Bearer $TOKEN"
{"status":"success","data":["__name__","cluster_ip","condition","configmap","container","container_id","cpu","created_by_kind","created_by_name","deployment","device","endpoint","host_ip","host_network","id","image","image_id","instance","interface","job","label_app","label_kubernetes_io_metadata_name","label_pod_template_hash","metrics_path","name","namespace","network_name","node","owner_is_controller","owner_kind","owner_name","phase","pod","pod_ip","prometheus","prometheus_replica","reason","replicaset","secret","service","status","type","uid","ulimit","version","workload","workload_type"]}

$ curl -X GET -kG 'https://localhost:9092/api/v1/label/__name__/values?namespace=ns1'  -H "Authorization: Bearer $TOKEN"
{"status":"success","data":["container_cpu_system_seconds_total","container_cpu_usage_seconds_total","container_cpu_user_seconds_total","container_file_descriptors","container_fs_usage_bytes","container_last_seen","container_memory_cache","container_memory_failcnt","container_memory_mapped_file","container_memory_max_usage_bytes","container_memory_rss","container_memory_swap","container_memory_usage_bytes","container_memory_working_set_bytes","container_network_receive_bytes_total","container_network_receive_errors_total","container_network_receive_packets_dropped_total","container_network_receive_packets_total","container_network_transmit_bytes_total","container_network_transmit_errors_total","container_network_transmit_packets_dropped_total","container_network_transmit_packets_total","container_processes","container_sockets","container_spec_cpu_period","container_spec_cpu_shares","container_spec_memory_limit_bytes","container_spec_memory_reservation_limit_bytes","container_spec_memory_swap_limit_bytes","container_start_time_seconds","container_threads","container_threads_max","container_ulimits_soft","kube_configmap_info","kube_deployment_labels","kube_deployment_metadata_generation","kube_deployment_spec_paused","kube_deployment_spec_replicas","kube_deployment_spec_strategy_rollingupdate_max_surge","kube_deployment_spec_strategy_rollingupdate_max_unavailable","kube_deployment_status_condition","kube_deployment_status_observed_generation","kube_deployment_status_replicas","kube_deployment_status_replicas_available","kube_deployment_status_replicas_unavailable","kube_deployment_status_replicas_updated","kube_endpoint_address_available","kube_endpoint_address_not_ready","kube_endpoint_info","kube_endpoint_labels","kube_namespace_labels","kube_namespace_status_phase","kube_pod_container_info","kube_pod_container_state_started","kube_pod_container_status_ready","kube_pod_container_status_restarts_total","kube_pod_container_status_waiting","kube_pod_info","kube_pod_labels","kube_pod_owner","kube_pod_start_time","kube_pod_status_phase","kube_pod_status_ready","kube_pod_status_reason","kube_replicaset_labels","kube_replicaset_owner","kube_replicaset_spec_replicas","kube_replicaset_status_fully_labeled_replicas","kube_replicaset_status_ready_replicas","kube_replicaset_status_replicas","kube_running_pod_ready","kube_secret_info","kube_secret_type","kube_service_info","kube_service_labels","kube_service_spec_type","kubelet_container_log_filesystem_used_bytes","namespace:container_cpu_usage:sum","namespace:container_memory_usage_bytes:sum","namespace_workload_pod:kube_pod_owner:relabel","node_namespace_pod:kube_pod_info:","node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate","node_namespace_pod_container:container_memory_cache","node_namespace_pod_container:container_memory_rss","node_namespace_pod_container:container_memory_swap","node_namespace_pod_container:container_memory_working_set_bytes","pod:container_cpu_usage:sum","pod:container_fs_usage_bytes:sum","pod_network_name_info","scrape_duration_seconds","scrape_samples_post_metric_relabeling","scrape_samples_scraped","scrape_series_added","up","version"]}

$ curl -X GET -kG 'https://localhost:9092/api/v1/series?namespace=ns1'  -H "Authorization: Bearer $TOKEN"
{"status":"success","data":[{"__name__":"container_cpu_system_seconds_total","container":"POD","endpoint":"https-metrics","id":"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-poda9d7c8cb_4320_4937_aef8_c8c94a3d5653.slice/crio-74283bda373d3c53c64ab94e52b674841e0da1d7c1bf5f7f77be0f252d77296b.scope","instance":"10.0.128.4:10250","job":"kubelet","metrics_path":"/metrics/cadvisor","name":"k8s_POD_prometheus-example-app-d748cfb54-z2xh6_ns1_a9d7c8cb-4320-4937-aef8-c8c94a3d5653_0","namespace":"ns1","node":"ci-ln-zjbdptk-72292-fg6kj-worker-b-2rkrp","pod":"prometheus-example-app-d748cfb54-z2xh6","prometheus":"openshift-monitoring/k8s","service":"kubelet"},{"__name__":"container_cpu_system_seconds_total","container":"POD","endpoint":"https-metrics"
...

```
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
