### PR TITLE
pkg: drop code removing the legacy Alertmanager service monitor

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -278,7 +278,6 @@ var (
 
 	TrustedCABundleKey = "ca-bundle.crt"
 
-	AlertmanagerLegacyServiceMonitorName                = "alertmanager"
 	AdditionalAlertmanagerConfigSecretKey               = "alertmanager-configs.yaml"
 	PrometheusK8sAdditionalAlertmanagerConfigSecretName = "prometheus-k8s-additional-alertmanager-configs"
 	PrometheusUWAdditionalAlertmanagerConfigSecretName  = "prometheus-user-workload-additional-alertmanager-configs"

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -201,14 +201,6 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Alertmanager ServiceMonitor failed")
 	}
 
-	// Alertmanager ServiceMonitor has been renamed from alertmanager to alertmanager-${config}.
-	// This deletion ensures that the previous ServiceMonitor will be always removed after a CMO upgrade.
-	// Refer https://github.com/prometheus-operator/kube-prometheus/pull/1471 for more info.
-	t.client.DeleteServiceMonitorByNamespaceAndName(ctx, smam.Namespace, manifests.AlertmanagerLegacyServiceMonitorName)
-	if err != nil {
-		return errors.Wrap(err, "deleting legacy Alertmanager ServiceMonitor failed")
-	}
-
 	err = t.client.CreateOrUpdateServiceMonitor(ctx, smam)
 	return errors.Wrap(err, "reconciling Alertmanager ServiceMonitor failed")
 }


### PR DESCRIPTION
The Alertmanager service monitor was renamed from "alertmanager" to
"alertmanager-main" in 4.10 and the operator took care of removing the
old service monitor for clusters that upgraded from 4.9. Now that the
master branch targets 4.11, we can drop this code.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
