### PR TITLE
[MON-2151] remove the Oauth-proxy before AlertManager

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -24,33 +24,15 @@ spec:
         topologyKey: kubernetes.io/hostname
   containers:
   - args:
-    - -provider=openshift
-    - -https-address=:9095
-    - -http-address=
-    - -email-domain=*
-    - -upstream=http://localhost:9093
-    - '-openshift-sar=[{"resource": "namespaces", "verb": "get"}, {"resource": "alertmanagers",
-      "resourceAPIGroup": "monitoring.coreos.com", "namespace": "openshift-monitoring",
-      "verb": "patch", "resourceName": "non-existant"}]'
-    - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}, "/":
-      {"resource":"alertmanagers", "group": "monitoring.coreos.com", "namespace":
-      "openshift-monitoring", "verb": "patch", "name": "non-existant"}}'
-    - -tls-cert=/etc/tls/private/tls.crt
-    - -tls-key=/etc/tls/private/tls.key
-    - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-    - -cookie-secret-file=/etc/proxy/secrets/session_secret
-    - -openshift-service-account=alertmanager-main
-    - -openshift-ca=/etc/pki/tls/cert.pem
-    - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    env:
-    - name: HTTP_PROXY
-      value: ""
-    - name: HTTPS_PROXY
-      value: ""
-    - name: NO_PROXY
-      value: ""
-    image: quay.io/openshift/oauth-proxy:latest
-    name: alertmanager-proxy
+    - --secure-listen-address=0.0.0.0:9095
+    - --upstream=http://127.0.0.1:9093
+    - --config-file=/etc/kube-rbac-proxy/config.yaml
+    - --tls-cert-file=/etc/tls/private/tls.crt
+    - --tls-private-key-file=/etc/tls/private/tls.key
+    - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    - --logtostderr=true
+    image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+    name: kube-rbac-proxy-web
     ports:
     - containerPort: 9095
       name: web
@@ -60,10 +42,10 @@ spec:
         memory: 20Mi
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
+    - mountPath: /etc/kube-rbac-proxy
+      name: secret-alertmanager-kube-rbac-proxy-web
     - mountPath: /etc/tls/private
       name: secret-alertmanager-main-tls
-    - mountPath: /etc/proxy/secrets
-      name: secret-alertmanager-main-proxy
   - args:
     - --secure-listen-address=0.0.0.0:9092
     - --upstream=http://127.0.0.1:9096
@@ -150,9 +132,9 @@ spec:
       memory: 40Mi
   secrets:
   - alertmanager-main-tls
-  - alertmanager-main-proxy
   - alertmanager-kube-rbac-proxy
   - alertmanager-kube-rbac-proxy-metric
+  - alertmanager-kube-rbac-proxy-web
   securityContext:
     fsGroup: 65534
     runAsNonRoot: true

--- a/assets/alertmanager/kube-rbac-proxy-web-secret.yaml
+++ b/assets/alertmanager/kube-rbac-proxy-web-secret.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: alertmanager-main
+  name: alertmanager-kube-rbac-proxy-web
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "resourceAttributes":
+        "apiGroup": "monitoring.coreos.com"
+        "namespace": "openshift-monitoring"
+        "resource": "alertmanagers"
+        "verbs":
+        - "create"
+        - "get"
+        - "patch"
+        - "update"
+        - "delete"
+      "static":
+      - "resourceRequest": true
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+      - "resourceRequest": true
+        "user":
+          "name": "system:serviceaccount:openshift-user-workload-monitoring:prometheus-user-workload"
+      - "resourceRequest": true
+        "user":
+          "name": "system:serviceaccount:openshift-user-workload-monitoring:thanos-ruler"
+type: Opaque

--- a/assets/alertmanager/proxy-secret.yaml
+++ b/assets/alertmanager/proxy-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-data: {}
-kind: Secret
-metadata:
-  labels:
-    app.kubernetes.io/name: alertmanager-main
-  name: alertmanager-main-proxy
-  namespace: openshift-monitoring
-type: Opaque

--- a/assets/alertmanager/service-account.yaml
+++ b/assets/alertmanager/service-account.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
-  annotations:
-    serviceaccounts.openshift.io/oauth-redirectreference.alertmanager-main: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"alertmanager-main"}}'
   labels:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/instance: main

--- a/assets/alertmanager/trusted-ca-bundle.yaml
+++ b/assets/alertmanager/trusted-ca-bundle.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data: {}
-kind: ConfigMap
-metadata:
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"
-  name: alertmanager-trusted-ca-bundle
-  namespace: openshift-monitoring

--- a/assets/cluster-monitoring-operator/monitoring-alertmanager-edit-role.yaml
+++ b/assets/cluster-monitoring-operator/monitoring-alertmanager-edit-role.yaml
@@ -6,9 +6,7 @@ metadata:
 rules:
 - apiGroups:
   - monitoring.coreos.com
-  resourceNames:
-  - non-existant
   resources:
   - alertmanagers
   verbs:
-  - patch
+  - '*'

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -314,14 +314,16 @@ function(params) {
     metadata: {
       name: 'cluster-monitoring-view',
     },
-    rules: [{
-      apiGroups: [''],
-      resources: ['namespaces'],
-      verbs: ['get'],
-    }],
+    rules: [
+      {
+        apiGroups: [''],
+        resources: ['namespaces'],
+        verbs: ['get'],
+      },
+    ],
   },
 
-  // This role enables access to the Alertmanager APIs and UIs through OAuth proxy.
+  // This role enables access to the Alertmanager APIs through kube-rbac-proxy
   monitoringAlertmanagerEditRole: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'Role',
@@ -332,8 +334,7 @@ function(params) {
     rules: [{
       apiGroups: ['monitoring.coreos.com'],
       resources: ['alertmanagers'],
-      verbs: ['patch'],
-      resourceNames: ['non-existant'],
+      verbs: ['*'],
     }],
   },
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -769,7 +769,11 @@ func (c *Client) DeletePrometheusRuleByNamespaceAndName(ctx context.Context, nam
 }
 
 func (c *Client) DeleteSecret(ctx context.Context, s *v1.Secret) error {
-	err := c.kclient.CoreV1().Secrets(s.Namespace).Delete(ctx, s.GetName(), metav1.DeleteOptions{})
+	return c.DeleteSecretByNamespaceAndName(ctx, s.Namespace, s.GetName())
+}
+
+func (c *Client) DeleteSecretByNamespaceAndName(ctx context.Context, namespace, name string) error {
+	err := c.kclient.CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -249,7 +249,7 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.AlertmanagerMain(nil)
+	_, err = f.AlertmanagerMain()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -704,11 +704,6 @@ func TestUnconfiguredManifests(t *testing.T) {
 	}
 
 	_, err = f.TelemeterTrustedCABundle()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = f.AlertmanagerTrustedCABundle()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2579,9 +2574,7 @@ func TestAlertmanagerMainStartupProbe(t *testing.T) {
 				t.Fatal(err)
 			}
 			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, tc.infrastructure, &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
-			a, err := f.AlertmanagerMain(
-				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-			)
+			a, err := f.AlertmanagerMain()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2643,9 +2636,7 @@ ingress:
 	})
 
 	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
-	a, err := f.AlertmanagerMain(
-		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-	)
+	a, err := f.AlertmanagerMain()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3363,9 +3354,7 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 		{
 			name: "Alertmanager",
 			getSpec: func(f *Factory) (spec, error) {
-				a, err := f.AlertmanagerMain(
-					&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-				)
+				a, err := f.AlertmanagerMain()
 				if err != nil {
 					return spec{}, err
 				}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
