### PR TITLE
Bug 2050707: test: account for pdb and Prometheus' staleness period

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -84,7 +84,7 @@ func testMain(m *testing.M) error {
 			body []byte
 			v    int
 		)
-		body, loopErr = f.ThanosQuerierClient.PrometheusQuery("count(up{job=\"prometheus-k8s\"})")
+		body, loopErr = f.ThanosQuerierClient.PrometheusQuery("count(last_over_time(up{job=\"prometheus-k8s\"}[2m]))")
 		if loopErr != nil {
 			loopErr = errors.Wrap(loopErr, "error executing prometheus query")
 			return false, nil


### PR DESCRIPTION
Problem: We recently introduced pod disruption budgets and improved
availability on Prometheus. This is reflected in the up metric for
Prometheus. By virtue of Prometheus staleness mechanism (it will return
samples up to 5m old for a series) the old query can appear to see 4
Prometheus instances.

Solution: Use the last_over_time aggregation with a 2m interval to only
look at the last sample in that interval. This effectively adjusts
Prometheus staleness period to 2m.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
