### PR TITLE
Bug 2043518: set degraded and available status based on Prometheus resource status

### DIFF
--- a/pkg/client/state_error.go
+++ b/pkg/client/state_error.go
@@ -1,0 +1,64 @@
+// Copyright 2022 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"fmt"
+)
+
+type State string
+
+const (
+	DegradedState    State = "degraded"
+	UnavailableState State = "unavailable"
+)
+
+// StateError indicates if an operation performed by the client has
+// resulted in an invalid state such as Degraded, Unavailable, Unknown
+type StateError struct {
+	State   State
+	Unknown bool
+	Reason  string
+}
+
+var _ error = (*StateError)(nil)
+
+func (se StateError) Error() string {
+	unknown := ""
+	if se.Unknown {
+		unknown = " (unknown)"
+	}
+	return fmt.Sprintf("%s%s: %s", se.State, unknown, se.Reason)
+}
+
+func NewDegradedError(reason string) *StateError {
+	return &StateError{State: DegradedState, Unknown: false, Reason: reason}
+}
+
+func NewAvailabilityError(reason string) *StateError {
+	return &StateError{State: UnavailableState, Unknown: false, Reason: reason}
+}
+
+func NewUnknownStateError(s State, reason string) *StateError {
+	return &StateError{State: s, Unknown: true, Reason: reason}
+}
+
+func NewUnknownAvailabiltyError(reason string) *StateError {
+	return NewUnknownStateError(UnavailableState, reason)
+}
+
+func NewUnknownDegradedError(reason string) *StateError {
+	return NewUnknownStateError(DegradedState, reason)
+}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1557,8 +1557,12 @@ func (f *Factory) PrometheusK8sTrustedCABundle() (*v1.ConfigMap, error) {
 	return cm, nil
 }
 
+func (f *Factory) NewPrometheusK8s() (*monv1.Prometheus, error) {
+	return f.NewPrometheus(f.assets.MustNewAssetReader(PrometheusK8s))
+}
+
 func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.ConfigMap) (*monv1.Prometheus, error) {
-	p, err := f.NewPrometheus(f.assets.MustNewAssetReader(PrometheusK8s))
+	p, err := f.NewPrometheusK8s()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -445,3 +445,52 @@ func TestUpgradeableStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestRunReport(t *testing.T) {
+	tt := []struct {
+		name       string
+		degraded   client.StateInfo
+		isDegraded bool
+
+		available     client.StateInfo
+		isUnavailable bool
+	}{{
+		name:     "all nils",
+		degraded: nil, isDegraded: false,
+		available: nil, isUnavailable: false,
+	}, {
+		name:     "degraded: false",
+		degraded: asExpected(client.FalseStatus), isDegraded: false,
+		available: nil, isUnavailable: false,
+	}, {
+		name:     "available: false",
+		degraded: nil, isDegraded: false,
+		available: asExpected(client.TrueStatus), isUnavailable: false,
+	}, {
+		name:     "degraded: stateInfo",
+		degraded: &stateInfo{}, isDegraded: true,
+		available: nil, isUnavailable: false,
+	}, {
+		name:     "available: stateInfo",
+		degraded: nil, isDegraded: false,
+		available: &stateInfo{}, isUnavailable: true,
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := runReport{
+				degraded:  tc.degraded,
+				available: tc.available,
+			}
+
+			if got, want := rr.isDegraded(), tc.isDegraded; got != want {
+				t.Errorf("expected degraded to be %t but got %t", want, got)
+			}
+
+			if got, want := rr.isUnavailable(), tc.isUnavailable; got != want {
+				t.Errorf("expected degraded to be %t but got %t", want, got)
+			}
+		})
+
+	}
+}

--- a/pkg/tasks/prometheus_validation.go
+++ b/pkg/tasks/prometheus_validation.go
@@ -1,0 +1,56 @@
+// Copyright 2022 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+type PrometheusValidationTask struct {
+	client  *client.Client
+	factory *manifests.Factory
+}
+
+func NewPrometheusValidationTask(client *client.Client, factory *manifests.Factory) *PrometheusValidationTask {
+	return &PrometheusValidationTask{
+		client:  client,
+		factory: factory,
+	}
+}
+
+func (t *PrometheusValidationTask) Run(ctx context.Context) error {
+
+	prom, err := t.factory.NewPrometheusK8s()
+	if err != nil {
+		return err
+	}
+
+	promNsName := types.NamespacedName{
+		Name:      prom.Name,
+		Namespace: prom.Namespace,
+	}
+
+	if err := t.client.ValidatePrometheus(ctx, promNsName); err != nil {
+		klog.V(4).ErrorS(err, "prometheus validation failed")
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Bug 2043518: set degraded and available status based on Prometheus pod status

NOTE: This patch addresses 2 related Bugs:
   1. Bug 2043518: Better message in the CMO degraded/unavailable
      conditions when pods can't be scheduled
   2. Bug 2039411: Monitoring operator reports unavailable=true while
      one Prometheus pod is ready

The patch sets the Degraded and Availability status of ClusterOperator
by inspecting Prometheus Resource status. To achieve this, a new
PrometheusValidationTask is added that inspects the Prometheus resource status
and returns degraded and/or unavailable validation errors.

If at least one of the pod is running, the state will be marked as `Degraded`
but `Available` thus fixing the previous implementation which
incorrectly reported `Availability` as `False`.

Thus, given the following invalid monitoring config which uses a non-existent PVC

```yaml
  prometheusK8s:
    volumeClaimTemplate:
      metadata:
        name: prometheus-db
      spec:
        storageClassName: foo
        resources: { requests: {storage: 100Mi} }
```

It now correctly marks the ClusterOperator status as follows (formatted
for readability)

```
 {
    "type": "Degraded"
    "message": "<message from prometheus CR>",
    reason": "UpdatingPrometheusK8S",
    "status": "True",
  },
  {
    "type": "Available"
    "message": "<message from prometheus CR>",
    "reason": "UpdatingPrometheusK8S",
    "status": "False",
  }
]
```

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

---

[ ] I added CHANGELOG entry for this change.
[x] No user facing changes, so no entry in CHANGELOG was needed.