### PR TITLE
manifest: use path module to construct externalURL

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 
@@ -447,7 +448,7 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 	a.Spec.Image = &f.config.Images.Alertmanager
 
 	if f.consoleConfig != nil {
-		a.Spec.ExternalURL = f.consoleConfig.Status.ConsoleURL + "/monitoring"
+		a.Spec.ExternalURL = path.Join(f.consoleConfig.Status.ConsoleURL, "monitoring")
 	}
 
 	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.LogLevel != "" {
@@ -1426,7 +1427,7 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 	p.Spec.Image = &f.config.Images.Prometheus
 
 	if f.consoleConfig != nil {
-		p.Spec.ExternalURL = f.consoleConfig.Status.ConsoleURL + "/monitoring"
+		p.Spec.ExternalURL = path.Join(f.consoleConfig.Status.ConsoleURL, "monitoring")
 	}
 
 	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Resources != nil {


### PR DESCRIPTION
path.Join will ensure the result is a proper path.
Follow up from review on 7d46ea0bf5b2ebd299aa100deee68c93fdd38ff9.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
