### PR TITLE
Bug 2057025: fix init-config-reloader resource requests

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -129,11 +129,6 @@ spec:
         cpu: 1m
         memory: 20Mi
     terminationMessagePolicy: FallbackToLogsOnError
-  - name: config-reloader
-    resources:
-      requests:
-        cpu: 1m
-        memory: 10Mi
   image: quay.io/prometheus/alertmanager:v0.23.0
   listenLocal: true
   nodeSelector:

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -154,11 +154,6 @@ spec:
     - mountPath: /etc/tls/grpc
       name: secret-grpc-tls
   - name: prometheus
-  - name: config-reloader
-    resources:
-      requests:
-        cpu: 1m
-        memory: 10Mi
   enableFeatures: []
   externalLabels: {}
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         - --thanos-ruler-instance-namespaces=openshift-user-workload-monitoring
         - --config-reloader-cpu-limit=0
         - --config-reloader-memory-limit=0
+        - --config-reloader-cpu-request=1m
+        - --config-reloader-memory-request=10Mi
         image: quay.io/prometheus-operator/prometheus-operator:v0.53.1
         name: prometheus-operator
         ports:

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -37,6 +37,8 @@ spec:
         - --alertmanager-instance-namespaces=openshift-monitoring
         - --config-reloader-cpu-limit=0
         - --config-reloader-memory-limit=0
+        - --config-reloader-cpu-request=1m
+        - --config-reloader-memory-request=10Mi
         - --web.enable-tls=true
         - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --web.tls-min-version=VersionTLS12

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -115,11 +115,6 @@ spec:
     volumeMounts:
     - mountPath: /etc/tls/grpc
       name: secret-grpc-tls
-  - name: config-reloader
-    resources:
-      requests:
-        cpu: 1m
-        memory: 10Mi
   enableFeatures: []
   enforcedNamespaceLabel: namespace
   externalLabels: {}

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -66,11 +66,6 @@ spec:
       name: secret-thanos-ruler-tls
     - mountPath: /etc/proxy/secrets
       name: secret-thanos-ruler-oauth-cookie
-  - name: config-reloader
-    resources:
-      requests:
-        cpu: 1m
-        memory: 10Mi
   enforcedNamespaceLabel: namespace
   grpcServerTlsConfig:
     caFile: /etc/tls/grpc/ca.crt

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -387,15 +387,6 @@ function(params)
             },
             terminationMessagePolicy: 'FallbackToLogsOnError',
           },
-          {
-            name: 'config-reloader',
-            resources: {
-              requests: {
-                cpu: '1m',
-                memory: '10Mi',
-              },
-            },
-          },
         ],
         volumes+: [
           {

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -73,6 +73,8 @@ function(params)
                         '--thanos-ruler-instance-namespaces=' + cfg.namespace,
                         '--config-reloader-cpu-limit=0',
                         '--config-reloader-memory-limit=0',
+                        '--config-reloader-cpu-request=1m',
+                        '--config-reloader-memory-request=10Mi',
                       ],
                       securityContext: {},
                       resources: {

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -45,6 +45,8 @@ function(params)
                         '--alertmanager-instance-namespaces=' + cfg.namespace,
                         '--config-reloader-cpu-limit=0',
                         '--config-reloader-memory-limit=0',
+                        '--config-reloader-cpu-request=1m',
+                        '--config-reloader-memory-request=10Mi',
                         '--web.enable-tls=true',
                         '--web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
                         '--web.tls-min-version=VersionTLS12',

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -353,15 +353,6 @@ function(params)
               },
             ],
           },
-          {
-            name: 'config-reloader',
-            resources: {
-              requests: {
-                cpu: '1m',
-                memory: '10Mi',
-              },
-            },
-          },
         ],
       },
     },

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -534,15 +534,6 @@ function(params)
           {
             name: 'prometheus',
           },
-          {
-            name: 'config-reloader',
-            resources: {
-              requests: {
-                cpu: '1m',
-                memory: '10Mi',
-              },
-            },
-          },
         ],
       },
     },

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -452,17 +452,6 @@ function(params)
               },
             ],
           },
-          {
-            // Note: this is performing strategic-merge-patch for config-reloader container.
-            // Remainder of the container configuration is managed by prometheus-operator based on $.thanosRuler.spec
-            name: 'config-reloader',
-            resources: {
-              requests: {
-                cpu: '1m',
-                memory: '10Mi',
-              },
-            },
-          },
         ],
       },
     },


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
