### PR TITLE
Bug 2057403: jsonnet: Give CMO explicit get permissions for ReplicaSets

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -121,6 +121,16 @@ function(params) {
       },
     },
     rules: [
+      // The permissions mixed-in in main.jsonnet don't seem to include GET
+      // access on these, but the operator needs them when fetching
+      // OwnerReferences.
+      //
+      // See: https://bugzilla.redhat.com/show_bug.cgi?id=2057403
+      {
+        apiGroups: ['apps'],
+        resources: ['replicasets'],
+        verbs: ['get'],
+      },
       {
         apiGroups: ['rbac.authorization.k8s.io'],
         resources: ['roles', 'rolebindings', 'clusterroles', 'clusterrolebindings'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -8,6 +8,12 @@ metadata:
   name: cluster-monitoring-operator
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles


### PR DESCRIPTION
The cluster-monitoring-operator reads the owner reference for its pod,
and fetches that ReplicaSet as part of setting up event recording.
None of the mixed-in permissions end up allowing GET actions on these,
so the fetch fails and an error is reported in the logs.  This adds
the permission explicitly.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
