### PR TITLE
MON-2222: Enable validating webhook for AlertmanagerConfig custom resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+# 4.11
+
+- [#1567](https://github.com/openshift/cluster-monitoring-operator/pull/1567) Enable validating webhook for AlertmanagerConfig customer resources
+
 ## 4.10
 
 - [#1509](https://github.com/openshift/cluster-monitoring-operator/pull/1509) add NLB usage metrics for network edge

--- a/assets/prometheus-operator/alertmanager-config-validating-webhook.yaml
+++ b/assets/prometheus-operator/alertmanager-config-validating-webhook.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: true
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+  name: alertmanagerconfigs.openshift.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: prometheus-operator
+      namespace: openshift-monitoring
+      path: /admission-alertmanagerconfigs/validate
+      port: 8080
+  failurePolicy: Ignore
+  name: alertmanagerconfigs.openshift.io
+  rules:
+  - apiGroups:
+    - monitoring.coreos.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - alertmanagerconfigs
+    scope: Namespaced
+  sideEffects: None
+  timeoutSeconds: 5

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -143,7 +143,7 @@ function(params) {
       },
       {
         apiGroups: ['admissionregistration.k8s.io'],
-        resourceNames: ['prometheusrules.openshift.io'],
+        resourceNames: ['prometheusrules.openshift.io', 'alertmanagerconfigs.openshift.io'],
         resources: ['validatingwebhookconfigurations'],
         verbs: ['create', 'get', 'list', 'watch', 'update', 'delete'],
       },

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -213,4 +213,45 @@ function(params)
         },
       ],
     },
+
+    alertmanagerConfigValidatingWebhook: {
+      apiVersion: 'admissionregistration.k8s.io/v1',
+      kind: 'ValidatingWebhookConfiguration',
+      metadata: {
+        name: 'alertmanagerconfigs.openshift.io',
+        labels: {
+          'app.kubernetes.io/component': 'controller',
+          'app.kubernetes.io/name': 'prometheus-operator',
+        },
+        annotations: {
+          'service.beta.openshift.io/inject-cabundle': true,
+        },
+      },
+      webhooks: [
+        {
+          name: 'alertmanagerconfigs.openshift.io',
+          rules: [
+            {
+              apiGroups: ['monitoring.coreos.com'],
+              apiVersions: ['v1alpha1'],
+              operations: ['CREATE', 'UPDATE'],
+              resources: ['alertmanagerconfigs'],
+              scope: 'Namespaced',
+            },
+          ],
+          clientConfig: {
+            service: {
+              namespace: 'openshift-monitoring',
+              name: 'prometheus-operator',
+              port: 8080,
+              path: '/admission-alertmanagerconfigs/validate',
+            },
+          },
+          admissionReviewVersions: ['v1'],
+          sideEffects: 'None',
+          timeoutSeconds: 5,
+          failurePolicy: 'Ignore',
+        },
+      ],
+    },
   }

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -40,6 +40,7 @@ rules:
   - admissionregistration.k8s.io
   resourceNames:
   - prometheusrules.openshift.io
+  - alertmanagerconfigs.openshift.io
   resources:
   - validatingwebhookconfigurations
   verbs:

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -162,16 +162,17 @@ var (
 	PrometheusAdapterServiceMonitor                     = "prometheus-adapter/service-monitor.yaml"
 	PrometheusAdapterServiceAccount                     = "prometheus-adapter/service-account.yaml"
 
-	PrometheusOperatorClusterRoleBinding    = "prometheus-operator/cluster-role-binding.yaml"
-	PrometheusOperatorClusterRole           = "prometheus-operator/cluster-role.yaml"
-	PrometheusOperatorServiceAccount        = "prometheus-operator/service-account.yaml"
-	PrometheusOperatorDeployment            = "prometheus-operator/deployment.yaml"
-	PrometheusOperatorService               = "prometheus-operator/service.yaml"
-	PrometheusOperatorServiceMonitor        = "prometheus-operator/service-monitor.yaml"
-	PrometheusOperatorCertsCABundle         = "prometheus-operator/operator-certs-ca-bundle.yaml"
-	PrometheusOperatorRuleValidatingWebhook = "prometheus-operator/prometheus-rule-validating-webhook.yaml"
-	PrometheusOperatorPrometheusRule        = "prometheus-operator/prometheus-rule.yaml"
-	PrometheusOperatorKubeRbacProxySecret   = "prometheus-operator/kube-rbac-proxy-secret.yaml"
+	PrometheusOperatorClusterRoleBinding                  = "prometheus-operator/cluster-role-binding.yaml"
+	PrometheusOperatorClusterRole                         = "prometheus-operator/cluster-role.yaml"
+	PrometheusOperatorServiceAccount                      = "prometheus-operator/service-account.yaml"
+	PrometheusOperatorDeployment                          = "prometheus-operator/deployment.yaml"
+	PrometheusOperatorService                             = "prometheus-operator/service.yaml"
+	PrometheusOperatorServiceMonitor                      = "prometheus-operator/service-monitor.yaml"
+	PrometheusOperatorCertsCABundle                       = "prometheus-operator/operator-certs-ca-bundle.yaml"
+	PrometheusOperatorRuleValidatingWebhook               = "prometheus-operator/prometheus-rule-validating-webhook.yaml"
+	PrometheusOperatorAlertmanagerConfigValidatingWebhook = "prometheus-operator/alertmanager-config-validating-webhook.yaml"
+	PrometheusOperatorPrometheusRule                      = "prometheus-operator/prometheus-rule.yaml"
+	PrometheusOperatorKubeRbacProxySecret                 = "prometheus-operator/kube-rbac-proxy-secret.yaml"
 
 	PrometheusOperatorUserWorkloadServiceAccount      = "prometheus-operator-user-workload/service-account.yaml"
 	PrometheusOperatorUserWorkloadClusterRole         = "prometheus-operator-user-workload/cluster-role.yaml"
@@ -2342,6 +2343,14 @@ func setArg(args []string, argName string, argValue string) []string {
 
 func (f *Factory) PrometheusRuleValidatingWebhook() (*admissionv1.ValidatingWebhookConfiguration, error) {
 	wc, err := f.NewValidatingWebhook(f.assets.MustNewAssetReader(PrometheusOperatorRuleValidatingWebhook))
+	if err != nil {
+		return nil, err
+	}
+	return wc, nil
+}
+
+func (f *Factory) AlertManagerConfigValidatingWebhook() (*admissionv1.ValidatingWebhookConfiguration, error) {
+	wc, err := f.NewValidatingWebhook(f.assets.MustNewAssetReader(PrometheusOperatorAlertmanagerConfigValidatingWebhook))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tasks/prometheusoperator.go
+++ b/pkg/tasks/prometheusoperator.go
@@ -16,6 +16,7 @@ package tasks
 
 import (
 	"context"
+
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -117,6 +118,16 @@ func (t *PrometheusOperatorTask) Run(ctx context.Context) error {
 	err = t.client.CreateOrUpdateValidatingWebhookConfiguration(ctx, w)
 	if err != nil {
 		return errors.Wrap(err, "reconciling Prometheus Rule Validating Webhook failed")
+	}
+
+	aw, err := t.factory.AlertManagerConfigValidatingWebhook()
+	if err != nil {
+		return errors.Wrap(err, "initializing AlertManagerConfig Validating Webhook failed")
+	}
+
+	err = t.client.CreateOrUpdateValidatingWebhookConfiguration(ctx, aw)
+	if err != nil {
+		return errors.Wrap(err, "reconciling AlertManagerConfig Validating Webhook failed")
 	}
 
 	pr, err := t.factory.PrometheusOperatorPrometheusRule()


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Fixes https://issues.redhat.com/browse/MON-2222

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
