### PR TITLE
Revert "Bug 2057403: jsonnet: Give CMO explicit get permissions for ReplicaSets"

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -121,16 +121,6 @@ function(params) {
       },
     },
     rules: [
-      // The permissions mixed-in in main.jsonnet don't seem to include GET
-      // access on these, but the operator needs them when fetching
-      // OwnerReferences.
-      //
-      // See: https://bugzilla.redhat.com/show_bug.cgi?id=2057403
-      {
-        apiGroups: ['apps'],
-        resources: ['replicasets'],
-        verbs: ['get'],
-      },
       {
         apiGroups: ['rbac.authorization.k8s.io'],
         resources: ['roles', 'rolebindings', 'clusterroles', 'clusterrolebindings'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -8,12 +8,6 @@ metadata:
   name: cluster-monitoring-operator
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles


### PR DESCRIPTION
Reverts openshift/cluster-monitoring-operator#1564

This change looks fairly innocuous, but it's in a monitoring repository and the title included "permissions".  4.11 Azure CI broke recently between [4.11.0-0.nightly-2022-02-24-113743][1] and [4.11.0-0.nightly-2022-02-24-173451][2] with failures like:

    level=error msg=Cluster operator monitoring Degraded is True with UpdatingPrometheusK8SFailed: Failed to rollout the stack. Error: updating prometheus-k8s: waiting for Prometheus object changes failed: waiting for Prometheus openshift-monitoring/k8s: expected 2 replicas, got 0 updated replicas

and:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure/1496904660361940992/artifacts/e2e-azure/gather-extra/artifacts/pods.json | jq -r '.items[] | select(.metadata.namespace == "openshift-monitoring") | .metadata.name as $pod | .status.containerStatuses[] | select(.restartCount > 0) | $pod + " " + .name + " restarted " + (.restartCount | tostring) + "\n" + .lastState.terminated.message'
kube-state-metrics-5958bfb549-c2czl kube-state-metrics restarted 4

prometheus-adapter-9fc586648-sfffr prometheus-adapter restarted 4
Fatalf(...)
        /go/src/github.com/kubernetes-sigs/prometheus-adapter/vendor/k8s.io/klog/v2/klog.go:1514
main.main()
        /go/src/github.com/kubernetes-sigs/prometheus-adapter/cmd/adapter/adapter.go:334 +0x937

goroutine 6 [chan receive]:
...more noisy stack trace stuff...
goroutine 71 [chan receive]:
k8s.io/apiserver/pkg/server.SetupSignalContext.func1()
        /go/src/github.com/kubernetes-sigs/prometheus-adapter/vendor/k8s.io/apiserver/pkg/server/signal.go:48 +0x2b
created by k8s.io/apiserver/pkg/server.SetupSignalContext
        /go/src/github.com/kubernetes-sigs/prometheus-adapter/vendor/k8s.io/apiserver/pkg/server/signal.go:47 +0xe7

prometheus-k8s-0 prometheus restarted 12
ts=2022-02-24T19:08:33.801Z caller=main.go:532 level=info msg="Starting Prometheus" version="(version=2.32.1, branch=rhaos-4.11-rhel-8, revision=b03b48349eefa239db793579817626ce37881afb)"
ts=2022-02-24T19:08:33.801Z caller=main.go:537 level=info build_context="(go=go1.17.5, user=root@3236b62a1bb1, date=20220216-02:47:44)"
ts=2022-02-24T19:08:33.801Z caller=main.go:538 level=info host_details="(Linux 4.18.0-348.el8.x86_64 #1 SMP Mon Oct 4 12:17:22 EDT 2021 x86_64 prometheus-k8s-0 (none))"
ts=2022-02-24T19:08:33.801Z caller=main.go:539 level=info fd_limits="(soft=1048576, hard=1048576)"
ts=2022-02-24T19:08:33.801Z caller=main.go:540 level=info vm_limits="(soft=unlimited, hard=unlimited)"
ts=2022-02-24T19:08:33.801Z caller=query_logger.go:86 level=error component=activeQueryTracker msg="Error opening query log file" file=/prometheus/queries.active err="open /prometheus/queries.active: permission denied"
panic: Unable to create mmap-ed active query log

goroutine 1 [running]:
github.com/prometheus/prometheus/promql.NewActiveQueryTracker({0x7ffcc3cbee72, 0xb}, 0x14, {0x354b680, 0xc0011892c0})
        /go/src/github.com/prometheus/prometheus/promql/query_logger.go:116 +0x3d7
main.main()
        /go/src/github.com/prometheus/prometheus/cmd/prometheus/main.go:584 +0x5e53

prometheus-k8s-1 prometheus restarted 11
ts=2022-02-24T19:03:45.535Z caller=main.go:532 level=info msg="Starting Prometheus" version="(version=2.32.1, branch=rhaos-4.11-rhel-8, revision=b03b48349eefa239db793579817626ce37881afb)"
ts=2022-02-24T19:03:45.535Z caller=main.go:537 level=info build_context="(go=go1.17.5, user=root@3236b62a1bb1, date=20220216-02:47:44)"
ts=2022-02-24T19:03:45.535Z caller=main.go:538 level=info host_details="(Linux 4.18.0-348.el8.x86_64 #1 SMP Mon Oct 4 12:17:22 EDT 2021 x86_64 prometheus-k8s-1 (none))"
ts=2022-02-24T19:03:45.535Z caller=main.go:539 level=info fd_limits="(soft=1048576, hard=1048576)"
ts=2022-02-24T19:03:45.535Z caller=main.go:540 level=info vm_limits="(soft=unlimited, hard=unlimited)"
ts=2022-02-24T19:03:45.536Z caller=query_logger.go:86 level=error component=activeQueryTracker msg="Error opening query log file" file=/prometheus/queries.active err="open /prometheus/queries.active: permission denied"
panic: Unable to create mmap-ed active query log

goroutine 1 [running]:
github.com/prometheus/prometheus/promql.NewActiveQueryTracker({0x7fff40164e72, 0xb}, 0x14, {0x354b680, 0xc0011c0eb0})
        /go/src/github.com/prometheus/prometheus/promql/query_logger.go:116 +0x3d7
main.main()
        /go/src/github.com/prometheus/prometheus/cmd/prometheus/main.go:584 +0x5e53
```

Nothing else in [the nightly diff][3] looked suspicious enough, although I'm not really sure what I'd be looking for.  But opening a revert so we can run some CI and see if the revert helps is cheap, so that's what I'm doing here.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure/1496815947703390208
[2]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure/1496904660361940992
[3]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.11.0-0.nightly/release/4.11.0-0.nightly-2022-02-24-173451?4.11.0-0.nightly-2022-02-24-113743