### PR TITLE
Bug 2051470: Update prometheus-operator and sync jsonnet

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -750,6 +750,10 @@ spec:
           )
         ) by (cluster)
       record: :node_memory_MemAvailable_bytes:sum
+    - expr: |
+        sum(rate(node_cpu_seconds_total{job="node-exporter",mode!="idle",mode!="iowait",mode!="steal"}[5m])) /
+        count(sum(node_cpu_seconds_total{job="node-exporter"}) by (cluster, instance, cpu))
+      record: cluster:node_cpu:ratio_rate5m
   - name: kubelet.rules
     rules:
     - expr: |

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -3303,7 +3303,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "1 - sum(avg by (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval])))",
+                                  "expr": "cluster:node_cpu:ratio_rate5m{cluster=\"$cluster\"}",
                                   "format": "time_series",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -19214,8 +19214,8 @@ items:
               "list": [
                   {
                       "current": {
-                          "text": "Prometheus",
-                          "value": "Prometheus"
+                          "text": "default",
+                          "value": "default"
                       },
                       "hide": 0,
                       "label": "Data Source",
@@ -20270,8 +20270,8 @@ items:
               "list": [
                   {
                       "current": {
-                          "text": "Prometheus",
-                          "value": "Prometheus"
+                          "text": "default",
+                          "value": "default"
                       },
                       "hide": 0,
                       "label": "Data Source",

--- a/assets/prometheus-operator-user-workload/cluster-role-binding.yaml
+++ b/assets/prometheus-operator-user-workload/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-user-workload-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-operator-user-workload/cluster-role.yaml
+++ b/assets/prometheus-operator-user-workload/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-user-workload-operator
 rules:
 - apiGroups:

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:
@@ -26,12 +26,12 @@ spec:
         app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 0.54.0
+        app.kubernetes.io/version: 0.54.1
     spec:
       automountServiceAccountToken: true
       containers:
       - args:
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.54.0
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.54.1
         - --prometheus-instance-namespaces=openshift-user-workload-monitoring
         - --alertmanager-instance-namespaces=openshift-user-workload-monitoring
         - --thanos-ruler-instance-namespaces=openshift-user-workload-monitoring
@@ -39,7 +39,7 @@ spec:
         - --config-reloader-memory-limit=0
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
-        image: quay.io/prometheus-operator/prometheus-operator:v0.54.0
+        image: quay.io/prometheus-operator/prometheus-operator:v0.54.1
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/assets/prometheus-operator-user-workload/service-account.yaml
+++ b/assets/prometheus-operator-user-workload/service-account.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring

--- a/assets/prometheus-operator-user-workload/service-monitor.yaml
+++ b/assets/prometheus-operator-user-workload/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:
@@ -22,4 +22,4 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 0.54.0
+      app.kubernetes.io/version: 0.54.1

--- a/assets/prometheus-operator-user-workload/service.yaml
+++ b/assets/prometheus-operator-user-workload/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/prometheus-operator/cluster-role-binding.yaml
+++ b/assets/prometheus-operator/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/prometheus-operator/cluster-role.yaml
+++ b/assets/prometheus-operator/cluster-role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
 rules:
 - apiGroups:

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:
@@ -26,13 +26,13 @@ spec:
         app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 0.54.0
+        app.kubernetes.io/version: 0.54.1
     spec:
       automountServiceAccountToken: true
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.54.0
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.54.1
         - --prometheus-instance-namespaces=openshift-monitoring
         - --thanos-ruler-instance-namespaces=openshift-monitoring
         - --alertmanager-instance-namespaces=openshift-monitoring
@@ -43,7 +43,7 @@ spec:
         - --web.enable-tls=true
         - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --web.tls-min-version=VersionTLS12
-        image: quay.io/prometheus-operator/prometheus-operator:v0.54.0
+        image: quay.io/prometheus-operator/prometheus-operator:v0.54.1
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/assets/prometheus-operator/prometheus-rule.yaml
+++ b/assets/prometheus-operator/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
     prometheus: k8s
     role: alert-rules
   name: prometheus-operator-rules

--- a/assets/prometheus-operator/service-account.yaml
+++ b/assets/prometheus-operator/service-account.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: openshift-monitoring

--- a/assets/prometheus-operator/service-monitor.yaml
+++ b/assets/prometheus-operator/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:
@@ -24,4 +24,4 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 0.54.0
+      app.kubernetes.io/version: 0.54.1

--- a/assets/prometheus-operator/service.yaml
+++ b/assets/prometheus-operator/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "a63fa17b76bbc53e09d50fdb1cc52a2b99a0c261",
+      "version": "af7154c1f432d2ec896e281b36a127cfc09faff7",
       "sum": "zhLYhUNcXNkMRfJhMUX0UiOpi8TOuLmUqJfO9NFKFkg="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "grafana-mixin"
         }
       },
-      "version": "636af1fff45934a422393d76e1a2583dc45cbaaa",
+      "version": "9b6552c7b4c89c03bc077a55aef5984d7daded13",
       "sum": "MkjR7zCgq6MUZgjDzop574tFKoTX2OBr7DTwm1K+Ofs="
     },
     {
@@ -48,7 +48,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "03d32a72a2a0bf0ee00ffc853be5f07ad3bafcbe",
+      "version": "857530e2e73565c40a3d06aaf8e2195a77cda55b",
       "sum": "0KkygBQd/AFzUvVzezE4qF/uDYgrwUXVpZfINBti0oc="
     },
     {
@@ -69,8 +69,8 @@
           "subdir": ""
         }
       },
-      "version": "2b33b82dfe04e4b37d62008ead7a04272a0fb42d",
-      "sum": "aE4obJU9mxKR0pX/aF46JUvcvaVLkc5fra7HatmzdQg="
+      "version": "177bc8ec789fa049a9585713d232035b159f8c92",
+      "sum": "FmC8wErB/CVwI3w5RDmtOMVegDGCiQMSdKts/u/TlG8="
     },
     {
       "source": {
@@ -79,7 +79,7 @@
           "subdir": "lib/promgrafonnet"
         }
       },
-      "version": "2b33b82dfe04e4b37d62008ead7a04272a0fb42d",
+      "version": "177bc8ec789fa049a9585713d232035b159f8c92",
       "sum": "zv7hXGui6BfHzE9wPatHI/AGZa4A2WKo6pq7ZdqBsps="
     },
     {
@@ -89,7 +89,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "929f4acd01262eeb8e0395d4673cbce176322c09",
+      "version": "6a8c6f8f1a84401fcc4cb41cd17ffb48990f6a49",
       "sum": "P0dCnbzyPScQGNXwXRcwiPkMLeTq0IPNbSTysDbySnM="
     },
     {
@@ -99,7 +99,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "929f4acd01262eeb8e0395d4673cbce176322c09",
+      "version": "6a8c6f8f1a84401fcc4cb41cd17ffb48990f6a49",
       "sum": "u8gaydJoxEjzizQ8jY8xSjYgWooPmxw+wIWdDxifMAk="
     },
     {
@@ -131,8 +131,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "53542d5ccea5d02958b10cd1b8ba80979051b454",
-      "sum": "N4vaitXumJDZGXQYYYi3Wnf1bwuT/O+9nbLiWwBB36Q="
+      "version": "15664a1983426c76498cbc2b86ebf7bffbf26945",
+      "sum": "ClAg/nR4aHbx9865gr7PE34fZ25ESoeB62fPVYfGB6g="
     },
     {
       "source": {
@@ -141,7 +141,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "c0baa01acd516ffc26fe8cd5763c0eaa0cd93c88",
+      "version": "f156f4ff3bd2e600cbd7758e48fadfa0590c850e",
       "sum": "qZ4WgiweaE6eeKtFK60QUjLO8sf2L9Q8fgafWvDcyfY=",
       "name": "prometheus-operator-mixin"
     },
@@ -152,8 +152,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "c0baa01acd516ffc26fe8cd5763c0eaa0cd93c88",
-      "sum": "ATGBsVlAVmzIvrRLKh7DWkI+uwM19BTtOVKMV801axo="
+      "version": "f156f4ff3bd2e600cbd7758e48fadfa0590c850e",
+      "sum": "/HVgGcQcgj+pAzRFrXlYFE9algvDEXmxcoh4tj3Le3U="
     },
     {
       "source": {
@@ -162,7 +162,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "4030e3670b359b8814aa8340ea1144f32b1f5ab3",
+      "version": "1138a088f60aa8cf4c6ef9c3c3ca23aabfbdd6e0",
       "sum": "iqF63VWQovIGBb7JI5oVVgMShz0dKptSzEVQQjsy+Jo=",
       "name": "alertmanager"
     },
@@ -173,8 +173,8 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "c2b4b2a33b91464f2e6bf1ca3fc87c851118c6d5",
-      "sum": "MlWDAKGZ+JArozRKdKEvewHeWn8j2DNBzesJfLVd0dk="
+      "version": "e3a18fdd37447992c213f42d61fdaed997fe9351",
+      "sum": "/SFdKggqBEmznyeGfpyEZl4rC69mMtLGEB9lG1mQhVA="
     },
     {
       "source": {
@@ -183,7 +183,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "e239e3ee8b13b51b0f791a199813a14f74600a7e",
+      "version": "4cc25c0cb0b96042a7d36a0dd53dc6970ad607fd",
       "sum": "ZjQoYhvgKwJNkg+h+m9lW3SYjnjv5Yx5btEipLhru88=",
       "name": "prometheus"
     },
@@ -204,7 +204,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "d0249f17e8ff561dbbedb491f4525d93518cb43b",
+      "version": "7528375b8f7181c15f8df64e1fcb8acb182c454c",
       "sum": "dBm9ML50quhu6dwTIgfNmVruMqfaUeQVCO/6EKtQLxE="
     }
   ],

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -22,5 +22,5 @@ versions:
   promLabelProxy: 0.4.0
   prometheus: 2.32.1
   prometheusAdapter: 0.9.1
-  prometheusOperator: 0.54.0
+  prometheusOperator: 0.54.1
   thanos: 0.23.1

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -5166,8 +5166,9 @@ spec:
                 type: object
               retention:
                 description: Time duration Prometheus shall retain data for. Default
-                  is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
-                  (milliseconds seconds minutes hours days weeks years).
+                  is '24h' if retentionSize is not set, and must match the regular
+                  expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes
+                  hours days weeks years).
                 type: string
               retentionSize:
                 description: 'Maximum amount of disk space used by blocks. Supported

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -3306,7 +3306,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "1 - sum(avg by (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=~\"idle|iowait|steal\", cluster=\"$cluster\"}[$__rate_interval])))",
+                                "expr": "cluster:node_cpu:ratio_rate5m{cluster=\"$cluster\"}",
                                 "format": "time_series",
                                 "instant": true,
                                 "intervalFactor": 2,
@@ -19235,8 +19235,8 @@ data:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": "Data Source",
@@ -20293,8 +20293,8 @@ data:
             "list": [
                 {
                     "current": {
-                        "text": "Prometheus",
-                        "value": "Prometheus"
+                        "text": "default",
+                        "value": "default"
                     },
                     "hide": 0,
                     "label": "Data Source",


### PR DESCRIPTION
Updated prometheus-operator version to 0.54.1 and regenerates assets

https://github.com/openshift/prometheus-operator/pull/158 is merged

This should fix both [2037762](https://bugzilla.redhat.com/show_bug.cgi?id=2037762) and [2051470](https://bugzilla.redhat.com/show_bug.cgi?id=2051470)
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
