### PR TITLE
add verticalpodautoscalers to kube-state-metrics

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -50,6 +50,7 @@ spec:
           ^kube_pod_container_status_running$,
           ^kube_pod_completion_time$,
           ^kube_pod_status_scheduled$
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,verticalpodautoscalers,volumeattachments
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         name: kube-state-metrics
         resources:

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -243,6 +243,13 @@ rules:
   - list
   - watch
 - apiGroups:
+    - autoscaling.k8s.io
+  resources:
+    - verticalpodautoscalers
+  verbs:
+    - list
+    - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
