### PR TITLE
Bug 2050120: Sanitize all regex allow/denylist used in KSM component

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -35,7 +35,10 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        - --metric-denylist=kube_secret_labels,kube_.*_annotations
+        - |
+          --metric-denylist=
+          ^kube_secret_labels$,
+          ^kube_.+_annotations$
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]
         - |
           --metric-denylist=

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -138,7 +138,11 @@ function(params)
                   else
                     c {
                       args+: [
-                        '--metric-denylist=kube_secret_labels,kube_.*_annotations',
+                        |||
+                          --metric-denylist=
+                          ^kube_secret_labels$,
+                          ^kube_.+_annotations$
+                        |||,
                         // TODO: Remove "poddisruptionbudget" once upstream KSM addresses a typo in PDB label metrics allowlist key.
                         '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]',
                       ],


### PR DESCRIPTION
Similar to https://github.com/prometheus-operator/kube-prometheus/pull/1614, but for allow/deny list passed from CMO to KSM.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
