### PR TITLE
Bug 2060083: React to changes in clusteroperators

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -475,6 +475,12 @@ func (o *Operator) handleEvent(obj interface{}) {
 		return
 	}
 
+	if _, ok := obj.(*configv1.Console); ok {
+		klog.Info("Triggering update due to a console update")
+		o.enqueue(cmoConfigMap)
+		return
+	}
+
 	key, ok := o.keyFunc(obj)
 	if !ok {
 		return


### PR DESCRIPTION
There are already eventhandlers for the various clusteroperators
configured, but the actual handlefunc drops events from them.

I manually deployed a CMO with this and change the consoles .status.URL, which successfully triggered a reconcile:
```
I0302 16:39:30.018897       1 operator.go:507] Triggering an update due to cluster resource: *v1.Console
```

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
