### PR TITLE
Bug 2060091: Properly deal with an empty console URL

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -448,7 +448,7 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 
 	a.Spec.Image = &f.config.Images.Alertmanager
 
-	if f.consoleConfig != nil {
+	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
 		a.Spec.ExternalURL = path.Join(f.consoleConfig.Status.ConsoleURL, "monitoring")
 	}
 
@@ -1427,7 +1427,7 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 
 	p.Spec.Image = &f.config.Images.Prometheus
 
-	if f.consoleConfig != nil {
+	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
 		p.Spec.ExternalURL = path.Join(f.consoleConfig.Status.ConsoleURL, "monitoring")
 	}
 


### PR DESCRIPTION
Currently, when the console object exist but has an empty url (happens
e.G. during cluster creation), an invalid alertmanager statefulset is
produced that has an argument of `--web.external-url=monitoring`.

This is made worse by the fact that we wait up to five minutes for the
alertmanager pods to become ready, which will never happen with this config,
resulting in a lot of startup delay if the CMO happens to be quicker
than the console operator.

This also fixes this for Prometheus, where it isn't strictly required as
prometheus seems to accept `monitoring` as a valid `external-url`. Odds
are this validation will be added there too, so fix that while we are at
it.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
