### PR TITLE
MON-2193: pkg/manifests: Expose retention size settings for Platform Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#1617](https://github.com/openshift/cluster-monitoring-operator/pull/1617) Add Oauth2 setting to PrometheusK8s remoteWrite config
 - [#1598](https://github.com/openshift/cluster-monitoring-operator/pull/1598) Expose Authorization settings for remote write in the CMO configuration
 - [#1638](https://github.com/openshift/cluster-monitoring-operator/pull/1638) Expose sigv4 setting to Prometheus remoteWrite
+- [#1579](https://github.com/openshift/cluster-monitoring-operator/pull/1579) Expose retention size settings for Platform Prometheus
 
 ## 4.10
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -175,6 +175,7 @@ type RemoteWriteSpec struct {
 type PrometheusK8sConfig struct {
 	LogLevel            string                               `json:"logLevel"`
 	Retention           string                               `json:"retention"`
+	RetentionSize       string                               `json:"retentionSize"`
 	NodeSelector        map[string]string                    `json:"nodeSelector"`
 	Tolerations         []v1.Toleration                      `json:"tolerations"`
 	Resources           *v1.ResourceRequirements             `json:"resources"`
@@ -343,7 +344,7 @@ func (c *Config) applyDefaults() {
 	if c.ClusterMonitoringConfiguration.PrometheusK8sConfig == nil {
 		c.ClusterMonitoringConfiguration.PrometheusK8sConfig = &PrometheusK8sConfig{}
 	}
-	if c.ClusterMonitoringConfiguration.PrometheusK8sConfig.Retention == "" {
+	if c.ClusterMonitoringConfiguration.PrometheusK8sConfig.Retention == "" && c.ClusterMonitoringConfiguration.PrometheusK8sConfig.RetentionSize == "" {
 		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.Retention = DefaultRetentionValue
 	}
 	if c.ClusterMonitoringConfiguration.AlertmanagerMainConfig == nil {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1442,6 +1442,10 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 		p.Spec.Retention = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Retention
 	}
 
+	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.RetentionSize != "" {
+		p.Spec.RetentionSize = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.RetentionSize
+	}
+
 	p.Spec.Image = &f.config.Images.Prometheus
 
 	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -118,6 +118,7 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 	data := fmt.Sprintf(`prometheusK8s:
   logLevel: debug
   retention: 10h
+  retentionSize: 15GB
   queryLogFile: /tmp/test.log
   tolerations:
     - operator: "Exists"
@@ -156,6 +157,7 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 					expectMatchingRequests(podName, containerName, mem, cpu),
 					expectContainerArg("--log.level=debug", containerName),
 					expectContainerArg("--storage.tsdb.retention.time=10h", containerName),
+					expectContainerArg("--storage.tsdb.retention.size=15GB", containerName),
 				},
 			),
 		},


### PR DESCRIPTION
[MON-2216](https://issues.redhat.com/browse/MON-2216): Expose retention size settings for Platform Prometheus in the CMO configuration

Introduce a new "retentionSize" field under the prometheusK8s key
When neither retention nor retentionSize are defined, a default of 15d for time retention applies.
When "retentionSize" is defined and "retention" isn't, only size retention applies.
When "retentionSize" isn't defined and "retention" is, only time retention applies
When both time and size retention fields are defined, both apply.

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
