### PR TITLE
WIP: test/e2e: Update query log path

### DIFF
--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -528,7 +528,7 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
   enforcedTargetLimit: 10
   logLevel: debug
   retention: 10h
-  queryLogFile: /tmp/test.log
+  queryLogFile: test.log
   tolerations:
     - operator: "Exists"
   externalLabels:
@@ -585,7 +585,7 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
 		},
 		{
 			name:      "assert query log file value is set and correct",
-			assertion: assertQueryLogValueEquals(f.UserWorkloadMonitoringNs, crName, "/tmp/test.log"),
+			assertion: assertQueryLogValueEquals(f.UserWorkloadMonitoringNs, crName, "/var/log/prometheus/test.log"),
 		},
 	} {
 		t.Run(tc.name, tc.assertion)


### PR DESCRIPTION
prometheus-operator now enforces a root read-only filesystem for
prometheus container. Hence you either can use queryLog without
specifying a full file path as prometheus-operator will mount the file
into an emptyDir volume at `/var/log/prometheus` or If a full path is
provided, e.g. /tmp/query.log, you must mount a volume in the specified
directory and it must be writable.

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

This is a work in progress PR

We can upgrade [prometheus-operator to 0.55](https://github.com/openshift/prometheus-operator/pull/162) once we update CMO in respective places where we use query log

**TODO:**

- Update documentation for queryLog usage

cc: @simonpasquier 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
