### PR TITLE
 e2e: redirect prometheus query log to stdout

### DIFF
--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -151,7 +151,7 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 	data := fmt.Sprintf(`prometheusK8s:
   logLevel: debug
   retention: 10h
-  queryLogFile: /tmp/test.log
+  queryLogFile: /dev/stdout
   tolerations:
     - operator: "Exists"
   externalLabels:
@@ -202,7 +202,7 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 		},
 		{
 			name:      "assert query log file value is set and correct",
-			assertion: assertQueryLogValueEquals(f.Ns, crName, "/tmp/test.log"),
+			assertion: assertQueryLogValueEquals(f.Ns, crName, "/dev/stdout"),
 		},
 		{
 			name:      "assert rule for Thanos sidecar exists",
@@ -528,7 +528,7 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
   enforcedTargetLimit: 10
   logLevel: debug
   retention: 10h
-  queryLogFile: /tmp/test.log
+  queryLogFile: /dev/stdout
   tolerations:
     - operator: "Exists"
   externalLabels:
@@ -585,7 +585,7 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
 		},
 		{
 			name:      "assert query log file value is set and correct",
-			assertion: assertQueryLogValueEquals(f.UserWorkloadMonitoringNs, crName, "/tmp/test.log"),
+			assertion: assertQueryLogValueEquals(f.UserWorkloadMonitoringNs, crName, "/dev/stdout"),
 		},
 	} {
 		t.Run(tc.name, tc.assertion)


### PR DESCRIPTION
TestClusterMonitorPrometheusK8Config test sets `/tmp/query.log` as queryLogFile which would fail on readonly root file system, use `/dev/stdout` instead.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
