### PR TITLE
Makefile: add tools to path for run-local target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ clean:
 
 .PHONY: run-local
 run-local: build
-	KUBECONFIG=$(KUBECONFIG) ./hack/local-cmo.sh
+	PATH="$(PATH):$(BIN_DIR)" KUBECONFIG=$(KUBECONFIG) ./hack/local-cmo.sh
 
 .PHONY: build
 build: operator


### PR DESCRIPTION
Problem: The run-local target requires gojsontoyaml, which is installed
to tmp/bin. Without gojsontoyaml installed or tmp/bin in the PATH, this
target fails.

Solution: add tmp/bin to PATH as part of the run-local target.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
