### PR TITLE
MON-2148: changes to replace oauth-proxy with kube-rbac-proxy in prometheus pod

### DIFF
--- a/assets/prometheus-k8s/kube-rbac-proxy-metric-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-metric-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: kube-rbac-proxy-metric
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
@@ -9,10 +9,8 @@ metadata:
 stringData:
   config.yaml: |-
     "authorization":
-      "static":
-      - "path": "/metrics"
-        "resourceRequest": false
-        "user":
-          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
-        "verb": "get"
+      "resourceAttributes":
+        "apiVersion": "v1"
+        "resource": "namespaces"
+        "verbs": "get"
 type: Opaque

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -42,43 +42,6 @@ spec:
   - metrics-client-ca
   containers:
   - args:
-    - -provider=openshift
-    - -https-address=:9091
-    - -http-address=
-    - -email-domain=*
-    - -upstream=http://localhost:9090
-    - -openshift-service-account=prometheus-k8s
-    - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
-    - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
-    - -tls-cert=/etc/tls/private/tls.crt
-    - -tls-key=/etc/tls/private/tls.key
-    - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-    - -cookie-secret-file=/etc/proxy/secrets/session_secret
-    - -openshift-ca=/etc/pki/tls/cert.pem
-    - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    env:
-    - name: HTTP_PROXY
-      value: ""
-    - name: HTTPS_PROXY
-      value: ""
-    - name: NO_PROXY
-      value: ""
-    image: quay.io/openshift/oauth-proxy:latest
-    name: prometheus-proxy
-    ports:
-    - containerPort: 9091
-      name: web
-    resources:
-      requests:
-        cpu: 1m
-        memory: 20Mi
-    terminationMessagePolicy: FallbackToLogsOnError
-    volumeMounts:
-    - mountPath: /etc/tls/private
-      name: secret-prometheus-k8s-tls
-    - mountPath: /etc/proxy/secrets
-      name: secret-prometheus-k8s-proxy
-  - args:
     - --secure-listen-address=0.0.0.0:9092
     - --upstream=http://127.0.0.1:9090
     - --allow-paths=/metrics
@@ -90,7 +53,7 @@ spec:
     - --logtostderr=true
     - --v=10
     image: quay.io/brancz/kube-rbac-proxy:v0.11.0
-    name: kube-rbac-proxy
+    name: kube-rbac-proxy-metrics
     ports:
     - containerPort: 9092
       name: metrics
@@ -106,7 +69,7 @@ spec:
       name: configmap-metrics-client-ca
       readOnly: true
     - mountPath: /etc/kube-rbac-proxy
-      name: secret-kube-rbac-proxy
+      name: secret-kube-rbac-proxy-metric
   - args:
     - --secure-listen-address=[$(POD_IP)]:10902
     - --upstream=http://127.0.0.1:10902
@@ -135,6 +98,33 @@ spec:
     volumeMounts:
     - mountPath: /etc/tls/private
       name: secret-prometheus-k8s-thanos-sidecar-tls
+    - mountPath: /etc/kube-rbac-proxy
+      name: secret-kube-rbac-proxy-metric
+  - args:
+    - --secure-listen-address=0.0.0.0:9091
+    - --upstream=http://127.0.0.1:9090
+    - --tls-cert-file=/etc/tls/private/tls.crt
+    - --tls-private-key-file=/etc/tls/private/tls.key
+    - --client-ca-file=/etc/tls/client/client-ca.crt
+    - --config-file=/etc/kube-rbac-proxy/config.yaml
+    - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    - --logtostderr=true
+    image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+    name: kube-rbac-proxy
+    ports:
+    - containerPort: 9091
+      name: web
+    resources:
+      requests:
+        cpu: 1m
+        memory: 10Mi
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /etc/tls/private
+      name: secret-prometheus-k8s-tls
+    - mountPath: /etc/tls/client
+      name: configmap-metrics-client-ca
+      readOnly: true
     - mountPath: /etc/kube-rbac-proxy
       name: secret-kube-rbac-proxy
   - args:
@@ -193,8 +183,9 @@ spec:
   - prometheus-k8s-tls
   - prometheus-k8s-proxy
   - prometheus-k8s-thanos-sidecar-tls
-  - kube-rbac-proxy
+  - kube-rbac-proxy-metric
   - metrics-client-certs
+  - kube-rbac-proxy
   securityContext:
     fsGroup: 65534
     runAsNonRoot: true

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -102,12 +102,23 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "creating Prometheus proxy Secret failed")
 	}
 
-	rs, err := t.factory.PrometheusRBACProxySecret()
+	rs, err := t.factory.PrometheusRBACMetricsProxySecret()
+
+	if err != nil {
+		return errors.Wrap(err, "initializing Prometheus RBAC metrics proxy Secret failed")
+	}
+
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
+	if err != nil {
+		return errors.Wrap(err, "creating or updating Prometheus RBAC metrics proxy Secret failed")
+	}
+
+	ras, err := t.factory.PrometheusRBACProxySecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus RBAC proxy Secret failed")
 	}
 
-	err = t.client.CreateOrUpdateSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, ras)
 	if err != nil {
 		return errors.Wrap(err, "creating or updating Prometheus RBAC proxy Secret failed")
 	}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
