### PR TITLE
Bug 2065076: manifests: advertise public urls without path component

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1380,15 +1380,15 @@ func (f *Factory) SharingConfig(promHost, amHost, thanosHost *url.URL) *v1.Confi
 	// Configmap keys need to include "public" to indicate that they are public values.
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=1807100.
 	if promHost != nil {
-		data["prometheusPublicURL"] = promHost.String()
+		data["prometheusPublicURL"] = fmt.Sprintf("%s://%s", promHost.Scheme, promHost.Host)
 	}
 
 	if amHost != nil {
-		data["alertmanagerPublicURL"] = amHost.String()
+		data["alertmanagerPublicURL"] = fmt.Sprintf("%s://%s", amHost.Scheme, amHost.Host)
 	}
 
 	if thanosHost != nil {
-		data["thanosPublicURL"] = thanosHost.String()
+		data["thanosPublicURL"] = fmt.Sprintf("%s://%s", thanosHost.Scheme, thanosHost.Host)
 	}
 
 	return &v1.ConfigMap{


### PR DESCRIPTION
Problem: When we removed some UIs (see
7d46ea0bf5b2ebd299aa100deee68c93fdd38ff9,
f85d2c15a8d686ab44de695d7617c1ad618ccd6d and
b8b6a503e82cf7e7b7c7f0f197184e047953de36), some Routes gained a path constraint.
We expose the Route URLs to the `monitoring-shared-config` configmap,
using `url.String()`. By using `url.String()` any path constraint on a
Route is added to the exposed URLs. For users who use those exposed URL
and add a path component, this causes issues.

Solution: Only expose <scheme>://<host> of the respective Route URLs.

Issues: https://bugzilla.redhat.com/show_bug.cgi?id=2065076

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
