### PR TITLE
Bug 2065682: manifest: explicitly drop the temporary cluster id label

### DIFF
--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -910,6 +910,10 @@ func TestPrometheusK8sRemoteWriteClusterIDRelabel(t *testing.T) {
 						TargetLabel: "__tmp_openshift_cluster_id__",
 						Replacement: "",
 					},
+					{
+						Regex:  "__tmp_openshift_cluster_id__",
+						Action: "labeldrop",
+					},
 				},
 			},
 		},
@@ -946,6 +950,10 @@ func TestPrometheusK8sRemoteWriteClusterIDRelabel(t *testing.T) {
 					{
 						SourceLabels: []string{"__tmp_openshift_cluster_id__"},
 						TargetLabel:  "cluster",
+					},
+					{
+						Regex:  "__tmp_openshift_cluster_id__",
+						Action: "labeldrop",
 					},
 				},
 			},
@@ -997,6 +1005,10 @@ func TestPrometheusK8sRemoteWriteClusterIDRelabel(t *testing.T) {
 						SourceLabels: []string{"__tmp_openshift_cluster_id__"},
 						TargetLabel:  "cluster",
 					},
+					{
+						Regex:  "__tmp_openshift_cluster_id__",
+						Action: "labeldrop",
+					},
 				},
 				{
 					{
@@ -1010,6 +1022,10 @@ func TestPrometheusK8sRemoteWriteClusterIDRelabel(t *testing.T) {
 					{
 						TargetLabel: "unrelated_to_cluster_id",
 						Replacement: "some_value",
+					},
+					{
+						Regex:  "__tmp_openshift_cluster_id__",
+						Action: "labeldrop",
 					},
 				},
 			},


### PR DESCRIPTION
Problem: In commit 461653b460267b2246a18781169df92a9572ec94 we added the tmeporary label
__tmp_openshift_cluster_id__ label as the first entry to all
remote_write relabel configs. The assumption was that all __-prefixed
labels are dropped at the end of the relabeling step. This is however
not true for write_relabel_configs.
See also https://github.com/prometheus/prometheus/discussions/9416

Solution: Explicitly drop the temprary label by adding a drop step at
the end of all write_relabel_configs.

Issues: https://bugzilla.redhat.com/show_bug.cgi?id=2065682

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
