### PR TITLE
MON-2207: Expose Authorization settings for remote write in the CMO configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1350](https://github.com/openshift/cluster-monitoring-operator/pull/1350) Support label scrape limits in user-workload monitoring
 - [#1601](https://github.com/openshift/cluster-monitoring-operator/pull/1601) Expose the /federate endpoint of UWM Prometheus as a service
 - [#1617](https://github.com/openshift/cluster-monitoring-operator/pull/1617) Add Oauth2 setting to PrometheusK8s remoteWrite config
+- [#1598](https://github.com/openshift/cluster-monitoring-operator/pull/1598) Expose Authorization settings for remote write in the CMO configuration
 
 ## 4.10
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -156,6 +156,8 @@ type RemoteWriteSpec struct {
 	BasicAuth *monv1.BasicAuth `json:"basicAuth,omitempty"`
 	// Bearer token for remote write.
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
+	// Authorization section for remote write
+	Authorization *monv1.Authorization `json:"authorization,omitempty"`
 	// TLS Config to use for remote write.
 	TLSConfig *monv1.SafeTLSConfig `json:"tlsConfig,omitempty"`
 	// Optional ProxyURL

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -157,7 +157,7 @@ type RemoteWriteSpec struct {
 	// Bearer token for remote write.
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 	// Authorization section for remote write
-	Authorization *monv1.Authorization `json:"authorization,omitempty"`
+	Authorization *monv1.SafeAuthorization `json:"authorization,omitempty"`
 	// TLS Config to use for remote write.
 	TLSConfig *monv1.SafeTLSConfig `json:"tlsConfig,omitempty"`
 	// Optional ProxyURL

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -4226,6 +4226,7 @@ func addRemoteWriteConfigs(clusterID string, rw []monv1.RemoteWriteSpec, rwTarge
 			WriteRelabelConfigs: writeRelabelConfigs,
 			BasicAuth:           target.BasicAuth,
 			BearerTokenFile:     target.BearerTokenFile,
+			Authorization:       target.Authorization,
 			ProxyURL:            target.ProxyURL,
 			MetadataConfig:      target.MetadataConfig,
 			OAuth2:              target.OAuth2,

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -4226,7 +4226,6 @@ func addRemoteWriteConfigs(clusterID string, rw []monv1.RemoteWriteSpec, rwTarge
 			WriteRelabelConfigs: writeRelabelConfigs,
 			BasicAuth:           target.BasicAuth,
 			BearerTokenFile:     target.BearerTokenFile,
-			Authorization:       target.Authorization,
 			ProxyURL:            target.ProxyURL,
 			MetadataConfig:      target.MetadataConfig,
 			OAuth2:              target.OAuth2,
@@ -4234,6 +4233,11 @@ func addRemoteWriteConfigs(clusterID string, rw []monv1.RemoteWriteSpec, rwTarge
 		if target.TLSConfig != nil {
 			rwConf.TLSConfig = &monv1.TLSConfig{
 				SafeTLSConfig: *target.TLSConfig,
+			}
+		}
+		if target.Authorization != nil {
+			rwConf.Authorization = &monv1.Authorization{
+				SafeAuthorization: *target.Authorization,
 			}
 		}
 		rw = append(rw, rwConf)

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1345,23 +1345,23 @@ func TestRemoteWriteAuthorizationConfig(t *testing.T) {
 			},
 		},
 	} {
-		c, err := NewConfigFromString(tc.config)
-		if err != nil {
-			t.Fatal(err)
-		}
-		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
-		p, err := f.PrometheusK8s(
-			&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-			&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(p.Spec.RemoteWrite) != len(tc.checkFn) {
-			t.Fatalf("The number of RemoteWrite targets is different from the number of check functions for test case %s", tc.name)
-		}
-
 		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewConfigFromString(tc.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+			p, err := f.PrometheusK8s(
+				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(p.Spec.RemoteWrite) != len(tc.checkFn) {
+				t.Fatalf("got %d check functions but only %d RemoteWrite targets", len(tc.checkFn), len(p.Spec.RemoteWrite))
+			}
+
 			for i, target := range p.Spec.RemoteWrite {
 				tc.checkFn[i](t, target)
 			}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1317,6 +1317,11 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
     datacenter: eu-west
   remoteWrite:
   - url: "https://test.remotewrite.com/api/write"
+    Authorization:
+      type: Bearer
+      credentials:
+        name: credentials
+        key: token
   queryLogFile: /tmp/test
 ingress:
   baseAddress: monitoring-demo.staging.core-os.net
@@ -1449,6 +1454,16 @@ ingress:
 
 	if p.Spec.RemoteWrite[0].URL != "https://test.remotewrite.com/api/write" {
 		t.Fatal("Prometheus remote-write is not configured correctly")
+	}
+
+    if p.Spec.RemoteWrite[0].Authorization.Type != "Bearer" {
+		t.Fatal("Prometheus remote-write authorization type is not configured correctly")
+	}
+	if p.Spec.RemoteWrite[0].Authorization.Credentials.Name != "credentials" {
+		t.Fatal("Prometheus remote-write authorization credentials name is not configured correctly")
+	}
+	if p.Spec.RemoteWrite[0].Authorization.Credentials.Key != "token" {
+		t.Fatal("Prometheus remote-write authorization credentials token is not configured correctly")
 	}
 
 	if p.Spec.QueryLogFile != "/tmp/test" {
@@ -1753,6 +1768,9 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			)
+            if err != nil{
+                t.Fatal(err)
+            }
 
 			secrets := make(map[string]struct{})
 			for _, s := range p.Spec.Secrets {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -254,7 +254,7 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 
 		cmoConfigMap := fmt.Sprintf(`prometheusK8s:
   logLevel: debug
-  remoteWrite: %s
+  remoteWrite:%s
 `, rw)
 
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Problem: Although the prometheus-operator already supports RemoteWriteSpec.Authorization, the CMO did not support this configuration.

Solution: Allow CMO to pass the RemoteWriteSpec.Authorization from the ConfigMap to the Prometheus CRD  

Issues: https://issues.redhat.com/browse/MON-2207

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
