### PR TITLE
MON-2212: Expose the /federate endpoint of UWM Prometheus as a service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#1557](https://github.com/openshift/cluster-monitoring-operator/pull/1557) Removing grafana from monitoring stack
 - [1578](https://github.com/openshift/cluster-monitoring-operator/pull/1578) Add temporary cluster id label to remote write relabel configs.
 - [#1350](https://github.com/openshift/cluster-monitoring-operator/pull/1350) Support label scrape limits in user-workload monitoring
+- [#1601](https://github.com/openshift/cluster-monitoring-operator/pull/1601) Expose the /federate endpoint of UWM Prometheus as a service
 
 ## 4.10
 

--- a/assets/prometheus-user-workload/cluster-role.yaml
+++ b/assets/prometheus-user-workload/cluster-role.yaml
@@ -20,6 +20,18 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/assets/prometheus-user-workload/kube-rbac-proxy-federate-secret.yaml
+++ b/assets/prometheus-user-workload/kube-rbac-proxy-federate-secret.yaml
@@ -4,15 +4,13 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
-  name: kube-rbac-proxy
+  name: kube-rbac-proxy-federate
   namespace: openshift-user-workload-monitoring
 stringData:
   config.yaml: |-
     "authorization":
-      "static":
-      - "path": "/metrics"
-        "resourceRequest": false
-        "user":
-          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+      "resourceAttributes":
+        "apiVersion": "v1"
+        "resource": "namespaces"
         "verb": "get"
 type: Opaque

--- a/assets/prometheus-user-workload/kube-rbac-proxy-metrics-secret.yaml
+++ b/assets/prometheus-user-workload/kube-rbac-proxy-metrics-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: kube-rbac-proxy-metrics
+  namespace: openshift-user-workload-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -40,6 +40,33 @@ spec:
   - metrics-client-ca
   containers:
   - args:
+    - --secure-listen-address=0.0.0.0:9092
+    - --upstream=http://127.0.0.1:9090
+    - --allow-paths=/federate
+    - --config-file=/etc/kube-rbac-proxy/config.yaml
+    - --tls-cert-file=/etc/tls/private/tls.crt
+    - --tls-private-key-file=/etc/tls/private/tls.key
+    - --client-ca-file=/etc/tls/client/client-ca.crt
+    - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+    name: kube-rbac-proxy-federate
+    ports:
+    - containerPort: 9092
+      name: federate
+    resources:
+      requests:
+        cpu: 1m
+        memory: 10Mi
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /etc/tls/private
+      name: secret-prometheus-user-workload-tls
+    - mountPath: /etc/tls/client
+      name: configmap-metrics-client-ca
+      readOnly: true
+    - mountPath: /etc/kube-rbac-proxy
+      name: secret-kube-rbac-proxy-federate
+  - args:
     - --secure-listen-address=0.0.0.0:9091
     - --upstream=http://127.0.0.1:9090
     - --allow-paths=/metrics
@@ -49,7 +76,7 @@ spec:
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     image: quay.io/brancz/kube-rbac-proxy:v0.11.0
-    name: kube-rbac-proxy
+    name: kube-rbac-proxy-metrics
     ports:
     - containerPort: 9091
       name: metrics
@@ -65,7 +92,7 @@ spec:
       name: configmap-metrics-client-ca
       readOnly: true
     - mountPath: /etc/kube-rbac-proxy
-      name: secret-kube-rbac-proxy
+      name: secret-kube-rbac-proxy-metrics
   - args:
     - --secure-listen-address=[$(POD_IP)]:10902
     - --upstream=http://127.0.0.1:10902
@@ -98,7 +125,7 @@ spec:
       name: configmap-metrics-client-ca
       readOnly: true
     - mountPath: /etc/kube-rbac-proxy
-      name: secret-kube-rbac-proxy
+      name: secret-kube-rbac-proxy-metrics
   - args:
     - sidecar
     - --prometheus.url=http://localhost:9090/
@@ -178,7 +205,8 @@ spec:
   secrets:
   - prometheus-user-workload-tls
   - prometheus-user-workload-thanos-sidecar-tls
-  - kube-rbac-proxy
+  - kube-rbac-proxy-metrics
+  - kube-rbac-proxy-federate
   securityContext:
     fsGroup: 65534
     runAsNonRoot: true

--- a/assets/prometheus-user-workload/service.yaml
+++ b/assets/prometheus-user-workload/service.yaml
@@ -16,6 +16,9 @@ spec:
   - name: metrics
     port: 9091
     targetPort: metrics
+  - name: federate
+    port: 9092
+    targetPort: federate
   - name: thanos-proxy
     port: 10902
     targetPort: thanos-proxy

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -66,6 +66,11 @@ function(params)
             targetPort: 'metrics',
           },
           {
+            name: 'federate',
+            port: 9092,
+            targetPort: 'federate',
+          },
+          {
             name: 'thanos-proxy',
             port: 10902,
             targetPort: 'thanos-proxy',
@@ -79,11 +84,18 @@ function(params)
 
     // As Prometheus is protected by the kube-rbac-proxy it requires the
     // ability to create TokenReview and SubjectAccessReview requests.
-    // Additionally in order to authenticate with the Alertmanager it
-    // requires `get` method on all `namespaces`, which is the
-    // SubjectAccessReview required by the Alertmanager instances.
     clusterRole+: {
       rules+: [
+        {
+          apiGroups: ['authentication.k8s.io'],
+          resources: ['tokenreviews'],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['authorization.k8s.io'],
+          resources: ['subjectaccessreviews'],
+          verbs: ['create'],
+        },
         {
           apiGroups: [''],
           resources: ['namespaces'],
@@ -185,7 +197,30 @@ function(params)
       },
     },
 
-    kubeRbacProxySecret: generateSecret.staticAuthSecret(cfg.namespace, cfg.commonLabels, 'kube-rbac-proxy'),
+    kubeRbacProxyMetricsSecret: generateSecret.staticAuthSecret(cfg.namespace, cfg.commonLabels, 'kube-rbac-proxy-metrics'),
+
+    kubeRbacProxyFederateSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'kube-rbac-proxy-federate',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
+      },
+      type: 'Opaque',
+      data: {},
+      stringData: {
+        'config.yaml': std.manifestYamlDoc({
+          authorization: {
+            resourceAttributes: {
+              apiVersion: 'v1',
+              resource: 'namespaces',
+              verb: 'get',
+            },
+          },
+        }),
+      },
+    },
 
     prometheus+: {
       spec+: {
@@ -235,7 +270,8 @@ function(params)
         secrets: [
           'prometheus-user-workload-tls',
           'prometheus-user-workload-thanos-sidecar-tls',
-          $.kubeRbacProxySecret.metadata.name,
+          $.kubeRbacProxyMetricsSecret.metadata.name,
+          $.kubeRbacProxyFederateSecret.metadata.name,
         ],
         configMaps: ['serving-certs-ca-bundle', 'metrics-client-ca'],
         probeNamespaceSelector: cfg.namespaceSelector,
@@ -247,7 +283,49 @@ function(params)
         priorityClassName: 'openshift-user-critical',
         containers: [
           {
-            name: 'kube-rbac-proxy',
+            name: 'kube-rbac-proxy-federate',
+            image: cfg.kubeRbacProxyImage,
+            resources: {
+              requests: {
+                memory: '10Mi',
+                cpu: '1m',
+              },
+            },
+            ports: [
+              {
+                containerPort: 9092,
+                name: 'federate',
+              },
+            ],
+            args: [
+              '--secure-listen-address=0.0.0.0:9092',
+              '--upstream=http://127.0.0.1:9090',
+              '--allow-paths=/federate',
+              '--config-file=/etc/kube-rbac-proxy/config.yaml',
+              '--tls-cert-file=/etc/tls/private/tls.crt',
+              '--tls-private-key-file=/etc/tls/private/tls.key',
+              '--client-ca-file=/etc/tls/client/client-ca.crt',
+              '--tls-cipher-suites=' + cfg.tlsCipherSuites,
+            ],
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+            volumeMounts: [
+              {
+                mountPath: '/etc/tls/private',
+                name: 'secret-prometheus-user-workload-tls',
+              },
+              {
+                mountPath: '/etc/tls/client',
+                name: 'configmap-metrics-client-ca',
+                readOnly: true,
+              },
+              {
+                mountPath: '/etc/kube-rbac-proxy',
+                name: 'secret-' + $.kubeRbacProxyFederateSecret.metadata.name,
+              },
+            ],
+          },
+          {
+            name: 'kube-rbac-proxy-metrics',
             image: cfg.kubeRbacProxyImage,
             resources: {
               requests: {
@@ -284,7 +362,7 @@ function(params)
               },
               {
                 mountPath: '/etc/kube-rbac-proxy',
-                name: 'secret-' + $.kubeRbacProxySecret.metadata.name,
+                name: 'secret-' + $.kubeRbacProxyMetricsSecret.metadata.name,
               },
             ],
           },
@@ -335,7 +413,7 @@ function(params)
               },
               {
                 mountPath: '/etc/kube-rbac-proxy',
-                name: 'secret-' + $.kubeRbacProxySecret.metadata.name,
+                name: 'secret-' + $.kubeRbacProxyMetricsSecret.metadata.name,
               },
             ],
           },

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -16,6 +16,7 @@ package tasks
 
 import (
 	"context"
+
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -188,7 +189,7 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "error creating UserWorkload Prometheus Client GRPC TLS secret")
 	}
 
-	rs, err := t.factory.PrometheusUserWorkloadRBACProxySecret()
+	rs, err := t.factory.PrometheusUserWorkloadRBACProxyMetricsSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus RBAC proxy Secret failed")
 	}
@@ -196,6 +197,16 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 	err = t.client.CreateOrUpdateSecret(ctx, rs)
 	if err != nil {
 		return errors.Wrap(err, "creating or updating UserWorkload Prometheus RBAC proxy Secret failed")
+	}
+
+	fs, err := t.factory.PrometheusUserWorkloadRBACProxyFederateSecret()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload Prometheus RBAC federate endpoint Secret failed")
+	}
+
+	err = t.client.CreateOrUpdateSecret(ctx, fs)
+	if err != nil {
+		return errors.Wrap(err, "creating or updating UserWorkload Prometheus RBAC federate endpoint Secret failed")
 	}
 
 	secret, err := t.factory.PrometheusUserWorkloadAdditionalAlertManagerConfigsSecret()
@@ -429,7 +440,7 @@ func (t *PrometheusUserWorkloadTask) destroy(ctx context.Context) error {
 		return errors.Wrap(err, "initializing UserWorkload serving certs CA Bundle ConfigMap failed")
 	}
 
-	rs, err := t.factory.PrometheusUserWorkloadRBACProxySecret()
+	rs, err := t.factory.PrometheusUserWorkloadRBACProxyMetricsSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus RBAC proxy Secret failed")
 	}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -87,7 +87,7 @@ func TestAlertmanagerKubeRbacProxy(t *testing.T) {
 
 	// The tenancy port (9092) is only exposed in-cluster so we need to use
 	// port forwarding to access kube-rbac-proxy.
-	host, cleanUp, err := f.ForwardPort(t, "alertmanager-main", 9092)
+	host, cleanUp, err := f.ForwardPort(t, f.Ns, "alertmanager-main", 9092)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -411,12 +411,12 @@ func (f *Framework) CreateRoleBindingFromRole(namespace, serviceAccount, role st
 	}, nil
 }
 
-func (f *Framework) ForwardPort(t *testing.T, svc string, port int) (string, func(), error) {
+func (f *Framework) ForwardPort(t *testing.T, ns, svc string, port int) (string, func(), error) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// Taken from github.com/openshift/origin/test/extended/etcd/etcd_test_runner.go
-	cmd := exec.CommandContext(ctx, "oc", "port-forward", fmt.Sprintf("service/%s", svc), fmt.Sprintf(":%d", port), "-n", f.Ns, "--kubeconfig", f.kubeConfigPath)
+	cmd := exec.CommandContext(ctx, "oc", "port-forward", fmt.Sprintf("service/%s", svc), fmt.Sprintf(":%d", port), "-n", ns, "--kubeconfig", f.kubeConfigPath)
 
 	cleanUp := func() {
 		cancel()

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -118,7 +118,7 @@ func createPrometheusRule(t *testing.T) {
 
 func verifyAlertmanagerAlertReceived(t *testing.T) {
 
-	host, cleanUp, err := f.ForwardPort(t, "alertmanager-operated", 9093)
+	host, cleanUp, err := f.ForwardPort(t, f.Ns, "alertmanager-operated", 9093)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
