### PR TITLE
Bug 2065577:  CMO now creates by default an empty CM for UWM

### DIFF
--- a/assets/cluster-monitoring-operator/user-workload-config-edit-role.yaml
+++ b/assets/cluster-monitoring-operator/user-workload-config-edit-role.yaml
@@ -11,4 +11,8 @@ rules:
   resources:
   - configmaps
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - patch
+  - update

--- a/assets/prometheus-user-workload/config-map.yaml
+++ b/assets/prometheus-user-workload/config-map.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -354,7 +354,7 @@ function(params) {
       apiGroups: [''],
       resourceNames: ['user-workload-monitoring-config'],
       resources: ['configmaps'],
-      verbs: ['*'],
+      verbs: ['get', 'list', 'watch', 'patch', 'update'],
     }],
   },
 

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -32,6 +32,16 @@ function(params)
       data: {},
     },
 
+    configMap: {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'user-workload-monitoring-config',
+        namespace: cfg.namespace,
+      },
+      data: {},
+    },
+
     // Adding the serving certs annotation causes the serving certs controller
     // to generate a valid and signed serving certificate and put it in the
     // specified secret.

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -187,7 +187,11 @@ rules:
   resources:
   - configmaps
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - patch
+  - update
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -271,6 +271,11 @@ func (c *Client) ConsoleListWatch(ctx context.Context) *cache.ListWatch {
 	}
 }
 
+func (c *Client) EnsurePrometheusUserWorkloadConfigMapExists(ctx context.Context, cm *v1.ConfigMap) error {
+	_, err := c.CreateIfNotExistConfigMap(ctx, cm)
+	return errors.Wrapf(err, "creating empty  ConfigMap object fauled")
+}
+
 func (c *Client) AssurePrometheusOperatorCRsExist(ctx context.Context) error {
 	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		_, err := c.mclient.MonitoringV1().Prometheuses(c.namespace).List(ctx, metav1.ListOptions{})

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -147,6 +147,7 @@ var (
 	PrometheusUserWorkloadThanosSidecarServiceMonitor = "prometheus-user-workload/service-monitor-thanos-sidecar.yaml"
 	PrometheusUserWorkloadAlertmanagerRoleBinding     = "prometheus-user-workload/alertmanager-role-binding.yaml"
 	PrometheusUserWorkloadPodDisruptionBudget         = "prometheus-user-workload/pod-disruption-budget.yaml"
+	PrometheusUserWorkloadConfigMap                   = "prometheus-user-workload/config-map.yaml"
 
 	PrometheusAdapterAPIService                         = "prometheus-adapter/api-service.yaml"
 	PrometheusAdapterClusterRole                        = "prometheus-adapter/cluster-role.yaml"
@@ -1293,6 +1294,18 @@ func (f *Factory) PrometheusK8sServingCertsCABundle() (*v1.ConfigMap, error) {
 	}
 
 	c.Namespace = f.namespace
+
+	return c, nil
+}
+
+func (f *Factory) PrometheusUserWorkloadConfigMap() (*v1.ConfigMap, error) {
+
+	c, err := f.NewConfigMap(f.assets.MustNewAssetReader(PrometheusUserWorkloadConfigMap))
+	if err != nil {
+		return nil, err
+	}
+
+	c.Namespace = f.namespaceUserWorkload
 
 	return c, nil
 }

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -120,6 +120,16 @@ func (t *PrometheusOperatorUserWorkloadTask) create(ctx context.Context) error {
 		}
 	}
 
+	userCM, err := t.factory.PrometheusUserWorkloadConfigMap()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload ConfigMap failed")
+	}
+
+	_, err = t.client.CreateIfNotExistConfigMap(ctx, userCM)
+	if err != nil {
+		return errors.Wrap(err, "reconciling UserWorkload ConfigMap failed")
+	}
+
 	// The CRs will be created externally,
 	// but we still have to wait for them here.
 	err = t.client.AssurePrometheusOperatorCRsExist(ctx)


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
