### PR TITLE
Bug 2096315: Create a patch im CMO for NodeClockNotSynchronising

### DIFF
--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -206,6 +206,7 @@ spec:
       annotations:
         description: Clock on {{ $labels.instance }} is not synchronising. Ensure
           NTP is configured on this host.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeClockNotSynchronising.md
         summary: Clock not synchronising.
       expr: |
         min_over_time(node_timex_sync_status[5m]) == 0
@@ -213,7 +214,7 @@ spec:
         node_timex_maxerror_seconds >= 16
       for: 10m
       labels:
-        severity: warning
+        severity: critical
     - alert: NodeRAIDDegraded
       annotations:
         description: RAID array '{{ $labels.device }}' on {{ $labels.instance }} is

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -162,6 +162,17 @@ local patchedRules = [
     ],
   },
   {
+    name: 'node-exporter',
+    rules: [
+      {
+        alert: 'NodeClockNotSynchronising',
+        labels: {
+          severity: 'critical',
+        },
+      },
+    ],
+  },
+  {
     name: 'kubernetes-apps',
     rules: [
       // Stop-gap fix for https://bugzilla.redhat.com/show_bug.cgi?id=1943667
@@ -353,6 +364,7 @@ local includeRunbooks = {
   NodeFilesystemFilesFillingUp: openShiftRunbookCMO('NodeFilesystemFilesFillingUp.md'),
   NodeFilesystemSpaceFillingUp: openShiftRunbookCMO('NodeFilesystemSpaceFillingUp.md'),
   NodeRAIDDegraded: openShiftRunbookCMO('NodeRAIDDegraded.md'),
+  NodeClockNotSynchronising: openShiftRunbookCMO('NodeClockNotSynchronising.md'),
   PrometheusTargetSyncFailure: openShiftRunbookCMO('PrometheusTargetSyncFailure.md'),
   ThanosRuleQueueIsDroppingAlerts: openShiftRunbookCMO('ThanosRuleQueueIsDroppingAlerts.md'),
   ThanosRuleRuleEvaluationLatencyHigh: openShiftRunbookCMO('ThanosRuleRuleEvaluationLatencyHigh.md'),


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.


The runbook PR: https://github.com/openshift/runbooks/pull/36/files
The related Jira card: https://issues.redhat.com/browse/OSD-8737
