### PR TITLE
Documentation/data-collection: Assign cluster-version metrics to Cincinnati team

### DIFF
--- a/Documentation/data-collection.md
+++ b/Documentation/data-collection.md
@@ -55,7 +55,7 @@ data:
     # flake.
     - '{__name__="count:up1"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_version reports what payload and version the cluster is being
     # configured to and is used to identify what versions are on a cluster that
@@ -64,7 +64,7 @@ data:
     # consumers: (@openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_version"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_version_available_updates reports the channel and version server
     # the cluster is configured to use and how many updates are available. This
@@ -73,7 +73,7 @@ data:
     # consumers: (@openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_version_available_updates"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_operator_up reports the health status of the core cluster
     # operators - like up, an upgrade that fails due to a configuration value
@@ -82,7 +82,7 @@ data:
     # consumers: (@openshift/openshift-team-olm, @openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_operator_up"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_operator_conditions exposes the status conditions cluster
     # operators report for debugging. The condition and status are reported.
@@ -90,7 +90,7 @@ data:
     # consumers: (@openshift/openshift-team-olm, @openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_operator_conditions"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_version_payload captures how far through a payload the cluster
     # version operator has progressed and can be used to identify whether
@@ -99,9 +99,8 @@ data:
     # consumers: (@openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_version_payload"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-installer, @openshift/openshift-team-cincinnati)
     #
-    # owners: (@openshift/openshift-team-olm)
     # cluster_installer reports what installed the cluster, along with its
     # version number and invoker.
     #

--- a/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
@@ -47,7 +47,7 @@ data:
     # flake.
     - '{__name__="count:up1"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_version reports what payload and version the cluster is being
     # configured to and is used to identify what versions are on a cluster that
@@ -56,7 +56,7 @@ data:
     # consumers: (@openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_version"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_version_available_updates reports the channel and version server
     # the cluster is configured to use and how many updates are available. This
@@ -65,7 +65,7 @@ data:
     # consumers: (@openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_version_available_updates"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_operator_up reports the health status of the core cluster
     # operators - like up, an upgrade that fails due to a configuration value
@@ -74,7 +74,7 @@ data:
     # consumers: (@openshift/openshift-team-olm, @openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_operator_up"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_operator_conditions exposes the status conditions cluster
     # operators report for debugging. The condition and status are reported.
@@ -82,7 +82,7 @@ data:
     # consumers: (@openshift/openshift-team-olm, @openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_operator_conditions"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-cincinnati)
     #
     # cluster_version_payload captures how far through a payload the cluster
     # version operator has progressed and can be used to identify whether
@@ -91,9 +91,8 @@ data:
     # consumers: (@openshift/openshift-team-cluster-manager)
     - '{__name__="cluster_version_payload"}'
     #
-    # owners: (@openshift/openshift-team-installer)
+    # owners: (@openshift/openshift-team-installer, @openshift/openshift-team-cincinnati)
     #
-    # owners: (@openshift/openshift-team-olm)
     # cluster_installer reports what installed the cluster, along with its
     # version number and invoker.
     #


### PR DESCRIPTION
The installer assignments are from a7146706b4 (#1273).  Not clear to me why
that assignment was chosen then, but [the Cincinnati team][1] (the GitHub name of the OpenShift-core updates team) is in charge of the cluster-version operator, and [these are all metrics served by the CVO][2].

`cluster_installer` leans heavily on installer-supplied data, so I'm leaving that one co-owned by the installer team.

Also from a7146706b4 was the two `owners` lines for `cluster_installer`.  I don't think OLM was intended to be an owner for this metric (and they're separately listed as a consumer), so I've dropped their owner line.

[1]: https://github.com/orgs/openshift/teams/openshift-team-cincinnati/members
[2]: https://github.com/openshift/cluster-version-operator/blob/fc7d096f5fcde2758dafd1ce968601cd774479f4/pkg/cvo/metrics.go#L65-L105