### PR TITLE
Bug 2063047: Add condition to check for relative paths in query log file path

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1657,7 +1657,7 @@ func (f *Factory) setupQueryLogFile(p *monv1.Prometheus, queryLogFile string) er
 		return nil
 	}
 	dirPath := filepath.Dir(queryLogFile)
-	if strings.HasPrefix(dirPath, ".") {
+	if dirPath != "." && strings.HasPrefix(dirPath, ".") {
 		return errors.Wrap(ErrConfigValidation, `relative paths to query log file are not supported`)
 	}
 	if dirPath == "/" {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1657,7 +1657,8 @@ func (f *Factory) setupQueryLogFile(p *monv1.Prometheus, queryLogFile string) er
 		return nil
 	}
 	dirPath := filepath.Dir(queryLogFile)
-	if dirPath != "." && strings.HasPrefix(dirPath, ".") {
+	// queryLogFile is not an absolute path nor a simple filename
+	if !filepath.IsAbs(queryLogFile) && dirPath != "." {
 		return errors.Wrap(ErrConfigValidation, `relative paths to query log file are not supported`)
 	}
 	if dirPath == "/" {
@@ -1666,8 +1667,10 @@ func (f *Factory) setupQueryLogFile(p *monv1.Prometheus, queryLogFile string) er
 
 	// /prometheus is where Prometheus will store the TSDB so it is
 	// already mounted inside the pod (either from a persistent volume claim or from an empty dir).
+	// When queryLogFile is a simple filename the prometheus-operator will take
+	// care of mounting an emptyDir under /var/log/prometheus
 	p.Spec.QueryLogFile = queryLogFile
-	if dirPath == "/prometheus" {
+	if dirPath == "/prometheus" || dirPath == "." {
 		return nil
 	}
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1657,6 +1657,9 @@ func (f *Factory) setupQueryLogFile(p *monv1.Prometheus, queryLogFile string) er
 		return nil
 	}
 	dirPath := filepath.Dir(queryLogFile)
+	if strings.HasPrefix(dirPath, ".") {
+		return errors.Wrap(ErrConfigValidation, `relative paths to query log file are not supported`)
+	}
 	if dirPath == "/" {
 		return errors.Wrap(ErrConfigValidation, `query log file can't be stored on the root directory`)
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1440,6 +1440,13 @@ func TestPrometheusQueryLogFileConfig(t *testing.T) {
 			errExpected:      true,
 			volumeExpected:   false,
 		},
+		{
+			name:             "filename only",
+			queryLogFilePath: "query.log",
+			expected:         "query.log",
+			errExpected:      false,
+			volumeExpected:   false,
+		},
 	} {
 		c := NewDefaultConfig()
 		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile = tc.queryLogFilePath

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1391,7 +1391,7 @@ ingress:
 }
 
 func TestPrometheusQueryLogFileConfig(t *testing.T) {
-	testCases := []struct {
+	for _, tc := range []struct {
 		name             string
 		queryLogFilePath string
 		expected         string
@@ -1440,30 +1440,29 @@ func TestPrometheusQueryLogFileConfig(t *testing.T) {
 			errExpected:      true,
 			volumeExpected:   false,
 		},
-	}
-	for _, tt := range testCases {
+	} {
 		c := NewDefaultConfig()
-		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile = tt.queryLogFilePath
+		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile = tc.queryLogFilePath
 		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 		p, err := f.PrometheusK8s(
 			&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 		)
 		if err != nil {
-			if !tt.errExpected {
+			if !tc.errExpected {
 				t.Fatalf("Expecting no error but got %v", err)
 			}
 			return
 		}
-		if tt.errExpected {
-			t.Fatalf("Expected query log file %s to give an error, but err is nil", tt.queryLogFilePath)
+		if tc.errExpected {
+			t.Fatalf("Expected query log file %s to give an error, but err is nil", tc.queryLogFilePath)
 		}
 
-		if p.Spec.QueryLogFile != tt.expected {
+		if p.Spec.QueryLogFile != tc.expected {
 			t.Fatal("Prometheus query log is not configured correctly")
 		}
 
-		if tt.volumeExpected {
+		if tc.volumeExpected {
 			volumeName := "query-log"
 			if !volumeConfigured(p.Spec.Volumes, volumeName) {
 				t.Fatal("Query log file volume is not configured correctly")

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1420,7 +1420,7 @@ func TestPrometheusQueryLogFileConfig(t *testing.T) {
 			volumeExpected:   false,
 		},
 		{
-			name:             "invalid path",
+			name:             "invalid path, query log on root",
 			queryLogFilePath: "/query.log",
 			expected:         "",
 			errExpected:      true,
@@ -1429,6 +1429,13 @@ func TestPrometheusQueryLogFileConfig(t *testing.T) {
 		{
 			name:             "invalid file under dev",
 			queryLogFilePath: "/dev/query.log",
+			expected:         "",
+			errExpected:      true,
+			volumeExpected:   false,
+		},
+		{
+			name:             "invalid path, relative path",
+			queryLogFilePath: "./dev/query.log",
 			expected:         "",
 			errExpected:      true,
 			volumeExpected:   false,


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2063047

problem: prometheus-operator does not support relative paths for the query
log file path

solution: add condition to not allow the field queryLogFilePath to start
with a '.'

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
