### PR TITLE
Bug 2067004: manifests: Remove Grafana image references

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -55,7 +55,6 @@ spec:
         - -images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest
         - -images=prometheus=quay.io/openshift/origin-prometheus:latest
         - -images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest
-        - -images=grafana=quay.io/openshift/origin-grafana:latest
         - -images=oauth-proxy=quay.io/openshift/origin-oauth-proxy:latest
         - -images=node-exporter=quay.io/openshift/origin-prometheus-node-exporter:latest
         - -images=kube-state-metrics=quay.io/openshift/origin-kube-state-metrics:latest

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -83,7 +83,6 @@ spec:
         - "-images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest"
         - "-images=prometheus=quay.io/openshift/origin-prometheus:latest"
         - "-images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest"
-        - "-images=grafana=quay.io/openshift/origin-grafana:latest"
         - "-images=oauth-proxy=quay.io/openshift/origin-oauth-proxy:latest"
         - "-images=node-exporter=quay.io/openshift/origin-prometheus-node-exporter:latest"
         - "-images=kube-state-metrics=quay.io/openshift/origin-kube-state-metrics:latest"

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -26,10 +26,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-prometheus-alertmanager:latest
-  - name: grafana
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-grafana:latest
   - name: oauth-proxy
     from:
       kind: DockerImage


### PR DESCRIPTION
The Grafana deployment was removed in #1557, this removes the image
references from the CVO manifests.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
