### PR TITLE
[MON-2208] Add Oauth2 settings to prometheusK8s.remoteWrite config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [1578](https://github.com/openshift/cluster-monitoring-operator/pull/1578) Add temporary cluster id label to remote write relabel configs.
 - [#1350](https://github.com/openshift/cluster-monitoring-operator/pull/1350) Support label scrape limits in user-workload monitoring
 - [#1601](https://github.com/openshift/cluster-monitoring-operator/pull/1601) Expose the /federate endpoint of UWM Prometheus as a service
+- [#1617](https://github.com/openshift/cluster-monitoring-operator/pull/1617) Add Oauth2 setting to PrometheusK8s remoteWrite config
 
 ## 4.10
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -164,6 +164,8 @@ type RemoteWriteSpec struct {
 	QueueConfig *monv1.QueueConfig `json:"queueConfig,omitempty"`
 	// MetadataConfig configures the sending of series metadata to remote storage.
 	MetadataConfig *monv1.MetadataConfig `json:"metadataConfig,omitempty"`
+	// OAuth2 configures OAuth2 authentication for remote write.
+	OAuth2 *monv1.OAuth2 `json:"oauth2,omitempty"`
 }
 
 type PrometheusK8sConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -4228,6 +4228,7 @@ func addRemoteWriteConfigs(clusterID string, rw []monv1.RemoteWriteSpec, rwTarge
 			BearerTokenFile:     target.BearerTokenFile,
 			ProxyURL:            target.ProxyURL,
 			MetadataConfig:      target.MetadataConfig,
+			OAuth2:              target.OAuth2,
 		}
 		if target.TLSConfig != nil {
 			rwConf.TLSConfig = &monv1.TLSConfig{


### PR DESCRIPTION
This PR addes Oauth2 settings to PrometheusK8s.remoteWrite config, allowing prometheus remoteWrite use client secret to access the remote write server. An example config can be:
```yaml
prometheusK8s:
  remoteWrite:
    - url: https://test.remotewrite.com/api/write
      remoteTimeout: 30s
      oauth2:
        clientId:
          secret:
            name: oauth2-credentials
            key: id
        clientSecret:
          name: oauth2-credentials
          key: secret
        tokenUrl: https://example.com/oauth2/token
        scopes:
          - scope1
          - scope2
        endpointParams:
          param1: value1
          param2: value2
```

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
