### PR TITLE
pkg/manifest: remove unused function AlertmanagerExternalURL

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -331,14 +331,6 @@ func NewFactory(namespace, namespaceUserWorkload string, c *Config, infrastructu
 	}
 }
 
-func (f *Factory) AlertmanagerExternalURL(host string) *url.URL {
-	return &url.URL{
-		Scheme: "https",
-		Host:   host,
-		Path:   "/",
-	}
-}
-
 func (f *Factory) AlertmanagerConfig() (*v1.Secret, error) {
 	s, err := f.NewSecret(f.assets.MustNewAssetReader(AlertmanagerConfig))
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
