### PR TITLE
MON-1261: exposing topology spread constraints through config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.12
+- [#1624](https://github.com/openshift/cluster-monitoring-operator/pull/1624) Add option to specify TopologySpreadConstraints for Prometheus, Alertmanager, and ThanosRuler.
+
 ## 4.11
 - [#1652](https://github.com/openshift/cluster-monitoring-operator/pull/1652) Double scrape interval for all CMO controlled ServiceMonitors on single node deployments
 - [#1567](https://github.com/openshift/cluster-monitoring-operator/pull/1567) Enable validating webhook for AlertmanagerConfig custom resources

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -205,7 +205,8 @@ type PrometheusK8sConfig struct {
 	 * 2. a value in Prometheus size format, e.g. "64MB"
 	 * 3. string "automatic", which means the limit will be automatically calculated based on cluster capacity.
 	 */
-	EnforcedBodySizeLimit string `json:"enforcedBodySizeLimit,omitempty"`
+	EnforcedBodySizeLimit     string                        `json:"enforcedBodySizeLimit,omitempty"`
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints"`
 }
 
 type AdditionalAlertmanagerConfig struct {
@@ -247,6 +248,7 @@ type AlertmanagerMainConfig struct {
 	Tolerations                  []v1.Toleration                      `json:"tolerations"`
 	Resources                    *v1.ResourceRequirements             `json:"resources"`
 	VolumeClaimTemplate          *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+	TopologySpreadConstraints    []v1.TopologySpreadConstraint        `json:"topologySpreadConstraints"`
 }
 
 func (a AlertmanagerMainConfig) IsEnabled() bool {
@@ -254,13 +256,14 @@ func (a AlertmanagerMainConfig) IsEnabled() bool {
 }
 
 type ThanosRulerConfig struct {
-	LogLevel             string                               `json:"logLevel"`
-	NodeSelector         map[string]string                    `json:"nodeSelector"`
-	Retention            string                               `json:"retention"`
-	Tolerations          []v1.Toleration                      `json:"tolerations"`
-	Resources            *v1.ResourceRequirements             `json:"resources"`
-	VolumeClaimTemplate  *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
-	AlertmanagersConfigs []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
+	LogLevel                  string                               `json:"logLevel"`
+	NodeSelector              map[string]string                    `json:"nodeSelector"`
+	Retention                 string                               `json:"retention"`
+	Tolerations               []v1.Toleration                      `json:"tolerations"`
+	Resources                 *v1.ResourceRequirements             `json:"resources"`
+	VolumeClaimTemplate       *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`
+	AlertmanagersConfigs      []AdditionalAlertmanagerConfig       `json:"additionalAlertmanagerConfigs"`
+	TopologySpreadConstraints []v1.TopologySpreadConstraint        `json:"topologySpreadConstraints"`
 }
 
 type ThanosQuerierConfig struct {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -676,6 +676,11 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 		a.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Tolerations
 	}
 
+	if len(f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.TopologySpreadConstraints) > 0 {
+		a.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.TopologySpreadConstraints
+	}
+
 	for i, c := range a.Spec.Containers {
 		switch c.Name {
 		case "alertmanager-proxy":
@@ -1648,6 +1653,11 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 
 	if len(f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Tolerations) > 0 {
 		p.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Tolerations
+	}
+
+	if len(f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.TopologySpreadConstraints) > 0 {
+		p.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.TopologySpreadConstraints
 	}
 
 	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels != nil {
@@ -4056,6 +4066,10 @@ func (f *Factory) ThanosRulerCustomResource(
 
 	if f.config.UserWorkloadConfiguration.ThanosRuler.Retention != "" {
 		t.Spec.Retention = monv1.Duration(f.config.UserWorkloadConfiguration.ThanosRuler.Retention)
+	}
+
+	if len(f.config.UserWorkloadConfiguration.ThanosRuler.TopologySpreadConstraints) > 0 {
+		t.Spec.TopologySpreadConstraints = f.config.UserWorkloadConfiguration.ThanosRuler.TopologySpreadConstraints
 	}
 
 	if len(f.config.UserWorkloadConfiguration.ThanosRuler.Tolerations) > 0 {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1492,6 +1492,13 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
       resources:
         requests:
           storage: 15Gi
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar
   resources:
     limits:
       cpu: 200m
@@ -1622,6 +1629,14 @@ ingress:
 	}
 	if p.Spec.Tolerations[0].Operator != "Exists" {
 		t.Fatal("Prometheus toleration effect not configured correctly")
+	}
+
+	if p.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Prometheus topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if p.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Prometheus topology spread contraints WhenUnsatisfiable not configured correctly")
 	}
 
 	if p.Spec.ExternalLabels["datacenter"] != "eu-west" {
@@ -2620,6 +2635,13 @@ func TestAlertmanagerMainConfiguration(t *testing.T) {
   tolerations:
   - effect: PreferNoSchedule
     operator: Exists
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar
   resources:
     limits:
       cpu: 20m
@@ -2688,6 +2710,14 @@ ingress:
 	}
 	if a.Spec.Tolerations[0].Operator != "Exists" {
 		t.Fatal("Prometheus toleration effect not configured correctly")
+	}
+
+	if a.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Alertmanager main topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if a.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Alertmanager main topology spread contraints WhenUnsatisfiable not configured correctly")
 	}
 
 	storageRequest := a.Spec.Storage.VolumeClaimTemplate.Spec.Resources.Requests[v1.ResourceStorage]
@@ -3287,6 +3317,16 @@ func TestTelemeterConfiguration(t *testing.T) {
 
 func TestThanosRulerConfiguration(t *testing.T) {
 	c, err := NewConfigFromString(``)
+	uwc, err := NewUserConfigFromString(`thanosRuler:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar`)
+
+	c.UserWorkloadConfiguration = uwc
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3312,6 +3352,14 @@ func TestThanosRulerConfiguration(t *testing.T) {
 			}
 		}
 	}
+	if tr.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Thanos ruler topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if tr.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Thanos ruler topology spread contraints WhenUnsatisfiable not configured correctly")
+	}
+
 }
 
 func TestThanosRulerRetentionConfig(t *testing.T) {


### PR DESCRIPTION
This PR exposes the [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) through the CMO config.

This is just #1469 rebased on master.
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
