### PR TITLE
Added a KubeCronJobFailed alert

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -184,6 +184,17 @@ spec:
       for: 12h
       labels:
         severity: warning
+    - alert: KubeCronJobFailed
+      annotations:
+        description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to
+          complete. Running the failed job after investigation should clear this alert.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeCronJobFailed.md
+        summary: Job failed to complete.
+      expr: |
+        max by (namespace, owner_name)(kube_job_status_completion_time {namespace=~"(openshift-.*|kube-.*|default)"} * on (job_name) group_left(owner_name) max by(namespace, owner_name, job_name)(kube_job_owner{owner_kind="CronJob"}))- max by(namespace, owner_name)(kube_job_status_start_time {namespace=~"(openshift-.*|kube-.*|default)"} * on(job_name) group_left(owner_name)max by (namespace, owner_name, job_name)(kube_job_owner{owner_kind="CronJob"}))<0 unless max by (namespace, owner_name) (kube_cronjob_status_active{namespace=~"(openshift-.*|kube-.*|default)"})
+      for: 15m
+      labels:
+        severity: warning    
     - alert: KubeJobFailed
       annotations:
         description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to


### PR DESCRIPTION
In this commit, I added the KubeCronJobFailed alert per [OSD-8667](https://issues.redhat.com/browse/OSD-8667).

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ X] No user facing changes, so no entry in CHANGELOG was needed.
