### PR TITLE
[Do not merge] Test only - Prometheus: activate feature extra-scrape-metrics

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -154,7 +154,8 @@ spec:
     - mountPath: /etc/tls/grpc
       name: secret-grpc-tls
   - name: prometheus
-  enableFeatures: []
+  enableFeatures:
+  - extra-scrape-metrics
   externalLabels: {}
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091
   image: quay.io/prometheus/prometheus:v2.34.0

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -305,6 +305,7 @@ function(params)
     // disabled, these things are not injected.
     prometheus+: {
       spec+: {
+        enableFeatures: ['extra-scrape-metrics'],
         alerting+: {
           alertmanagers:
             std.map(


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
