### PR TITLE
Bug  2067005: Remove Grafana from Prometheus rules added by CMO

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -371,7 +371,7 @@ spec:
     - expr: topk(3, max by(namespace, job) (topk by(namespace,job) (1, scrape_samples_post_metric_relabeling)))
       record: namespace_job:scrape_samples_post_metric_relabeling:topk3
     - expr: sum by(exported_service) (rate(haproxy_server_http_responses_total{exported_namespace="openshift-monitoring",
-        exported_service=~"alertmanager-main|grafana|prometheus-k8s"}[5m]))
+        exported_service=~"alertmanager-main|prometheus-k8s"}[5m]))
       record: monitoring:haproxy_server_http_responses_total:sum
     - expr: max by (cluster, namespace, workload, pod) (label_replace(label_replace(kube_pod_owner{job="kube-state-metrics",
         owner_kind="ReplicationController"},"replicationcontroller", "$1", "owner_name",

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -528,7 +528,7 @@ function(params) {
           record: 'namespace_job:scrape_samples_post_metric_relabeling:topk3',
         },
         {
-          expr: 'sum by(exported_service) (rate(haproxy_server_http_responses_total{exported_namespace="openshift-monitoring", exported_service=~"alertmanager-main|grafana|prometheus-k8s"}[5m]))',
+          expr: 'sum by(exported_service) (rate(haproxy_server_http_responses_total{exported_namespace="openshift-monitoring", exported_service=~"alertmanager-main|prometheus-k8s"}[5m]))',
           record: 'monitoring:haproxy_server_http_responses_total:sum',
         },
         {


### PR DESCRIPTION
This PR removes grafana from record rule `monitoring:haproxy_server_http_responses_total:sum`.


* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
