### PR TITLE
MON-2193: pkg/manifests: Expose retention size settings for UWM Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1598](https://github.com/openshift/cluster-monitoring-operator/pull/1598) Expose Authorization settings for remote write in the CMO configuration
 - [#1638](https://github.com/openshift/cluster-monitoring-operator/pull/1638) Expose sigv4 setting to Prometheus remoteWrite
 - [#1579](https://github.com/openshift/cluster-monitoring-operator/pull/1579) Expose retention size settings for Platform Prometheus
+- [#1630](https://github.com/openshift/cluster-monitoring-operator/pull/1630) Expose retention size settings for UWM Prometheus
 
 ## 4.10
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -500,6 +500,7 @@ type UserWorkloadConfiguration struct {
 type PrometheusRestrictedConfig struct {
 	LogLevel                      string                               `json:"logLevel"`
 	Retention                     string                               `json:"retention"`
+	RetentionSize                 string                               `json:"retentionSize"`
 	NodeSelector                  map[string]string                    `json:"nodeSelector"`
 	Tolerations                   []v1.Toleration                      `json:"tolerations"`
 	Resources                     *v1.ResourceRequirements             `json:"resources"`

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1762,6 +1762,10 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		p.Spec.Retention = f.config.UserWorkloadConfiguration.Prometheus.Retention
 	}
 
+	if f.config.UserWorkloadConfiguration.Prometheus.RetentionSize != "" {
+		p.Spec.RetentionSize = f.config.UserWorkloadConfiguration.Prometheus.RetentionSize
+	}
+
 	p.Spec.Image = &f.config.Images.Prometheus
 
 	if f.config.UserWorkloadConfiguration.Prometheus.Resources != nil {

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -472,6 +472,7 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
   enforcedLabelValueLengthLimit: 600
   logLevel: debug
   retention: 10h
+  retentionSize: 15GB
   queryLogFile: /tmp/test.log
   tolerations:
     - operator: "Exists"
@@ -512,6 +513,7 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
 					expectMatchingRequests(podName, containerName, mem, cpu),
 					expectContainerArg("--log.level=debug", containerName),
 					expectContainerArg("--storage.tsdb.retention.time=10h", containerName),
+					expectContainerArg("--storage.tsdb.retention.size=15GB", containerName),
 				},
 			),
 		},


### PR DESCRIPTION
WIP: Need to wait till #1579 gets merged and rebase on top of that

[MON-2217](https://issues.redhat.com/browse/MON-2217): Expose retention size settings for UWM Prometheus in the CMO configuration

Introduce a new "retentionSize" field under the prometheus key

Signed-off-by: Jayapriya Pai [janantha@redhat.com](mailto:janantha@redhat.com)

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
