### PR TITLE
MON-2148: Replace oauth-proxy with kube-rbac-proxy in prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#1640](https://github.com/openshift/cluster-monitoring-operator/pull/1640) Deploy standalone admission webhook for HA.
 - [#1651](https://github.com/openshift/cluster-monitoring-operator/pull/1651) Allow retention to be configurable for Thanos-Ruler in UWM
 - [#1467](https://github.com/openshift/cluster-monitoring-operator/pull/1467) Add bodysize limit for metric scraping
+- [#1631](https://github.com/openshift/cluster-monitoring-operator/pull/1631) Replace oauth-proxy with kube-rbac-proxy in prometheus
 
 ## 4.10
 

--- a/assets/prometheus-k8s/htpasswd-secret.yaml
+++ b/assets/prometheus-k8s/htpasswd-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-data: {}
-kind: Secret
-metadata:
-  labels:
-    app.kubernetes.io/name: prometheus-k8s
-  name: prometheus-k8s-htpasswd
-  namespace: openshift-monitoring
-type: Opaque

--- a/assets/prometheus-k8s/kube-rbac-proxy-metric-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-metric-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: kube-rbac-proxy-metric
+  namespace: openshift-monitoring
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
+type: Opaque

--- a/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
@@ -13,4 +13,8 @@ stringData:
         "apiVersion": "v1"
         "resource": "namespaces"
         "verbs": "get"
+      "static":
+      - "resourceRequest": true
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
 type: Opaque

--- a/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
@@ -9,10 +9,8 @@ metadata:
 stringData:
   config.yaml: |-
     "authorization":
-      "static":
-      - "path": "/metrics"
-        "resourceRequest": false
-        "user":
-          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
-        "verb": "get"
+      "resourceAttributes":
+        "apiVersion": "v1"
+        "resource": "namespaces"
+        "verbs": "get"
 type: Opaque

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -42,43 +42,6 @@ spec:
   - metrics-client-ca
   containers:
   - args:
-    - -provider=openshift
-    - -https-address=:9091
-    - -http-address=
-    - -email-domain=*
-    - -upstream=http://localhost:9090
-    - -openshift-service-account=prometheus-k8s
-    - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
-    - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
-    - -tls-cert=/etc/tls/private/tls.crt
-    - -tls-key=/etc/tls/private/tls.key
-    - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-    - -cookie-secret-file=/etc/proxy/secrets/session_secret
-    - -openshift-ca=/etc/pki/tls/cert.pem
-    - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    env:
-    - name: HTTP_PROXY
-      value: ""
-    - name: HTTPS_PROXY
-      value: ""
-    - name: NO_PROXY
-      value: ""
-    image: quay.io/openshift/oauth-proxy:latest
-    name: prometheus-proxy
-    ports:
-    - containerPort: 9091
-      name: web
-    resources:
-      requests:
-        cpu: 1m
-        memory: 20Mi
-    terminationMessagePolicy: FallbackToLogsOnError
-    volumeMounts:
-    - mountPath: /etc/tls/private
-      name: secret-prometheus-k8s-tls
-    - mountPath: /etc/proxy/secrets
-      name: secret-prometheus-k8s-proxy
-  - args:
     - --secure-listen-address=0.0.0.0:9092
     - --upstream=http://127.0.0.1:9090
     - --allow-paths=/metrics
@@ -90,7 +53,7 @@ spec:
     - --logtostderr=true
     - --v=10
     image: quay.io/brancz/kube-rbac-proxy:v0.11.0
-    name: kube-rbac-proxy
+    name: kube-rbac-proxy-metrics
     ports:
     - containerPort: 9092
       name: metrics
@@ -106,7 +69,7 @@ spec:
       name: configmap-metrics-client-ca
       readOnly: true
     - mountPath: /etc/kube-rbac-proxy
-      name: secret-kube-rbac-proxy
+      name: secret-kube-rbac-proxy-metric
   - args:
     - --secure-listen-address=[$(POD_IP)]:10902
     - --upstream=http://127.0.0.1:10902
@@ -135,6 +98,33 @@ spec:
     volumeMounts:
     - mountPath: /etc/tls/private
       name: secret-prometheus-k8s-thanos-sidecar-tls
+    - mountPath: /etc/kube-rbac-proxy
+      name: secret-kube-rbac-proxy-metric
+  - args:
+    - --secure-listen-address=0.0.0.0:9091
+    - --upstream=http://127.0.0.1:9090
+    - --tls-cert-file=/etc/tls/private/tls.crt
+    - --tls-private-key-file=/etc/tls/private/tls.key
+    - --client-ca-file=/etc/tls/client/client-ca.crt
+    - --config-file=/etc/kube-rbac-proxy/config.yaml
+    - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    - --logtostderr=true
+    image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+    name: kube-rbac-proxy
+    ports:
+    - containerPort: 9091
+      name: web
+    resources:
+      requests:
+        cpu: 1m
+        memory: 10Mi
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /etc/tls/private
+      name: secret-prometheus-k8s-tls
+    - mountPath: /etc/tls/client
+      name: configmap-metrics-client-ca
+      readOnly: true
     - mountPath: /etc/kube-rbac-proxy
       name: secret-kube-rbac-proxy
   - args:
@@ -193,8 +183,9 @@ spec:
   - prometheus-k8s-tls
   - prometheus-k8s-proxy
   - prometheus-k8s-thanos-sidecar-tls
-  - kube-rbac-proxy
+  - kube-rbac-proxy-metric
   - metrics-client-certs
+  - kube-rbac-proxy
   securityContext:
     fsGroup: 65534
     runAsNonRoot: true

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -181,7 +181,6 @@ spec:
   secrets:
   - kube-etcd-client-certs
   - prometheus-k8s-tls
-  - prometheus-k8s-proxy
   - prometheus-k8s-thanos-sidecar-tls
   - kube-rbac-proxy-metric
   - metrics-client-certs

--- a/assets/prometheus-k8s/proxy-secret.yaml
+++ b/assets/prometheus-k8s/proxy-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-data: {}
-kind: Secret
-metadata:
-  labels:
-    app.kubernetes.io/name: prometheus-k8s
-  name: prometheus-k8s-proxy
-  namespace: openshift-monitoring
-type: Opaque

--- a/assets/prometheus-k8s/service-account.yaml
+++ b/assets/prometheus-k8s/service-account.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
-  annotations:
-    serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus-k8s"}}'
   labels:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/instance: k8s

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -195,6 +195,12 @@ function(params)
               resource: 'namespaces',
               verbs: 'get',
             },
+            static: [{
+              resourceRequest: true,
+              user: {
+                name: 'system:serviceaccount:openshift-monitoring:prometheus-k8s',
+              },
+            }],
           },
         },),
       },

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -730,13 +730,17 @@ func (c *Client) DeletePrometheusRuleByNamespaceAndName(ctx context.Context, nam
 	return nil
 }
 
-func (c *Client) DeleteSecret(ctx context.Context, s *v1.Secret) error {
-	err := c.kclient.CoreV1().Secrets(s.Namespace).Delete(ctx, s.GetName(), metav1.DeleteOptions{})
+func (c *Client) DeleteSecretByNamespaceAndName(ctx context.Context, namespace, name string) error {
+	err := c.kclient.CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
 
 	return err
+}
+
+func (c *Client) DeleteSecret(ctx context.Context, s *v1.Secret) error {
+	return c.DeleteSecretByNamespaceAndName(ctx, s.Namespace, s.GetName())
 }
 
 func (c *Client) WaitForPrometheus(ctx context.Context, p *monv1.Prometheus) error {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -117,6 +117,7 @@ var (
 	PrometheusK8sService                              = "prometheus-k8s/service.yaml"
 	PrometheusK8sServiceThanosSidecar                 = "prometheus-k8s/service-thanos-sidecar.yaml"
 	PrometheusK8sProxySecret                          = "prometheus-k8s/proxy-secret.yaml"
+	PrometheusRBACMetricsProxySecret                  = "prometheus-k8s/kube-rbac-proxy-metric-secret.yaml"
 	PrometheusRBACProxySecret                         = "prometheus-k8s/kube-rbac-proxy-secret.yaml"
 	PrometheusUserWorkloadRBACProxyMetricsSecret      = "prometheus-user-workload/kube-rbac-proxy-metrics-secret.yaml"
 	PrometheusUserWorkloadRBACProxyFederateSecret     = "prometheus-user-workload/kube-rbac-proxy-federate-secret.yaml"
@@ -1243,6 +1244,17 @@ func (f *Factory) ThanosRulerAlertmanagerConfigSecret() (*v1.Secret, error) {
 	return s, nil
 }
 
+func (f *Factory) PrometheusRBACMetricsProxySecret() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetReader(PrometheusRBACMetricsProxySecret))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespace
+
+	return s, nil
+}
+
 func (f *Factory) PrometheusRBACProxySecret() (*v1.Secret, error) {
 	s, err := f.NewSecret(f.assets.MustNewAssetReader(PrometheusRBACProxySecret))
 	if err != nil {
@@ -1595,8 +1607,10 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 			p.Spec.Containers[i].Image = f.config.Images.OauthProxy
 
 			f.injectProxyVariables(&p.Spec.Containers[i])
-
 		case "kube-rbac-proxy":
+			p.Spec.Containers[i].Image = f.config.Images.KubeRbacProxy
+			p.Spec.Containers[i].Args = f.setTLSSecurityConfiguration(container.Args, KubeRbacProxyTLSCipherSuitesFlag, KubeRbacProxyMinTLSVersionFlag)
+		case "kube-rbac-proxy-metrics":
 			p.Spec.Containers[i].Image = f.config.Images.KubeRbacProxy
 			p.Spec.Containers[i].Args = f.setTLSSecurityConfiguration(container.Args, KubeRbacProxyTLSCipherSuitesFlag, KubeRbacProxyMinTLSVersionFlag)
 		case "kube-rbac-proxy-thanos":

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1627,11 +1627,9 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 		})
 		p.Spec.Volumes = append(p.Spec.Volumes, volume)
 
-		// we only need the trusted CA bundle in:
-		// 1. Prometheus, because users might want to configure external remote write.
-		// 2. In OAuth proxy, as that communicates externally when executing the OAuth handshake.
+		// We only need the trusted CA bundle in Prometheus, because users might want to configure external remote write.
 		for i, container := range p.Spec.Containers {
-			if container.Name == "prometheus-proxy" || container.Name == "prometheus" {
+			if container.Name == "prometheus" {
 				p.Spec.Containers[i].VolumeMounts = append(
 					p.Spec.Containers[i].VolumeMounts,
 					trustedCABundleVolumeMount(volumeName),

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -103,12 +103,23 @@ func (t *PrometheusTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "creating Prometheus proxy Secret failed")
 	}
 
-	rs, err := t.factory.PrometheusRBACProxySecret()
+	rs, err := t.factory.PrometheusRBACMetricsProxySecret()
+
+	if err != nil {
+		return errors.Wrap(err, "initializing Prometheus RBAC metrics proxy Secret failed")
+	}
+
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
+	if err != nil {
+		return errors.Wrap(err, "creating or updating Prometheus RBAC metrics proxy Secret failed")
+	}
+
+	ras, err := t.factory.PrometheusRBACProxySecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus RBAC proxy Secret failed")
 	}
 
-	err = t.client.CreateOrUpdateSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, ras)
 	if err != nil {
 		return errors.Wrap(err, "creating or updating Prometheus RBAC proxy Secret failed")
 	}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

This one supersedes https://github.com/openshift/cluster-monitoring-operator/pull/1594

* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
