### PR TITLE
MON-2213: Expose the /federate endpoint of UWM Prometheus as a route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1601](https://github.com/openshift/cluster-monitoring-operator/pull/1601) Expose the /federate endpoint of UWM Prometheus as a service
 - [#1617](https://github.com/openshift/cluster-monitoring-operator/pull/1617) Add Oauth2 setting to PrometheusK8s remoteWrite config
 - [#1598](https://github.com/openshift/cluster-monitoring-operator/pull/1598) Expose Authorization settings for remote write in the CMO configuration
+- [#1633](https://github.com/openshift/cluster-monitoring-operator/pull/1633) Expose the /federate endpoint of UWM Prometheus as a route
 - [#1638](https://github.com/openshift/cluster-monitoring-operator/pull/1638) Expose sigv4 setting to Prometheus remoteWrite
 
 ## 4.10

--- a/assets/prometheus-user-workload/federate-route.yaml
+++ b/assets/prometheus-user-workload/federate-route.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Route
+metadata:
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: federate
+  namespace: openshift-user-workload-monitoring
+spec:
+  path: /federate
+  port:
+    targetPort: federate
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: Reencrypt
+  to:
+    kind: Service
+    name: prometheus-user-workload

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -80,6 +80,30 @@ function(params)
       },
     },
 
+    federateRoute: {
+      apiVersion: 'v1',
+      kind: 'Route',
+      metadata: {
+        name: 'federate',
+        namespace: cfg.namespace,
+        labels: cfg.commonLabels,
+      },
+      spec: {
+        path: '/federate',
+        to: {
+          kind: 'Service',
+          name: $.service.metadata.name,
+        },
+        port: {
+          targetPort: 'federate',
+        },
+        tls: {
+          termination: 'Reencrypt',
+          insecureEdgeTerminationPolicy: 'Redirect',
+        },
+      },
+    },
+
     servingCertsCaBundle+: generateCertInjection.SCOCaBundleCM(cfg.namespace, 'serving-certs-ca-bundle'),
 
     // As Prometheus is protected by the kube-rbac-proxy it requires the

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -149,6 +149,7 @@ var (
 	PrometheusUserWorkloadAlertmanagerRoleBinding     = "prometheus-user-workload/alertmanager-role-binding.yaml"
 	PrometheusUserWorkloadPodDisruptionBudget         = "prometheus-user-workload/pod-disruption-budget.yaml"
 	PrometheusUserWorkloadConfigMap                   = "prometheus-user-workload/config-map.yaml"
+	PrometheusUserWorkloadFederateRoute               = "prometheus-user-workload/federate-route.yaml"
 
 	PrometheusAdapterAPIService                         = "prometheus-adapter/api-service.yaml"
 	PrometheusAdapterClusterRole                        = "prometheus-adapter/cluster-role.yaml"
@@ -1027,6 +1028,17 @@ func (f *Factory) PrometheusUserWorkloadRoleList() (*rbacv1.RoleList, error) {
 	}
 
 	return rl, nil
+}
+
+func (f *Factory) PrometheusUserWorkloadFederateRoute() (*routev1.Route, error) {
+	r, err := f.NewRoute(f.assets.MustNewAssetReader(PrometheusUserWorkloadFederateRoute))
+	if err != nil {
+		return nil, err
+	}
+
+	r.Namespace = f.namespaceUserWorkload
+
+	return r, nil
 }
 
 func (f *Factory) PrometheusK8sPrometheusRule() (*monv1.PrometheusRule, error) {


### PR DESCRIPTION
Successor of https://github.com/openshift/cluster-monitoring-operator/pull/1601 to expose UWM federate service as a Openshift Route.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
