### PR TITLE
Bug 2074084: CMO metrics not visible in the OCP webconsole UI

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_03-service.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_03-service.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
-    app: cluster-monitoring-operator
+    app.kubernetes.io/name: cluster-monitoring-operator
   name: cluster-monitoring-operator
   namespace: openshift-monitoring
 spec:
@@ -17,4 +17,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    app: cluster-monitoring-operator
+    app.kubernetes.io/name: cluster-monitoring-operator

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -124,6 +124,7 @@ func TestTargetsUp(t *testing.T) {
 		"prometheus-k8s",
 		"prometheus-operator",
 		"alertmanager-main",
+		"cluster-monitoring-operator",
 	}
 
 	for _, target := range targets {


### PR DESCRIPTION
This PR corrects the selector of Service Monitor of CMO, thus correct the bug.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
