### PR TITLE
MON-2206: Adds sigv4 settings for remote write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 - [#1567](https://github.com/openshift/cluster-monitoring-operator/pull/1567) Enable validating webhook for AlertmanagerConfig custom resources
 - [#1557](https://github.com/openshift/cluster-monitoring-operator/pull/1557) Removing grafana from monitoring stack
-- [1578](https://github.com/openshift/cluster-monitoring-operator/pull/1578) Add temporary cluster id label to remote write relabel configs.
+- [#1578](https://github.com/openshift/cluster-monitoring-operator/pull/1578) Add temporary cluster id label to remote write relabel configs.
 - [#1350](https://github.com/openshift/cluster-monitoring-operator/pull/1350) Support label scrape limits in user-workload monitoring
 - [#1601](https://github.com/openshift/cluster-monitoring-operator/pull/1601) Expose the /federate endpoint of UWM Prometheus as a service
 - [#1617](https://github.com/openshift/cluster-monitoring-operator/pull/1617) Add Oauth2 setting to PrometheusK8s remoteWrite config
 - [#1598](https://github.com/openshift/cluster-monitoring-operator/pull/1598) Expose Authorization settings for remote write in the CMO configuration
+- [#1638](https://github.com/openshift/cluster-monitoring-operator/pull/1638) Expose sigv4 setting to Prometheus remoteWrite
 
 ## 4.10
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -158,6 +158,8 @@ type RemoteWriteSpec struct {
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 	// Authorization section for remote write
 	Authorization *monv1.SafeAuthorization `json:"authorization,omitempty"`
+	// Sigv4 allows to configures AWS's Signature Verification 4
+	Sigv4 *monv1.Sigv4 `json:"sigv4,omitempty"`
 	// TLS Config to use for remote write.
 	TLSConfig *monv1.SafeTLSConfig `json:"tlsConfig,omitempty"`
 	// Optional ProxyURL

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -4226,6 +4226,7 @@ func addRemoteWriteConfigs(clusterID string, rw []monv1.RemoteWriteSpec, rwTarge
 			WriteRelabelConfigs: writeRelabelConfigs,
 			BasicAuth:           target.BasicAuth,
 			BearerTokenFile:     target.BearerTokenFile,
+			Sigv4:               target.Sigv4,
 			ProxyURL:            target.ProxyURL,
 			MetadataConfig:      target.MetadataConfig,
 			OAuth2:              target.OAuth2,

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1344,6 +1344,48 @@ func TestRemoteWriteAuthorizationConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "sigv4 authentication configuration",
+			config: `prometheusK8s:
+  remoteWrite:
+  - url: "https://authorization.remotewrite.com/api/write"
+    sigv4:
+      region: eu
+      accessKey:
+        name: aws-credentials
+        key: access
+      secretKey:
+        name: aws-credentials
+        key: secret
+      profile: "SomeProfile"
+      roleArn: "SomeRoleArn"
+`,
+			checkFn: []func(*testing.T, monv1.RemoteWriteSpec){
+				func(t *testing.T, target monv1.RemoteWriteSpec) {
+					if target.Sigv4.Region != "eu" {
+						t.Fatalf("Region field not correct in section RemoteWriteSpec.Sigv4 expected 'eu', got %s", target.Sigv4)
+					}
+					if target.Sigv4.AccessKey.Name != "aws-credentials" {
+						t.Fatalf("Name field not correct in section RemoteWriteSpec.Sigv4.AccessKey expected 'aws-credentials', got %s", target.Sigv4.AccessKey.Name)
+					}
+					if target.Sigv4.AccessKey.Key != "access" {
+						t.Fatalf("Key field not correct in section RemoteWriteSpec.Sigv4.AccessKey expected 'access', got %s", target.Sigv4.AccessKey.Key)
+					}
+					if target.Sigv4.SecretKey.Name != "aws-credentials" {
+						t.Fatalf("Name field not correct in section RemoteWriteSpec.Sigv4.SecretKey expected 'aws-credentials', got %s", target.Sigv4.SecretKey.Name)
+					}
+					if target.Sigv4.SecretKey.Key != "secret" {
+						t.Fatalf("Key field not correct in section RemoteWriteSpec.Sigv4.SecretKey expected 'secret', got %s", target.Sigv4.SecretKey.Key)
+					}
+					if target.Sigv4.Profile != "SomeProfile" {
+						t.Fatalf("Profile field not correct in section RemoteWriteSpec.Sigv4 expected 'SomeProfile', got %s", target.Sigv4.Profile)
+					}
+					if target.Sigv4.RoleArn != "SomeRoleArn" {
+						t.Fatalf("RoleArn field not correct in section RemoteWriteSpec.Sigv4 expected 'SomeRoleArn', got %s", target.Sigv4.RoleArn)
+					}
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := NewConfigFromString(tc.config)


### PR DESCRIPTION
Issue https://issues.redhat.com/browse/MON-2206

Problem: Prometheus and Prometheus operator already support sigv4 authentication for
remote write. This should be possible to configure the same in the CMO configuration

Solution: Add to the RemoteWriteSpec struct the Sigv4 field so users can
specify Sigv4 configuration in the CMO ConfigMap, pass this field to the
Prometheus CRD

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
