### PR TITLE
Bug 1933144: Extend KubeAggregatedAPIDown alert "for" to 15m

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -461,7 +461,7 @@ spec:
         summary: Kubernetes aggregated API is down.
       expr: |
         (1 - max by(name, namespace, cluster)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
-      for: 5m
+      for: 15m
       labels:
         severity: warning
     - alert: KubeAPIDown

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -252,6 +252,15 @@ local patchedRules = [
     ],
   },
   {
+    name: 'kubernetes-system-apiserver',
+    rules: [
+      {
+        alert: 'KubeAggregatedAPIDown',
+        'for': '15m',
+      },
+    ],
+  },
+  {
     name: 'prometheus',
     rules: [
       {


### PR DESCRIPTION
Per discussion in this PR thread, and also given the fact that [BZ 1933144](https://bugzilla.redhat.com/show_bug.cgi?id=1933144) is being solved with https://github.com/kubernetes/kubernetes/pull/110039, this PR raises the KubeAggregatedAPIDown `for` duration to 15m instead of 5m.

SNO deployments will see some downtime on upgrades and cert rotations, but this new duration allows for enough time to perform those operations.

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
