### PR TITLE
*: add standalone admission webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#1638](https://github.com/openshift/cluster-monitoring-operator/pull/1638) Expose sigv4 setting to Prometheus remoteWrite
 - [#1579](https://github.com/openshift/cluster-monitoring-operator/pull/1579) Expose retention size settings for Platform Prometheus
 - [#1630](https://github.com/openshift/cluster-monitoring-operator/pull/1630) Expose retention size settings for UWM Prometheus
+- [#1640](https://github.com/openshift/cluster-monitoring-operator/pull/1640) Deploy standalone admission webhook for HA.
 
 ## 4.10
 

--- a/assets/admission-webhook/alertmanager-config-validating-webhook.yaml
+++ b/assets/admission-webhook/alertmanager-config-validating-webhook.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    service.beta.openshift.io/inject-cabundle: true
+    service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
@@ -12,10 +12,10 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: prometheus-operator
+      name: prometheus-operator-admission-webhook
       namespace: openshift-monitoring
       path: /admission-alertmanagerconfigs/validate
-      port: 8080
+      port: 8443
   failurePolicy: Ignore
   name: alertmanagerconfigs.openshift.io
   rules:

--- a/assets/admission-webhook/deployment.yaml
+++ b/assets/admission-webhook/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.55.1
+  name: prometheus-operator-admission-webhook
+  namespace: openshift-monitoring
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-operator-admission-webhook
+      app.kubernetes.io/part-of: openshift-monitoring
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: prometheus-operator-admission-webhook
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app.kubernetes.io/managed-by: cluster-monitoring-operator
+        app.kubernetes.io/name: prometheus-operator-admission-webhook
+        app.kubernetes.io/part-of: openshift-monitoring
+        app.kubernetes.io/version: 0.55.1
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: prometheus-operator-admission-webhook
+                app.kubernetes.io/part-of: openshift-monitoring
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --web.enable-tls=true
+        - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --web.tls-min-version=VersionTLS12
+        - --web.cert-file=/etc/tls/private/tls.crt
+        - --web.key-file=/etc/tls/private/tls.key
+        image: quay.io/prometheus-operator/admission-webhook:v0.55.1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+        name: prometheus-operator-admission-webhook
+        ports:
+        - containerPort: 8443
+          name: https
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+        resources:
+          requests:
+            cpu: 5m
+            memory: 30Mi
+        securityContext: {}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: tls-certificates
+          readOnly: true
+      priorityClassName: system-cluster-critical
+      securityContext: {}
+      serviceAccountName: prometheus-operator-admission-webhook
+      volumes:
+      - name: tls-certificates
+        secret:
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          secretName: prometheus-operator-admission-webhook-tls

--- a/assets/admission-webhook/deployment.yaml
+++ b/assets/admission-webhook/deployment.yaml
@@ -32,6 +32,8 @@ spec:
               matchLabels:
                 app.kubernetes.io/name: prometheus-operator-admission-webhook
                 app.kubernetes.io/part-of: openshift-monitoring
+            namespaces:
+            - openshift-monitoring
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:

--- a/assets/admission-webhook/pod-disruption-budget.yaml
+++ b/assets/admission-webhook/pod-disruption-budget.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.55.1
+  name: prometheus-operator-admission-webhook
+  namespace: openshift-monitoring
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-operator-admission-webhook
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/admission-webhook/prometheus-rule-validating-webhook.yaml
+++ b/assets/admission-webhook/prometheus-rule-validating-webhook.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    service.beta.openshift.io/inject-cabundle: true
+    service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
@@ -12,10 +12,10 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: prometheus-operator
+      name: prometheus-operator-admission-webhook
       namespace: openshift-monitoring
       path: /admission-prometheusrules/validate
-      port: 8080
+      port: 8443
   failurePolicy: Ignore
   name: prometheusrules.openshift.io
   rules:

--- a/assets/admission-webhook/service-account.yaml
+++ b/assets/admission-webhook/service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.55.1
+  name: prometheus-operator-admission-webhook
+  namespace: openshift-monitoring

--- a/assets/admission-webhook/service.yaml
+++ b/assets/admission-webhook/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-admission-webhook-tls
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.55.1
+  name: prometheus-operator-admission-webhook
+  namespace: openshift-monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/part-of: openshift-monitoring

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -1,0 +1,213 @@
+local tlsVolumeName = 'prometheus-operator-admission-webhook-tls';
+local admissionWebhook = import 'github.com/prometheus-operator/prometheus-operator/jsonnet/prometheus-operator/admission-webhook.libsonnet';
+
+function(params)
+  local aw = admissionWebhook(params);
+
+  aw {
+    deployment+: {
+      metadata+: {
+        labels+: {
+          'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+        },
+      },
+      spec+: {
+        template+: {
+          metadata+: {
+            labels+: {
+              'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
+            },
+          },
+          spec+: {
+            // TODO(simonpasquier): configure client certificate authority to
+            // enforce client authentication.
+            affinity+: {
+              podAntiAffinity: {
+                requiredDuringSchedulingIgnoredDuringExecution: [
+                  {
+                    labelSelector: {
+                      matchLabels: aw.deployment.spec.selector.matchLabels,
+                    },
+                    topologyKey: 'kubernetes.io/hostname',
+                  },
+                ],
+              },
+            },
+            securityContext: {},
+            priorityClassName: 'system-cluster-critical',
+            containers:
+              std.map(
+                function(c)
+                  if c.name == 'prometheus-operator-admission-webhook' then
+                    c {
+                      args+: [
+                        '--web.enable-tls=true',
+                        '--web.tls-cipher-suites=' + params.tlsCipherSuites,
+                        '--web.tls-min-version=VersionTLS12',
+                        '--web.cert-file=/etc/tls/private/tls.crt',
+                        '--web.key-file=/etc/tls/private/tls.key',
+                      ],
+                      livenessProbe: {
+                        httpGet: {
+                          path: '/healthz',
+                          port: 'https',
+                          scheme: 'HTTPS',
+                        },
+                      },
+                      readinessProbe: {
+                        httpGet: {
+                          path: '/healthz',
+                          port: 'https',
+                          scheme: 'HTTPS',
+                        },
+                      },
+                      securityContext: {},
+                      terminationMessagePolicy: 'FallbackToLogsOnError',
+                      volumeMounts+: [
+                        {
+                          mountPath: '/etc/tls/private',
+                          name: 'tls-certificates',
+                          readOnly: true,
+                        },
+                      ],
+                    }
+                  else
+                    c,
+                super.containers,
+              ),
+            volumes+: [
+              {
+                name: 'tls-certificates',
+                secret: {
+                  secretName: 'prometheus-operator-admission-webhook-tls',
+                  items: [
+                    {
+                      key: 'tls.crt',
+                      path: 'tls.crt',
+                    },
+                    {
+                      key: 'tls.key',
+                      path: 'tls.key',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+
+    service+: {
+      metadata+: {
+        annotations+: {
+          'service.beta.openshift.io/serving-cert-secret-name': 'prometheus-operator-admission-webhook-tls',
+        },
+      },
+    },
+
+    // We collect no metrics from the admission webhook service.
+    // The availability of the service is measured at the Kubernetes API
+    // level using the apiserver_admission_webhook_* metrics available from
+    // the API server.
+    serviceMonitor:: {},
+
+    podDisruptionBudget: {
+      apiVersion: 'policy/v1',
+      kind: 'PodDisruptionBudget',
+      metadata: {
+        name: aw._config.name,
+        namespace: aw._config.namespace,
+        labels: aw._config.commonLabels,
+      },
+      spec: {
+        minAvailable: 1,
+        selector: {
+          matchLabels: aw._config.selectorLabels,
+        },
+
+      },
+    },
+
+    prometheusRuleValidatingWebhook: {
+      apiVersion: 'admissionregistration.k8s.io/v1',
+      kind: 'ValidatingWebhookConfiguration',
+      metadata: {
+        name: 'prometheusrules.openshift.io',
+        labels: {
+          'app.kubernetes.io/component': 'controller',
+          'app.kubernetes.io/name': 'prometheus-operator',
+        },
+        annotations: {
+          'service.beta.openshift.io/inject-cabundle': 'true',
+        },
+      },
+      webhooks: [
+        {
+          name: 'prometheusrules.openshift.io',
+          rules: [
+            {
+              apiGroups: ['monitoring.coreos.com'],
+              apiVersions: ['v1'],
+              operations: ['CREATE', 'UPDATE'],
+              resources: ['prometheusrules'],
+              scope: 'Namespaced',
+            },
+          ],
+          clientConfig: {
+            service: {
+              namespace: 'openshift-monitoring',
+              name: 'prometheus-operator-admission-webhook',
+              port: 8443,
+              path: '/admission-prometheusrules/validate',
+            },
+          },
+          admissionReviewVersions: ['v1'],
+          sideEffects: 'None',
+          timeoutSeconds: 5,
+          failurePolicy: 'Ignore',
+        },
+      ],
+    },
+
+    alertmanagerConfigValidatingWebhook: {
+      apiVersion: 'admissionregistration.k8s.io/v1',
+      kind: 'ValidatingWebhookConfiguration',
+      metadata: {
+        name: 'alertmanagerconfigs.openshift.io',
+        labels: {
+          'app.kubernetes.io/component': 'controller',
+          'app.kubernetes.io/name': 'prometheus-operator',
+        },
+        annotations: {
+          'service.beta.openshift.io/inject-cabundle': 'true',
+        },
+      },
+      webhooks: [
+        {
+          name: 'alertmanagerconfigs.openshift.io',
+          rules: [
+            {
+              apiGroups: ['monitoring.coreos.com'],
+              apiVersions: ['v1alpha1'],
+              operations: ['CREATE', 'UPDATE'],
+              resources: ['alertmanagerconfigs'],
+              scope: 'Namespaced',
+            },
+          ],
+          clientConfig: {
+            service: {
+              namespace: 'openshift-monitoring',
+              name: 'prometheus-operator-admission-webhook',
+              port: 8443,
+              path: '/admission-alertmanagerconfigs/validate',
+            },
+          },
+          admissionReviewVersions: ['v1'],
+          sideEffects: 'None',
+          timeoutSeconds: 5,
+          failurePolicy: 'Ignore',
+        },
+      ],
+    },
+  }

--- a/jsonnet/utils/generate-certificate-injection.libsonnet
+++ b/jsonnet/utils/generate-certificate-injection.libsonnet
@@ -1,5 +1,5 @@
 {
-  // this ca bundle is injected by the cluster-network-operator
+  // This CA bundle is injected by the cluster-network-operator.
   trustedCNOCaBundleCM(cfgNamespace, cfgName):: {
     apiVersion: 'v1',
     kind: 'ConfigMap',
@@ -12,7 +12,7 @@
     },
     data: {},
   },
-  // this ca bundle is injected by the service-ca-operator
+  // This CA bundle is injected by the service-ca-operator.
   SCOCaBundleCM(cfgNamespace, cfgName):: {
     apiVersion: 'v1',
     kind: 'ConfigMap',

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -52,6 +52,7 @@ spec:
         - -v=2
         - -images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest
         - -images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest
+        - -images=prometheus-operator-admission-webhook=quay.io/openshift/origin-prometheus-operator-admission-webhook:latest
         - -images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest
         - -images=prometheus=quay.io/openshift/origin-prometheus:latest
         - -images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -80,6 +80,7 @@ spec:
         - "-v=2"
         - "-images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest"
         - "-images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest"
+        - "-images=prometheus-operator-admission-webhook=quay.io/openshift/origin-prometheus-operator-admission-webhook:latest"
         - "-images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest"
         - "-images=prometheus=quay.io/openshift/origin-prometheus:latest"
         - "-images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest"

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -14,6 +14,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-prometheus-config-reloader:latest
+  - name: prometheus-operator-admission-webhook
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-prometheus-operator-admission-webhook:latest
   - name: configmap-reloader
     from:
       kind: DockerImage

--- a/pkg/manifests/apiserver_config.go
+++ b/pkg/manifests/apiserver_config.go
@@ -35,9 +35,9 @@ func NewAPIServerConfig(config *configv1.APIServer) *APIServerConfig {
 	}
 }
 
-// GetTLSCiphers returns the TLS ciphers for the
+// TLSCiphers returns the TLS ciphers for the
 // TLS security profile defined in the APIServerConfig.
-func (c *APIServerConfig) GetTLSCiphers() []string {
+func (c *APIServerConfig) TLSCiphers() []string {
 	profile := c.getTLSProfile()
 	if len(profile.Ciphers) == 0 {
 		return APIServerDefaultTLSCiphers
@@ -45,14 +45,14 @@ func (c *APIServerConfig) GetTLSCiphers() []string {
 	return profile.Ciphers
 }
 
-// GetMinTLSVersion returns the minimum TLS version for the
+// MinTLSVersion returns the minimum TLS version for the
 // TLS security profile defined in the APIServerConfig.
-func (c *APIServerConfig) GetMinTLSVersion() configv1.TLSProtocolVersion {
+func (c *APIServerConfig) MinTLSVersion() string {
 	profile := c.getTLSProfile()
 	if profile.MinTLSVersion == "" {
-		return APIServerDefaultMinTLSVersion
+		return string(APIServerDefaultMinTLSVersion)
 	}
-	return profile.MinTLSVersion
+	return string(profile.MinTLSVersion)
 }
 
 func (c *APIServerConfig) getTLSProfile() configv1.TLSProfileSpec {

--- a/pkg/manifests/apiserver_config_test.go
+++ b/pkg/manifests/apiserver_config_test.go
@@ -140,13 +140,13 @@ func TestGetTLSCiphers(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			actualCiphers := tt.config.GetTLSCiphers()
+			actualCiphers := tt.config.TLSCiphers()
 			if !reflect.DeepEqual(tt.expectedCiphers, actualCiphers) {
 				t.Fatalf("invalid ciphers, got %s, want %s", strings.Join(actualCiphers, ", "), strings.Join(tt.expectedCiphers, ", "))
 			}
 
-			actualTLSVersion := tt.config.GetMinTLSVersion()
-			if tt.expectedMinTLSVersion != actualTLSVersion {
+			actualTLSVersion := tt.config.MinTLSVersion()
+			if string(tt.expectedMinTLSVersion) != actualTLSVersion {
 				t.Fatalf("invalid min TLS version, got %s, want %s", actualTLSVersion, tt.expectedMinTLSVersion)
 			}
 		})

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -107,20 +107,21 @@ type ClusterMonitoringConfiguration struct {
 }
 
 type Images struct {
-	K8sPrometheusAdapter     string
-	PromLabelProxy           string
-	PrometheusOperator       string
-	PrometheusConfigReloader string
-	Prometheus               string
-	Alertmanager             string
-	Grafana                  string
-	OauthProxy               string
-	NodeExporter             string
-	KubeStateMetrics         string
-	OpenShiftStateMetrics    string
-	KubeRbacProxy            string
-	TelemeterClient          string
-	Thanos                   string
+	K8sPrometheusAdapter               string
+	PromLabelProxy                     string
+	PrometheusOperatorAdmissionWebhook string
+	PrometheusOperator                 string
+	PrometheusConfigReloader           string
+	Prometheus                         string
+	Alertmanager                       string
+	Grafana                            string
+	OauthProxy                         string
+	NodeExporter                       string
+	KubeStateMetrics                   string
+	OpenShiftStateMetrics              string
+	KubeRbacProxy                      string
+	TelemeterClient                    string
+	Thanos                             string
 }
 
 type HTTPConfig struct {
@@ -388,6 +389,7 @@ func (c *Config) applyDefaults() {
 }
 
 func (c *Config) SetImages(images map[string]string) {
+	c.Images.PrometheusOperatorAdmissionWebhook = images["prometheus-operator-admission-webhook"]
 	c.Images.PrometheusOperator = images["prometheus-operator"]
 	c.Images.PrometheusConfigReloader = images["prometheus-config-reloader"]
 	c.Images.Prometheus = images["prometheus"]

--- a/test/e2e/validatingwebhook_test.go
+++ b/test/e2e/validatingwebhook_test.go
@@ -95,19 +95,11 @@ spec:
     groupWait: 30s
     groupInterval: 5m
     repeatInterval: 12h
-    receiver: 'webhook'
+    receiver: 'missing-ref'
   receivers:
   - name: 'webhook'
     webhookConfigs:
     - url: 'https://example.com'
-  receivers:
-  - name: wechat-example
-    wechatConfigs:
-    - apiURL: https://<>wechatserver:8080/
-      corpID: wechat-corpid
-      apiSecret:
-        name: wechat-config
-        key: apiSecret
 `, framework.E2eTestLabel)
 )
 


### PR DESCRIPTION
Before this commit, the validating webhook configurations for
PrometheusRule and AlertmanagerConfig resources leveraged the webhook
service of Prometheus operator. Because the operator doesn't implement
any leader election, it has to run as a single replica meaning that the
webhook service couldn't be highly-available (especially during
upgrades).

This change deploys the admission webhook as a standalone service with 2
replicas + hard anti-affinity + pod disruption budget. A follow-up PR
will switch the failure policy of the validating webhook configurations
for PrometheusRule and AlertmanagerConfig resources from 'Ignore' to
'Fail'.

JIRA ref: https://issues.redhat.com/browse/MON-2221

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.