### PR TITLE
Extend e2e metric test

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -121,10 +121,15 @@ func TestTargetsUp(t *testing.T) {
 	targets := []string{
 		"node-exporter",
 		"kube-state-metrics",
+		"kubelet",
 		"prometheus-k8s",
+		"prometheus-k8s-thanos-sidecar",
 		"prometheus-operator",
 		"alertmanager-main",
 		"cluster-monitoring-operator",
+		"openshift-state-metrics",
+		"telemeter-client",
+		"thanos-querier",
 	}
 
 	for _, target := range targets {


### PR DESCRIPTION
Follow-up of #1634

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
