### PR TITLE
Bug 2073112: Adds UWM extrenalLabels from Prometheus to ThanosRuler labels

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3784,6 +3784,10 @@ func (f *Factory) ThanosRulerCustomResource(
 		t.Spec.Tolerations = f.config.UserWorkloadConfiguration.ThanosRuler.Tolerations
 	}
 
+	if f.config.UserWorkloadConfiguration.Prometheus.ExternalLabels != nil {
+		t.Spec.Labels = f.config.UserWorkloadConfiguration.Prometheus.ExternalLabels
+	}
+
 	for i, container := range t.Spec.Containers {
 		switch container.Name {
 		case "thanos-ruler-proxy":


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2073112

Problem: When UWM was configured with external labels due to the
quering architecture in some queries we would see the external label
where in other queries we wouldn't depending if we were hitting the UWM
prometheus intance or the one in openshift-monitoring.

Solution: Add to thanos ruler labels (thanos equivalent of
externalLabels) the labels present in the field externalLabels of
prometheus

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
