### PR TITLE
Bug 2057832: Updates recording rule cluster:telemetry_selected_series:count

### DIFF
--- a/assets/telemeter-client/prometheus-rule.yaml
+++ b/assets/telemeter-client/prometheus-rule.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: telemetry
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: telemeter.rules
+    rules:
+    - expr: max(federate_samples - federate_filtered_samples)
+      record: cluster:telemetry_selected_series:count

--- a/jsonnet/components/telemeter-client.libsonnet
+++ b/jsonnet/components/telemeter-client.libsonnet
@@ -21,6 +21,7 @@ function(params) {
   },
 
   // Remapping everything as this is the only way I could think of without refactoring imported library
+  prometheusRule: tc.telemeterClient.prometheusRule,
   clusterRoleBindingView: tc.telemeterClient.clusterRoleBindingView,
   clusterRoleBinding: tc.telemeterClient.clusterRoleBinding,
   clusterRole: tc.telemeterClient.clusterRole,

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -120,8 +120,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "987128a17c198270ff22cf36ff7b7df396f51826",
-      "sum": "vsJuJBdzAERSX8hvz0NRP6Lj13kGRztw/Wm8jFpwHAQ=",
+      "version": "76493ca3d439dc9d1ab5476a25d36c83d1947289",
+      "sum": "qaSPKpik0WiU5BMtW0Q51+NvEcWhdVE2XLqwZDyvJ+c=",
       "name": "telemeter-client"
     },
     {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -44,7 +44,6 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -232,6 +231,7 @@ var (
 	TelemeterClientServiceMonitor         = "telemeter-client/service-monitor.yaml"
 	TelemeterClientServingCertsCABundle   = "telemeter-client/serving-certs-ca-bundle.yaml"
 	TelemeterClientKubeRbacProxySecret    = "telemeter-client/kube-rbac-proxy-secret.yaml"
+	TelemeterClientPrometheusRule         = "telemeter-client/prometheus-rule.yaml"
 
 	ThanosQuerierDeployment             = "thanos-querier/deployment.yaml"
 	ThanosQuerierPodDisruptionBudget    = "thanos-querier/pod-disruption-budget.yaml"
@@ -3294,33 +3294,6 @@ func (f *Factory) NewPrometheusRule(manifest io.Reader) (*monv1.PrometheusRule, 
 	return p, nil
 }
 
-func (f *Factory) NewTelemeterPrometheusRecRuleFromString(expr string) (*monv1.PrometheusRule, error) {
-	p := &monv1.PrometheusRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "telemetry",
-		},
-		Spec: monv1.PrometheusRuleSpec{
-			Groups: []monv1.RuleGroup{
-				{
-					Name: "telemeter.rules",
-					Rules: []monv1.Rule{
-						{
-							Record: "cluster:telemetry_selected_series:count",
-							Expr:   intstr.FromString(expr),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	if p.GetNamespace() == "" {
-		p.SetNamespace(f.namespace)
-	}
-
-	return p, nil
-}
-
 func (f *Factory) NewAlertmanager(manifest io.Reader) (*monv1.Alertmanager, error) {
 	a, err := NewAlertmanager(manifest)
 	if err != nil {
@@ -3631,6 +3604,16 @@ func (f *Factory) TelemeterClientKubeRbacProxySecret() (*v1.Secret, error) {
 
 	secret.Namespace = f.namespace
 	return secret, nil
+}
+
+func (f *Factory) TelemeterClientPrometheusRule() (*monv1.PrometheusRule, error) {
+	promRule, err := f.NewPrometheusRule(f.assets.MustNewAssetReader(TelemeterClientPrometheusRule))
+	if err != nil {
+		return nil, err
+	}
+
+	promRule.Namespace = f.namespace
+	return promRule, nil
 }
 
 // TelemeterClientDeployment generates a new Deployment for Telemeter client.

--- a/pkg/tasks/telemeter.go
+++ b/pkg/tasks/telemeter.go
@@ -160,12 +160,7 @@ func (t *TelemeterClientTask) create(ctx context.Context) error {
 		}
 	}
 
-	rec, err := generateTelemeterWhitelistRec(t.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.TelemetryMatches)
-	if err != nil {
-		return errors.Wrap(err, "generating Telemeter client Prometheus Rule failed")
-	}
-
-	rule, err := t.factory.NewTelemeterPrometheusRecRuleFromString(rec)
+	rule, err := t.factory.TelemeterClientPrometheusRule()
 	if err != nil {
 		return errors.Wrap(err, "initializing Telemeter client Prometheus Rule failed")
 	}


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2057832

Problem: Current recording rule expression isn't completely accurate since it may count more series than what is effectively sent to telemeter.

Solution: Use instead metrics from telemeter-client which capture
exactly the number of samples being sent.

Relates to:
https://github.com/openshift/telemeter/pull/411
https://github.com/openshift/cluster-monitoring-operator/pull/1647
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
