### PR TITLE
Bug 2075757: UWM: add SAR capabilities to prometheus cluster role

### DIFF
--- a/assets/prometheus-user-workload/cluster-role.yaml
+++ b/assets/prometheus-user-workload/cluster-role.yaml
@@ -21,6 +21,18 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -75,6 +75,16 @@ function(params)
     clusterRole+: {
       rules+: [
         {
+          apiGroups: ['authentication.k8s.io'],
+          resources: ['tokenreviews'],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['authorization.k8s.io'],
+          resources: ['subjectaccessreviews'],
+          verbs: ['create'],
+        },
+        {
           apiGroups: [''],
           resources: ['namespaces'],
           verbs: ['get'],


### PR DESCRIPTION
Problem: In
https://github.com/openshift/cluster-monitoring-operator/pull/1641 SA
token where added back to ServiceMonitor authentication in order to
mitigate https://github.com/prometheus/prometheus/issues/9512. This has
worked for the original PR since SAR was added to the cluster role for
an unrelated change which is not present in 4.10.

Solution: Add SAR RBAC.

Issues:
https://bugzilla.redhat.com/show_bug.cgi?id=2075757
https://github.com/openshift/cluster-monitoring-operator/pull/1641
https://github.com/openshift/cluster-monitoring-operator/pull/1637
https://github.com/prometheus/prometheus/issues/9512

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
