### PR TITLE
Bug 2083460: Set timeout across Grafana components

### DIFF
--- a/assets/grafana/config.yaml
+++ b/assets/grafana/config.yaml
@@ -22,6 +22,8 @@ stringData:
     auto_sign_up = true
     enabled = true
     header_name = X-Forwarded-User
+    [dataproxy]
+    timeout = 120
     [paths]
     data = /var/lib/grafana
     logs = /var/lib/grafana/logs

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/grafana-config: 28b9b36ac4d235c1c5f2f9ca81714d1c
+        checksum/grafana-config: 3d7da91f60439323422be78538e56505
         checksum/grafana-dashboardproviders: 9ac0e8fe144a3a59f7ab62b4e733f22d
         checksum/grafana-datasources: 58dfbb3df9951f2ac8acf4c625c7173c
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'

--- a/assets/grafana/route.yaml
+++ b/assets/grafana/route.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
   name: grafana
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/components/grafana.libsonnet
+++ b/jsonnet/components/grafana.libsonnet
@@ -44,6 +44,9 @@ function(params)
       metadata: {
         name: 'grafana',
         namespace: cfg.namespace,
+        annotations: {
+          'haproxy.router.openshift.io/timeout': cfg.grafanaTimeout + 's',
+        },
       },
       spec: {
         to: {

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -75,6 +75,7 @@ local commonConfig = {
   },
   // TLS Cipher suite applied to every component serving HTTPS traffic
   tlsCipherSuites: 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
+  grafanaTimeout: 120,  // 2 mins
 };
 
 // objects deployed in openshift-monitoring namespace
@@ -194,10 +195,14 @@ local inCluster =
               reporting_enabled: false,
               check_for_updates: false,
             },
+            dataproxy: {
+              timeout: $.values.common.grafanaTimeout,
+            },
           },
         },
         tlsCipherSuites: $.values.common.tlsCipherSuites,
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
+        grafanaTimeout: $.values.common.grafanaTimeout,
       },
       kubeStateMetrics: {
         namespace: $.values.common.namespace,


### PR DESCRIPTION
This commit sets timeout value across Grafana components
e.g. data source proxy and router. By default 120s is set as a
timeout and can be overridden using a jsonnet variable `grafanaTimeout`
during build time.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
