### PR TITLE
Add runbook for kube persistent volume inodes filling up

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -375,6 +375,7 @@ spec:
         description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
           }} in Namespace {{ $labels.namespace }} only has {{ $value | humanizePercentage
           }} free inodes.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeInodesFillingUp.md
         summary: PersistentVolumeInodes are filling up.
       expr: |
         (
@@ -397,6 +398,7 @@ spec:
           $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is
           expected to run out of inodes within four days. Currently {{ $value | humanizePercentage
           }} of its inodes are free.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeInodesFillingUp.md
         summary: PersistentVolumeInodes are filling up.
       expr: |
         (

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -344,6 +344,7 @@ local includeRunbooks = {
   KubeJobFailed: openShiftRunbookCMO('KubeJobFailed.md'),
   KubeNodeNotReady: openShiftRunbookCMO('KubeNodeNotReady.md'),
   KubePersistentVolumeFillingUp: openShiftRunbookCMO('KubePersistentVolumeFillingUp.md'),
+  KubePersistentVolumeInodesFillingUp: openShiftRunbookCMO('KubePersistentVolumeInodesFillingUp.md'),
   KubePodNotReady: openShiftRunbookCMO('KubePodNotReady.md'),
   KubeletDown: openShiftRunbookCMO('KubeletDown.md'),
   NodeFileDescriptorLimit: openShiftRunbookCMO('NodeFileDescriptorLimit.md'),


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
