### PR TITLE
Adjust poll parameters

### DIFF
--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -713,7 +713,7 @@ func expectVolumeMountsInContainer(containerName, mountName string) framework.Po
 
 func assertExternalLabelExists(namespace, crName, expectKey, expectValue string) func(t *testing.T) {
 	return func(t *testing.T) {
-		err := framework.Poll(time.Second, time.Minute*5, func() error {
+		err := framework.PollImmediate(time.Second, time.Minute*5, func() error {
 			prom, err := f.MonitoringClient.Prometheuses(namespace).Get(context.Background(), crName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal("failed to get required prometheus cr", err)
@@ -741,7 +741,7 @@ func assertExternalLabelExists(namespace, crName, expectKey, expectValue string)
 
 func assertExternalLabelExistsThanosRuler(namespace, crName, expectKey, expectValue string) func(t *testing.T) {
 	return func(t *testing.T) {
-		err := framework.Poll(time.Second, time.Minute*5, func() error {
+		err := framework.PollImmediate(time.Second, time.Minute*5, func() error {
 			tr, err := f.MonitoringClient.ThanosRulers(namespace).Get(context.Background(), crName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal("failed to get required thanos ruler cr", err)
@@ -769,7 +769,7 @@ func assertExternalLabelExistsThanosRuler(namespace, crName, expectKey, expectVa
 
 func assertRemoteWriteWasSet(namespace, crName, urlValue string) func(t *testing.T) {
 	return func(t *testing.T) {
-		err := framework.Poll(time.Second, time.Minute*5, func() error {
+		err := framework.PollImmediate(time.Second, time.Minute*5, func() error {
 			prom, err := f.MonitoringClient.Prometheuses(namespace).Get(context.Background(), crName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal("failed to get required prometheus cr", err)
@@ -795,7 +795,7 @@ func assertRemoteWriteWasSet(namespace, crName, urlValue string) func(t *testing
 func assertEnforcedTargetLimit(limit uint64) func(*testing.T) {
 	ctx := context.Background()
 	return func(t *testing.T) {
-		err := framework.Poll(time.Second, 5*time.Minute, func() error {
+		err := framework.PollImmediate(time.Second, 5*time.Minute, func() error {
 			prom, err := f.MonitoringClient.Prometheuses(f.UserWorkloadMonitoringNs).Get(ctx, "user-workload", metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -819,7 +819,7 @@ func assertEnforcedTargetLimit(limit uint64) func(*testing.T) {
 func assertEnforcedLabelLimit(limit uint64) func(*testing.T) {
 	ctx := context.Background()
 	return func(t *testing.T) {
-		err := framework.Poll(time.Second, 5*time.Minute, func() error {
+		err := framework.PollImmediate(time.Second, 5*time.Minute, func() error {
 			prom, err := f.MonitoringClient.Prometheuses(f.UserWorkloadMonitoringNs).Get(ctx, "user-workload", metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -843,7 +843,7 @@ func assertEnforcedLabelLimit(limit uint64) func(*testing.T) {
 func assertEnforcedLabelNameLengthLimit(limit uint64) func(*testing.T) {
 	ctx := context.Background()
 	return func(t *testing.T) {
-		err := framework.Poll(time.Second, 5*time.Minute, func() error {
+		err := framework.PollImmediate(time.Second, 5*time.Minute, func() error {
 			prom, err := f.MonitoringClient.Prometheuses(f.UserWorkloadMonitoringNs).Get(ctx, "user-workload", metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -867,7 +867,7 @@ func assertEnforcedLabelNameLengthLimit(limit uint64) func(*testing.T) {
 func assertEnforcedLabelValueLengthLimit(limit uint64) func(*testing.T) {
 	ctx := context.Background()
 	return func(t *testing.T) {
-		err := framework.Poll(time.Second, 5*time.Minute, func() error {
+		err := framework.PollImmediate(time.Second, 5*time.Minute, func() error {
 			prom, err := f.MonitoringClient.Prometheuses(f.UserWorkloadMonitoringNs).Get(ctx, "user-workload", metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -890,7 +890,7 @@ func assertEnforcedLabelValueLengthLimit(limit uint64) func(*testing.T) {
 
 func assertQueryLogValueEquals(namespace, crName, value string) func(t *testing.T) {
 	return func(t *testing.T) {
-		err := framework.Poll(time.Second, time.Minute*5, func() error {
+		err := framework.PollImmediate(time.Second, time.Minute*5, func() error {
 			prom, err := f.MonitoringClient.Prometheuses(namespace).Get(context.Background(), crName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal("failed to get required prometheus cr", err)

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -360,7 +360,7 @@ func (c *PrometheusClient) WaitForQueryReturnOne(t *testing.T, timeout time.Dura
 func (c *PrometheusClient) WaitForQueryReturn(t *testing.T, timeout time.Duration, query string, validate func(int) error) {
 	t.Helper()
 
-	err := Poll(5*time.Second, timeout, func() error {
+	err := PollImmediate(time.Second, timeout, func() error {
 		body, err := c.PrometheusQuery(query)
 		if err != nil {
 			return errors.Wrapf(err, "error getting response for query %q", query)
@@ -388,7 +388,7 @@ func (c *PrometheusClient) WaitForQueryReturn(t *testing.T, timeout time.Duratio
 func (c *PrometheusClient) WaitForRulesReturn(t *testing.T, timeout time.Duration, validate func([]byte) error) {
 	t.Helper()
 
-	err := Poll(5*time.Second, timeout, func() error {
+	err := PollImmediate(time.Second, timeout, func() error {
 		body, err := c.PrometheusRules()
 		if err != nil {
 			return errors.Wrap(err, "error getting rules")
@@ -411,7 +411,7 @@ func (c *PrometheusClient) WaitForRulesReturn(t *testing.T, timeout time.Duratio
 func (c *PrometheusClient) WaitForTargetsReturn(t *testing.T, timeout time.Duration, validate func([]byte) error) {
 	t.Helper()
 
-	err := Poll(5*time.Second, timeout, func() error {
+	err := PollImmediate(time.Second, timeout, func() error {
 		body, err := c.PrometheusTargets()
 		if err != nil {
 			return errors.Wrap(err, "error getting targets")

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -7,7 +7,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -22,7 +21,7 @@ const (
 func (f *Framework) MustCreateOrUpdateConfigMap(t *testing.T, cm *v1.ConfigMap) {
 	t.Helper()
 	ensureCreatedByTestLabel(cm)
-	err := Poll(time.Second, 10*time.Second, func() error {
+	err := PollImmediate(time.Second, 10*time.Second, func() error {
 		return f.OperatorClient.CreateOrUpdateConfigMap(ctx, cm)
 	})
 	if err != nil {
@@ -33,7 +32,7 @@ func (f *Framework) MustCreateOrUpdateConfigMap(t *testing.T, cm *v1.ConfigMap) 
 // MustDeleteConfigMap or fail the test
 func (f *Framework) MustDeleteConfigMap(t *testing.T, cm *v1.ConfigMap) {
 	t.Helper()
-	err := Poll(time.Second, 10*time.Second, func() error {
+	err := PollImmediate(time.Second, 10*time.Second, func() error {
 		return f.OperatorClient.DeleteConfigMap(ctx, cm)
 	})
 	if err != nil {
@@ -45,14 +44,14 @@ func (f *Framework) MustDeleteConfigMap(t *testing.T, cm *v1.ConfigMap) {
 func (f *Framework) MustGetConfigMap(t *testing.T, name, namespace string) *v1.ConfigMap {
 	t.Helper()
 	var clusterCm *v1.ConfigMap
-	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+	err := PollImmediate(time.Second, 5*time.Minute, func() error {
 		cm, err := f.KubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			return false, nil
+			return err
 		}
 
 		clusterCm = cm
-		return true, nil
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("failed to get configmap %s in namespace %s - %s", name, namespace, err.Error())
@@ -64,14 +63,14 @@ func (f *Framework) MustGetConfigMap(t *testing.T, name, namespace string) *v1.C
 func (f *Framework) MustGetStatefulSet(t *testing.T, name, namespace string) *appsv1.StatefulSet {
 	t.Helper()
 	var statefulSet *appsv1.StatefulSet
-	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+	err := PollImmediate(time.Second, 5*time.Minute, func() error {
 		ss, err := f.KubeClient.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			return false, nil
+			return err
 		}
 
 		statefulSet = ss
-		return true, nil
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("failed to get statefulset %s in namespace %s - %s", name, namespace, err.Error())
@@ -83,14 +82,14 @@ func (f *Framework) MustGetStatefulSet(t *testing.T, name, namespace string) *ap
 func (f *Framework) MustGetPods(t *testing.T, namespace string) *v1.PodList {
 	t.Helper()
 	var pods *v1.PodList
-	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+	err := PollImmediate(time.Second, 5*time.Minute, func() error {
 		pl, err := f.KubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return false, nil
+			return err
 		}
 
 		pods = pl
-		return true, nil
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("failed to get pods in namespace %s - %s", namespace, err.Error())

--- a/test/e2e/kube_state_metrics_test.go
+++ b/test/e2e/kube_state_metrics_test.go
@@ -28,7 +28,7 @@ func TestKSMMetricsSuppression(t *testing.T) {
 
 	suppressedPattern, _ := regexp.Compile("kube_.*_annotations")
 
-	err := framework.Poll(5*time.Second, time.Minute, func() error {
+	err := framework.PollImmediate(time.Second, time.Minute, func() error {
 
 		client := f.PrometheusK8sClient
 

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestMultinamespacePrometheusRule(t *testing.T) {
@@ -78,21 +77,16 @@ func TestMultinamespacePrometheusRule(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var lastErr error
 	// wait for proxies bootstrap
-	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+	err = framework.Poll(time.Second, 5*time.Minute, func() error {
 		_, err := f.ThanosQuerierClient.Do("GET", "/-/ready", nil)
-		lastErr = errors.Wrap(err, "establishing connection to thanos proxy failed")
 		if err != nil {
-			return false, nil
+			return errors.Wrap(err, "establishing connection to thanos proxy failed")
 		}
-		return true, nil
+		return nil
 	})
 
 	if err != nil {
-		if err == wait.ErrWaitTimeout && lastErr != nil {
-			err = lastErr
-		}
 		t.Fatal(err)
 	}
 

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -124,7 +124,7 @@ func verifyAlertmanagerAlertReceived(t *testing.T) {
 	}
 	t.Cleanup(cleanUp)
 
-	err = framework.Poll(time.Second, 5*time.Minute, func() error {
+	err = framework.PollImmediate(time.Second, 5*time.Minute, func() error {
 		resp, err := http.Get(fmt.Sprintf("http://%s/api/v2/alerts", host))
 		if err != nil {
 			return err

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -134,7 +134,7 @@ func assertCorrectTLSConfiguration(t *testing.T, componentName, objectType, tlsC
 	ctx := context.Background()
 	var containers []v1.Container
 
-	if err := framework.Poll(5*time.Second, 5*time.Minute, func() (err error) {
+	if err := framework.PollImmediate(time.Second, 5*time.Minute, func() (err error) {
 		switch objectType {
 		case "deployment":
 			d, err := f.KubeClient.AppsV1().Deployments("openshift-monitoring").Get(ctx, componentName, metav1.GetOptions{})


### PR DESCRIPTION
Make poll interval and timeout consistent across the board. This may also reduce a bit the e2e tests duration.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
