### PR TITLE
Ignore tunbr NodeNetworkInterfaceFlapping alert

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -428,7 +428,7 @@ spec:
           often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
         summary: Network interface is often changing its status
       expr: |
-        changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m]) > 2
+        changes(node_network_up{job="node-exporter",device!~"[veth.+|tunbr]"}[2m]) > 2
       for: 2m
       labels:
         severity: warning


### PR DESCRIPTION
tunbr is an ephemeral bridge interface that can go up an down depending
on if the ephemeral network is created/deleted, we shouldnt care if that
happens. Same as we dont care if a veth interface goes up/down as that
is going to happen with CNI pod events.

https://issues.redhat.com/browse/SDN-3008

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
