### PR TITLE
Bug 2090422: pkg/manifest: Allow retention to be configurable for Thanos-Ruler in UWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#1543](https://github.com/openshift/cluster-monitoring-operator/pull/1543) Bump Grafana version to v8.3.4
 - [#1545](https://github.com/openshift/cluster-monitoring-operator/pull/1545) Add ClusterRole to allow editing of AlertManagerConfig
 - [#1657](https://github.com/openshift/cluster-monitoring-operator/pull/1657) Federation for UWM metrics
+- [#1678](https://github.com/openshift/cluster-monitoring-operator/pull/1651) Allow retention to be configurable for Thanos-Ruler in UWM
 
 ## 4.9
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -229,6 +229,7 @@ func (a AlertmanagerMainConfig) IsEnabled() bool {
 type ThanosRulerConfig struct {
 	LogLevel             string                               `json:"logLevel"`
 	NodeSelector         map[string]string                    `json:"nodeSelector"`
+	Retention            string                               `json:"retention"`
 	Tolerations          []v1.Toleration                      `json:"tolerations"`
 	Resources            *v1.ResourceRequirements             `json:"resources"`
 	VolumeClaimTemplate  *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate"`

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3737,6 +3737,10 @@ func (f *Factory) ThanosRulerCustomResource(
 		t.Spec.NodeSelector = f.config.UserWorkloadConfiguration.ThanosRuler.NodeSelector
 	}
 
+	if f.config.UserWorkloadConfiguration.ThanosRuler.Retention != "" {
+		t.Spec.Retention = f.config.UserWorkloadConfiguration.ThanosRuler.Retention
+	}
+
 	if len(f.config.UserWorkloadConfiguration.ThanosRuler.Tolerations) > 0 {
 		t.Spec.Tolerations = f.config.UserWorkloadConfiguration.ThanosRuler.Tolerations
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2631,6 +2631,29 @@ func TestThanosRulerConfiguration(t *testing.T) {
 	}
 }
 
+func TestThanosRulerRetentionConfig(t *testing.T) {
+	c := NewDefaultConfig()
+	c.UserWorkloadConfiguration.ThanosRuler.Retention = "30d"
+
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+
+	tr, err := f.ThanosRulerCustomResource(
+		"",
+		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+		nil,
+	)
+
+	if err != nil {
+		t.Fatalf("Unexpected error occured %v", err)
+		return
+	}
+
+	if tr.Spec.Retention != "30d" {
+		t.Fatal("Retention is not configured correctly")
+	}
+}
+
 func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 	type spec struct {
 		replicas int32

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -615,6 +615,7 @@ func TestUserWorkloadMonitorThanosRulerConfig(t *testing.T) {
 		Data: map[string]string{
 			"config.yaml": fmt.Sprintf(`thanosRuler:
   logLevel: debug
+  retention: 15d
   tolerations:
     - operator: "Exists"
   volumeClaimTemplate:
@@ -648,6 +649,7 @@ func TestUserWorkloadMonitorThanosRulerConfig(t *testing.T) {
 				[]framework.PodAssertion{
 					expectCatchAllToleration(),
 					expectMatchingRequests("*", containerName, mem, cpu),
+					expectContainerArg("--tsdb.retention=15d", containerName),
 				},
 			),
 		},


### PR DESCRIPTION
Introduce a new "retention" field under the thanosRuler key. This is approved backport
of [feature introduced in  4.11](https://github.com/openshift/cluster-monitoring-operator/pull/1651)

Details in https://issues.redhat.com/browse/MON-2558

/hold

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
