### PR TITLE
Bug 2089574: Removes master node selector from PO when running with HostedControlPlane external

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -58,6 +58,8 @@ const (
 	clientCAArg = "--client-ca-file=/etc/tls/client/client-ca.crt"
 
 	tmpClusterIDLabelName = "__tmp_openshift_cluster_id__"
+
+	nodeSelectorMaster = "node-role.kubernetes.io/master"
 )
 
 var (
@@ -2384,7 +2386,6 @@ func (f *Factory) PrometheusOperatorDeployment() (*appsv1.Deployment, error) {
 	}
 
 	if len(f.config.ClusterMonitoringConfiguration.PrometheusOperatorConfig.NodeSelector) > 0 {
-
 		d.Spec.Template.Spec.NodeSelector = f.config.ClusterMonitoringConfiguration.PrometheusOperatorConfig.NodeSelector
 	}
 
@@ -3378,6 +3379,10 @@ func (f *Factory) NewDeployment(manifest io.Reader) (*appsv1.Deployment, error) 
 
 	if d.GetNamespace() == "" {
 		d.SetNamespace(f.namespace)
+	}
+
+	if f.infrastructure.HostedControlPlane() {
+		delete(d.Spec.Template.Spec.NodeSelector, nodeSelectorMaster)
 	}
 
 	if !f.infrastructure.HighlyAvailableInfrastructure() {


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2089574

Problem: When UWM is run with HostedControlPlane external (HyperShift)
this makes it so the prometheus operator pods cannot start because of
the default node selector we set, where PO pods have to run on master

Solution: Add new default nodeSelector for UWM Prometheus Operator
when HostedControlPlane is external

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
