### PR TITLE
control plane: ignore flapping host interface 'tunbr'

### DIFF
--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -342,7 +342,7 @@ local inCluster =
           ruleLabels: $.values.common.ruleLabels,
           _config+: {
             diskDeviceSelector: $.values.nodeExporter.mixin._config.diskDeviceSelector,
-            hostNetworkInterfaceSelector: 'device!~"veth.+"',
+            hostNetworkInterfaceSelector: 'device!~"veth.+|tunbr"',
             kubeSchedulerSelector: 'job="scheduler"',
             namespaceSelector: $.values.common.mixinNamespaceSelector,
             cpuThrottlingSelector: $.values.common.mixinNamespaceSelector,


### PR DESCRIPTION
It's an ephemeral interface like veths are; it's not a host NIC.
Thus it's not something we should be tracking as a host level
problem as it's managed by other components like secondary
network plugins.

https://issues.redhat.com/browse/SDN-3008

Replaces https://github.com/openshift/origin/pull/27157