### PR TITLE
Bug 2090838: ignore flapping host interface 'tunbr' 

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -428,7 +428,7 @@ spec:
           often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
         summary: Network interface is often changing its status
       expr: |
-        changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m]) > 2
+        changes(node_network_up{job="node-exporter",device!~"veth.+|tunbr"}[2m]) > 2
       for: 2m
       labels:
         severity: warning

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -96,6 +96,7 @@ local inCluster =
           _config+: {
             diskDeviceSelector: $.values.nodeExporter.mixin._config.diskDeviceSelector,
             namespaceSelector: $.values.common.mixinNamespaceSelector,
+            hostNetworkInterfaceSelector: 'device!~"veth.+|tunbr"',
           },
         },
       },
@@ -342,7 +343,6 @@ local inCluster =
           ruleLabels: $.values.common.ruleLabels,
           _config+: {
             diskDeviceSelector: $.values.nodeExporter.mixin._config.diskDeviceSelector,
-            hostNetworkInterfaceSelector: 'device!~"veth.+"',
             kubeSchedulerSelector: 'job="scheduler"',
             namespaceSelector: $.values.common.mixinNamespaceSelector,
             cpuThrottlingSelector: $.values.common.mixinNamespaceSelector,


### PR DESCRIPTION
Issue https://bugzilla.redhat.com/show_bug.cgi?id=2090838

Problem: tunbr is an ephemeral (eg, virtual) interface much like
veths. It's not a node NIC and should be ignored.

Solution: Add tunbr host interface to regex of interfaces to be ignored

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
