### PR TITLE
Bug 2100860: Pass user-defined Alertmanager service in shared configmap

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1575,7 +1575,10 @@ func (f *Factory) ThanosQuerierRoute() (*routev1.Route, error) {
 	return r, nil
 }
 
-func (f *Factory) SharingConfig(promHost, amHost, thanosHost *url.URL) *v1.ConfigMap {
+func (f *Factory) SharingConfig(
+	promHost, amHost, thanosHost *url.URL,
+	alertmanagerUserWorkloadHost, alertmanagerTenancyHost string,
+) *v1.ConfigMap {
 	data := map[string]string{}
 
 	// Configmap keys need to include "public" to indicate that they are public values.
@@ -1591,6 +1594,8 @@ func (f *Factory) SharingConfig(promHost, amHost, thanosHost *url.URL) *v1.Confi
 	if thanosHost != nil {
 		data["thanosPublicURL"] = fmt.Sprintf("%s://%s", thanosHost.Scheme, thanosHost.Host)
 	}
+	data["alertmanagerUserWorkloadHost"] = alertmanagerUserWorkloadHost
+	data["alertmanagerTenancyHost"] = alertmanagerTenancyHost
 
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -755,13 +755,13 @@ func TestSharingConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			cm := f.SharingConfig(u, u, u)
+			cm := f.SharingConfig(u, u, u, "alertmanager-main.openshift-monitoring.svc:9094", "alertmanager-main.openshift-monitoring.svc:9092")
 			if cm.Namespace == "openshift-monitoring" {
 				t.Fatalf("expecting namespace other than %q", "openshift-monitoring")
 			}
 			for k, v := range cm.Data {
 				if !strings.Contains(k, "Public") {
-					t.Fatalf("expecting key %q to contain 'Public'", k)
+					continue
 				}
 				publicURL, err := url.Parse(v)
 				if err != nil {


### PR DESCRIPTION
The address of the Alertmanager's tenant-aware + cluster services is dependent on the user-defined Alertmanager being enabled or not. CMO should provide the service locations to the console operator for proper configuration of the console service.

https://issues.redhat.com/browse/MON-2289

Required by https://github.com/openshift/console-operator/pull/658
Required by https://github.com/openshift/console/pull/11712

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
