### PR TITLE
Bug 2098505: Backport PR#1692 to release-4.10

### DIFF
--- a/assets/prometheus-adapter/configmap-prometheus.yaml
+++ b/assets/prometheus-adapter/configmap-prometheus.yaml
@@ -5,18 +5,18 @@ data:
     clusters:
     - cluster:
         certificate-authority: /etc/ssl/certs/service-ca.crt
-        server: https://thanos-querier.openshift-monitoring.svc:9091
-      name: thanos-querier
+        server: https://prometheus-k8s.openshift-monitoring.svc:9091
+      name: prometheus-k8s
     contexts:
     - context:
-        cluster: thanos-querier
-        user: thanos-querier
-      name: thanos-querier
-    current-context: thanos-querier
+        cluster: prometheus-k8s
+        user: prometheus-k8s
+      name: prometheus-k8s
+    current-context: prometheus-k8s
     kind: Config
     preferences: {}
     users:
-    - name: thanos-querier
+    - name: prometheus-k8s
       user:
         tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 kind: ConfigMap

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --logtostderr=true
         - --metrics-relist-interval=1m
-        - --prometheus-url=https://thanos-querier.openshift-monitoring.svc:9091
+        - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc:9091
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         image: directxman12/k8s-prometheus-adapter:v0.9.1

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -203,17 +203,17 @@ function(params)
           - cluster:
               certificate-authority: %s
               server: %s
-            name: thanos-querier
+            name: prometheus-k8s
           contexts:
           - context:
-              cluster: thanos-querier
-              user: thanos-querier
-            name: thanos-querier
-          current-context: thanos-querier
+              cluster: prometheus-k8s
+              user: prometheus-k8s
+            name: prometheus-k8s
+          current-context: prometheus-k8s
           kind: Config
           preferences: {}
           users:
-          - name: thanos-querier
+          - name: prometheus-k8s
             user:
               tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
         ||| % [

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -274,7 +274,7 @@ local inCluster =
         namespace: $.values.common.namespace,
         version: $.values.common.versions.prometheusAdapter,
         image: $.values.common.images.prometheusAdapter,
-        prometheusURL: 'https://thanos-querier' + '.' + $.values.common.namespace + '.svc:9091',
+        prometheusURL: 'https://prometheus-' + $.values.prometheus.name + '.' + $.values.common.namespace + '.svc:9091',
         commonLabels+: $.values.common.commonLabels,
         tlsCipherSuites: $.values.common.tlsCipherSuites,
       },


### PR DESCRIPTION
Backport PR#1692 to release-4.10. 
This is a fix originally to [bug 2091902](https://bugzilla.redhat.com/show_bug.cgi?id=2091902).

This reverts commit 421a65c5b32779c4cc3752732e8c4e6d03124ab5.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
