### PR TITLE
Bug 2099526: Adds readinessProbe and livenessProbe to prometheus-adapter

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -51,9 +51,26 @@ spec:
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         image: directxman12/k8s-prometheus-adapter:v0.9.1
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 30
         name: prometheus-adapter
         ports:
         - containerPort: 6443
+          name: https
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
         resources:
           requests:
             cpu: 1m

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -111,6 +111,7 @@ function(params)
                           '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                         ],
                         terminationMessagePolicy: 'FallbackToLogsOnError',
+                        ports: [{ containerPort: 6443, name: 'https' }],
                         volumeMounts: [
                           {
                             mountPath: '/tmp',
@@ -138,6 +139,26 @@ function(params)
                             memory: '40Mi',
                             cpu: '1m',
                           },
+                        },
+                        livenessProbe: {
+                          httpGet: {
+                            path: '/livez',
+                            port: 'https',
+                            scheme: 'HTTPS',
+                          },
+                          initialDelaySeconds: 5,
+                          periodSeconds: 30,
+                          failureThreshold: 5,
+                        },
+                        readinessProbe: {
+                          httpGet: {
+                            path: '/readyz',
+                            port: 'https',
+                            scheme: 'HTTPS',
+                          },
+                          initialDelaySeconds: 30,
+                          periodSeconds: 5,
+                          failureThreshold: 5,
                         },
                       }
                     else


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2099526

Problem: Currently the prometheus-adapter pods are restarted at the same
time even though the deployment is configured with strategy RollingUpdate.
This happens because the kubelet does not know when the prometheus-adapter
pods are ready to start receiving requests.

Solution: Add both readinessProbe and livenessProbe to the
prometheus-adapter, this way the kubelet will know when either the pod
stoped working and should be restarted or simply when it ready to start
receiving requests.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
