### PR TITLE
add alerts ThanosQueryOverload and PrometheusQueryOverload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#1467](https://github.com/openshift/cluster-monitoring-operator/pull/1467) Add bodysize limit for metric scraping
 - [#1661](https://github.com/openshift/cluster-monitoring-operator/pull/1661) Support deployment of dedicated Alertmanager for user-defined alerts.
 - [#1682](https://github.com/openshift/cluster-monitoring-operator/pull/1682) Support AlertmanagerConfig v1beta1.
+- [#1699](https://github.com/openshift/cluster-monitoring-operator/pull/1699) Add alerts ThanosQueryOverload and PrometheusQueryOverload.
 
 ## 4.10
 

--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -382,6 +382,34 @@ spec:
       labels:
         workload_type: deploymentconfig
       record: namespace_workload_pod:kube_pod_owner:relabel
+    - alert: ThanosQueryOverload
+      annotations:
+        description: Thanos Query pod {{ $labels.pod }} in {{ $labels.namespace }}
+          namespace have been overloaded for more than 15 minutes. This may be a symptom
+          of excessive simultanous complex requests, low performance of the Prometheus
+          API, or failures within these components. Assess the health of the Thanos
+          query instances, the connnected Prometheus instances, look for potential
+          senders of these requests and then contact support.
+        summary: Thanos query reaches its maximum capacity serving concurrent requests
+      expr: thanos_query_concurrent_gate_queries_max - thanos_query_concurrent_gate_queries_in_flight
+        < 1
+      for: 15m
+      labels:
+        severity: warning
+    - alert: PrometheusQueryOverload
+      annotations:
+        description: Prometheus pod {{ $labels.pod }} in {{ $labels.namespace }} namespace
+          have been overloaded for more than 15 minutes. This may be a symptom of
+          excessive simultanous complex requests, low performance of the storage backend,
+          or failures within these components. Assess the health of the Prometheus
+          instances, the connnected Prometheus instances, look for potential senders
+          of these requests and then contact support.
+        summary: Prometheus reaches its maximum capacity serving concurrent requests
+      expr: prometheus_engine_queries_concurrent_max{job="prometheus-k8s"} - prometheus_engine_queries{job="prometheus-k8s"}
+        < 1
+      for: 15m
+      labels:
+        severity: warning
   - name: openshift-etcd-telemetry.rules
     rules:
     - expr: sum by (instance) (etcd_mvcc_db_total_size_in_bytes{job="etcd"})

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -536,6 +536,30 @@ function(params) {
           labels: { workload_type: 'deploymentconfig' },
           record: 'namespace_workload_pod:kube_pod_owner:relabel',
         },
+        {
+          expr: 'thanos_query_concurrent_gate_queries_max - thanos_query_concurrent_gate_queries_in_flight < 1',
+          alert: 'ThanosQueryOverload',
+          'for': '15m',
+          annotations: {
+            description: 'Thanos Query pod {{ $labels.pod }} in {{ $labels.namespace }} namespace have been overloaded for more than 15 minutes. This may be a symptom of excessive simultanous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connnected Prometheus instances, look for potential senders of these requests and then contact support.',
+            summary: 'Thanos query reaches its maximum capacity serving concurrent requests',
+          },
+          labels: {
+            severity: 'warning',
+          },
+        },
+        {
+          expr: 'prometheus_engine_queries_concurrent_max{job="prometheus-k8s"} - prometheus_engine_queries{job="prometheus-k8s"} < 1',
+          alert: 'PrometheusQueryOverload',
+          'for': '15m',
+          annotations: {
+            description: 'Prometheus pod {{ $labels.pod }} in {{ $labels.namespace }} namespace have been overloaded for more than 15 minutes. This may be a symptom of excessive simultanous complex requests, low performance of the storage backend, or failures within these components. Assess the health of the Prometheus instances, the connnected Prometheus instances, look for potential senders of these requests and then contact support.',
+            summary: 'Prometheus reaches its maximum capacity serving concurrent requests',
+          },
+          labels: {
+            severity: 'warning',
+          },
+        },
       ],
     },
     {


### PR DESCRIPTION
This pull request adds 2 alerts to notify user that the capacity of serving query has been exceeded for Thanos or Prometheus. 

These alerts can warn user to take action before the functionalities depending on metrics API such as autoscalers stops working.

Related bugs:
- https://bugzilla.redhat.com/show_bug.cgi?id=2091902
- https://bugzilla.redhat.com/show_bug.cgi?id=2091211

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
