### PR TITLE
Bug 2100472: start alert controllers only when techpreview

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -191,6 +191,12 @@ function(params) {
         resources: ['consoles'],
         verbs: ['get', 'list', 'watch'],
       },
+      // The operator needs to know whether TechPreview features are enabled or not.
+      {
+        apiGroups: ['config.openshift.io'],
+        resources: ['featuregates'],
+        verbs: ['get'],
+      },
       {
         apiGroups: ['certificates.k8s.io'],
         resources: ['certificatesigningrequests'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -120,6 +120,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - featuregates
+  verbs:
+  - get
+- apiGroups:
   - certificates.k8s.io
   resources:
   - certificatesigningrequests

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -472,6 +472,15 @@ func (c *Client) GetConsoleConfig(ctx context.Context, name string) (*configv1.C
 	return c.oscclient.ConfigV1().Consoles().Get(ctx, name, metav1.GetOptions{})
 }
 
+func (c *Client) TechPreviewEnabled(ctx context.Context) (bool, error) {
+	fg, err := c.oscclient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	return fg.Spec.FeatureSet == configv1.TechPreviewNoUpgrade, nil
+}
+
 func (c *Client) GetConfigmap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 	return c.kclient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -186,6 +186,16 @@ func New(
 		return nil, err
 	}
 
+	ruleController, err := alert.NewRuleController(ctx, c, version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create alerting rule controller: %w", err)
+	}
+
+	relabelController, err := alert.NewRelabelConfigController(ctx, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create alert relabel config controller: %w", err)
+	}
+
 	o := &Operator{
 		images:                    images,
 		telemetryMatches:          telemetryMatches,
@@ -202,8 +212,8 @@ func New(
 		informerFactories:         make([]informers.SharedInformerFactory, 0),
 		controllersToRunFunc:      make([]func(context.Context, int), 0),
 		rebalancer:                rebalancer.NewRebalancer(ctx, c.KubernetesInterface()),
-		ruleController:            alert.NewRuleController(c, version),
-		relabelController:         alert.NewRelabelConfigController(c),
+		ruleController:            ruleController,
+		relabelController:         relabelController,
 	}
 
 	informer := cache.NewSharedIndexInformer(


### PR DESCRIPTION
When the TechPreview feature gate isn't enabled, the AlertingRule and
AlertRelabelConfig CRDs don't exist which triggers warning logs when the
operator wants to start the respective informers.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
