### PR TITLE
Revert "Bug 2100472: start alert controllers only when techpreview"

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -191,12 +191,6 @@ function(params) {
         resources: ['consoles'],
         verbs: ['get', 'list', 'watch'],
       },
-      // The operator needs to know whether TechPreview features are enabled or not.
-      {
-        apiGroups: ['config.openshift.io'],
-        resources: ['featuregates'],
-        verbs: ['get'],
-      },
       {
         apiGroups: ['certificates.k8s.io'],
         resources: ['certificatesigningrequests'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -120,12 +120,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - config.openshift.io
-  resources:
-  - featuregates
-  verbs:
-  - get
-- apiGroups:
   - certificates.k8s.io
   resources:
   - certificatesigningrequests

--- a/pkg/alert/relabel_controller.go
+++ b/pkg/alert/relabel_controller.go
@@ -61,16 +61,7 @@ type RelabelConfigController struct {
 }
 
 // NewRelabelConfigController returns a new RelabelConfigController instance.
-func NewRelabelConfigController(ctx context.Context, client *client.Client) (*RelabelConfigController, error) {
-	tp, err := client.TechPreviewEnabled(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if !tp {
-		return &RelabelConfigController{}, nil
-	}
-
+func NewRelabelConfigController(client *client.Client) *RelabelConfigController {
 	// Only AlertRelabelConfig resources in the operator namespace are watched.
 	relabelConfigInformer := cache.NewSharedIndexInformer(
 		client.AlertRelabelConfigListWatchForNamespace(client.Namespace()),
@@ -112,17 +103,12 @@ func NewRelabelConfigController(ctx context.Context, client *client.Client) (*Re
 		DeleteFunc: controller.handleSecretDelete,
 	})
 
-	return controller, nil
+	return controller
 }
 
 // Run starts the controller, and blocks until the done channel for the given
 // context is closed.
 func (c *RelabelConfigController) Run(ctx context.Context, workers int) {
-	if c.client == nil {
-		klog.V(4).Info("Not starting alert relabel config controller (tech preview not enabled)")
-		return
-	}
-
 	klog.Info("Starting alert relabel config controller")
 
 	defer c.queue.ShutDown()

--- a/pkg/alert/rule_controller.go
+++ b/pkg/alert/rule_controller.go
@@ -56,16 +56,7 @@ type RuleController struct {
 }
 
 // NewRuleController returns a new AlertingRule controller instance.
-func NewRuleController(ctx context.Context, client *client.Client, version string) (*RuleController, error) {
-	tp, err := client.TechPreviewEnabled(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if !tp {
-		return &RuleController{}, nil
-	}
-
+func NewRuleController(client *client.Client, version string) *RuleController {
 	// AlertingRule resources are only allowed in the operator namespace.
 	ruleInformer := cache.NewSharedIndexInformer(
 		client.AlertingRuleListWatchForNamespace(client.Namespace()),
@@ -108,17 +99,12 @@ func NewRuleController(ctx context.Context, client *client.Client, version strin
 		DeleteFunc: rc.handlePrometheusRuleDelete,
 	})
 
-	return rc, nil
+	return rc
 }
 
 // Run starts the controller, and blocks until the done channel for the given
 // context is closed.
 func (rc *RuleController) Run(ctx context.Context, workers int) {
-	if rc.client == nil {
-		klog.V(4).Info("Not starting alerting rules controller (tech preview not enabled)")
-		return
-	}
-
 	klog.Info("Starting alerting rules controller")
 
 	defer rc.queue.ShutDown()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -472,15 +472,6 @@ func (c *Client) GetConsoleConfig(ctx context.Context, name string) (*configv1.C
 	return c.oscclient.ConfigV1().Consoles().Get(ctx, name, metav1.GetOptions{})
 }
 
-func (c *Client) TechPreviewEnabled(ctx context.Context) (bool, error) {
-	fg, err := c.oscclient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-
-	return fg.Spec.FeatureSet == configv1.TechPreviewNoUpgrade, nil
-}
-
 func (c *Client) GetConfigmap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 	return c.kclient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -186,16 +186,6 @@ func New(
 		return nil, err
 	}
 
-	ruleController, err := alert.NewRuleController(ctx, c, version)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create alerting rule controller: %w", err)
-	}
-
-	relabelController, err := alert.NewRelabelConfigController(ctx, c)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create alert relabel config controller: %w", err)
-	}
-
 	o := &Operator{
 		images:                    images,
 		telemetryMatches:          telemetryMatches,
@@ -212,8 +202,8 @@ func New(
 		informerFactories:         make([]informers.SharedInformerFactory, 0),
 		controllersToRunFunc:      make([]func(context.Context, int), 0),
 		rebalancer:                rebalancer.NewRebalancer(ctx, c.KubernetesInterface()),
-		ruleController:            ruleController,
-		relabelController:         relabelController,
+		ruleController:            alert.NewRuleController(c, version),
+		relabelController:         alert.NewRelabelConfigController(c),
 	}
 
 	informer := cache.NewSharedIndexInformer(


### PR DESCRIPTION
Reverts openshift/cluster-monitoring-operator#1701

It introduces a regression in CMO as platform alerts aren't labeled anymore with `openshift_io_alert_source="platform"`. This has been caught in https://github.com/openshift/cluster-monitoring-operator/pull/1703 which re-enables the CMO e2e tests.