### PR TITLE
Bug 2100472: fix alert controllers when not in techpreview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,12 +208,7 @@ test-unit:
 .PHONY: test-e2e
 test-e2e: KUBECONFIG?=$(HOME)/.kube/config
 test-e2e:
-	go test -run='!TechPreview' -v -timeout=120m ./test/e2e/ --kubeconfig $(KUBECONFIG)
-
-.PHONY: test-e2e-tp
-test-e2e-tp: KUBECONFIG?=$(HOME)/.kube/config
-test-e2e-tp:
-	go test -run='TechPreview' -v -timeout=20m ./test/e2e/ --kubeconfig $(KUBECONFIG)
+	go test -v -timeout=120m ./test/e2e/ --kubeconfig $(KUBECONFIG)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -191,6 +191,12 @@ function(params) {
         resources: ['consoles'],
         verbs: ['get', 'list', 'watch'],
       },
+      // The operator needs to know whether TechPreview features are enabled or not.
+      {
+        apiGroups: ['config.openshift.io'],
+        resources: ['featuregates'],
+        verbs: ['get'],
+      },
       {
         apiGroups: ['certificates.k8s.io'],
         resources: ['certificatesigningrequests'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -120,6 +120,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - featuregates
+  verbs:
+  - get
+- apiGroups:
   - certificates.k8s.io
   resources:
   - certificatesigningrequests

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -472,6 +472,15 @@ func (c *Client) GetConsoleConfig(ctx context.Context, name string) (*configv1.C
 	return c.oscclient.ConfigV1().Consoles().Get(ctx, name, metav1.GetOptions{})
 }
 
+func (c *Client) TechPreviewEnabled(ctx context.Context) (bool, error) {
+	fg, err := c.oscclient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	return fg.Spec.FeatureSet == configv1.TechPreviewNoUpgrade, nil
+}
+
 func (c *Client) GetConfigmap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 	return c.kclient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -186,6 +186,16 @@ func New(
 		return nil, err
 	}
 
+	ruleController, err := alert.NewRuleController(ctx, c, version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create alerting rule controller: %w", err)
+	}
+
+	relabelController, err := alert.NewRelabelConfigController(ctx, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create alert relabel config controller: %w", err)
+	}
+
 	o := &Operator{
 		images:                    images,
 		telemetryMatches:          telemetryMatches,
@@ -202,8 +212,8 @@ func New(
 		informerFactories:         make([]informers.SharedInformerFactory, 0),
 		controllersToRunFunc:      make([]func(context.Context, int), 0),
 		rebalancer:                rebalancer.NewRebalancer(ctx, c.KubernetesInterface()),
-		ruleController:            alert.NewRuleController(c, version),
-		relabelController:         alert.NewRelabelConfigController(c),
+		ruleController:            ruleController,
+		relabelController:         relabelController,
 	}
 
 	informer := cache.NewSharedIndexInformer(

--- a/test/e2e/alert_relabel_config_test.go
+++ b/test/e2e/alert_relabel_config_test.go
@@ -23,6 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	osmv1alpha1 "github.com/openshift/api/monitoring/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -38,6 +39,15 @@ const (
 
 func TestAlertRelabelConfigTechPreview(t *testing.T) {
 	ctx := context.Background()
+
+	fg, err := f.OpenShiftConfigClient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fg.Spec.FeatureSet != configv1.TechPreviewNoUpgrade {
+		t.Skip("TechPreview not enabled")
+	}
 
 	arcName := framework.E2eTestLabelValue
 
@@ -66,7 +76,7 @@ func TestAlertRelabelConfigTechPreview(t *testing.T) {
 	secrets := f.KubeClient.CoreV1().Secrets(f.Ns)
 
 	// Create an AlertRelabelConfig.
-	_, err := relabelConfigs.Create(ctx, arc, metav1.CreateOptions{})
+	_, err = relabelConfigs.Create(ctx, arc, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "failed to create AlertRelabelConfig"))
 	}


### PR DESCRIPTION
When the TechPreview feature gate isn't enabled, the AlertingRule
and AlertRelabelConfig CRDs don't exist which triggers warning logs when
the operator wants to start the respective informers.

When not in techpreview mode, the controllers initialize the informers
with fake lister+watcher that return no items.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
