### PR TITLE
MON-2658: Add security context to additional containers in e2e tests

### DIFF
--- a/test/e2e/alertmanager_helpers.go
+++ b/test/e2e/alertmanager_helpers.go
@@ -109,7 +109,7 @@ func setupWebhookReceiver(t *testing.T, f *framework.Framework, namespace string
 								"--log.level=debug",
 								`--id.template={{ .CommonLabels.alertname }}_{{ .CommonLabels.namespace }}`,
 							},
-							SecurityContext: getSecurityContext(),
+							SecurityContext: getSecurityContextRestrictedProfile(),
 						},
 					},
 				},

--- a/test/e2e/alertmanager_helpers.go
+++ b/test/e2e/alertmanager_helpers.go
@@ -84,8 +84,6 @@ func setupWebhookReceiver(t *testing.T, f *framework.Framework, namespace string
 		return nil, err
 	}
 
-	allowPrivilegeEscalation := false
-	runAsNonRoot := true
 	if err := f.OperatorClient.CreateOrUpdateDeployment(ctx, &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookReceiverService,
@@ -111,16 +109,7 @@ func setupWebhookReceiver(t *testing.T, f *framework.Framework, namespace string
 								"--log.level=debug",
 								`--id.template={{ .CommonLabels.alertname }}_{{ .CommonLabels.namespace }}`,
 							},
-							SecurityContext: &v1.SecurityContext{
-								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-								Capabilities: &v1.Capabilities{
-									Drop: []v1.Capability{"ALL"},
-								},
-								RunAsNonRoot: &runAsNonRoot,
-								SeccompProfile: &v1.SeccompProfile{
-									Type: v1.SeccompProfileTypeRuntimeDefault,
-								},
-							},
+							SecurityContext: getSecurityContext(),
 						},
 					},
 				},

--- a/test/e2e/alertmanager_helpers.go
+++ b/test/e2e/alertmanager_helpers.go
@@ -84,6 +84,8 @@ func setupWebhookReceiver(t *testing.T, f *framework.Framework, namespace string
 		return nil, err
 	}
 
+	allowPrivilegeEscalation := false
+	runAsNonRoot := true
 	if err := f.OperatorClient.CreateOrUpdateDeployment(ctx, &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookReceiverService,
@@ -108,6 +110,16 @@ func setupWebhookReceiver(t *testing.T, f *framework.Framework, namespace string
 							Args: []string{
 								"--log.level=debug",
 								`--id.template={{ .CommonLabels.alertname }}_{{ .CommonLabels.namespace }}`,
+							},
+							SecurityContext: &v1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								Capabilities: &v1.Capabilities{
+									Drop: []v1.Capability{"ALL"},
+								},
+								RunAsNonRoot: &runAsNonRoot,
+								SeccompProfile: &v1.SeccompProfile{
+									Type: v1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 						},
 					},

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -141,3 +141,19 @@ func createSelfSignedMTLSArtifacts(s *v1.Secret) error {
 
 	return nil
 }
+
+func getSecurityContext() *v1.SecurityContext {
+	allowPrivilegeEscalation := false
+	runAsNonRoot := true
+
+	return &v1.SecurityContext{
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{"ALL"},
+		},
+		RunAsNonRoot: &runAsNonRoot,
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -142,7 +142,7 @@ func createSelfSignedMTLSArtifacts(s *v1.Secret) error {
 	return nil
 }
 
-func getSecurityContext() *v1.SecurityContext {
+func getSecurityContextRestrictedProfile() *v1.SecurityContext {
 	allowPrivilegeEscalation := false
 	runAsNonRoot := true
 

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -140,6 +140,7 @@ func deployUserApplication(t *testing.T, f *framework.Framework) error {
 						{
 							Name:  "prometheus-example-app",
 							Image: "ghcr.io/rhobs/prometheus-example-app:0.3.0",
+							SecurityContext: getSecurityContext(),
 						},
 					},
 				},

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -140,7 +140,7 @@ func deployUserApplication(t *testing.T, f *framework.Framework) error {
 						{
 							Name:            "prometheus-example-app",
 							Image:           "ghcr.io/rhobs/prometheus-example-app:0.3.0",
-							SecurityContext: getSecurityContext(),
+							SecurityContext: getSecurityContextRestrictedProfile(),
 						},
 					},
 				},

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -138,8 +138,8 @@ func deployUserApplication(t *testing.T, f *framework.Framework) error {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:  "prometheus-example-app",
-							Image: "ghcr.io/rhobs/prometheus-example-app:0.3.0",
+							Name:            "prometheus-example-app",
+							Image:           "ghcr.io/rhobs/prometheus-example-app:0.3.0",
 							SecurityContext: getSecurityContext(),
 						},
 					},


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
