### PR TITLE
Bug 2090988: Set HA convention on admission-webhook

### DIFF
--- a/assets/admission-webhook/deployment.yaml
+++ b/assets/admission-webhook/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: prometheus-operator-admission-webhook
       app.kubernetes.io/part-of: openshift-monitoring
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       annotations:

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -13,6 +13,12 @@ function(params)
         },
       },
       spec+: {
+        strategy+: {
+          // Apply HA conventions
+          rollingUpdate: {
+            maxUnavailable: 1,
+          },
+        },
         template+: {
           metadata+: {
             labels+: {


### PR DESCRIPTION
Set `spec.rollingUpdate.maxUnavailable: 1` explicitly on prometheus-operator admission webhook
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
