### PR TITLE
Bug 2083226: increase alertmanager startupProbe failure threshold

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -23,6 +23,18 @@ spec:
         - openshift-monitoring
         topologyKey: kubernetes.io/hostname
   containers:
+  - name: alertmanager-main
+    startupProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - exec curl http://localhost:9093/-/ready
+      failureThreshold: 10
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 3
   - args:
     - -provider=openshift
     - -https-address=:9095

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -231,6 +231,19 @@ function(params)
         },
         containers: [
           {
+            name: 'alertmanager-main',
+            startupProbe+: {
+              exec: {
+                command: ['sh', '-c', 'exec curl http://localhost:9093/-/ready'],
+              },
+              failureThreshold: 10,
+              initialDelaySeconds: 20,
+              periodSeconds: 10,
+              successThreshold: 1,
+              timeoutSeconds: 3,
+            },
+          },
+          {
             name: 'alertmanager-proxy',
             image: 'quay.io/openshift/oauth-proxy:latest',  //FIXME(paulfantom)
             ports: [


### PR DESCRIPTION
The actual issue in the Bug[1] seems to be DNS related where
alertmanager fails to establish a quorum since its peers can be reached.
The  stop gap fix is to increase failure threshold of alertmanager's
startupProbe.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2083226

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
