### PR TITLE
Bug 2099939: Sets status when UserAlertmanagerConfig is missconfigured

### DIFF
--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -27,10 +27,12 @@ import (
 )
 
 const (
-	unavailableMessage          string = "Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error."
-	asExpectedReason            string = "AsExpected"
-	StorageNotConfiguredMessage        = "Prometheus is running without persistent storage which can lead to data loss during upgrades and cluster disruptions. Please refer to the official documentation to see how to configure storage for Prometheus: https://docs.openshift.com/container-platform/4.8/monitoring/configuring-the-monitoring-stack.html"
-	StorageNotConfiguredReason         = "PrometheusDataPersistenceNotConfigured"
+	unavailableMessage                        string = "Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error."
+	asExpectedReason                          string = "AsExpected"
+	StorageNotConfiguredMessage                      = "Prometheus is running without persistent storage which can lead to data loss during upgrades and cluster disruptions. Please refer to the official documentation to see how to configure storage for Prometheus: https://docs.openshift.com/container-platform/4.8/monitoring/configuring-the-monitoring-stack.html"
+	StorageNotConfiguredReason                       = "PrometheusDataPersistenceNotConfigured"
+	UserAlermanagerConfigMisconfiguredMessage        = "Misconfigured Alertmanager:  Alertmanager for user-defined alerting is enabled in the openshift-monitoring/cluster-monitoring-config configmap by setting 'enableUserAlertmanagerConfig: true' field. This conflicts with a dedicated Alertmanager instance enabled in  openshift-user-workload-monitoring/user-workload-monitoring-config. Alertmanager enabled in openshift-user-workload-monitoring takes precedence over the one in openshift-monitoring, so please remove the 'enableUserAlertmanagerConfig' field in openshift-monitoring/cluster-monitoring-config."
+	UserAlermanagerConfigMisconfiguredReason         = "UserAlertmanagerMisconfigured"
 )
 
 type StatusReporter struct {

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -66,6 +66,21 @@ func (c Config) IsStorageConfigured() bool {
 	return prometheusK8sConfig.VolumeClaimTemplate != nil
 }
 
+func (c Config) HasInconsistentAlertmanagerConfigurations() bool {
+	if c.ClusterMonitoringConfiguration == nil || c.UserWorkloadConfiguration == nil {
+		return false
+	}
+
+	amConfig := c.ClusterMonitoringConfiguration.AlertmanagerMainConfig
+	uwmConfig := c.UserWorkloadConfiguration.Alertmanager
+
+	if amConfig == nil || uwmConfig == nil {
+		return false
+	}
+
+	return amConfig.EnableUserAlertManagerConfig && uwmConfig.Enabled
+}
+
 // AdditionalAlertmanagerConfigsForPrometheusUserWorkload returns the alertmanager configurations for
 // the User Workload Monitoring Prometheus instance.
 // If no additional configurations are specified, GetPrometheusUWAdditionalAlertmanagerConfigs returns nil.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -684,6 +684,9 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	if !config.IsStorageConfigured() {
 		degradedConditionMessage = client.StorageNotConfiguredMessage
 		degradedConditionReason = client.StorageNotConfiguredReason
+	} else if config.HasInconsistentAlertmanagerConfigurations() {
+		degradedConditionMessage = client.UserAlermanagerConfigMisconfiguredMessage
+		degradedConditionReason = client.UserAlermanagerConfigMisconfiguredReason
 	}
 
 	klog.Info("Updating ClusterOperator status to done.")

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -350,7 +350,7 @@ func (f *Framework) AssertOperatorCondition(conditionType configv1.ClusterStatus
 		err := Poll(time.Second, 5*time.Minute, func() error {
 			co, err := reporter.Get(ctx)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
 			for _, c := range co.Status.Conditions {
 				if c.Type == conditionType {
@@ -358,6 +358,54 @@ func (f *Framework) AssertOperatorCondition(conditionType configv1.ClusterStatus
 						return nil
 					}
 					return fmt.Errorf("expecting condition %q to be %q, got %q", conditionType, conditionStatus, c.Status)
+				}
+			}
+			return fmt.Errorf("failed to find condition %q", conditionType)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (f *Framework) AssertOperatorConditionReason(conditionType configv1.ClusterStatusConditionType, conditionReason string) func(t *testing.T) {
+	return func(t *testing.T) {
+		reporter := f.OperatorClient.StatusReporter()
+		err := Poll(time.Second, 5*time.Minute, func() error {
+			co, err := reporter.Get(ctx)
+			if err != nil {
+				return err
+			}
+			for _, c := range co.Status.Conditions {
+				if c.Type == conditionType {
+					if c.Reason == conditionReason {
+						return nil
+					}
+					return fmt.Errorf("expecting condition %q to have reason %q, got %q", conditionType, conditionReason, c.Reason)
+				}
+			}
+			return fmt.Errorf("failed to find condition %q", conditionType)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (f *Framework) AssertOperatorConditionMessage(conditionType configv1.ClusterStatusConditionType, conditionMessage string) func(t *testing.T) {
+	return func(t *testing.T) {
+		reporter := f.OperatorClient.StatusReporter()
+		err := Poll(time.Second, 5*time.Minute, func() error {
+			co, err := reporter.Get(ctx)
+			if err != nil {
+				return err
+			}
+			for _, c := range co.Status.Conditions {
+				if c.Type == conditionType {
+					if c.Message == conditionMessage {
+						return nil
+					}
+					return fmt.Errorf("expecting condition %q to have message %q, got %q", conditionType, conditionMessage, c.Message)
 				}
 			}
 			return fmt.Errorf("failed to find condition %q", conditionType)


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2099939

Problem: When users enable in the platform configuration the flag
enableUserAlertmanagerConfig and at the same time enable the user
dedicated Alermanager instance, then if they do not enable in the UWM
configmap enableAlertmanagerConfig, user alertmanager configuration will
neither be consumed by the main alertmanager instance nor by the user
one.

Solution: Report in the status of the operator this inconsistent state.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
