### PR TITLE
Bug 2116382: Give precedence to CMO config map proxy config 

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -573,6 +573,22 @@ func (o *Operator) enqueue(obj interface{}) {
 	o.queue.Add(key)
 }
 
+type proxyConfigSupplier func(context.Context) (*ProxyConfig, error)
+
+func getProxyReader(ctx context.Context, config *manifests.Config, proxyConfigSupplier proxyConfigSupplier) manifests.ProxyReader {
+	if config.HTTPProxy() != "" || config.HTTPSProxy() != "" || config.NoProxy() != "" {
+		return config
+	}
+
+	clusterProxyConfig, err := proxyConfigSupplier(ctx)
+	if err != nil {
+		klog.Warningf("Proxy config in CMO configmap is empty and fallback to cluster proxy config failed - no proxy will be used: %v", err)
+		return config
+	}
+
+	return clusterProxyConfig
+}
+
 func (o *Operator) sync(ctx context.Context, key string) error {
 	// The operator may have left some nodes as unschedulable during a previous
 	// sync in an attempt to rebalance workloads.
@@ -591,12 +607,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	config.SetTelemetryMatches(o.telemetryMatches)
 	config.SetRemoteWrite(o.remoteWrite)
 
-	var proxyConfig manifests.ProxyReader
-	proxyConfig, err = o.loadProxyConfig(ctx)
-	if err != nil {
-		klog.Warningf("using proxy config from CMO configmap: %v", err)
-		proxyConfig = config
-	}
+	var proxyConfig = getProxyReader(ctx, config, o.loadProxyConfig)
 
 	var apiServerConfig *manifests.APIServerConfig
 	apiServerConfig, err = o.loadApiServerConfig(ctx)


### PR DESCRIPTION
Problem: Customers cannot configure a proxy for telemeter
client without setting up the cluster wide proxy.

Solution: Give precedence to CMO config map proxy config
over cluster proxy config for the proxy configuration,
otherwise cluster proxy config is always used, because
openshift.io/v1/Proxy/cluster is always present.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2116382

Signed-off-by: Juan Rodriguez Hortala <juanrh@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
