### PR TITLE
Add client certificate and key to service monitor

### DIFF
--- a/assets/kube-state-metrics/service-monitor.yaml
+++ b/assets/kube-state-metrics/service-monitor.yaml
@@ -34,6 +34,8 @@ spec:
     scrapeTimeout: 1m
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: server-name-replaced-at-runtime
   jobLabel: app.kubernetes.io/name
   selector:

--- a/assets/prometheus-adapter/service-monitor.yaml
+++ b/assets/prometheus-adapter/service-monitor.yaml
@@ -21,7 +21,9 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: server-name-replaced-at-runtime
   selector:
     matchLabels:

--- a/assets/prometheus-operator-user-workload/service-monitor.yaml
+++ b/assets/prometheus-operator-user-workload/service-monitor.yaml
@@ -16,6 +16,8 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: server-name-replaced-at-runtime
   selector:
     matchLabels:

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -67,6 +67,8 @@ function(params)
             tlsConfig: {
               caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
               serverName: 'server-name-replaced-at-runtime',
+              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
             },
           },
         ],

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -60,6 +60,8 @@ function(params)
             tlsConfig+: {
               caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
               serverName: 'server-name-replaced-at-runtime',
+              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
               insecureSkipVerify: false,
               // TODO: prometheus-adapter currently is a stock upstream aggregated api server.
               // It does not support static authorization.

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -168,6 +168,8 @@ function(params)
             tlsConfig: {
               caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
               serverName: 'server-name-replaced-at-runtime',
+              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
             },
           },
         ],


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

Description of the change:
Add client certificate and key to service monitor so that prometheus scraper does not depend on API server availability.

Motivation for the change:
https://github.com/deads2k/openshift-enhancements/blob/master/enhancements/monitoring/client-cert-scraping.md

