### PR TITLE
OWNERS: Add myself, and move former team members to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,10 +5,9 @@ reviewers:
 - jan--f
 - raptorsun
 - slashpai
-- prashbnair
-- arajkumar
 - sthaha
 - JoaoBraveCoding
+- juanrh
 
 approvers:
 - bparees
@@ -16,10 +15,9 @@ approvers:
 - jan--f
 - raptorsun
 - slashpai
-- prashbnair
-- arajkumar
 - sthaha
 - JoaoBraveCoding
+- juanrh
 
 emeritus_approvers:
 - brancz
@@ -33,3 +31,5 @@ emeritus_approvers:
 - fpetkovski
 - PhilipGough
 - bison
+- prashbnair
+- arajkumar


### PR DESCRIPTION
OWNERS: Add myself, and move former team members to emeritus

Signed-off-by: Juan Rodriguez Hortala <juanrh@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
