### PR TITLE
OCPBUGS-864: sorted condition and update on change

### DIFF
--- a/pkg/client/condition.go
+++ b/pkg/client/condition.go
@@ -15,6 +15,8 @@
 package client
 
 import (
+	"sort"
+
 	v1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -102,11 +104,16 @@ func (cs *conditions) setCondition(condition v1.ClusterStatusConditionType, stat
 	cs.entryMap = entries
 }
 
+// entries returns a sorted list of status conditions from the mapped values.
+// The list is sorted by  by type ClusterStatusConditionType to ensure consistent ordering for deep equal checks.
 func (cs *conditions) entries() []v1.ClusterOperatorStatusCondition {
 	var res []v1.ClusterOperatorStatusCondition
 	for _, v := range cs.entryMap {
 		res = append(res, v)
 	}
+	sort.SliceStable(res, func(i, j int) bool {
+		return string(res[i].Type) < string(res[j].Type)
+	})
 	return res
 }
 

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	cmostr "github.com/openshift/cluster-monitoring-operator/pkg/strings"
 
@@ -24,6 +25,7 @@ import (
 	clientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -107,9 +109,14 @@ func (r *StatusReporter) newClusterOperator() *v1.ClusterOperator {
 }
 
 func (r *StatusReporter) setConditions(ctx context.Context, co *v1.ClusterOperator, conditions *conditions) error {
-	co.Status.Conditions = conditions.entries()
-	co.Status.RelatedObjects = r.relatedObjects()
-
+	updatedStatus := co.Status.DeepCopy()
+	updatedStatus.Conditions = conditions.entries()
+	updatedStatus.RelatedObjects = r.relatedObjects()
+	if reflect.DeepEqual(co.Status, *updatedStatus) {
+		klog.V(4).Infof("No status update necessary, objects are identical")
+		return nil
+	}
+	co.Status = *updatedStatus
 	_, err := r.client.UpdateStatus(ctx, co, metav1.UpdateOptions{})
 	return err
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

Added sorting of conditions for deep equal checks
Added conditional check for status updates on changes
