### PR TITLE
Bug 2114721: Adds telemeter token hash to Deployment annotation

### DIFF
--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -16,6 +16,7 @@ package manifests
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/url"
@@ -698,7 +699,7 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.TelemeterClientDeployment(nil)
+	_, err = f.TelemeterClientDeployment(nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3277,7 +3278,7 @@ func TestTelemeterConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
-	d, err := f.TelemeterClientDeployment(&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	d, err := f.TelemeterClientDeployment(&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}, &v1.Secret{Data: map[string][]byte{"token": []byte("test")}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3300,6 +3301,15 @@ func TestTelemeterConfiguration(t *testing.T) {
 		}
 	}
 
+	hash := sha256.New()
+	expectedTokenHash := string(hash.Sum([]byte("test")))
+
+	if tokenHash, ok := d.Spec.Template.Annotations["telemeter-token-hash"]; !ok {
+		t.Fatalf("telemeter-token-hash annotation not set in telemeter-client deployment")
+	} else if expectedTokenHash != tokenHash {
+		t.Fatalf("incorrect token hash on telemeter-token-hash annotation, \n got %s, \nwant %s", tokenHash, expectedTokenHash)
+	}
+
 	expectedKubeRbacProxyTLSCipherSuitesArg := fmt.Sprintf("%s%s",
 		KubeRbacProxyTLSCipherSuitesFlag,
 		strings.Join(crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), ","))
@@ -3313,6 +3323,87 @@ func TestTelemeterConfiguration(t *testing.T) {
 	if expectedKubeRbacProxyMinTLSVersionArg != kubeRbacProxyMinTLSVersionArg {
 		t.Fatalf("incorrect TLS version \n got %s, \nwant %s", kubeRbacProxyMinTLSVersionArg, expectedKubeRbacProxyMinTLSVersionArg)
 	}
+}
+
+func TestTelemeterClientSecret(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		config               string
+		existingData         map[string][]byte
+		expectedData         map[string][]byte
+		updateToSaltExpected bool
+	}{
+		{
+			name: "No existing secret",
+			config: `telemeterClient:
+  token: mySecretToken
+`,
+			existingData: map[string][]byte{},
+			expectedData: map[string][]byte{
+				"token": []byte("mySecretToken"),
+			},
+			updateToSaltExpected: true,
+		},
+		{
+			name: "Existing secret, salt gets deleted",
+			config: `telemeterClient:
+  token: mySecretToken
+`,
+			existingData: map[string][]byte{
+				"token": []byte("mySecretToken"),
+			},
+			expectedData: map[string][]byte{
+				"token": []byte("mySecretToken"),
+			},
+			updateToSaltExpected: true,
+		},
+		{
+			name: "Existing secret, secret changes",
+			config: `telemeterClient:
+  token: myNewSecretToken
+`,
+			existingData: map[string][]byte{
+				"token": []byte("mySecretToken"),
+				"salt":  []byte("1234456789ABCDEF"),
+			},
+			expectedData: map[string][]byte{
+				"token": []byte("myNewSecretToken"),
+			},
+			updateToSaltExpected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewConfigFromString(tc.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.UserWorkloadConfiguration = NewDefaultUserWorkloadMonitoringConfig()
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+			generatedS, err := f.TelemeterClientSecret()
+			if err != nil {
+				t.Fatal(err)
+			}
+			byteT, exists := generatedS.Data["token"]
+			newToken := string(byteT)
+			if !exists {
+				t.Fatalf("generated TelemeterClientSecret does not contain a token")
+			}
+			byteS, exists := generatedS.Data["salt"]
+			newSalt := string(byteS)
+			if !exists {
+				t.Fatalf("generated TelemeterClientSecret does not contain a salt")
+			}
+			if string(tc.expectedData["token"]) != newToken {
+				t.Fatalf("generated token is different from expected, expected %s, got %s", tc.expectedData["token"], newToken)
+			}
+			if tc.updateToSaltExpected && string(tc.existingData["salt"]) == newSalt {
+				t.Fatalf("generated salt remain the same expected it to be different, got %s", newSalt)
+			} else if !tc.updateToSaltExpected && string(tc.expectedData["salt"]) != newSalt {
+				t.Fatalf("generated salt is different from expected, expected %s, got %s", tc.expectedData["salt"], newSalt)
+			}
+		})
+	}
+
 }
 
 func TestThanosRulerConfiguration(t *testing.T) {

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -386,6 +386,24 @@ func (f *Framework) AssertValueInConfigMapNotEquals(name, namespace, key, compar
 	}
 }
 
+func (f *Framework) AssertValueInSecretEquals(name, namespace, key, compareWith string) func(t *testing.T) {
+	return func(t *testing.T) {
+		s := f.MustGetSecret(t, name, namespace)
+		if string(s.Data[key]) != compareWith {
+			t.Fatalf("wanted value %s for key %s but got %s", compareWith, key, string(s.Data[key]))
+		}
+	}
+}
+
+func (f *Framework) AssertValueInSecretNotEquals(name, namespace, key, compareWith string) func(t *testing.T) {
+	return func(t *testing.T) {
+		s := f.MustGetSecret(t, name, namespace)
+		if string(s.Data[key]) == compareWith {
+			t.Fatalf("did not want value %s for key %s", compareWith, key)
+		}
+	}
+}
+
 type getResourceFunc func() (metav1.Object, error)
 
 func assertResourceExists(t *testing.T, getResource getResourceFunc) {

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -60,6 +60,25 @@ func (f *Framework) MustGetConfigMap(t *testing.T, name, namespace string) *v1.C
 	return clusterCm
 }
 
+// MustGetSecret `name` from `namespace` within 5 minutes or fail
+func (f *Framework) MustGetSecret(t *testing.T, name, namespace string) *v1.Secret {
+	t.Helper()
+	var secret *v1.Secret
+	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+		s, err := f.KubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		secret = s
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to get secret %s in namespace %s - %s", name, namespace, err.Error())
+	}
+	return secret
+}
+
 // MustGetStatefulSet `name` from `namespace` within 5 minutes or fail
 func (f *Framework) MustGetStatefulSet(t *testing.T, name, namespace string) *appsv1.StatefulSet {
 	t.Helper()


### PR DESCRIPTION
Problem: Currently after a pull secret is changed/updated the telemeter
client starts failing to authenticate with telemeter server. This
happens because the client does not load the new secret unless it is
restarted. The salt in the secret is being continuously updated which is
not correct.

Solution: Add a hash of the secret to the deployment so that when the
secret is rottated the deployment is restarted. Only update the salt
in the secret when the token is updated

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
