### PR TITLE
OCPBUGS-641: grafana: bump to 7.5.11

### DIFF
--- a/assets/grafana/config.yaml
+++ b/assets/grafana/config.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana-config
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/grafana/dashboard-datasources.yaml
+++ b/assets/grafana/dashboard-datasources.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana-datasources
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -1872,7 +1872,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-cluster-total
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -3236,7 +3236,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-etcd
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -6253,7 +6253,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-cluster
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -8990,7 +8990,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-namespace
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -9961,7 +9961,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-node
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -12381,7 +12381,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-pod
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -14360,7 +14360,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-workload
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -16504,7 +16504,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-workloads-namespace
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -17961,7 +17961,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-namespace-by-pod
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -19017,7 +19017,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-node-cluster-rsrc-use
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -20099,7 +20099,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-node-rsrc-use
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -21320,7 +21320,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-pod-total
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -22548,7 +22548,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-prometheus
     namespace: openshift-monitoring
 kind: ConfigMapList

--- a/assets/grafana/dashboard-sources.yaml
+++ b/assets/grafana/dashboard-sources.yaml
@@ -21,6 +21,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana-dashboards
   namespace: openshift-monitoring

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana
   namespace: openshift-monitoring
 spec:
@@ -18,20 +18,20 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/grafana-config: 94f8833aca0fbf265de53ed84b7547b9
-        checksum/grafana-datasources: 408092253404497e8938a433721d0242
+        checksum/grafana-config: bcf6fd722b2c76f194401f4b8e20d0af
+        checksum/grafana-datasources: ae625c50302c7e8068dc3600dbd686cc
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 7.5.5
+        app.kubernetes.io/version: 7.5.11
     spec:
       containers:
       - args:
         - -config=/etc/grafana/grafana.ini
         env: []
-        image: grafana/grafana:7.5.5
+        image: grafana/grafana:7.5.11
         name: grafana
         ports:
         - containerPort: 3001

--- a/assets/grafana/service-monitor.yaml
+++ b/assets/grafana/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana
   namespace: openshift-monitoring
 spec:

--- a/assets/grafana/service.yaml
+++ b/assets/grafana/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -15,7 +15,7 @@ repos:
   thanos: openshift/thanos
 versions:
   alertmanager: 0.22.2
-  grafana: 7.5.5
+  grafana: 7.5.11
   kubeRbacProxy: 0.11.0
   kubeStateMetrics: 2.0.0
   nodeExporter: 1.1.2

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1871,7 +1871,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-cluster-total
   namespace: openshift-config-managed
@@ -3237,7 +3237,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-etcd
   namespace: openshift-config-managed
@@ -6256,7 +6256,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-cluster
   namespace: openshift-config-managed
@@ -8995,7 +8995,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-namespace
@@ -9969,7 +9969,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-node
   namespace: openshift-config-managed
@@ -12391,7 +12391,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-pod
@@ -14373,7 +14373,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-workload
@@ -16520,7 +16520,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: grafana-dashboard-k8s-resources-workloads-namespace
@@ -17980,7 +17980,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-namespace-by-pod
   namespace: openshift-config-managed
@@ -19038,7 +19038,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-node-cluster-rsrc-use
   namespace: openshift-config-managed
@@ -20122,7 +20122,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-node-rsrc-use
   namespace: openshift-config-managed
@@ -21345,7 +21345,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-pod-total
   namespace: openshift-config-managed
@@ -22575,7 +22575,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-prometheus
   namespace: openshift-config-managed


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
