### PR TITLE
OCPBUGS-644: grafana: bump to 7.5.11

### DIFF
--- a/assets/grafana/config.yaml
+++ b/assets/grafana/config.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana-config
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/grafana/dashboard-datasources.yaml
+++ b/assets/grafana/dashboard-datasources.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana-datasources
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/grafana/dashboard-definitions.yaml
+++ b/assets/grafana/dashboard-definitions.yaml
@@ -1872,7 +1872,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-cluster-total
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -3111,7 +3111,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-etcd
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -6128,7 +6128,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-cluster
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -8865,7 +8865,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-namespace
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -9836,7 +9836,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-node
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -12256,7 +12256,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-pod
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -14235,7 +14235,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-workload
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -16379,7 +16379,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-k8s-resources-workloads-namespace
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -17836,7 +17836,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-namespace-by-pod
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -18793,7 +18793,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-node-cluster-rsrc-use
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -19777,7 +19777,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-node-rsrc-use
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -20998,7 +20998,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-pod-total
     namespace: openshift-monitoring
 - apiVersion: v1
@@ -22218,7 +22218,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: openshift-monitoring
-      app.kubernetes.io/version: 7.5.5
+      app.kubernetes.io/version: 7.5.11
     name: grafana-dashboard-prometheus
     namespace: openshift-monitoring
 kind: ConfigMapList

--- a/assets/grafana/dashboard-sources.yaml
+++ b/assets/grafana/dashboard-sources.yaml
@@ -21,6 +21,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana-dashboards
   namespace: openshift-monitoring

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana
   namespace: openshift-monitoring
 spec:
@@ -18,20 +18,20 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/grafana-config: 94f8833aca0fbf265de53ed84b7547b9
-        checksum/grafana-datasources: 408092253404497e8938a433721d0242
+        checksum/grafana-config: bcf6fd722b2c76f194401f4b8e20d0af
+        checksum/grafana-datasources: ae625c50302c7e8068dc3600dbd686cc
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 7.5.5
+        app.kubernetes.io/version: 7.5.11
     spec:
       containers:
       - args:
         - -config=/etc/grafana/grafana.ini
         env: []
-        image: grafana/grafana:7.5.5
+        image: grafana/grafana:7.5.11
         name: grafana
         ports:
         - containerPort: 3001

--- a/assets/grafana/service-monitor.yaml
+++ b/assets/grafana/service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana
   namespace: openshift-monitoring
 spec:

--- a/assets/grafana/service.yaml
+++ b/assets/grafana/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
   name: grafana
   namespace: openshift-monitoring
 spec:

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -58,7 +58,7 @@ local commonConfig = {
   versions: {
     alertmanager: '0.21.0',
     prometheus: '2.26.1',
-    grafana: '7.5.5',
+    grafana: '7.5.11',
     kubeStateMetrics: '2.0.0',
     nodeExporter: '1.1.2',
     prometheusAdapter: '0.8.4',

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1871,7 +1871,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-cluster-total
   namespace: openshift-config-managed
@@ -3112,7 +3112,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-etcd
   namespace: openshift-config-managed
@@ -6131,7 +6131,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-cluster
   namespace: openshift-config-managed
@@ -8870,7 +8870,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-namespace
   namespace: openshift-config-managed
@@ -9843,7 +9843,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-node
   namespace: openshift-config-managed
@@ -12265,7 +12265,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-pod
   namespace: openshift-config-managed
@@ -14246,7 +14246,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-workload
   namespace: openshift-config-managed
@@ -16392,7 +16392,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-k8s-resources-workloads-namespace
   namespace: openshift-config-managed
@@ -17851,7 +17851,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-namespace-by-pod
   namespace: openshift-config-managed
@@ -18810,7 +18810,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-node-cluster-rsrc-use
   namespace: openshift-config-managed
@@ -19796,7 +19796,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-node-rsrc-use
   namespace: openshift-config-managed
@@ -21019,7 +21019,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-pod-total
   namespace: openshift-config-managed
@@ -22241,7 +22241,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 7.5.5
+    app.kubernetes.io/version: 7.5.11
     console.openshift.io/dashboard: "true"
   name: grafana-dashboard-prometheus
   namespace: openshift-config-managed


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
