### PR TITLE
OCPBUGS-924: increase alertmanager's startupProbe failure threshold

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -505,9 +505,13 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 		// returns (20s is twice the time that Alertmanager waits before
 		// declaring that it can start sending notfications).
 		//
-		// We also account for slow DNS resolvers by retrying for 40 seconds in
-		// case the endpoint isn't ready after 20s (see
-		// https://bugzilla.redhat.com/show_bug.cgi?id=2037073 for details).
+		// We also account for slow DNS resolvers by retrying for 400 seconds
+		// (PeriodSeconds x FailureThreshold) thus giving AlertManager a total
+		// of 7 minutes (420 seconds) in case the endpoint isn't ready after 20s.
+		//
+		// See bugs below for details:
+		//  - https://bugzilla.redhat.com/show_bug.cgi?id=2037073
+		//  - https://bugzilla.redhat.com/show_bug.cgi?id=2083226
 		a.Spec.Containers = append(a.Spec.Containers,
 			v1.Container{
 				Name: "alertmanager",
@@ -523,7 +527,7 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 					},
 					InitialDelaySeconds: 20,
 					PeriodSeconds:       10,
-					FailureThreshold:    4,
+					FailureThreshold:    40,
 					TimeoutSeconds:      3,
 				},
 			},


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->
On some clusters, during the initial boot, DNS resolution of services
may fail and this can cause Alertmanager pods to fail, which in turn
causes CMO to be in degraded state.

This patch fixes the issue by increasing the startupProbe's tolerance.

NOTE: The actual issue in the Bug[1] seems to be DNS related where
alertmanager fails to establish a quorum since its peers can't be
reached.

[1]: https://issues.redhat.com/browse/OCPBUGSM-47741

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

---

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
