### PR TITLE
[release-4.8] OCPBUGS-1098: Give precedence to CMO config map proxy config

### DIFF
--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
 )
 
@@ -145,6 +146,58 @@ func TestNewProxyConfig(t *testing.T) {
 
 			if err := tc.check(c); err != nil {
 				t.Error(err)
+			}
+		})
+	}
+}
+
+func proxyReaderEquals(p1, p2 manifests.ProxyReader) bool {
+	return p1.HTTPProxy() == p2.HTTPProxy() && p1.HTTPSProxy() == p2.HTTPSProxy() && p1.NoProxy() == p2.NoProxy()
+}
+
+func TestGetProxyReader(t *testing.T) {
+	emptyConfig := &manifests.Config{
+		ClusterMonitoringConfiguration: &manifests.ClusterMonitoringConfiguration{
+			HTTPConfig: &manifests.HTTPConfig{},
+		},
+	}
+	nonEmptyConfig := &manifests.Config{
+		ClusterMonitoringConfiguration: &manifests.ClusterMonitoringConfiguration{
+			HTTPConfig: &manifests.HTTPConfig{
+				HTTPProxy: "foo",
+			},
+		},
+	}
+	proxyConfig := &ProxyConfig{}
+	for _, tc := range []struct {
+		name                string
+		proxyConfigSupplier proxyConfigSupplier
+		config              *manifests.Config
+		expectedProxyReader manifests.ProxyReader
+	}{
+		{
+			name:                "A non empty CMO configmap proxy configuration should get priority over the cluster-wide proxy configuration",
+			proxyConfigSupplier: func() (*ProxyConfig, error) { return nil, nil },
+			config:              nonEmptyConfig,
+			expectedProxyReader: nonEmptyConfig,
+		},
+		{
+			name:                "An empty CMO configmap proxy configuration should not get priority over the cluster-wide proxy configuration",
+			proxyConfigSupplier: func() (*ProxyConfig, error) { return proxyConfig, nil },
+			config:              emptyConfig,
+			expectedProxyReader: proxyConfig,
+		},
+		{
+			name:                "An empty proxy configuration should be used as default if the CMO configmap proxy configuration is empty and we fail to read the cluster-wide proxy configuration",
+			proxyConfigSupplier: func() (*ProxyConfig, error) { return proxyConfig, errors.New("forced error") },
+			config:              emptyConfig,
+			expectedProxyReader: emptyConfig,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proxyReader := getProxyReader(tc.config, tc.proxyConfigSupplier)
+			if !proxyReaderEquals(proxyReader, tc.expectedProxyReader) {
+				t.Error()
 			}
 		})
 	}


### PR DESCRIPTION
Problem: Customers cannot configure a proxy for telemeter client without setting up the cluster wide proxy.

Solution: Give precedence to CMO config map proxy config over cluster proxy config for the proxy configuration, otherwise cluster proxy config is always used, because openshift.io/v1/Proxy/cluster is always present.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2112381

Signed-off-by: Juan Rodriguez Hortala <juanrh@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

