### PR TITLE
Makefile: add docgen tool dependency to the docs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ versions: $(GOJSONTOYAML_BIN)
 	./hack/generate-versions.sh
 
 .PHONY: docs
-docs: $(EMBEDMD_BIN) Documentation/telemetry/telemeter_query
+docs: $(EMBEDMD_BIN) $(DOCGEN_BIN) Documentation/telemetry/telemeter_query
 	$(EMBEDMD_BIN) -w `find Documentation -name "*.md"`
 	$(DOCGEN_BIN) markdown $(K8S_VERSION) $(PO_VERSION) $(TYPES_TARGET) > Documentation/api.md
 	$(DOCGEN_BIN) asciidocs $(K8S_VERSION) $(PO_VERSION) $(TYPES_TARGET)


### PR DESCRIPTION
`make generate` has failed for me. I suppose when embedmd is already present the `docs` target doesn't pull in the tooling install target.
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
