### PR TITLE
[WIP] *: remove merge patch of Thanos sidecar

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -137,23 +137,6 @@ spec:
       name: secret-prometheus-k8s-thanos-sidecar-tls
     - mountPath: /etc/kube-rbac-proxy
       name: secret-kube-rbac-proxy
-  - args:
-    - sidecar
-    - --prometheus.url=http://localhost:9090/
-    - --tsdb.path=/prometheus
-    - --http-address=127.0.0.1:10902
-    - --grpc-server-tls-cert=/etc/tls/grpc/server.crt
-    - --grpc-server-tls-key=/etc/tls/grpc/server.key
-    - --grpc-server-tls-client-ca=/etc/tls/grpc/ca.crt
-    name: thanos-sidecar
-    resources:
-      requests:
-        cpu: 1m
-        memory: 25Mi
-    volumeMounts:
-    - mountPath: /etc/tls/grpc
-      name: secret-grpc-tls
-  - name: prometheus
   enableFeatures: []
   externalLabels: {}
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091
@@ -205,10 +188,18 @@ spec:
       openshift.io/cluster-monitoring: "true"
   serviceMonitorSelector: {}
   thanos:
+    grpcServerTlsConfig:
+      caFile: /etc/tls/grpc/ca.crt
+      certFile: /etc/tls/grpc/server.crt
+      keyFile: /etc/tls/grpc/server.key
     image: quay.io/thanos/thanos:v0.28.0
+    listenLocal: true
     resources:
       requests:
         cpu: 1m
-        memory: 100Mi
+        memory: 25Mi
     version: 0.28.0
+    volumeMounts:
+    - mountPath: /etc/tls/grpc
+      name: secret-grpc-tls
   version: 2.38.0

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -141,27 +141,6 @@ spec:
       readOnly: true
     - mountPath: /etc/kube-rbac-proxy
       name: secret-kube-rbac-proxy-metrics
-  - args:
-    - sidecar
-    - --prometheus.url=http://localhost:9090/
-    - --tsdb.path=/prometheus
-    - --http-address=127.0.0.1:10902
-    - --grpc-server-tls-cert=/etc/tls/grpc/server.crt
-    - --grpc-server-tls-key=/etc/tls/grpc/server.key
-    - --grpc-server-tls-client-ca=/etc/tls/grpc/ca.crt
-    name: thanos-sidecar
-    resources:
-      requests:
-        cpu: 1m
-        memory: 17Mi
-    securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-    volumeMounts:
-    - mountPath: /etc/tls/grpc
-      name: secret-grpc-tls
   enableFeatures: []
   enforcedNamespaceLabel: namespace
   externalLabels: {}
@@ -246,10 +225,18 @@ spec:
       - "false"
   serviceMonitorSelector: {}
   thanos:
+    grpcServerTlsConfig:
+      caFile: /etc/tls/grpc/ca.crt
+      certFile: /etc/tls/grpc/server.crt
+      keyFile: /etc/tls/grpc/server.key
     image: quay.io/thanos/thanos:v0.28.0
+    listenLocal: true
     resources:
       requests:
         cpu: 1m
-        memory: 100Mi
+        memory: 17Mi
     version: 0.28.0
+    volumeMounts:
+    - mountPath: /etc/tls/grpc
+      name: secret-grpc-tls
   version: 2.38.0

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -310,6 +310,26 @@ function(params)
         listenLocal: true,
         priorityClassName: 'system-cluster-critical',
         additionalAlertRelabelConfigs: cfg.additionalRelabelConfigs,
+        thanos+: {
+          grpcServerTlsConfig: {
+            caFile: '/etc/tls/grpc/ca.crt',
+            certFile: '/etc/tls/grpc/server.crt',
+            keyFile: '/etc/tls/grpc/server.key',
+          },
+          listenLocal: true,
+          volumeMounts: [
+            {
+              mountPath: '/etc/tls/grpc',
+              name: 'secret-grpc-tls',
+            },
+          ],
+          resources: {
+            requests: {
+              cpu: '1m',
+              memory: '25Mi',
+            },
+          },
+        },
         containers: [
           {
             name: 'prometheus-proxy',
@@ -456,33 +476,6 @@ function(params)
                 name: 'secret-' + $.kubeRbacProxySecret.metadata.name,
               },
             ],
-          },
-          {
-            name: 'thanos-sidecar',
-            args: [
-              'sidecar',
-              '--prometheus.url=http://localhost:9090/',
-              '--tsdb.path=/prometheus',
-              '--http-address=127.0.0.1:10902',
-              '--grpc-server-tls-cert=/etc/tls/grpc/server.crt',
-              '--grpc-server-tls-key=/etc/tls/grpc/server.key',
-              '--grpc-server-tls-client-ca=/etc/tls/grpc/ca.crt',
-            ],
-            volumeMounts: [
-              {
-                mountPath: '/etc/tls/grpc',
-                name: 'secret-grpc-tls',
-              },
-            ],
-            resources: {
-              requests: {
-                cpu: '1m',
-                memory: '25Mi',
-              },
-            },
-          },
-          {
-            name: 'prometheus',
           },
         ],
       },


### PR DESCRIPTION
Using strategic merge patch was necessary because the Prometheus CRD had no way to provide the TLS materials to the Thanos sidecar but with latest versions of the CRD, we can simplify.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
