### PR TITLE
OCPBUGS-1676: Dedicated kubelet ServiceMonitor for prometheus-adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.10
 
+- [#1777](https://github.com/openshift/cluster-monitoring-operator/pull/1777) Add option to improve consistency of prometheus-adapter CPU and RAM time series.
 - [#1509](https://github.com/openshift/cluster-monitoring-operator/pull/1509) add NLB usage metrics for network edge
 - [#1299](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose /api/v1/labels and /api/v1/labels/*/values endpoint on the Thanos query tenancy port.
 - [#1529](https://github.com/openshift/cluster-monitoring-operator/pull/1299) Expose /api/v1/series endpoint on the Thanos query tenancy port.

--- a/assets/control-plane/service-monitor-kubelet-prometheus-adapter.yaml
+++ b/assets/control-plane/service-monitor-kubelet-prometheus-adapter.yaml
@@ -1,0 +1,60 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kubelet
+    app.kubernetes.io/part-of: openshift-monitoring
+    k8s-app: kubelet
+  name: kubelet-for-pa
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    honorTimestamps: true
+    interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: (container_spec_.*|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      sourceLabels:
+      - __name__
+      - pod
+      - namespace
+    - action: drop
+      regex: (container_blkio_device_usage_total);.+
+      sourceLabels:
+      - __name__
+      - container
+    - action: keep
+      regex: container_cpu_usage_seconds_total|container_memory_working_set_bytes
+      sourceLabels:
+      - __name__
+    - action: replace
+      replacement: pa_$1
+      sourceLabels:
+      - __name__
+      targetLabel: __name__
+    path: /metrics/cadvisor
+    port: https-metrics
+    relabelings:
+    - sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    scrapeTimeout: 30s
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      insecureSkipVerify: false
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: kubelet

--- a/assets/control-plane/service-monitor-kubelet-prometheus-adapter.yaml
+++ b/assets/control-plane/service-monitor-kubelet-prometheus-adapter.yaml
@@ -14,21 +14,6 @@ spec:
     honorTimestamps: true
     interval: 30s
     metricRelabelings:
-    - action: drop
-      regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
-      sourceLabels:
-      - __name__
-    - action: drop
-      regex: (container_spec_.*|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
-      sourceLabels:
-      - __name__
-      - pod
-      - namespace
-    - action: drop
-      regex: (container_blkio_device_usage_total);.+
-      sourceLabels:
-      - __name__
-      - container
     - action: keep
       regex: container_cpu_usage_seconds_total|container_memory_working_set_bytes
       sourceLabels:
@@ -38,7 +23,7 @@ spec:
       sourceLabels:
       - __name__
       targetLabel: __name__
-    path: /metrics/cadvisor
+    path: /metrics/resource
     port: https-metrics
     relabelings:
     - sourceLabels:

--- a/assets/control-plane/service-monitor-kubelet-resource-metrics.yaml
+++ b/assets/control-plane/service-monitor-kubelet-resource-metrics.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: kubelet
     app.kubernetes.io/part-of: openshift-monitoring
     k8s-app: kubelet
-  name: kubelet-for-pa
+  name: kubelet-resource-metrics
   namespace: openshift-monitoring
 spec:
   endpoints:

--- a/assets/control-plane/service-monitor-kubelet-resource-metrics.yaml
+++ b/assets/control-plane/service-monitor-kubelet-resource-metrics.yaml
@@ -15,7 +15,7 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: keep
-      regex: container_cpu_usage_seconds_total|container_memory_working_set_bytes
+      regex: container_cpu_usage_seconds_total|container_memory_working_set_bytes|scrape_error
       sourceLabels:
       - __name__
     - action: replace

--- a/assets/prometheus-adapter/config-map-dedicated-service-monitors.yaml
+++ b/assets/prometheus-adapter/config-map-dedicated-service-monitors.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+data:
+  config.yaml: |-
+    "resourceRules":
+      "cpu":
+        "containerLabel": "container"
+        "containerQuery": |
+          sum by (<<.GroupBy>>) (
+            irate (
+                pa_container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[4m]
+            )
+          )
+        "nodeQuery": |
+          sum by (<<.GroupBy>>) (
+            1 - irate(
+              node_cpu_seconds_total{mode="idle"}[4m]
+            )
+            * on(namespace, pod) group_left(node) (
+              node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}
+            )
+          )
+          or sum by (<<.GroupBy>>) (
+            1 - irate(
+              windows_cpu_time_total{mode="idle",
+              job="windows-exporter",<<.LabelMatchers>>}[4m]
+            )
+          )
+        "resources":
+          "overrides":
+            "namespace":
+              "resource": "namespace"
+            "node":
+              "resource": "node"
+            "pod":
+              "resource": "pod"
+      "memory":
+        "containerLabel": "container"
+        "containerQuery": |
+          sum by (<<.GroupBy>>) (
+            pa_container_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!=""}
+          )
+        "nodeQuery": |
+          sum by (<<.GroupBy>>) (
+            node_memory_MemTotal_bytes{job="node-exporter",<<.LabelMatchers>>}
+            -
+            node_memory_MemAvailable_bytes{job="node-exporter",<<.LabelMatchers>>}
+          )
+          or sum by (<<.GroupBy>>) (
+            windows_cs_physical_memory_bytes{job="windows-exporter",<<.LabelMatchers>>}
+            -
+            windows_memory_available_bytes{job="windows-exporter",<<.LabelMatchers>>}
+          )
+        "resources":
+          "overrides":
+            "instance":
+              "resource": "node"
+            "namespace":
+              "resource": "namespace"
+            "pod":
+              "resource": "pod"
+      "window": "5m"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.9.1
+  name: adapter-config-dedicated-sm
+  namespace: openshift-monitoring

--- a/assets/prometheus-adapter/config-map-dedicated-service-monitors.yaml
+++ b/assets/prometheus-adapter/config-map-dedicated-service-monitors.yaml
@@ -21,8 +21,7 @@ data:
           )
           or sum by (<<.GroupBy>>) (
             1 - irate(
-              windows_cpu_time_total{mode="idle",
-              job="windows-exporter",<<.LabelMatchers>>}[4m]
+              windows_cpu_time_total{mode="idle", job="windows-exporter",<<.LabelMatchers>>}[4m]
             )
           )
         "resources":

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -104,9 +104,6 @@ spec:
       - emptyDir: {}
         name: tmpfs
       - configMap:
-          name: adapter-config
-        name: config
-      - configMap:
           name: prometheus-adapter-prometheus-config
         name: prometheus-adapter-prometheus-config
       - configmap:

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -164,6 +164,7 @@ function(params)
             ,
             function(e)
               e {
+                path: '/metrics/resource',
                 tlsConfig+: {
                   caFile: '/etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt',
                   insecureSkipVerify: false,
@@ -175,7 +176,7 @@ function(params)
                 // because the kubelet metric endpoints might take more than the default
                 // 10 seconds to reply.
                 scrapeTimeout: '30s',
-                metricRelabelings+: [
+                metricRelabelings: [
                   {
                     sourceLabels: ['__name__'],
                     action: 'keep',

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -142,7 +142,7 @@ function(params)
     },
 
     // This adds a kubelet ServiceMonitor for special use with
-    // prometheus-adapter
+    // prometheus-adapter if enabled by the configuration of the cluster monitoring operator.
     serviceMonitorKubeletResourceMetrics: self.serviceMonitorKubelet {
       metadata+: {
         name: 'kubelet-resource-metrics',
@@ -161,8 +161,9 @@ function(params)
                   {
                     sourceLabels: ['__name__'],
                     action: 'keep',
-                    regex: 'container_cpu_usage_seconds_total|container_memory_working_set_bytes',
+                    regex: 'container_cpu_usage_seconds_total|container_memory_working_set_bytes|scrape_error',
                   },
+                   // To avoid clashes with the cAdvisor metrics, the resource metrics are prefixed with a distinct identifier.
                   {
                     sourceLabels: ['__name__'],
                     targetLabel: '__name__',

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -156,17 +156,7 @@ function(params)
             function(e)
               e {
                 path: '/metrics/resource',
-                tlsConfig+: {
-                  caFile: '/etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt',
-                  insecureSkipVerify: false,
-                  certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
-                  keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
-                },
                 honorTimestamps: true,
-                // Increase the scrape timeout to match the scrape interval
-                // because the kubelet metric endpoints might take more than the default
-                // 10 seconds to reply.
-                scrapeTimeout: '30s',
                 metricRelabelings: [
                   {
                     sourceLabels: ['__name__'],

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -143,20 +143,11 @@ function(params)
 
     // This adds a kubelet ServiceMonitor for special use with
     // prometheus-adapter
-    serviceMonitorKubeletPrometheusAdapter: super.serviceMonitorKubelet + {
+    serviceMonitorKubeletResourceMetrics: self.serviceMonitorKubelet {
       metadata+: {
-        labels+: {
-          'k8s-app': 'kubelet',
-        },
-        name: 'kubelet-for-pa',
+        name: 'kubelet-resource-metrics',
       },
       spec+: {
-        jobLabel: 'k8s-app',
-        selector: {
-          matchLabels: {
-            'k8s-app': 'kubelet',
-          },
-        },
         endpoints:
           std.filterMap(
             function(e)

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -158,12 +158,15 @@ function(params)
                 path: '/metrics/resource',
                 honorTimestamps: true,
                 metricRelabelings: [
+                  // Keep only container_cpu_usage_seconds_total and container_memory_working_set_bytes metrics.
+                  // This is all that the Prometheus adapter needs. Node metrics are provided by node_exporter (Linux) or Windows exporter.
+                  // scrape_errors will be useful for troubleshooting.
                   {
                     sourceLabels: ['__name__'],
                     action: 'keep',
                     regex: 'container_cpu_usage_seconds_total|container_memory_working_set_bytes|scrape_error',
                   },
-                   // To avoid clashes with the cAdvisor metrics, the resource metrics are prefixed with a distinct identifier.
+                  // To avoid clashes with the cAdvisor metrics, the resource metrics are prefixed with a distinct identifier.
                   {
                     sourceLabels: ['__name__'],
                     targetLabel: '__name__',

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -26,70 +26,6 @@ function(params)
       windowsExporter: '4m',
       metricPrefix: cfg.prometheusAdapterMetricPrefix,
     },
-
-    resourceRules: {
-      cpu: {
-        containerQuery: |||
-          sum by (<<.GroupBy>>) (
-            irate (
-                %(metricPrefix)scontainer_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[%(kubelet)s]
-            )
-          )
-        ||| % $.resourceRuleConfig,
-        nodeQuery: |||
-          sum by (<<.GroupBy>>) (
-            1 - irate(
-              node_cpu_seconds_total{mode="idle"}[%(nodeExporter)s]
-            )
-            * on(namespace, pod) group_left(node) (
-              node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}
-            )
-          )
-          or sum by (<<.GroupBy>>) (
-            1 - irate(
-              windows_cpu_time_total{mode="idle",
-              job="windows-exporter",<<.LabelMatchers>>}[%(windowsExporter)s]
-            )
-          )
-        ||| % $.resourceRuleConfig,
-        resources: {
-          overrides: {
-            node: { resource: 'node' },
-            namespace: { resource: 'namespace' },
-            pod: { resource: 'pod' },
-          },
-        },
-        containerLabel: 'container',
-      },
-      memory: {
-        containerQuery: |||
-          sum by (<<.GroupBy>>) (
-            %(metricPrefix)scontainer_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!=""}
-          )
-        ||| % $.resourceRuleConfig,
-        nodeQuery: |||
-          sum by (<<.GroupBy>>) (
-            node_memory_MemTotal_bytes{job="node-exporter",<<.LabelMatchers>>}
-            -
-            node_memory_MemAvailable_bytes{job="node-exporter",<<.LabelMatchers>>}
-          )
-          or sum by (<<.GroupBy>>) (
-            windows_cs_physical_memory_bytes{job="windows-exporter",<<.LabelMatchers>>}
-            -
-            windows_memory_available_bytes{job="windows-exporter",<<.LabelMatchers>>}
-          )
-        ||| % $.resourceRuleConfig,
-        resources: {
-          overrides: {
-            instance: { resource: 'node' },
-            namespace: { resource: 'namespace' },
-            pod: { resource: 'pod' },
-          },
-        },
-        containerLabel: 'container',
-      },
-      window: '5m',
-    },
   };
 
   pa {
@@ -99,7 +35,18 @@ function(params)
       metadata: pa._metadata {
         name: 'adapter-config-dedicated-sm',
       },
-      data: { 'config.yaml': std.manifestYamlDoc(config) },
+      data: {
+        'config.yaml': std.manifestYamlDoc(pa._config.config {
+          resourceRules+: {
+            cpu+: {
+              containerQuery: std.strReplace(pa._config.config.resourceRules.cpu.containerQuery, 'container_cpu_usage_seconds_total', cfg.prometheusAdapterMetricPrefix + 'container_cpu_usage_seconds_total'),
+            },
+            memory+: {
+              containerQuery: std.strReplace(pa._config.config.resourceRules.memory.containerQuery, 'container_memory_working_set_bytes', cfg.prometheusAdapterMetricPrefix + 'container_memory_working_set_bytes'),
+            },
+          },
+        }),
+      },
     },
 
     clusterRoleAggregatedMetricsReader+:

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -19,7 +19,89 @@ function(params)
   local cfg = params;
   local pa = prometheusAdapter(cfg);
 
+  local config = {
+    resourceRuleConfig:: {
+      kubelet: '4m',
+      nodeExporter: '4m',
+      windowsExporter: '4m',
+      metricPrefix: cfg.prometheusAdapterMetricPrefix,
+    },
+
+    resourceRules: {
+      cpu: {
+        containerQuery: |||
+          sum by (<<.GroupBy>>) (
+            irate (
+                %(metricPrefix)scontainer_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[%(kubelet)s]
+            )
+          )
+        ||| % $.resourceRuleConfig,
+        nodeQuery: |||
+          sum by (<<.GroupBy>>) (
+            1 - irate(
+              node_cpu_seconds_total{mode="idle"}[%(nodeExporter)s]
+            )
+            * on(namespace, pod) group_left(node) (
+              node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}
+            )
+          )
+          or sum by (<<.GroupBy>>) (
+            1 - irate(
+              windows_cpu_time_total{mode="idle",
+              job="windows-exporter",<<.LabelMatchers>>}[%(windowsExporter)s]
+            )
+          )
+        ||| % $.resourceRuleConfig,
+        resources: {
+          overrides: {
+            node: { resource: 'node' },
+            namespace: { resource: 'namespace' },
+            pod: { resource: 'pod' },
+          },
+        },
+        containerLabel: 'container',
+      },
+      memory: {
+        containerQuery: |||
+          sum by (<<.GroupBy>>) (
+            %(metricPrefix)scontainer_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!=""}
+          )
+        ||| % $.resourceRuleConfig,
+        nodeQuery: |||
+          sum by (<<.GroupBy>>) (
+            node_memory_MemTotal_bytes{job="node-exporter",<<.LabelMatchers>>}
+            -
+            node_memory_MemAvailable_bytes{job="node-exporter",<<.LabelMatchers>>}
+          )
+          or sum by (<<.GroupBy>>) (
+            windows_cs_physical_memory_bytes{job="windows-exporter",<<.LabelMatchers>>}
+            -
+            windows_memory_available_bytes{job="windows-exporter",<<.LabelMatchers>>}
+          )
+        ||| % $.resourceRuleConfig,
+        resources: {
+          overrides: {
+            instance: { resource: 'node' },
+            namespace: { resource: 'namespace' },
+            pod: { resource: 'pod' },
+          },
+        },
+        containerLabel: 'container',
+      },
+      window: '5m',
+    },
+  };
+
   pa {
+    configMapDedicatedServiceMonitors: {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: pa._metadata {
+        name: 'adapter-config-dedicated-sm',
+      },
+      data: { 'config.yaml': std.manifestYamlDoc(config) },
+    },
+
     clusterRoleAggregatedMetricsReader+:
       {
         metadata+: {
@@ -149,12 +231,6 @@ function(params)
                 {
                   name: 'tmpfs',
                   emptyDir: {},
-                },
-                {
-                  name: 'config',
-                  configMap: {
-                    name: 'adapter-config',
-                  },
                 },
                 {
                   name: prometheusAdapterPrometheusConfig,

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -19,20 +19,9 @@ function(params)
   local cfg = params;
   local pa = prometheusAdapter(cfg);
 
-  local config = {
-    resourceRuleConfig:: {
-      kubelet: '4m',
-      nodeExporter: '4m',
-      windowsExporter: '4m',
-      metricPrefix: cfg.prometheusAdapterMetricPrefix,
-    },
-  };
-
   pa {
-    configMapDedicatedServiceMonitors: {
-      apiVersion: 'v1',
-      kind: 'ConfigMap',
-      metadata: pa._metadata {
+    configMapDedicatedServiceMonitors: pa.configMap {
+      metadata+: {
         name: 'adapter-config-dedicated-sm',
       },
       data: {

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -76,6 +76,7 @@ local commonConfig = {
   // TLS Cipher suite applied to every component serving HTTPS traffic
   tlsCipherSuites: 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
   grafanaTimeout: 120,  // 2 mins
+  prometheusAdapterMetricPrefix: 'pa_',
 };
 
 // objects deployed in openshift-monitoring namespace
@@ -277,6 +278,7 @@ local inCluster =
         prometheusURL: 'https://prometheus-' + $.values.prometheus.name + '.' + $.values.common.namespace + '.svc:9091',
         commonLabels+: $.values.common.commonLabels,
         tlsCipherSuites: $.values.common.tlsCipherSuites,
+        prometheusAdapterMetricPrefix: $.values.common.prometheusAdapterMetricPrefix,
       },
       prometheusOperator: {
         namespace: $.values.common.namespace,
@@ -342,6 +344,7 @@ local inCluster =
             pvExcludedSelector: 'label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"',
           },
         },
+        prometheusAdapterMetricPrefix: $.values.common.prometheusAdapterMetricPrefix,
       },
     },
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -277,6 +277,12 @@ type K8sPrometheusAdapter struct {
 
 	// Prometheus Adapter audit logging related configuration
 	Audit *Audit `json:"audit"`
+
+	DedicatedServiceMonitors *DedicatedServiceMonitors `json:"dedicatedServiceMonitors"`
+}
+
+type DedicatedServiceMonitors struct {
+	Enabled *bool `json:"enabled"`
 }
 
 // Audit profile configurations
@@ -388,6 +394,13 @@ func (c *Config) applyDefaults() {
 
 	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter == nil {
 		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter = &K8sPrometheusAdapter{}
+	}
+	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors == nil ||
+		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled == nil {
+		disable := false
+		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors = &DedicatedServiceMonitors{
+			Enabled: &disable,
+		}
 	}
 	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit == nil {
 		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit = &Audit{}

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -282,7 +282,7 @@ type K8sPrometheusAdapter struct {
 }
 
 type DedicatedServiceMonitors struct {
-	Enabled *bool `json:"enabled"`
+	Enabled bool `json:"enabled"`
 }
 
 // Audit profile configurations
@@ -395,12 +395,8 @@ func (c *Config) applyDefaults() {
 	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter == nil {
 		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter = &K8sPrometheusAdapter{}
 	}
-	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors == nil ||
-		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled == nil {
-		disable := false
-		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors = &DedicatedServiceMonitors{
-			Enabled: &disable,
-		}
+	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors == nil {
+		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors = &DedicatedServiceMonitors{}
 	}
 	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit == nil {
 		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit = &Audit{}

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -288,7 +288,8 @@ type K8sPrometheusAdapter struct {
 // relevant for the pod resource queries of prometheus-adapter.
 // Additionally prometheus-adapter is configured to use these dedicated metrics.
 // Overall this will improve the consistency of prometheus-adapter based CPU
-// usage measurements used by for example the oc adm top pod command or HPAs.
+// usage measurements used by for example the oc adm top pod command or the
+// Horizontal Pod Autoscaler.
 type DedicatedServiceMonitors struct {
 	Enabled bool `json:"enabled"`
 }

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -278,10 +278,10 @@ type K8sPrometheusAdapter struct {
 	// Prometheus Adapter audit logging related configuration
 	Audit *Audit `json:"audit"`
 
-	DedicatedServiceMonitors *DedicatedServiceMonitors `json:"dedicatedServiceMonitors"`
+	DedicatedServiceMonitors *DedicatedServiceMonitors `json:"dedicatedServiceMonitors,omitempty"`
 }
 
-// Dedicated Service Monitors configuration
+// Configuration for prometheus-adapter dedicated Service Monitors.
 // When Enabled is set to true, CMO will deploy and scrape a dedicated
 // Service Monitor, that exposes the kubelet /metrics/resource endpoint. This
 // Service Monitor sets honorTimestamps: true and only keeps metrics that are
@@ -291,7 +291,7 @@ type K8sPrometheusAdapter struct {
 // usage measurements used by for example the oc adm top pod command or the
 // Horizontal Pod Autoscaler.
 type DedicatedServiceMonitors struct {
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // Audit profile configurations

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -281,6 +281,14 @@ type K8sPrometheusAdapter struct {
 	DedicatedServiceMonitors *DedicatedServiceMonitors `json:"dedicatedServiceMonitors"`
 }
 
+// Dedicated Service Monitors configuration
+// When Enabled is set to true, CMO will deploy and scrape a dedicated
+// Service Monitor, that exposes the kubelet /metrics/resource endpoint. This
+// Service Monitor sets honorTimestamps: true and only keeps metrics that are
+// relevant for the pod resource queries of prometheus-adapter.
+// Additionally prometheus-adapter is configured to use these dedicated metrics.
+// Overall this will improve the consistency of prometheus-adapter based CPU
+// usage measurements used by for example the oc adm top pod command or HPAs.
 type DedicatedServiceMonitors struct {
 	Enabled bool `json:"enabled"`
 }

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -188,6 +188,30 @@ func TestEtcdDefaultsToDisabled(t *testing.T) {
 	}
 }
 
+func TestPromAdapterDedicatedSMsDefaultsToDisabled(t *testing.T) {
+	c, err := NewConfigFromString("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+		t.Error("an empty configuration should have prometheus-adapter dedicated ServiceMonitors dislabled")
+	}
+	c, err = NewConfigFromString(`{"k8sPrometheusAdapter":{}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+		t.Error("an empty k8sPrometheusAdapter configuration should have prometheus-adapter dedicated ServiceMonitors dislabled")
+	}
+	c, err = NewConfigFromString(`{"k8sPrometheusAdapter":{"dedicatedServiceMonitors":{}}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+		t.Error("an empty dedicatedSericeMonitors configuration should have prometheus-adapter dedicated ServiceMonitors dislabled")
+	}
+}
+
 func TestHttpProxyConfig(t *testing.T) {
 	conf := `http:
   httpProxy: http://test.com

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -193,21 +193,21 @@ func TestPromAdapterDedicatedSMsDefaultsToDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
 		t.Error("an empty configuration should have prometheus-adapter dedicated ServiceMonitors dislabled")
 	}
 	c, err = NewConfigFromString(`{"k8sPrometheusAdapter":{}}`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
 		t.Error("an empty k8sPrometheusAdapter configuration should have prometheus-adapter dedicated ServiceMonitors dislabled")
 	}
 	c, err = NewConfigFromString(`{"k8sPrometheusAdapter":{"dedicatedServiceMonitors":{}}}`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
 		t.Error("an empty dedicatedSericeMonitors configuration should have prometheus-adapter dedicated ServiceMonitors dislabled")
 	}
 }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -261,7 +261,7 @@ var (
 
 	ControlPlanePrometheusRule          = "control-plane/prometheus-rule.yaml"
 	ControlPlaneKubeletServiceMonitor   = "control-plane/service-monitor-kubelet.yaml"
-	ControlPlaneKubeletServiceMonitorPA = "control-plane/service-monitor-kubelet-prometheus-adapter.yaml"
+	ControlPlaneKubeletServiceMonitorPA = "control-plane/service-monitor-kubelet-resource-metrics.yaml"
 	ControlPlaneEtcdServiceMonitor      = "control-plane/service-monitor-etcd.yaml"
 )
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -154,6 +154,7 @@ var (
 	PrometheusAdapterClusterRoleServerResources         = "prometheus-adapter/cluster-role-server-resources.yaml"
 	PrometheusAdapterClusterRoleAggregatedMetricsReader = "prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml"
 	PrometheusAdapterConfigMap                          = "prometheus-adapter/config-map.yaml"
+	PrometheusAdapterConfigMapDedicatedSM               = "prometheus-adapter/config-map-dedicated-service-monitors.yaml"
 	PrometheusAdapterConfigMapPrometheus                = "prometheus-adapter/configmap-prometheus.yaml"
 	PrometheusAdapterConfigMapAuditPolicy               = "prometheus-adapter/configmap-audit-profiles.yaml"
 	PrometheusAdapterDeployment                         = "prometheus-adapter/deployment.yaml"
@@ -258,9 +259,10 @@ var (
 
 	TelemeterTrustedCABundle = "telemeter-client/trusted-ca-bundle.yaml"
 
-	ControlPlanePrometheusRule        = "control-plane/prometheus-rule.yaml"
-	ControlPlaneKubeletServiceMonitor = "control-plane/service-monitor-kubelet.yaml"
-	ControlPlaneEtcdServiceMonitor    = "control-plane/service-monitor-etcd.yaml"
+	ControlPlanePrometheusRule          = "control-plane/prometheus-rule.yaml"
+	ControlPlaneKubeletServiceMonitor   = "control-plane/service-monitor-kubelet.yaml"
+	ControlPlaneKubeletServiceMonitorPA = "control-plane/service-monitor-kubelet-prometheus-adapter.yaml"
+	ControlPlaneEtcdServiceMonitor      = "control-plane/service-monitor-etcd.yaml"
 )
 
 var (
@@ -1912,6 +1914,17 @@ func (f *Factory) PrometheusAdapterConfigMap() (*v1.ConfigMap, error) {
 	return cm, nil
 }
 
+func (f *Factory) PrometheusAdapterConfigMapDedicated() (*v1.ConfigMap, error) {
+	cm, err := f.NewConfigMap(f.assets.MustNewAssetReader(PrometheusAdapterConfigMapDedicatedSM))
+	if err != nil {
+		return nil, err
+	}
+
+	cm.Namespace = f.namespace
+
+	return cm, nil
+}
+
 func (f *Factory) PrometheusAdapterConfigMapAuditPolicy() (*v1.ConfigMap, error) {
 	cm, err := f.NewConfigMap(f.assets.MustNewAssetReader(PrometheusAdapterConfigMapAuditPolicy))
 	if err != nil {
@@ -2879,6 +2892,17 @@ func (f *Factory) ControlPlaneEtcdServiceMonitor() (*monv1.ServiceMonitor, error
 
 func (f *Factory) ControlPlaneKubeletServiceMonitor() (*monv1.ServiceMonitor, error) {
 	s, err := f.NewServiceMonitor(f.assets.MustNewAssetReader(ControlPlaneKubeletServiceMonitor))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespace
+
+	return s, nil
+}
+
+func (f *Factory) ControlPlaneKubeletServiceMonitorPA() (*monv1.ServiceMonitor, error) {
+	s, err := f.NewServiceMonitor(f.assets.MustNewAssetReader(ControlPlaneKubeletServiceMonitorPA))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1963,7 +1963,7 @@ func validateAuditProfile(profile auditv1.Level) error {
 	}
 }
 
-func (f *Factory) PrometheusAdapterDeployment(apiAuthSecretName string, requestheader map[string]string) (*appsv1.Deployment, error) {
+func (f *Factory) PrometheusAdapterDeployment(apiAuthSecretName string, requestheader map[string]string, configName string) (*appsv1.Deployment, error) {
 	dep, err := f.NewDeployment(f.assets.MustNewAssetReader(PrometheusAdapterDeployment))
 	if err != nil {
 		return nil, err
@@ -2034,6 +2034,16 @@ func (f *Factory) PrometheusAdapterDeployment(apiAuthSecretName string, requesth
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
 					SecretName: apiAuthSecretName,
+				},
+			},
+		},
+		v1.Volume{
+			Name: "config",
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: configName,
+					},
 				},
 			},
 		},

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -539,7 +539,7 @@ func TestUnconfiguredManifests(t *testing.T) {
 		"requestheader-extra-headers-prefix": "",
 		"requestheader-group-headers":        "",
 		"requestheader-username-headers":     "",
-	})
+	}, "adapter-config")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1790,7 +1790,8 @@ k8sPrometheusAdapter:
 				"requestheader-extra-headers-prefix": "",
 				"requestheader-group-headers":        "",
 				"requestheader-username-headers":     "",
-			})
+			},
+				"adapter-config")
 
 			if test.err != nil || err != nil {
 				// fail only if the error isn't what is expected
@@ -1844,7 +1845,7 @@ k8sPrometheusAdapter:
 		"requestheader-extra-headers-prefix": "",
 		"requestheader-group-headers":        "",
 		"requestheader-username-headers":     "",
-	})
+	}, "adapter-config")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2740,7 +2741,8 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 						"requestheader-extra-headers-prefix": "",
 						"requestheader-group-headers":        "",
 						"requestheader-username-headers":     "",
-					})
+					},
+					"adapter-config")
 				if err != nil {
 					return spec{}, err
 				}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -630,7 +630,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 				tasks.NewTaskSpec("Updating node-exporter", tasks.NewNodeExporterTask(o.client, factory)),
 				tasks.NewTaskSpec("Updating kube-state-metrics", tasks.NewKubeStateMetricsTask(o.client, factory)),
 				tasks.NewTaskSpec("Updating openshift-state-metrics", tasks.NewOpenShiftStateMetricsTask(o.client, factory)),
-				tasks.NewTaskSpec("Updating prometheus-adapter", tasks.NewPrometheusAdapterTask(ctx, o.namespace, o.client, factory)),
+				tasks.NewTaskSpec("Updating prometheus-adapter", tasks.NewPrometheusAdapterTask(ctx, o.namespace, o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Telemeter client", tasks.NewTelemeterClientTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating Thanos Querier", tasks.NewThanosQuerierTask(o.client, factory, config)),
 				tasks.NewTaskSpec("Updating User Workload Thanos Ruler", tasks.NewThanosRulerUserWorkloadTask(o.client, factory, config)),

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -16,6 +16,7 @@ package tasks
 
 import (
 	"context"
+
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -53,6 +54,23 @@ func (t *ControlPlaneTask) Run(ctx context.Context) error {
 	err = t.client.CreateOrUpdateServiceMonitor(ctx, smk)
 	if err != nil {
 		return errors.Wrap(err, "reconciling control-plane kubelet ServiceMonitor failed")
+	}
+
+	smkpa, err := t.factory.ControlPlaneKubeletServiceMonitorPA()
+	if err != nil {
+		return errors.Wrap(err, "initializing prometheus-adapater dedicated control-plane kubelet ServiceMonitor failed")
+	}
+
+	if *t.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+		err = t.client.CreateOrUpdateServiceMonitor(ctx, smkpa)
+		if err != nil {
+			return errors.Wrap(err, "reconcilin prometheus-adapater dedicatedg control-plane kubelet ServiceMonitor failed")
+		}
+	} else {
+		err = t.client.DeleteServiceMonitor(ctx, smkpa)
+		if err != nil {
+			return errors.Wrap(err, "deleting prometheus-adapater dedicated control-plane etcd ServiceMonitor failed")
+		}
 	}
 
 	sme, err := t.factory.ControlPlaneEtcdServiceMonitor()

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -58,18 +58,18 @@ func (t *ControlPlaneTask) Run(ctx context.Context) error {
 
 	smkpa, err := t.factory.ControlPlaneKubeletServiceMonitorPA()
 	if err != nil {
-		return errors.Wrap(err, "initializing prometheus-adapater dedicated control-plane kubelet ServiceMonitor failed")
+		return errors.Wrap(err, "initializing prometheus-adapter dedicated kubelet ServiceMonitor failed")
 	}
 
-	if *t.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+	if t.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
 		err = t.client.CreateOrUpdateServiceMonitor(ctx, smkpa)
 		if err != nil {
-			return errors.Wrap(err, "reconcilin prometheus-adapater dedicatedg control-plane kubelet ServiceMonitor failed")
+			return errors.Wrap(err, "reconciling prometheus-adapter dedicated kubelet ServiceMonitor failed")
 		}
 	} else {
 		err = t.client.DeleteServiceMonitor(ctx, smkpa)
 		if err != nil {
-			return errors.Wrap(err, "deleting prometheus-adapater dedicated control-plane etcd ServiceMonitor failed")
+			return errors.Wrap(err, "deleting prometheus-adapter dedicated kubelet ServiceMonitor failed")
 		}
 	}
 

--- a/pkg/tasks/prometheusadapter.go
+++ b/pkg/tasks/prometheusadapter.go
@@ -158,7 +158,7 @@ func (t *PrometheusAdapterTask) Run(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "initializing PrometheusAdapter ConfigMap failed")
 		}
-		if *t.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
+		if t.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors.Enabled {
 			err = t.client.CreateOrUpdateConfigMap(ctx, cmD)
 			if err != nil {
 				return errors.Wrap(err, "reconciling PrometheusAdapter ConfigMap for dedicated ServiceMonitors failed")

--- a/test/e2e/prometheusadapter_test.go
+++ b/test/e2e/prometheusadapter_test.go
@@ -60,6 +60,37 @@ func isAPIServiceAvailable(conditions []apiservicesv1.APIServiceCondition) bool 
 }
 
 func TestMetricsAPIAvailability(t *testing.T) {
+	for _, tc := range []struct {
+		cmoConfig string
+	}{
+		{
+			cmoConfig: `prometheusK8s:
+  logLevel: debug
+  k8sPrometheusAdapter:
+    dedicatedServiceMonitors:
+      enabled: false
+`,
+		},
+		{
+			cmoConfig: `prometheusK8s:
+  logLevel: debug
+  k8sPrometheusAdapter:
+    dedicatedServiceMonitors:
+      enabled: true
+`,
+		},
+	} {
+		f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, tc.cmoConfig))
+
+		f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
+		f.AssertOperatorCondition(configv1.OperatorProgressing, configv1.ConditionFalse)(t)
+		f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+
+		checkMetricsAPIAvailability(t)
+	}
+}
+
+func checkMetricsAPIAvailability(t *testing.T) {
 	ctx := context.Background()
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -83,6 +114,37 @@ func TestMetricsAPIAvailability(t *testing.T) {
 }
 
 func TestNodeMetricsPresence(t *testing.T) {
+	for _, tc := range []struct {
+		cmoConfig string
+	}{
+		{
+			cmoConfig: `prometheusK8s:
+  logLevel: debug
+  k8sPrometheusAdapter:
+    dedicatedServiceMonitors:
+      enabled: false
+`,
+		},
+		{
+			cmoConfig: `prometheusK8s:
+  logLevel: debug
+  k8sPrometheusAdapter:
+    dedicatedServiceMonitors:
+      enabled: true
+`,
+		},
+	} {
+		f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, tc.cmoConfig))
+
+		f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
+		f.AssertOperatorCondition(configv1.OperatorProgressing, configv1.ConditionFalse)(t)
+		f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+
+		checkNodeMetricsPresence(t)
+	}
+}
+
+func checkNodeMetricsPresence(t *testing.T) {
 	ctx := context.Background()
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -121,6 +183,37 @@ func TestNodeMetricsPresence(t *testing.T) {
 }
 
 func TestPodMetricsPresence(t *testing.T) {
+	for _, tc := range []struct {
+		cmoConfig string
+	}{
+		{
+			cmoConfig: `prometheusK8s:
+  logLevel: debug
+  k8sPrometheusAdapter:
+    dedicatedServiceMonitors:
+      enabled: false
+`,
+		},
+		{
+			cmoConfig: `prometheusK8s:
+  logLevel: debug
+  k8sPrometheusAdapter:
+    dedicatedServiceMonitors:
+      enabled: true
+`,
+		},
+	} {
+		f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, tc.cmoConfig))
+
+		f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
+		f.AssertOperatorCondition(configv1.OperatorProgressing, configv1.ConditionFalse)(t)
+		f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+
+		checkPodMetricsPresence(t)
+	}
+}
+
+func checkPodMetricsPresence(t *testing.T) {
 	var lastErr error
 	ctx := context.Background()
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {


### PR DESCRIPTION
Backport of #1774 
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
