### PR TITLE
OCPBUGS-1321: Node Exporter - ignore virtual NICs from OVNK cluster

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -35,11 +35,11 @@ spec:
         - --path.rootfs=/host/root
         - --no-collector.wifi
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
         - --no-collector.cpufreq
+        - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|tun[0-9]*|br[0-9]*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext)$
         image: quay.io/prometheus/node-exporter:v1.4.0
         name: node-exporter
         resources:

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -165,7 +165,7 @@ function(params)
                       // gather that data (especially for bare metal clusters), and
                       // add flags to collect the node_cpu_info metric + metrics
                       // from the text file.
-                      args: [a for a in c.args if a != '--no-collector.hwmon'] +
+                      args: [a for a in c.args if (a != '--no-collector.hwmon') && !std.startsWith(a, '--collector.netclass.ignored-devices')] +
                             [
                               '--collector.cpu.info',
                               '--collector.textfile.directory=' + textfileDir,
@@ -177,6 +177,9 @@ function(params)
                               // https://bugzilla.redhat.com/show_bug.cgi?id=1972076
                               // https://github.com/prometheus/node_exporter/issues/1880
                               '--no-collector.cpufreq',
+                              // ignore OVNK network interfaces, too.
+                              // https://issues.redhat.com/browse/OCPBUGS-1321
+                              '--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|tun[0-9]*|br[0-9]*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext)$',
                             ],
                       terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts+: [{


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

These NICs are to ignore:

- tun[0-9]*
- br[0-9]*
- ovn-k8s-mp[0-9]*
- br-ex
- br-int
- br-ext
