### PR TITLE
Updating cluster-monitoring-operator images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # When bumping the Go version, don't forget to update the configuration of the
 # CI jobs in openshift/release.
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-monitoring-operator
 COPY . .
 ENV GOFLAGS="-mod=vendor"

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -570,8 +570,8 @@ func (f *Factory) AlertmanagerUserWorkload(trustedCABundleCM *v1.ConfigMap) (*mo
 // of 7 minutes (420 seconds) in case the endpoint isn't ready after 20s.
 //
 // See bugs below for details:
-//  - https://bugzilla.redhat.com/show_bug.cgi?id=2037073
-//  - https://bugzilla.redhat.com/show_bug.cgi?id=2083226
+//   - https://bugzilla.redhat.com/show_bug.cgi?id=2037073
+//   - https://bugzilla.redhat.com/show_bug.cgi?id=2083226
 func setupStartupProbe(a *monv1.Alertmanager) {
 	if a.Spec.Storage != nil {
 		return

--- a/pkg/manifests/tls.go
+++ b/pkg/manifests/tls.go
@@ -105,14 +105,14 @@ func (f *Factory) UserWorkloadMetricsClientCACM(apiAuthConfigmap *v1.ConfigMap) 
 //
 // The rotation scheme here assumes the following threat model:
 //
-// 1. CA certificates could be compromised as they are being mounted into multiple pods
-//    reachable externally i.e. via routes.
-//    This is addressed by expiry and time based rotation.
-// 2. Client and server certificates as well as their private key could be compromised
-//    as they are being mounted into multiple pods reachable externally i.e. via routes.
-//    This is addressed by re-issuing them at the same time the CA expires.
-// 3. The CA's private key is left out of the thread model as it is not mounted in any pod.
-//    This implementation assumes it can stay immutable and does not need rotation.
+//  1. CA certificates could be compromised as they are being mounted into multiple pods
+//     reachable externally i.e. via routes.
+//     This is addressed by expiry and time based rotation.
+//  2. Client and server certificates as well as their private key could be compromised
+//     as they are being mounted into multiple pods reachable externally i.e. via routes.
+//     This is addressed by re-issuing them at the same time the CA expires.
+//  3. The CA's private key is left out of the thread model as it is not mounted in any pod.
+//     This implementation assumes it can stay immutable and does not need rotation.
 func RotateGRPCSecret(s *v1.Secret) error {
 	var (
 		curCA, newCA              *crypto.CA


### PR DESCRIPTION
Supersedes #1786

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
