### PR TITLE
[WIP] Add "Role" filter option to k8s-resources-node dashboard

### DIFF
--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -8694,6 +8694,33 @@ data:
                     },
                     "datasource": "$datasource",
                     "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": true,
+                    "name": "role",
+                    "options": [
+
+                    ],
+                    "query": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 1,
+                    "tagValuesQuery": "",
+                    "tags": [
+
+                    ],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "",
+                        "value": ""
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
                     "includeAll": false,
                     "label": null,
                     "multi": true,
@@ -8701,7 +8728,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_node_info{cluster=\"$cluster\"}, node)",
+                    "query": "label_values(kube_node_role{cluster=\"$cluster\",role=~\"^$role$\"}, node)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,


### PR DESCRIPTION
The Role defaults to "All". Selecting a role filters the available Node options to just those with the selected role.
