### PR TITLE
[MON-2821] Patch Alert KubePodNotReady to exclude installer pods.

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -31,7 +31,8 @@ spec:
       expr: |
         sum by (namespace, pod, cluster) (
           max by(namespace, pod, cluster) (
-            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", phase=~"Pending|Unknown"}
+            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", pod!~"installer.+", phase=~"Pending|Unknown|Failed"} or
+            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", pod=~"installer.+", phase=~"Pending|Unknown"}
           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
           )

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -183,6 +183,27 @@ local patchedRules = [
         },
         'for': '30m',
       },
+      {
+        alert: 'KubePodNotReady',
+        expr: |||
+          sum by (namespace, pod, %(clusterLabel)s) (
+            max by(namespace, pod, %(clusterLabel)s) (
+              kube_pod_status_phase{%(prefixedNamespaceSelector)s,%(kubeStateMetricsSelector)s, pod!~"installer.+", phase=~"Pending|Unknown|Failed"} or
+              kube_pod_status_phase{%(prefixedNamespaceSelector)s,%(kubeStateMetricsSelector)s, pod=~"installer.+", phase=~"Pending|Unknown"}
+            ) * on(namespace, pod, %(clusterLabel)s) group_left(owner_kind) topk by(namespace, pod, %(clusterLabel)s) (
+              1, max by(namespace, pod, owner_kind, %(clusterLabel)s) (kube_pod_owner{owner_kind!="Job"})
+            )
+          ) > 0
+        ||| % {
+          clusterLabel: 'cluster',
+          prefixedNamespaceSelector: 'namespace=~"(openshift-.*|kube-.*|default)"',
+          kubeStateMetricsSelector: 'job="kube-state-metrics"',
+        },
+        labels: {
+          severity: 'warning',
+        },
+
+      },
     ],
   },
   {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

The alert `KubePodNotReady` will exclude installer pods.
This PR resolves the problem of pinning the alert while receiving other updates from upstream components. (ref https://github.com/openshift/cluster-monitoring-operator/pull/1788)

https://issues.redhat.com/browse/MON-2821

