### PR TITLE
OCPBUGS-1766: jsonnet: disable KubePersistentVolumeInodesFillingUp alert

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -370,53 +370,6 @@ spec:
       for: 1h
       labels:
         severity: warning
-    - alert: KubePersistentVolumeInodesFillingUp
-      annotations:
-        description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
-          }} in Namespace {{ $labels.namespace }} only has {{ $value | humanizePercentage
-          }} free inodes.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeInodesFillingUp.md
-        summary: PersistentVolumeInodes are filling up.
-      expr: |
-        (
-          kubelet_volume_stats_inodes_free{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
-            /
-          kubelet_volume_stats_inodes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
-        ) < 0.03
-        and
-        kubelet_volume_stats_inodes_used{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
-        unless on(namespace, persistentvolumeclaim)
-        kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
-        unless on(namespace, persistentvolumeclaim)
-        kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
-      for: 1m
-      labels:
-        severity: critical
-    - alert: KubePersistentVolumeInodesFillingUp
-      annotations:
-        description: Based on recent sampling, the PersistentVolume claimed by {{
-          $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is
-          expected to run out of inodes within four days. Currently {{ $value | humanizePercentage
-          }} of its inodes are free.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeInodesFillingUp.md
-        summary: PersistentVolumeInodes are filling up.
-      expr: |
-        (
-          kubelet_volume_stats_inodes_free{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
-            /
-          kubelet_volume_stats_inodes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
-        ) < 0.15
-        and
-        kubelet_volume_stats_inodes_used{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
-        and
-        predict_linear(kubelet_volume_stats_inodes_free{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
-        unless on(namespace, persistentvolumeclaim)
-        kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
-        unless on(namespace, persistentvolumeclaim)
-        kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
-      for: 1h
-      labels:
-        severity: warning
     - alert: KubePersistentVolumeErrors
       annotations:
         description: The persistent volume {{ $labels.persistentvolume }} has status

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -116,6 +116,18 @@ local excludedRules = [
       { alert: 'ThanosQueryRangeLatencyHigh' },
     ],
   },
+  {
+    name: 'kubernetes-storage',
+    rules: [
+      // we disable the inode almost full alert, because specially Ceph has caused
+      // false positives on several occassions. Since this alert seems of limited
+      // use anyway (unlikely to run out of inodes before running out of space) we
+      // disable it until Ceph has fixed their exporter.
+      // See also https://issues.redhat.com/browse/OCPBUGS-1766 and
+      // https://bugzilla.redhat.com/show_bug.cgi?id=2132270
+      { alert: 'KubePersistentVolumeInodesFillingUp' },
+    ],
+  },
 ];
 
 local patchedRules = [


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
