### PR TITLE
OCPBUGS-1994: Patch Alert KubePodNotReady

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -31,7 +31,8 @@ spec:
       expr: |
         sum by (namespace, pod, cluster) (
           max by(namespace, pod, cluster) (
-            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)", job="kube-state-metrics", phase=~"Pending|Unknown"}
+            unless ignoring(phase) (kube_pod_status_unschedulable{job="kube-state-metrics"} == 1)
           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
           )


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This PR contains Jsonnet depencies update on 5/10/2022, while the alert KubePodNotReady will keep excluding installer pods.
This works as a walkaround to [TRT-589](https://issues.redhat.com//browse/TRT-589). The alert will be no longer patched once the issue [TRT-589](https://issues.redhat.com//browse/TRT-589) is resolved.
The alert will stay as patched during future updates from Jsonnet components. (ref https://github.com/openshift/cluster-monitoring-operator/pull/1788).
