### PR TITLE
update to release.openshift.io/feature-set to match OCP 4.12

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -298,7 +298,7 @@ function(params) {
         'include.release.openshift.io/ibm-cloud-managed': 'true',
         'include.release.openshift.io/self-managed-high-availability': 'true',
         'include.release.openshift.io/single-node-developer': 'true',
-        'release.openshift.io/feature-gate': 'TechPreviewNoUpgrade',
+        'release.openshift.io/feature-set': 'TechPreviewNoUpgrade',
       },
     },
     rules: [

--- a/manifests/0000_50_cluster-monitoring-operator_02-techpreview-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-techpreview-role.yaml
@@ -5,7 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: cluster-monitoring-operator-techpreview-only
   namespace: openshift-monitoring
 rules:


### PR DESCRIPTION
Followup to https://github.com/openshift/cluster-monitoring-operator/pull/1764

The previous PR got the instances pulled in via dependencies, this is getting the last two from https://github.com/search?p=1&q=org%3Aopenshift+release.openshift.io%2Ffeature-gate&type=Code that escaped.