### PR TITLE
[WIP] Revert "Revert "[bot] Update jsonnet dependencies""

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -31,7 +31,7 @@ spec:
       expr: |
         sum by (namespace, pod, cluster) (
           max by(namespace, pod, cluster) (
-            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", phase=~"Pending|Unknown"}
+            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
           )

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "b886bbc89f31d7ac59bdfbb3d14a4263dae85a1b",
+      "version": "a932fb58f26ec862be858c884380c53a4975fb3b",
       "sum": "IkDHlaE0gvvcPjSNurFT+jQ2aCOAbqHF1WVmXbAgkds="
     },
     {
@@ -58,7 +58,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "dbf6fc14105c28b6fd0253005f7ca2da37d3d4e1",
+      "version": "2c06399b18ea6d31e61cab450c1a6ef9879a08b8",
       "sum": "tDR6yT2GVfw0wTU12iZH+m01HrbIr6g/xN+/8nzNkU0="
     },
     {
@@ -79,8 +79,8 @@
           "subdir": ""
         }
       },
-      "version": "1ddc6f6f739cc9fe4b8ac6a0fbb23cb09fe53bc3",
-      "sum": "0Goz56z5rF8rRarGQNj4f7VFvnsw7D7pSPUsYutt+J4="
+      "version": "5e44626d70c2bf2d35c37f3fee5a6261a5335cc6",
+      "sum": "F0lSJ5J+DUU7Y5u+j783bFLTHNd8Ir1IEkbXuK59RaA="
     },
     {
       "source": {
@@ -89,7 +89,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "20ef8a759681c8ed263184f481f4b60686f300bd",
+      "version": "12402a564cbf4557763079ab8e6e995d9afb4db9",
       "sum": "evJ+PXRzuM1tezCG5WzpAn4Lk3YJfMvDFcs+45fsscU="
     },
     {
@@ -99,7 +99,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "20ef8a759681c8ed263184f481f4b60686f300bd",
+      "version": "12402a564cbf4557763079ab8e6e995d9afb4db9",
       "sum": "u8gaydJoxEjzizQ8jY8xSjYgWooPmxw+wIWdDxifMAk="
     },
     {
@@ -131,8 +131,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "0a073679c6fd06c1d11812f2efd7be77092f78ca",
-      "sum": "2ZoIA4W0IQCvvxzFxyQcURLFh4FCxWg2FEtWzbMPRb8="
+      "version": "7d4529d3d73f5bad885a65ff4c28c6f7baec2378",
+      "sum": "JN2fy7b6ddRTVB9Bp1uYbVoRBsAe9Sigvf9CsUc3U6Y="
     },
     {
       "source": {
@@ -141,7 +141,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "ad64869358bfc470bac56c48a1ecee6dfb8dc88c",
+      "version": "0e18c5c1c32663f1e20adfb6b13cdbda8f94538a",
       "sum": "GQmaVFJwKMiD/P4n3N2LrAZVcwutriWrP8joclDtBYQ=",
       "name": "prometheus-operator-mixin"
     },
@@ -152,8 +152,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "ad64869358bfc470bac56c48a1ecee6dfb8dc88c",
-      "sum": "zMopZuzEV7tZcO5AiKZMK8tSxabMKNdObpAOaYNY1jo="
+      "version": "0e18c5c1c32663f1e20adfb6b13cdbda8f94538a",
+      "sum": "Xyd3/8Q+vhz7/zqTp/OGd/8nqDef4WqzT69HI3xP2bM="
     },
     {
       "source": {
@@ -162,7 +162,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "699bc4dfdf59cd0501d36808a02b302a4336d695",
+      "version": "545529639209d9838aef521a56afeda55e59d982",
       "sum": "PsK+V7oETCPKu2gLoPfqY0wwPKH9TzhNj6o2xezjjXc=",
       "name": "alertmanager"
     },
@@ -173,7 +173,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "8755e852fa40d14338cc56e4780406c42c7c2237",
+      "version": "d9b2634324aa93a4b680f732359185eb02528ab7",
       "sum": "tappaHscNBSJCA6ypSWt7DDhohIOkxNjcLFRb3WKpu4="
     },
     {
@@ -183,8 +183,8 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "161a3010d13d8e9d42e4106f2f247a7a554dad92",
-      "sum": "crD6rsagAMJFnVRw4pO63z3LLYfz4QFIiMR14zjjIfY=",
+      "version": "8120af22e2bc4f09e052cdb07e73def9e5b3b26e",
+      "sum": "Dq+wurABxuqRAHj4DGp2sCmjJWzNjrhP2XEScsS0kmY=",
       "name": "prometheus"
     },
     {
@@ -194,7 +194,7 @@
           "subdir": "config/crd/bases"
         }
       },
-      "version": "389fb2d2276d030a78551c472a131146f2cc0d48",
+      "version": "592e4ddd83cb4426bc254d78028de53108a3d83b",
       "sum": "d1550yhsX4VxdVN7b0gWT0cido/W90P6OGLzLqPwZcs="
     },
     {
@@ -214,7 +214,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "0d659bf171afa6bdf5c5ece3033df3a7e8245d8c",
+      "version": "d533abf8354ca26a6fddfbf6722ab57df0ebff3b",
       "sum": "095uB0qB1Ek+aNYf+CgydVZk5aFETsfD8GYf6gDwSJs="
     }
   ],

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -60,7 +60,7 @@ spec:
             properties:
               inhibitRules:
                 description: List of inhibition rules. The rules will only apply to
-                  alerts matching the resource’s namespace.
+                  alerts matching the resource's namespace.
                 items:
                   description: InhibitRule defines an inhibition rule that allows
                     to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
@@ -74,7 +74,7 @@ spec:
                     sourceMatch:
                       description: Matchers for which one or more alerts have to exist
                         for the inhibition to take effect. The operator enforces that
-                        the alert matches the resource’s namespace.
+                        the alert matches the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -107,7 +107,7 @@ spec:
                     targetMatch:
                       description: Matchers that have to be fulfilled in the alerts
                         to be muted. The operator enforces that the alert matches
-                        the resource’s namespace.
+                        the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -1793,7 +1793,7 @@ spec:
                             type: string
                           token:
                             description: The secret's key that contains the registered
-                              application’s API token, see https://pushover.net/apps.
+                              application's API token, see https://pushover.net/apps.
                               The secret needs to be in the same namespace as the
                               AlertmanagerConfig object and accessible by the Prometheus
                               Operator.
@@ -1823,7 +1823,7 @@ spec:
                             type: string
                           userKey:
                             description: The secret's key that contains the recipient
-                              user’s user key. The secret needs to be in the same
+                              user's user key. The secret needs to be in the same
                               namespace as the AlertmanagerConfig object and accessible
                               by the Prometheus Operator.
                             properties:
@@ -4394,7 +4394,7 @@ spec:
                 type: array
               route:
                 description: The Alertmanager route definition for alerts matching
-                  the resource’s namespace. If present, it will be added to the generated
+                  the resource's namespace. If present, it will be added to the generated
                   Alertmanager configuration as a first-level route.
                 properties:
                   continue:
@@ -4420,7 +4420,7 @@ spec:
                       Example: "30s"'
                     type: string
                   matchers:
-                    description: 'List of matchers that the alert’s labels should
+                    description: 'List of matchers that the alert''s labels should
                       match. For the first level route, the operator removes any existing
                       equality and regexp matcher on the `namespace` label and adds
                       a `namespace: <object namespace>` matcher.'
@@ -4513,7 +4513,7 @@ spec:
             properties:
               inhibitRules:
                 description: List of inhibition rules. The rules will only apply to
-                  alerts matching the resource’s namespace.
+                  alerts matching the resource's namespace.
                 items:
                   description: InhibitRule defines an inhibition rule that allows
                     to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
@@ -4527,7 +4527,7 @@ spec:
                     sourceMatch:
                       description: Matchers for which one or more alerts have to exist
                         for the inhibition to take effect. The operator enforces that
-                        the alert matches the resource’s namespace.
+                        the alert matches the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -4556,7 +4556,7 @@ spec:
                     targetMatch:
                       description: Matchers that have to be fulfilled in the alerts
                         to be muted. The operator enforces that the alert matches
-                        the resource’s namespace.
+                        the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -6131,7 +6131,7 @@ spec:
                             type: string
                           token:
                             description: The secret's key that contains the registered
-                              application’s API token, see https://pushover.net/apps.
+                              application's API token, see https://pushover.net/apps.
                               The secret needs to be in the same namespace as the
                               AlertmanagerConfig object and accessible by the Prometheus
                               Operator.
@@ -6159,7 +6159,7 @@ spec:
                             type: string
                           userKey:
                             description: The secret's key that contains the recipient
-                              user’s user key. The secret needs to be in the same
+                              user's user key. The secret needs to be in the same
                               namespace as the AlertmanagerConfig object and accessible
                               by the Prometheus Operator.
                             properties:
@@ -8700,7 +8700,7 @@ spec:
                 type: array
               route:
                 description: The Alertmanager route definition for alerts matching
-                  the resource’s namespace. If present, it will be added to the generated
+                  the resource's namespace. If present, it will be added to the generated
                   Alertmanager configuration as a first-level route.
                 properties:
                   continue:
@@ -8726,7 +8726,7 @@ spec:
                       Example: "30s"'
                     type: string
                   matchers:
-                    description: 'List of matchers that the alert’s labels should
+                    description: 'List of matchers that the alert''s labels should
                       match. For the first level route, the operator removes any existing
                       equality and regexp matcher on the `namespace` label and adds
                       a `namespace: <object namespace>` matcher.'

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -1413,14 +1413,17 @@ spec:
               configMaps:
                 description: ConfigMaps is a list of ConfigMaps in the same namespace
                   as the Alertmanager object, which shall be mounted into the Alertmanager
-                  Pods. The ConfigMaps are mounted into /etc/alertmanager/configmaps/<configmap-name>.
+                  Pods. Each ConfigMap is added to the StatefulSet definition as a
+                  volume named `configmap-<configmap-name>`. The ConfigMaps are mounted
+                  into `/etc/alertmanager/configmaps/<configmap-name>` in the 'alertmanager'
+                  container.
                 items:
                   type: string
                 type: array
               configSecret:
                 description: "ConfigSecret is the name of a Kubernetes Secret in the
                   same namespace as the Alertmanager object, which contains the configuration
-                  for this Alertmanager instance. If empty, it defaults to 'alertmanager-<alertmanager-name>'.
+                  for this Alertmanager instance. If empty, it defaults to `alertmanager-<alertmanager-name>`.
                   \n The Alertmanager configuration should be available under the
                   `alertmanager.yaml` key. Additional keys from the original secret
                   are copied to the generated secret. \n If either the secret or the
@@ -4065,7 +4068,9 @@ spec:
               secrets:
                 description: Secrets is a list of Secrets in the same namespace as
                   the Alertmanager object, which shall be mounted into the Alertmanager
-                  Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+                  Pods. Each Secret is added to the StatefulSet definition as a volume
+                  named `secret-<secret-name>`. The Secrets are mounted into `/etc/alertmanager/secrets/<secret-name>`
+                  in the 'alertmanager' container.
                 items:
                   type: string
                 type: array

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -188,6 +188,10 @@ spec:
                     enableHttp2:
                       description: Whether to enable HTTP2.
                       type: boolean
+                    filterRunning:
+                      description: 'Drop pods that are not running. (Failed, Succeeded).
+                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                      type: boolean
                     followRedirects:
                       description: FollowRedirects configures whether scrape requests
                         follow HTTP 3xx redirects.

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -1460,7 +1460,10 @@ spec:
               configMaps:
                 description: ConfigMaps is a list of ConfigMaps in the same namespace
                   as the Prometheus object, which shall be mounted into the Prometheus
-                  Pods. The ConfigMaps are mounted into /etc/prometheus/configmaps/<configmap-name>.
+                  Pods. Each ConfigMap is added to the StatefulSet definition as a
+                  volume named `configmap-<configmap-name>`. The ConfigMaps are mounted
+                  into /etc/prometheus/configmaps/<configmap-name> in the 'prometheus'
+                  container.
                 items:
                   type: string
                 type: array
@@ -5515,7 +5518,9 @@ spec:
               secrets:
                 description: Secrets is a list of Secrets in the same namespace as
                   the Prometheus object, which shall be mounted into the Prometheus
-                  Pods. The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
+                  Pods. Each Secret is added to the StatefulSet definition as a volume
+                  named `secret-<secret-name>`. The Secrets are mounted into /etc/prometheus/secrets/<secret-name>
+                  in the 'prometheus' container.
                 items:
                   type: string
                 type: array
@@ -6399,9 +6404,14 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  grpcListenLocal:
+                    description: If true, the Thanos sidecar listens on the loopback
+                      interface for the gRPC endpoints. It has no effect if `listenLocal`
+                      is true.
+                    type: boolean
                   grpcServerTlsConfig:
-                    description: 'GRPCServerTLSConfig configures the gRPC server from
-                      which Thanos Querier reads recorded rule data. Note: Currently
+                    description: 'GRPCServerTLSConfig configures the TLS parameters
+                      for the gRPC server providing the StoreAPI. Note: Currently
                       only the CAFile, CertFile, and KeyFile fields are supported.
                       Maps to the ''--grpc-server-tls-*'' CLI args.'
                     properties:
@@ -6534,6 +6544,11 @@ spec:
                         description: Used to verify the hostname for the targets.
                         type: string
                     type: object
+                  httpListenLocal:
+                    description: If true, the Thanos sidecar listens on the loopback
+                      interface for the HTTP endpoints. It has no effect if `listenLocal`
+                      is true.
+                    type: boolean
                   image:
                     description: Image if specified has precedence over baseImage,
                       tag and sha combinations. Specifying the version is still necessary
@@ -6541,8 +6556,10 @@ spec:
                       is being configured.
                     type: string
                   listenLocal:
-                    description: ListenLocal makes the Thanos sidecar listen on loopback,
-                      so that it does not bind against the Pod IP.
+                    description: 'If true, the Thanos sidecar listens on the loopback
+                      interface for the HTTP and gRPC endpoints. It takes precedence
+                      over `grpcListenLocal` and `httpListenLocal`. Deprecated: use
+                      `grpcListenLocal` and `httpListenLocal` instead.'
                     type: boolean
                   logFormat:
                     description: LogFormat for Thanos sidecar to be configured with.
@@ -8711,6 +8728,14 @@ spec:
                       description: Human-readable message indicating details for the
                         condition's last transition.
                       type: string
+                    observedGeneration:
+                      description: ObservedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: Reason for the condition's last transition.
                       type: string


### PR DESCRIPTION
Testing the revert to allow the "Failed" phase back into the KubePodNotReady alert definition to see if we can trigger installer failures again to further investigate the root cause. 

This reverts commit 24c71436e970bfc283005cf7734a4f14fdc33425.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
