### PR TITLE
test/e2e: improve getActiveTarget()

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -38,7 +38,7 @@ func getActiveTarget(body []byte, jobName string) error {
 	}
 
 	for _, job := range activeJobs {
-		name := job.S("discoveredLabels").S("job").Data().(string)
+		name := job.S("scrapePool").Data().(string)
 
 		if name == jobName {
 			return nil


### PR DESCRIPTION
It should fix the CMO e2e tests for
https://github.com/openshift/prometheus/pull/142.

getActiveTarget() can use the `scrapePool` key instead of iterating over the discovered labels.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
