### PR TITLE
jsonnet/components: remove PDB patches

### DIFF
--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -112,24 +112,6 @@ function(params)
     // the API server.
     serviceMonitor:: {},
 
-    // TODO(simonpasquier): move this to the upstream jsonnet.
-    podDisruptionBudget: {
-      apiVersion: 'policy/v1',
-      kind: 'PodDisruptionBudget',
-      metadata: {
-        name: aw._config.name,
-        namespace: aw._config.namespace,
-        labels: aw._config.commonLabels,
-      },
-      spec: {
-        minAvailable: 1,
-        selector: {
-          matchLabels: aw._config.selectorLabels,
-        },
-
-      },
-    },
-
     prometheusRuleValidatingWebhook: {
       apiVersion: 'admissionregistration.k8s.io/v1',
       kind: 'ValidatingWebhookConfiguration',

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -401,9 +401,4 @@ function(params)
         ],
       },
     },
-
-    // TODO: remove podDisruptionBudget once https://github.com/prometheus-operator/kube-prometheus/pull/1156 is merged
-    podDisruptionBudget+: {
-      apiVersion: 'policy/v1',
-    },
   }

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -236,8 +236,4 @@ function(params)
         ],
       },
     },
-    // TODO: remove podDisruptionBudget once https://github.com/prometheus-operator/kube-prometheus/pull/1156 is merged
-    podDisruptionBudget+: {
-      apiVersion: 'policy/v1',
-    },
   }

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -504,11 +504,6 @@ function(params)
       },
     },
 
-    // TODO: remove podDisruptionBudget once https://github.com/prometheus-operator/kube-prometheus/pull/1156 is merged
-    podDisruptionBudget+: {
-      apiVersion: 'policy/v1',
-    },
-
     serviceAccount+: {
       // service account token is managed by the operator.
       automountServiceAccountToken: false,

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -487,9 +487,4 @@ function(params)
         ],
       },
     },
-
-    // TODO: remove podDisruptionBudget once https://github.com/prometheus-operator/kube-prometheus/pull/1156 is merged
-    podDisruptionBudget+: {
-      apiVersion: 'policy/v1',
-    },
   }


### PR DESCRIPTION
All patches have been incorporated in upstream jsonnet projects.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
