### PR TITLE
OCPBUGS-2439: set the argument path.udev.data in node exporter

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
         - --collector.textfile.directory=/var/node_exporter/textfile
         - --no-collector.cpufreq
         - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|tun[0-9]*|br[0-9]*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext)$
+        - --path.udev.data=/host/root/run/udev/data
         image: quay.io/prometheus/node-exporter:v1.4.0
         name: node-exporter
         resources:

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -180,6 +180,7 @@ function(params)
                               // ignore OVNK network interfaces, too.
                               // https://issues.redhat.com/browse/OCPBUGS-1321
                               '--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|tun[0-9]*|br[0-9]*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext)$',
+                              '--path.udev.data=/host/root/run/udev/data',
                             ],
                       terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts+: [{


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

The diskstats collector in node exporter looks for the directory `/run/udev/data`. The correct path should be `/host/root/run/udev/data` in node exporter daemon set.
