### PR TITLE
Documentation: fix TelemeterClientConfig

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -319,11 +319,7 @@ The `TLSConfig` resource configures the settings for TLS connections.
 `TelemeterClientConfig` defines settings for the Telemeter Client component.
 
 #### Required
-   - ` clusterID `
-   - ` enabled `
    - ` nodeSelector `
-   - ` telemeterServerURL `
-   - ` token `
    - ` tolerations `
 
 <em>appears in: [ClusterMonitoringConfiguration](#clustermonitoringconfiguration)</em>

--- a/Documentation/openshiftdocs/modules/telemeterclientconfig.adoc
+++ b/Documentation/openshiftdocs/modules/telemeterclientconfig.adoc
@@ -12,11 +12,7 @@
 `TelemeterClientConfig` defines settings for the Telemeter Client component.
 
 === Required
-* `clusterID`
-* `enabled`
 * `nodeSelector`
-* `telemeterServerURL`
-* `token`
 * `tolerations`
 
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -210,15 +210,15 @@ type OpenShiftStateMetricsConfig struct {
 // component.
 type TelemeterClientConfig struct {
 	// OmitFromDoc
-	ClusterID string `json:"clusterID"`
+	ClusterID string `json:"clusterID,omitempty"`
 	// OmitFromDoc
-	Enabled *bool `json:"enabled"`
+	Enabled *bool `json:"enabled,omitempty"`
 	// Defines the nodes on which the pods are scheduled.
 	NodeSelector map[string]string `json:"nodeSelector"`
 	// OmitFromDoc
-	TelemeterServerURL string `json:"telemeterServerURL"`
+	TelemeterServerURL string `json:"telemeterServerURL,omitempty"`
 	// OmitFromDoc
-	Token string `json:"token"`
+	Token string `json:"token,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations"`
 }


### PR DESCRIPTION
Remove fields which don't need to be documented.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
