### PR TITLE
 *: don't expose Prometheus operator's port 

### DIFF
--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -39,11 +39,10 @@ spec:
         - --config-reloader-memory-limit=0
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
+        - --web.listen-address=127.0.0.1:8080
         image: quay.io/prometheus-operator/prometheus-operator:v0.60.1
         name: prometheus-operator
-        ports:
-        - containerPort: 8080
-          name: http
+        ports: []
         resources:
           requests:
             cpu: 1m
@@ -53,6 +52,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
       - args:
         - --logtostderr
@@ -80,7 +80,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/tls/private
           name: prometheus-operator-user-workload-tls
-          readOnly: false
+          readOnly: true
         - mountPath: /etc/kube-rbac-policy
           name: prometheus-operator-uwm-kube-rbac-proxy-config
           readOnly: true

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -40,33 +40,29 @@ spec:
         - --config-reloader-memory-limit=0
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
-        - --web.enable-tls=true
-        - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        - --web.tls-min-version=VersionTLS12
+        - --web.listen-address=127.0.0.1:8080
         image: quay.io/prometheus-operator/prometheus-operator:v0.60.1
         name: prometheus-operator
-        ports:
-        - containerPort: 8080
-          name: http
+        ports: []
         resources:
           requests:
             cpu: 5m
             memory: 150Mi
-        securityContext: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /etc/tls/private
-          name: prometheus-operator-tls
-          readOnly: false
       - args:
         - --logtostderr
         - --secure-listen-address=:8443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        - --upstream=https://prometheus-operator.openshift-monitoring.svc:8080/
+        - --upstream=http://localhost:8080/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        - --upstream-ca-file=/etc/configmaps/operator-cert-ca-bundle/service-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
         image: quay.io/brancz/kube-rbac-proxy:v0.13.0
         name: kube-rbac-proxy
@@ -82,13 +78,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/tls/private
           name: prometheus-operator-tls
-          readOnly: false
-        - mountPath: /etc/configmaps/operator-cert-ca-bundle
-          name: operator-certs-ca-bundle
-          readOnly: false
+          readOnly: true
         - mountPath: /etc/tls/client
           name: metrics-client-ca
-          readOnly: false
+          readOnly: true
         - mountPath: /etc/kube-rbac-policy
           name: prometheus-operator-kube-rbac-proxy-config
           readOnly: true
@@ -106,12 +99,6 @@ spec:
       - name: prometheus-operator-tls
         secret:
           secretName: prometheus-operator-tls
-      - configmap:
-          items:
-          - key: service-ca.crt
-            path: service-ca.crt
-          name: operator-certs-ca-bundle
-        name: operator-certs-ca-bundle
       - name: prometheus-operator-kube-rbac-proxy-config
         secret:
           secretName: prometheus-operator-kube-rbac-proxy-config

--- a/assets/prometheus-operator/operator-certs-ca-bundle.yaml
+++ b/assets/prometheus-operator/operator-certs-ca-bundle.yaml
@@ -1,8 +1,5 @@
 apiVersion: v1
-data: {}
 kind: ConfigMap
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: operator-certs-ca-bundle
   namespace: openshift-monitoring

--- a/assets/prometheus-operator/service.yaml
+++ b/assets/prometheus-operator/service.yaml
@@ -16,9 +16,6 @@ spec:
   - name: https
     port: 8443
     targetPort: https
-  - name: web
-    port: 8080
-    targetPort: 8080
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -32,7 +32,9 @@ function(params)
         name: 'prometheus-user-workload-operator',
       },
     },
+
     kubeRbacProxySecret: generateSecret.staticAuthSecret(cfg.namespace, cfg.commonLabels, 'prometheus-operator-uwm-kube-rbac-proxy-config'),
+
     deployment+: {
       metadata+: {
         labels+: {
@@ -80,13 +82,9 @@ function(params)
                         '--config-reloader-memory-limit=0',
                         '--config-reloader-cpu-request=1m',
                         '--config-reloader-memory-request=10Mi',
+                        '--web.listen-address=127.0.0.1:8080',
                       ],
-                      securityContext: {
-                        allowPrivilegeEscalation: false,
-                        capabilities: {
-                          drop: ['ALL'],
-                        },
-                      },
+                      ports: [],
                       resources: {
                         requests: {
                           memory: '17Mi',
@@ -107,7 +105,7 @@ function(params)
                         {
                           mountPath: '/etc/tls/private',
                           name: tlsVolumeName,
-                          readOnly: false,
+                          readOnly: true,
                         },
                         {
                           mountPath: '/etc/kube-rbac-policy',
@@ -150,6 +148,7 @@ function(params)
         },
       },
     },
+
     service+: {
       metadata+: {
         annotations+: {
@@ -157,6 +156,7 @@ function(params)
         },
       },
     },
+
     serviceMonitor+: {
       spec+: {
         endpoints: [

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2570,7 +2570,6 @@ func (f *Factory) PrometheusOperatorDeployment() (*appsv1.Deployment, error) {
 				args = append(args, fmt.Sprintf("--log-level=%s", f.config.ClusterMonitoringConfiguration.PrometheusOperatorConfig.LogLevel))
 			}
 
-			args = f.setTLSSecurityConfiguration(args, PrometheusOperatorWebTLSCipherSuitesFlag, PrometheusOperatorWebTLSMinTLSVersionFlag)
 			d.Spec.Template.Spec.Containers[i].Args = args
 		}
 	}
@@ -2618,7 +2617,7 @@ func (f *Factory) PrometheusOperatorUserWorkloadDeployment() (*appsv1.Deployment
 			if f.config.UserWorkloadConfiguration.PrometheusOperator.LogLevel != "" {
 				args = append(args, fmt.Sprintf("--log-level=%s", f.config.UserWorkloadConfiguration.PrometheusOperator.LogLevel))
 			}
-			args = f.setTLSSecurityConfiguration(args, PrometheusOperatorWebTLSCipherSuitesFlag, PrometheusOperatorWebTLSMinTLSVersionFlag)
+
 			d.Spec.Template.Spec.Containers[i].Args = args
 		}
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -741,8 +741,7 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 	}
 
 	prometheusReloaderFound := false
-	prometheusWebTLSCipherSuitesArg := ""
-	prometheusWebTLSVersionArg := ""
+	prometheusWebListenLocal := false
 	kubeRbacProxyTLSCipherSuitesArg := ""
 	kubeRbacProxyMinTLSVersionArg := ""
 	for _, container := range d.Spec.Template.Spec.Containers {
@@ -755,8 +754,10 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 			if getContainerArgValue(d.Spec.Template.Spec.Containers, PrometheusConfigReloaderFlag+"docker.io/openshift/origin-prometheus-config-reloader:latest", container.Name) != "" {
 				prometheusReloaderFound = true
 			}
-			prometheusWebTLSCipherSuitesArg = getContainerArgValue(d.Spec.Template.Spec.Containers, PrometheusOperatorWebTLSCipherSuitesFlag, container.Name)
-			prometheusWebTLSVersionArg = getContainerArgValue(d.Spec.Template.Spec.Containers, PrometheusOperatorWebTLSMinTLSVersionFlag, container.Name)
+
+			if getContainerArgValue(d.Spec.Template.Spec.Containers, "--web.listen-address=127.0.0.1:8080", container.Name) != "" {
+				prometheusWebListenLocal = true
+			}
 		case "kube-rbac-proxy":
 			if container.Image != "docker.io/openshift/origin-kube-rbac-proxy:latest" {
 				t.Fatalf("%s image incorrectly configured", container.Name)
@@ -770,17 +771,8 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 		t.Fatal("Configuring the Prometheus Config reloader image failed")
 	}
 
-	expectedPrometheusWebTLSCipherSuitesArg := fmt.Sprintf("%s%s",
-		PrometheusOperatorWebTLSCipherSuitesFlag,
-		strings.Join(crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), ","))
-	if expectedPrometheusWebTLSCipherSuitesArg != prometheusWebTLSCipherSuitesArg {
-		t.Fatalf("incorrect TLS ciphers, \n got %s, \nwant %s", prometheusWebTLSCipherSuitesArg, expectedPrometheusWebTLSCipherSuitesArg)
-	}
-
-	expectedPrometheusWebTLSVersionArg := fmt.Sprintf("%s%s",
-		PrometheusOperatorWebTLSMinTLSVersionFlag, APIServerDefaultMinTLSVersion)
-	if expectedPrometheusWebTLSVersionArg != prometheusWebTLSVersionArg {
-		t.Fatalf("incorrect TLS version \n got %s, \nwant %s", prometheusWebTLSVersionArg, expectedPrometheusWebTLSVersionArg)
+	if !prometheusWebListenLocal {
+		t.Fatal("expected Prometheus operator to listen on 127.0.0.1:8080")
 	}
 
 	expectedKubeRbacProxyTLSCipherSuitesArg := fmt.Sprintf("%s%s",
@@ -3736,8 +3728,7 @@ enableUserWorkload: true
 	}
 
 	prometheusReloaderFound := false
-	prometheusWebTLSCipherSuitesArg := ""
-	prometheusWebTLSVersionArg := ""
+	prometheusWebListenLocal := false
 	kubeRbacProxyTLSCipherSuitesArg := ""
 	kubeRbacProxyMinTLSVersionArg := ""
 	for _, container := range d.Spec.Template.Spec.Containers {
@@ -3750,9 +3741,9 @@ enableUserWorkload: true
 				prometheusReloaderFound = true
 			}
 
-			prometheusWebTLSCipherSuitesArg = getContainerArgValue(d.Spec.Template.Spec.Containers, PrometheusOperatorWebTLSCipherSuitesFlag, container.Name)
-			prometheusWebTLSVersionArg = getContainerArgValue(d.Spec.Template.Spec.Containers, PrometheusOperatorWebTLSMinTLSVersionFlag, container.Name)
-
+			if getContainerArgValue(d.Spec.Template.Spec.Containers, "--web.listen-address=127.0.0.1:8080", container.Name) != "" {
+				prometheusWebListenLocal = true
+			}
 		case "kube-rbac-proxy":
 			if container.Image != "docker.io/openshift/origin-kube-rbac-proxy:latest" {
 				t.Fatal("kube-rbac-proxy image incorrectly configured")
@@ -3766,18 +3757,8 @@ enableUserWorkload: true
 		t.Fatal("Configuring the Prometheus Config reloader image failed")
 	}
 
-	expectedPrometheusWebTLSCipherSuitesArg := fmt.Sprintf("%s%s",
-		PrometheusOperatorWebTLSCipherSuitesFlag,
-		strings.Join(crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), ","),
-	)
-	if expectedPrometheusWebTLSCipherSuitesArg != prometheusWebTLSCipherSuitesArg {
-		t.Fatalf("incorrect TLS ciphers, \n got %s, \nwant %s", prometheusWebTLSCipherSuitesArg, expectedPrometheusWebTLSCipherSuitesArg)
-	}
-
-	expectedPrometheusWebTLSVersionArg := fmt.Sprintf("%s%s",
-		PrometheusOperatorWebTLSMinTLSVersionFlag, APIServerDefaultMinTLSVersion)
-	if expectedPrometheusWebTLSVersionArg != prometheusWebTLSVersionArg {
-		t.Fatalf("incorrect TLS version \n got %s, \nwant %s", prometheusWebTLSVersionArg, expectedPrometheusWebTLSVersionArg)
+	if !prometheusWebListenLocal {
+		t.Fatal("expected Prometheus operator to listen on 127.0.0.1:8080")
 	}
 
 	expectedKubeRbacProxyTLSCipherSuitesArg := fmt.Sprintf("%s%s",

--- a/pkg/tasks/prometheusoperator.go
+++ b/pkg/tasks/prometheusoperator.go
@@ -35,15 +35,17 @@ func NewPrometheusOperatorTask(client *client.Client, factory *manifests.Factory
 }
 
 func (t *PrometheusOperatorTask) Run(ctx context.Context) error {
+	// TODO(simonpasquier): remove this section once 4.13 branch opens.
 	cacm, err := t.factory.PrometheusOperatorCertsCABundle()
 	if err != nil {
 		return errors.Wrap(err, "initializing serving certs CA Bundle ConfigMap failed")
 	}
 
-	_, err = t.client.CreateIfNotExistConfigMap(ctx, cacm)
+	err = t.client.DeleteConfigMap(ctx, cacm)
 	if err != nil {
-		return errors.Wrap(err, "creating serving certs CA Bundle ConfigMap failed")
+		return errors.Wrap(err, "deleting serving certs CA Bundle ConfigMap failed")
 	}
+	// TODO(simonpasquier): end
 
 	sa, err := t.factory.PrometheusOperatorServiceAccount()
 	if err != nil {

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -100,8 +100,8 @@ func TestTLSSecurityProfileConfiguration(t *testing.T) {
 				manifests.PrometheusOperatorWebTLSMinTLSVersionFlag, tt.expectedCipherSuite,
 				atLeastVersionTLS12(tt.expectedMinTLSVersion))
 			assertCorrectTLSConfiguration(t, "prometheus-operator", "deployment",
-				manifests.PrometheusOperatorWebTLSCipherSuitesFlag,
-				manifests.PrometheusOperatorWebTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
+				manifests.KubeRbacProxyTLSCipherSuitesFlag,
+				manifests.KubeRbacProxyMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
 			assertCorrectTLSConfiguration(t, "prometheus-adapter", "deployment",
 				manifests.PrometheusAdapterTLSCipherSuitesFlag,
 				manifests.PrometheusAdapterTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)


### PR DESCRIPTION


The Prometheus operator pod exposes the prometheus-operator container's
web service running on port 8080 by default. It isn't necessary because:
1) metrics are collected via the kube-rbac-proxy sidecar.
2) the admission webhook service is outsourced to the
   prometheus-operator-admission-webhook deployment.

This change configures the prometheus-operator container to listen on
127.0.0.1:8080 and removes 8080 from the list of ports exposed by the
prometheus-operator service. The same changes are applied to the
user-workload's Prometheus Operator.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

