### PR TITLE
Switch ksm registry to registry.k8s.io

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           ^kube_pod_container_status_running$,
           ^kube_pod_completion_time$,
           ^kube_pod_status_scheduled$
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.6.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
         name: kube-state-metrics
         resources:
           requests:

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -59,7 +59,7 @@ local commonConfig = {
   images: {
     alertmanager: 'quay.io/prometheus/alertmanager:v' + $.versions.alertmanager,
     prometheus: 'quay.io/prometheus/prometheus:v' + $.versions.prometheus,
-    kubeStateMetrics: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v' + $.versions.kubeStateMetrics,
+    kubeStateMetrics: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v' + $.versions.kubeStateMetrics,
     nodeExporter: 'quay.io/prometheus/node-exporter:v' + $.versions.nodeExporter,
     prometheusAdapter: 'directxman12/k8s-prometheus-adapter:v' + $.versions.prometheusAdapter,
     prometheusOperator: 'quay.io/prometheus-operator/prometheus-operator:v' + $.versions.prometheusOperator,


### PR DESCRIPTION
Kubernetes has switched registry from` k8s.gcr.io` to `registry.k8s.io` in kubernetes/kubernetes#109938.

kube-state-metrics also did the switch in kubernetes/kube-state-metrics#1750.
