### PR TITLE
back port #657 to 4.3: set CreationTimestamp at create time, not only at update time

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -266,6 +266,10 @@ func (c *Client) NamespacesToMonitor() ([]string, error) {
 }
 
 func (c *Client) CreateOrUpdatePrometheus(p *monv1.Prometheus) error {
+	if p.Spec.Storage != nil {
+		p.Spec.Storage.VolumeClaimTemplate.CreationTimestamp = metav1.Unix(0, 0)
+	}
+
 	pclient := c.mclient.MonitoringV1().Prometheuses(p.GetNamespace())
 	oldProm, err := pclient.Get(p.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
@@ -277,9 +281,6 @@ func (c *Client) CreateOrUpdatePrometheus(p *monv1.Prometheus) error {
 	}
 
 	p.ResourceVersion = oldProm.ResourceVersion
-	if p.Spec.Storage != nil {
-		p.Spec.Storage.VolumeClaimTemplate.CreationTimestamp = metav1.Unix(0, 0)
-	}
 	_, err = pclient.Update(p)
 	return errors.Wrap(err, "updating Prometheus object failed")
 }


### PR DESCRIPTION
back port https://github.com/openshift/cluster-monitoring-operator/pull/657/ to 4.3, 4.4+ don't have such issue
If the user configures a PVC before Prometheus is created
it fails because of validation errors.

launched 4.3.40 aws cluster with cluster-bot
`launch 4.3.40 aws`, since cluster-bot cluster is attached PVs for prometheus by default, the cluster is failed for below from [logs](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1587740548746186752)
```
level=error msg="Cluster operator monitoring Degraded is True with UpdatingPrometheusK8SFailed: Failed to rollout the stack. Error: running task Updating Prometheus-k8s failed: reconciling Prometheus object failed: creating Prometheus object failed: Prometheus.monitoring.coreos.com \"k8s\" is invalid: spec.storage.volumeClaimTemplate.metadata.creationTimestamp: Invalid value: \"null\": spec.storage.volumeClaimTemplate.metadata.creationTimestamp in body must be of type string: \"null\""
level=fatal msg="failed to initialize the cluster: Cluster operator monitoring is still updating" 
``` 
same for job [33630](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_release/33630/rehearse-33630-periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-4.12-upgrade-from-stable-4.3-aws-ipi/1587376420810657792)

launched cluster-bot cluster with PR `launch openshift/cluster-monitoring-operator#1810 aws`, no issue now
```
# oc get clusterversion
NAME      VERSION                                                  AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.3.0-0.ci.test-2022-11-04-043843-ci-ln-bvv8vrt-latest   True        False         41m     Cluster version is 4.3.0-0.ci.test-2022-11-04-043843-ci-ln-bvv8vrt-latest
# oc get co monitoring
NAME         VERSION                                                  AVAILABLE   PROGRESSING   DEGRADED   SINCE
monitoring   4.3.0-0.ci.test-2022-11-04-043843-ci-ln-bvv8vrt-latest   True        False         False      46m
# oc -n openshift-monitoring get pod | grep prometheus-k8s
prometheus-k8s-0                               7/7     Running   0          46m
prometheus-k8s-1                               7/7     Running   0          47m
# oc -n openshift-monitoring get pvc
NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
prometheus-data-prometheus-k8s-0   Bound    pvc-1928478f-a478-4505-93e8-e4c5bd9b23ac   20Gi       RWO            gp2            48m
prometheus-data-prometheus-k8s-1   Bound    pvc-4a776ab0-28b9-4c70-8319-30da93013b59   20Gi       RWO            gp2            48m
```