### PR TITLE
OCPBUGS-1998: pkg/client: Update daemonset degrade condition

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,6 +40,7 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/thanos"
 	thanosoperator "github.com/prometheus-operator/prometheus-operator/pkg/thanos"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -1298,33 +1299,29 @@ func (c *Client) WaitForDaemonSetRollout(ctx context.Context, ds *appsv1.DaemonS
 			klog.V(4).ErrorS(err, "WaitForDaemonSetRollout: failed to get DaemonSet")
 			return false, nil
 		}
+		want := d.Status.DesiredNumberScheduled
+		have := d.Status.NumberAvailable
+		numberUnavailable := want - have
+		maxUnavailableIntStr := intstr.FromInt(1)
+
 		if d.Generation > d.Status.ObservedGeneration {
 			lastErr = errors.Errorf("current generation %d, observed generation: %d",
 				d.Generation, d.Status.ObservedGeneration)
 			return false, nil
 		}
-		if d.Status.UpdatedNumberScheduled != d.Status.DesiredNumberScheduled {
-			lastErr = errors.Errorf("expected %d desired scheduled nodes, got %d updated scheduled nodes",
-				d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled)
+
+		if d.Spec.UpdateStrategy.RollingUpdate != nil && d.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable != nil {
+			maxUnavailableIntStr = *d.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable
+		}
+		maxUnavailable, intstrErr := intstr.GetScaledValueFromIntOrPercent(&maxUnavailableIntStr, int(want), true)
+
+		if intstrErr != nil {
+			lastErr = errors.Errorf("The daemonset has an invalid MaxUnavailable value: %v", intstrErr)
 			return false, nil
 		}
 
-		var nodeReadyCount int32
-		nodeList, err := c.kclient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-			LabelSelector: fields.SelectorFromSet(ds.Spec.Template.Spec.NodeSelector).String()})
-		for _, node := range nodeList.Items {
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
-					nodeReadyCount++
-				}
-			}
-		}
-		// It has been noticed that the number of available pods can be greater than
-		// the node ready count. This is because a node can be reported as not ready
-		// but the daemon set status states that all required pods are running.
-		if d.Status.NumberAvailable < nodeReadyCount {
-			lastErr = errors.Errorf("expected %d ready pods for %q daemonset, got %d ",
-				nodeReadyCount, d.GetName(), d.Status.NumberAvailable)
+		if int(numberUnavailable) > maxUnavailable {
+			lastErr = errors.Errorf("Too many daemonset pods are unavailable (%d > %d max unavailable).", numberUnavailable, maxUnavailable)
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
Currently the CMO degrades when it is not able to
rollout daemonset pod on a node that is not ready. This blocks the upgrade when a node is unavailable. This commit is to fix that by comparing number of
unavailable daemonset pods and maximum unavailable daemonset pods allowed.

Fixes #OCPBUGS-1998

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
