### PR TITLE
OCPBUGS-3665: adding check for node exporter daemon set

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -947,9 +947,20 @@ func (c *Client) WaitForDaemonSetRollout(ds *appsv1.DaemonSet) error {
 				d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled)
 			return false, nil
 		}
-		if d.Status.NumberUnavailable != 0 {
-			lastErr = errors.Errorf("got %d unavailable nodes",
-				d.Status.NumberUnavailable)
+
+		var nodeReadyCount int32
+		nodeList, err := c.kclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		for _, node := range nodeList.Items {
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+					nodeReadyCount++
+				}
+			}
+		}
+
+		if d.Status.NumberAvailable != nodeReadyCount {
+			lastErr = errors.Errorf("expected %d ready pods for %q daemonset, got %d ",
+				nodeReadyCount, d.GetName(), d.Status.NumberAvailable)
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
removing operator log

code review comments

correcting log message

changing to use context instead of todo

(cherry picked from commit 57df962638780d3e30d64e197121aa92489369e0)

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
