### PR TITLE
test: increase timeout when checking remote write metrics

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -289,7 +289,7 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 func remoteWriteCheckMetrics(ctx context.Context, t *testing.T, promClient *framework.PrometheusClient, tests []remoteWriteTest) {
 	for _, test := range tests {
 		promClient.WaitForQueryReturn(
-			t, 2*time.Minute, test.query,
+			t, 4*time.Minute, test.query,
 			func(v int) error {
 				if !test.expected(v) {
 					return fmt.Errorf(test.description)


### PR DESCRIPTION
The
TestPrometheusRemoteWrite/assert_remote_write_cluster_id_relabel_config_works test often fails in the CI. Looking at a successful run [1], the test takes more than 2 minutes to run while the sub-test checking the presence of the cluster_id label only retries for 2 minutes. Extending the timeout to 4 minutes makes sense to me because there are lots of conditions that need to be met for the test to succeed:
* Prometheus instance configured as remote write receiver is running.
* CMO propagates remote-write configuration to k8s Prometheus.
* Prometheus operator generates the new Prometheus configuration.
* config-reloader picks up the new configuration and reloads Prometheus.
* Samples with the new label appear in the remote write receiver.

[1] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_prometheus/145/pull-ci-openshift-prometheus-master-e2e-agnostic-cmo/1592089698631684096/artifacts/e2e-agnostic-cmo/test/build-log.txt

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
