### PR TITLE
Unpin and update jsonnet dependencies

### DIFF
--- a/assets/admission-webhook/deployment.yaml
+++ b/assets/admission-webhook/deployment.yaml
@@ -42,10 +42,10 @@ spec:
       containers:
       - args:
         - --web.enable-tls=true
-        - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        - --web.tls-min-version=VersionTLS12
         - --web.cert-file=/etc/tls/private/tls.crt
         - --web.key-file=/etc/tls/private/tls.key
+        - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --web.tls-min-version=VersionTLS12
         image: quay.io/prometheus-operator/admission-webhook:v0.61.1
         livenessProbe:
           httpGet:

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -800,8 +800,16 @@ spec:
         ) by (cluster)
       record: :node_memory_MemAvailable_bytes:sum
     - expr: |
-        sum(rate(node_cpu_seconds_total{job="node-exporter",mode!="idle",mode!="iowait",mode!="steal"}[5m])) /
-        count(sum(node_cpu_seconds_total{job="node-exporter"}) by (cluster, instance, cpu))
+        avg by (cluster, node) (
+          sum without (mode) (
+            rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",job="node-exporter"}[5m])
+          )
+        )
+      record: node:node_cpu_utilization:ratio_rate5m
+    - expr: |
+        avg by (cluster) (
+          node:node_cpu_utilization:ratio_rate5m
+        )
       record: cluster:node_cpu:ratio_rate5m
   - name: kubelet.rules
     rules:

--- a/assets/kube-state-metrics/cluster-role.yaml
+++ b/assets/kube-state-metrics/cluster-role.yaml
@@ -79,6 +79,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses
@@ -98,6 +105,7 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingressclasses
   - ingresses
   verbs:
   - list

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -33,6 +33,7 @@ spec:
         - --web.listen-address=127.0.0.1:9100
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
+        - --path.udev.data=/host/root/run/udev/data
         - --no-collector.wifi
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -36,11 +36,8 @@ function(params)
                   if c.name == 'prometheus-operator-admission-webhook' then
                     c {
                       args+: [
-                        '--web.enable-tls=true',
                         '--web.tls-cipher-suites=' + params.tlsCipherSuites,
                         '--web.tls-min-version=VersionTLS12',
-                        '--web.cert-file=/etc/tls/private/tls.crt',
-                        '--web.key-file=/etc/tls/private/tls.key',
                       ],
                       livenessProbe: {
                         httpGet: {
@@ -58,36 +55,11 @@ function(params)
                       },
                       securityContext: {},
                       terminationMessagePolicy: 'FallbackToLogsOnError',
-                      volumeMounts+: [
-                        {
-                          mountPath: '/etc/tls/private',
-                          name: 'tls-certificates',
-                          readOnly: true,
-                        },
-                      ],
                     }
                   else
                     c,
                 super.containers,
               ),
-            volumes+: [
-              {
-                name: 'tls-certificates',
-                secret: {
-                  secretName: 'prometheus-operator-admission-webhook-tls',
-                  items: [
-                    {
-                      key: 'tls.crt',
-                      path: 'tls.crt',
-                    },
-                    {
-                      key: 'tls.key',
-                      path: 'tls.key',
-                    },
-                  ],
-                },
-              },
-            ],
           } + antiAffinity.antiaffinity(
             aw.deployment.spec.selector.matchLabels,
             aw._config.namespace,

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -17,7 +17,7 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "1bf12a98422ed9e2f26c061beb07fa14035e8823"
+      "version": "main"
     },
     {
       "source": {
@@ -26,7 +26,7 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "release-0.60"
+      "version": "main"
     },
     {
       "source": {
@@ -35,7 +35,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "release-4.12",
+      "version": "master",
       "name": "openshift-state-metrics"
     },
     {
@@ -45,7 +45,7 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "release-4.12",
+      "version": "master",
       "name": "telemeter-client"
     },
     {
@@ -55,7 +55,7 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "f7da22f5c8b83f34c52da5e63ecc0c89d2dd40a2"
+      "version": "main"
     },
     {
       "source": {
@@ -64,7 +64,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "release-0.28"
+      "version": "main"
     }
   ],
   "legacyImports": true

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "39ca876f38f6bf0cd37eec14083a2ac67bc95c0a",
+      "version": "a4c6d1bbce25c56a5d23090544547c2554ad2371",
       "sum": "IkDHlaE0gvvcPjSNurFT+jQ2aCOAbqHF1WVmXbAgkds="
     },
     {
@@ -58,7 +58,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "fd5379a1fba2d572fc314a0395dd61e7df335948",
+      "version": "92239ea6312a4a8fec3ddecce86a505587e98501",
       "sum": "tDR6yT2GVfw0wTU12iZH+m01HrbIr6g/xN+/8nzNkU0="
     },
     {
@@ -79,8 +79,8 @@
           "subdir": ""
         }
       },
-      "version": "eb707bf721dc702baeac2827345e531d6fd207e1",
-      "sum": "PzmQo7PuXIvfRMXJtolk/CDFyHYTnbVlVD/8+jkz634="
+      "version": "3c386687c1f8ceb6b79ff887c4a934e9cee1b90a",
+      "sum": "H8lcnk7gQEUoRi58/xq+JTfd2PcjJUjMQHgxGklUiFY="
     },
     {
       "source": {
@@ -89,8 +89,8 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "b2c90e86b65444ea3002e4bb2394eac5b68a0fd5",
-      "sum": "evJ+PXRzuM1tezCG5WzpAn4Lk3YJfMvDFcs+45fsscU="
+      "version": "44aea58610a9fcfa7ca1158d9c71e55d2e33ace0",
+      "sum": "4PJ2ROxODsoYO/1Y70+dgLZVjW5zlfzB+TDpxJBHwaI="
     },
     {
       "source": {
@@ -99,7 +99,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "b2c90e86b65444ea3002e4bb2394eac5b68a0fd5",
+      "version": "44aea58610a9fcfa7ca1158d9c71e55d2e33ace0",
       "sum": "u8gaydJoxEjzizQ8jY8xSjYgWooPmxw+wIWdDxifMAk="
     },
     {
@@ -109,7 +109,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "4c711c74a0857e55604d11bd975b32b9956db6a0",
+      "version": "3c947be7ffab627dfcfeb113dd5841e31239756d",
       "sum": "9/dHjMKxPKGTAPV1fMAV0RuBck0O+Xyj/FkZjlN7DMs=",
       "name": "openshift-state-metrics"
     },
@@ -120,8 +120,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "4d304019274307c21afefa108493c8af89a2429d",
-      "sum": "079UoqPnQJWKoVi2qMsVUANGD0cBkx25D+S7guvrcGc=",
+      "version": "39bcfd573d705afab775e1d3d749a1ce26939dcd",
+      "sum": "ija4yqWaf7s4mr90euiwIP1cZZtsPwp4fpMYEhVRFag=",
       "name": "telemeter-client"
     },
     {
@@ -131,8 +131,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "1bf12a98422ed9e2f26c061beb07fa14035e8823",
-      "sum": "dH4ASLWys+s5L+xeK+82QoeCxwCNzdcuONwPS+9L03Y="
+      "version": "f4618411fddf8b0647ae9666050a12753f33dce0",
+      "sum": "y1X8522K0LslKgOjXjQ3o1yTM58HIYOhjh/LzY4XVx0="
     },
     {
       "source": {
@@ -141,7 +141,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "3ee8ce54baea4e99c1e2dfe6bd6d0b6b8b265e76",
+      "version": "fe4ba64258a56b407a7ca7fd2a8c44fb44ebcada",
       "sum": "GQmaVFJwKMiD/P4n3N2LrAZVcwutriWrP8joclDtBYQ=",
       "name": "prometheus-operator-mixin"
     },
@@ -152,8 +152,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "ab3fe2aba8f6e43461819d9648e2b8fae9d74c43",
-      "sum": "O/e9OtVscqHAiAvvWGR372ci6xadmQ09WWGjT7vDlbg="
+      "version": "fe4ba64258a56b407a7ca7fd2a8c44fb44ebcada",
+      "sum": "ZZQS9t5+R/90jXoEFEech7Mk93oN54C2586Q47O2YN0="
     },
     {
       "source": {
@@ -162,7 +162,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "9282b30a3c4de972bdc8164de39f88b828cafb5d",
+      "version": "1b202b91bf269b737d9fae2930fe4fb1a5c43ab2",
       "sum": "PsK+V7oETCPKu2gLoPfqY0wwPKH9TzhNj6o2xezjjXc=",
       "name": "alertmanager"
     },
@@ -173,7 +173,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "26e82af8a2cd3d930c60a640766d4bb78e465215",
+      "version": "9869d34a24d440ddd661c434556482935a09baac",
       "sum": "5H6gKQvR23QHpvNvLkNn9DL3Vx37g015eHG2iqrlCzE="
     },
     {
@@ -183,7 +183,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "8553a98267a56acfafc56ba69ab8946b71655304",
+      "version": "72a48321dabed43f2cd9e510dda96c50d4a48a58",
       "sum": "LRx0tbMnoE1p8KEn+i81j2YsA5Sgt3itE5Y6jBf5eOQ=",
       "name": "prometheus"
     },
@@ -204,7 +204,7 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "f7da22f5c8b83f34c52da5e63ecc0c89d2dd40a2",
+      "version": "c5c9cd256cd91bede770a03fa26ac89154071217",
       "sum": "sFdq83b0xqzvAREQcYyLKhnd+1MPYzyCxBOfctpiTDA="
     },
     {
@@ -214,8 +214,8 @@
           "subdir": "mixin"
         }
       },
-      "version": "41a8ce61c90734b81986b273e154e96358333f92",
-      "sum": "oksO55VdKbsLAVA3vl7b1woE9TLmfvH7sz5+1A7iOBE="
+      "version": "e6f0b6eb3e4a040693b24b964413293e2d08b950",
+      "sum": "7tyoT2wSJ8U7+zMmT5w549MRGk5k6ViDSz5A8/sia88="
     }
   ],
   "legacyImports": false

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -246,6 +246,8 @@ local inCluster =
         resources: {
           requests: { cpu: '5m', memory: '30Mi' },
         },
+        tlsSecretName: 'prometheus-operator-admission-webhook-tls',
+        port: 8443,
       },
       prometheusOperator: {
         namespace: $.values.common.namespace,

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -327,8 +327,8 @@ spec:
                             description: TLS configuration
                             properties:
                               ca:
-                                description: Struct containing the CA cert to use
-                                  for the targets.
+                                description: Certificate authority used when verifying
+                                  server certificates.
                                 properties:
                                   configMap:
                                     description: ConfigMap containing data to use
@@ -375,8 +375,8 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               cert:
-                                description: Struct containing the client cert file
-                                  for the targets.
+                                description: Client certificate to present when doing
+                                  client-authentication.
                                 properties:
                                   configMap:
                                     description: ConfigMap containing data to use
@@ -738,8 +738,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -787,8 +787,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -1184,8 +1184,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -1233,8 +1233,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -1640,8 +1640,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -1689,8 +1689,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -2174,8 +2174,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -2223,8 +2223,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -2566,8 +2566,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -2615,8 +2615,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -3040,8 +3040,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -3089,8 +3089,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -3451,8 +3451,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -3500,8 +3500,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -3822,8 +3822,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -3871,8 +3871,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -4243,8 +4243,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -4292,8 +4292,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -4686,8 +4686,8 @@ spec:
                             description: TLS configuration
                             properties:
                               ca:
-                                description: Struct containing the CA cert to use
-                                  for the targets.
+                                description: Certificate authority used when verifying
+                                  server certificates.
                                 properties:
                                   configMap:
                                     description: ConfigMap containing data to use
@@ -4734,8 +4734,8 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               cert:
-                                description: Struct containing the client cert file
-                                  for the targets.
+                                description: Client certificate to present when doing
+                                  client-authentication.
                                 properties:
                                   configMap:
                                     description: ConfigMap containing data to use
@@ -5092,8 +5092,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -5141,8 +5141,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -5529,8 +5529,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -5578,8 +5578,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -5978,8 +5978,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -6027,8 +6027,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -6503,8 +6503,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -6552,8 +6552,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -6892,8 +6892,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -6941,8 +6941,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -7361,8 +7361,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -7410,8 +7410,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -7767,8 +7767,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -7816,8 +7816,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -8135,8 +8135,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -8184,8 +8184,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -8549,8 +8549,8 @@ spec:
                                 description: TLS configuration for the client.
                                 properties:
                                   ca:
-                                    description: Struct containing the CA cert to
-                                      use for the targets.
+                                    description: Certificate authority used when verifying
+                                      server certificates.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -8598,8 +8598,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   cert:
-                                    description: Struct containing the client cert
-                                      file for the targets.
+                                    description: Client certificate to present when
+                                      doing client-authentication.
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -893,6 +893,22 @@ spec:
                         type: array
                     type: object
                 type: object
+              alertmanagerConfigMatcherStrategy:
+                description: The AlertmanagerConfigMatcherStrategy defines how AlertmanagerConfig
+                  objects match the alerts. In the future more options may be added.
+                properties:
+                  type:
+                    default: OnNamespace
+                    description: If set to `OnNamespace`, the operator injects a label
+                      matcher matching the namespace of the AlertmanagerConfig object
+                      for all its routes and inhibition rules. `None` will not add
+                      any additional matchers other than the ones specified in the
+                      AlertmanagerConfig. Default is `OnNamespace`.
+                    enum:
+                    - OnNamespace
+                    - None
+                    type: string
+                type: object
               alertmanagerConfigNamespaceSelector:
                 description: Namespaces to be selected for AlertmanagerConfig discovery.
                   If nil, only check own namespace.
@@ -1206,8 +1222,8 @@ spec:
                             description: TLS configuration for the client.
                             properties:
                               ca:
-                                description: Struct containing the CA cert to use
-                                  for the targets.
+                                description: Certificate authority used when verifying
+                                  server certificates.
                                 properties:
                                   configMap:
                                     description: ConfigMap containing data to use
@@ -1254,8 +1270,8 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               cert:
-                                description: Struct containing the client cert file
-                                  for the targets.
+                                description: Client certificate to present when doing
+                                  client-authentication.
                                 properties:
                                   configMap:
                                     description: ConfigMap containing data to use
@@ -1431,10 +1447,11 @@ spec:
                   for this Alertmanager instance. If empty, it defaults to `alertmanager-<alertmanager-name>`.
                   \n The Alertmanager configuration should be available under the
                   `alertmanager.yaml` key. Additional keys from the original secret
-                  are copied to the generated secret. \n If either the secret or the
-                  `alertmanager.yaml` key is missing, the operator provisions an Alertmanager
-                  configuration with one empty receiver (effectively dropping alert
-                  notifications)."
+                  are copied to the generated secret and mounted into the `/etc/alertmanager/config`
+                  directory in the `alertmanager` container. \n If either the secret
+                  or the `alertmanager.yaml` key is missing, the operator provisions
+                  a minimal Alertmanager configuration with one empty receiver (effectively
+                  dropping alert notifications)."
                 type: string
               containers:
                 description: 'Containers allows injecting additional containers. This
@@ -3976,8 +3993,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:
@@ -4264,9 +4282,9 @@ spec:
                       allows to remove any subPath usage in volume mounts.'
                     type: boolean
                   emptyDir:
-                    description: 'EmptyDirVolumeSource to be used by the Prometheus
-                      StatefulSets. If specified, used in place of any volumeClaimTemplate.
-                      More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
+                    description: 'EmptyDirVolumeSource to be used by the StatefulSet.
+                      If specified, used in place of any volumeClaimTemplate. More
+                      info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
                     properties:
                       medium:
                         description: 'medium represents what type of storage medium
@@ -4289,9 +4307,9 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   ephemeral:
-                    description: 'EphemeralVolumeSource to be used by the Prometheus
-                      StatefulSets. This is a beta field in k8s 1.21, for lower versions,
-                      starting with k8s 1.19, it requires enabling the GenericEphemeralVolume
+                    description: 'EphemeralVolumeSource to be used by the StatefulSet.
+                      This is a beta field in k8s 1.21, for lower versions, starting
+                      with k8s 1.19, it requires enabling the GenericEphemeralVolume
                       feature gate. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes'
                     properties:
                       volumeClaimTemplate:
@@ -4508,7 +4526,10 @@ spec:
                         type: object
                     type: object
                   volumeClaimTemplate:
-                    description: A PVC spec to be used by the Prometheus StatefulSets.
+                    description: A PVC spec to be used by the StatefulSet. The easiest
+                      way to use a volume that cannot be automatically provisioned
+                      (for whatever reason) is to use a label selector alongside manually
+                      created PersistentVolumes.
                     properties:
                       apiVersion:
                         description: 'APIVersion defines the versioned schema of this

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -43,8 +43,8 @@ spec:
               by Prometheus.
             properties:
               attachMetadata:
-                description: 'Attaches node metadata to discovered targets. Only valid
-                  for role: pod. Only valid in Prometheus versions 2.35.0 and newer.'
+                description: Attaches node metadata to discovered targets. Requires
+                  Prometheus v2.35.0 and above.
                 properties:
                   node:
                     description: When set to true, Prometheus must have permissions
@@ -478,8 +478,8 @@ spec:
                       description: TLS configuration to use when scraping the endpoint.
                       properties:
                         ca:
-                          description: Struct containing the CA cert to use for the
-                            targets.
+                          description: Certificate authority used when verifying server
+                            certificates.
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -523,8 +523,7 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Struct containing the client cert file for
-                            the targets.
+                          description: Client certificate to present when doing client-authentication.
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -590,7 +590,8 @@ spec:
                 description: TLS configuration to use when scraping the endpoint.
                 properties:
                   ca:
-                    description: Struct containing the CA cert to use for the targets.
+                    description: Certificate authority used when verifying server
+                      certificates.
                     properties:
                       configMap:
                         description: ConfigMap containing data to use for the targets.
@@ -631,7 +632,7 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   cert:
-                    description: Struct containing the client cert file for the targets.
+                    description: Client certificate to present when doing client-authentication.
                     properties:
                       configMap:
                         description: ConfigMap containing data to use for the targets.

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -1051,10 +1051,60 @@ spec:
                                 Bearer, Basic will cause an error
                               type: string
                           type: object
+                        basicAuth:
+                          description: BasicAuth allow an endpoint to authenticate
+                            over basic authentication
+                          properties:
+                            password:
+                              description: The secret in the service monitor namespace
+                                that contains the password for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            username:
+                              description: The secret in the service monitor namespace
+                                that contains the username for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         bearerTokenFile:
                           description: BearerTokenFile to read from filesystem to
                             use when authenticating to Alertmanager.
                           type: string
+                        enableHttp2:
+                          description: Whether to enable HTTP2.
+                          type: boolean
                         name:
                           description: Name of Endpoints object in Namespace.
                           type: string
@@ -1083,8 +1133,8 @@ spec:
                           description: TLS Config to use for alertmanager connection.
                           properties:
                             ca:
-                              description: Struct containing the CA cert to use for
-                                the targets.
+                              description: Certificate authority used when verifying
+                                server certificates.
                               properties:
                                 configMap:
                                   description: ConfigMap containing data to use for
@@ -1135,8 +1185,8 @@ spec:
                                 to use for the targets.
                               type: string
                             cert:
-                              description: Struct containing the client cert file
-                                for the targets.
+                              description: Client certificate to present when doing
+                                client-authentication.
                               properties:
                                 configMap:
                                   description: ConfigMap containing data to use for
@@ -1329,8 +1379,8 @@ spec:
                     description: TLS Config to use for accessing apiserver.
                     properties:
                       ca:
-                        description: Struct containing the CA cert to use for the
-                          targets.
+                        description: Certificate authority used when verifying server
+                          certificates.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the
@@ -1378,8 +1428,7 @@ spec:
                           to use for the targets.
                         type: string
                       cert:
-                        description: Struct containing the client cert file for the
-                          targets.
+                        description: Client certificate to present when doing client-authentication.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the
@@ -4180,8 +4229,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:
@@ -4575,6 +4625,11 @@ spec:
                     bearerTokenFile:
                       description: File to read bearer token for remote read.
                       type: string
+                    filterExternalLabels:
+                      description: Whether to use the external labels as selectors
+                        for the remote read endpoint. Requires Prometheus v2.34.0
+                        and above.
+                      type: boolean
                     headers:
                       additionalProperties:
                         type: string
@@ -4697,8 +4752,8 @@ spec:
                       description: TLS Config to use for remote read.
                       properties:
                         ca:
-                          description: Struct containing the CA cert to use for the
-                            targets.
+                          description: Certificate authority used when verifying server
+                            certificates.
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -4746,8 +4801,7 @@ spec:
                             to use for the targets.
                           type: string
                         cert:
-                          description: Struct containing the client cert file for
-                            the targets.
+                          description: Client certificate to present when doing client-authentication.
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -5148,8 +5202,8 @@ spec:
                       description: TLS Config to use for remote write.
                       properties:
                         ca:
-                          description: Struct containing the CA cert to use for the
-                            targets.
+                          description: Certificate authority used when verifying server
+                            certificates.
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -5197,8 +5251,7 @@ spec:
                             to use for the targets.
                           type: string
                         cert:
-                          description: Struct containing the client cert file for
-                            the targets.
+                          description: Client certificate to present when doing client-authentication.
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -5833,9 +5886,9 @@ spec:
                       allows to remove any subPath usage in volume mounts.'
                     type: boolean
                   emptyDir:
-                    description: 'EmptyDirVolumeSource to be used by the Prometheus
-                      StatefulSets. If specified, used in place of any volumeClaimTemplate.
-                      More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
+                    description: 'EmptyDirVolumeSource to be used by the StatefulSet.
+                      If specified, used in place of any volumeClaimTemplate. More
+                      info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
                     properties:
                       medium:
                         description: 'medium represents what type of storage medium
@@ -5858,9 +5911,9 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   ephemeral:
-                    description: 'EphemeralVolumeSource to be used by the Prometheus
-                      StatefulSets. This is a beta field in k8s 1.21, for lower versions,
-                      starting with k8s 1.19, it requires enabling the GenericEphemeralVolume
+                    description: 'EphemeralVolumeSource to be used by the StatefulSet.
+                      This is a beta field in k8s 1.21, for lower versions, starting
+                      with k8s 1.19, it requires enabling the GenericEphemeralVolume
                       feature gate. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes'
                     properties:
                       volumeClaimTemplate:
@@ -6077,7 +6130,10 @@ spec:
                         type: object
                     type: object
                   volumeClaimTemplate:
-                    description: A PVC spec to be used by the Prometheus StatefulSets.
+                    description: A PVC spec to be used by the StatefulSet. The easiest
+                      way to use a volume that cannot be automatically provisioned
+                      (for whatever reason) is to use a label selector alongside manually
+                      created PersistentVolumes.
                     properties:
                       apiVersion:
                         description: 'APIVersion defines the versioned schema of this
@@ -6437,8 +6493,8 @@ spec:
                       Maps to the ''--grpc-server-tls-*'' CLI args.'
                     properties:
                       ca:
-                        description: Struct containing the CA cert to use for the
-                          targets.
+                        description: Certificate authority used when verifying server
+                          certificates.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the
@@ -6486,8 +6542,7 @@ spec:
                           to use for the targets.
                         type: string
                       cert:
-                        description: Struct containing the client cert file for the
-                          targets.
+                        description: Client certificate to present when doing client-authentication.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -45,18 +45,25 @@ spec:
               groups:
                 description: Content of Prometheus rule file
                 items:
-                  description: 'RuleGroup is a list of sequentially evaluated recording
-                    and alerting rules. Note: PartialResponseStrategy is only used
-                    by ThanosRuler and will be ignored by Prometheus instances.  Valid
-                    values for this field are ''warn'' or ''abort''.  More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
+                  description: RuleGroup is a list of sequentially evaluated recording
+                    and alerting rules.
                   properties:
                     interval:
+                      description: Interval determines how often rules in the group
+                        are evaluated.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     name:
+                      description: Name of the rule group.
+                      minLength: 1
                       type: string
                     partial_response_strategy:
+                      description: 'PartialResponseStrategy is only used by ThanosRuler
+                        and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
+                      pattern: ^(?i)(abort|warn)?$
                       type: string
                     rules:
+                      description: List of alerting and recording rules.
                       items:
                         description: 'Rule describes an alerting or recording rule
                           See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
@@ -64,23 +71,35 @@ spec:
                           rule'
                         properties:
                           alert:
+                            description: Name of the alert. Must be a valid label
+                              value. Only one of `record` and `alert` must be set.
                             type: string
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations to add to each alert. Only valid
+                              for alerting rules.
                             type: object
                           expr:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: PromQL expression to evaluate.
                             x-kubernetes-int-or-string: true
                           for:
+                            description: Alerts are considered firing once they have
+                              been returned for this long.
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                             type: string
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels to add or overwrite.
                             type: object
                           record:
+                            description: Name of the time series to output to. Must
+                              be a valid metric name. Only one of `record` and `alert`
+                              must be set.
                             type: string
                         required:
                         - expr
@@ -91,6 +110,9 @@ spec:
                   - rules
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         required:
         - spec

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -42,6 +42,15 @@ spec:
             description: Specification of desired Service selection for target discovery
               by Prometheus.
             properties:
+              attachMetadata:
+                description: Attaches node metadata to discovered targets. Requires
+                  Prometheus v2.37.0 and above.
+                properties:
+                  node:
+                    description: When set to true, Prometheus must have permissions
+                      to get Nodes.
+                    type: boolean
+                type: object
               endpoints:
                 description: A list of endpoints allowed as part of this ServiceMonitor.
                 items:
@@ -147,6 +156,10 @@ spec:
                       x-kubernetes-map-type: atomic
                     enableHttp2:
                       description: Whether to enable HTTP2.
+                      type: boolean
+                    filterRunning:
+                      description: 'Drop pods that are not running. (Failed, Succeeded).
+                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
                       type: boolean
                     followRedirects:
                       description: FollowRedirects configures whether scrape requests
@@ -437,8 +450,8 @@ spec:
                       description: TLS configuration to use when scraping the endpoint
                       properties:
                         ca:
-                          description: Struct containing the CA cert to use for the
-                            targets.
+                          description: Certificate authority used when verifying server
+                            certificates.
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -486,8 +499,7 @@ spec:
                             to use for the targets.
                           type: string
                         cert:
-                          description: Struct containing the client cert file for
-                            the targets.
+                          description: Client certificate to present when doing client-authentication.
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -2239,7 +2239,8 @@ spec:
                   the ''--grpc-server-tls-*'' CLI args.'
                 properties:
                   ca:
-                    description: Struct containing the CA cert to use for the targets.
+                    description: Certificate authority used when verifying server
+                      certificates.
                     properties:
                       configMap:
                         description: ConfigMap containing data to use for the targets.
@@ -2284,7 +2285,7 @@ spec:
                       use for the targets.
                     type: string
                   cert:
-                    description: Struct containing the client cert file for the targets.
+                    description: Client certificate to present when doing client-authentication.
                     properties:
                       configMap:
                         description: ConfigMap containing data to use for the targets.
@@ -3660,8 +3661,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:
@@ -4092,9 +4094,9 @@ spec:
                       allows to remove any subPath usage in volume mounts.'
                     type: boolean
                   emptyDir:
-                    description: 'EmptyDirVolumeSource to be used by the Prometheus
-                      StatefulSets. If specified, used in place of any volumeClaimTemplate.
-                      More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
+                    description: 'EmptyDirVolumeSource to be used by the StatefulSet.
+                      If specified, used in place of any volumeClaimTemplate. More
+                      info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
                     properties:
                       medium:
                         description: 'medium represents what type of storage medium
@@ -4117,9 +4119,9 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                   ephemeral:
-                    description: 'EphemeralVolumeSource to be used by the Prometheus
-                      StatefulSets. This is a beta field in k8s 1.21, for lower versions,
-                      starting with k8s 1.19, it requires enabling the GenericEphemeralVolume
+                    description: 'EphemeralVolumeSource to be used by the StatefulSet.
+                      This is a beta field in k8s 1.21, for lower versions, starting
+                      with k8s 1.19, it requires enabling the GenericEphemeralVolume
                       feature gate. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes'
                     properties:
                       volumeClaimTemplate:
@@ -4336,7 +4338,10 @@ spec:
                         type: object
                     type: object
                   volumeClaimTemplate:
-                    description: A PVC spec to be used by the Prometheus StatefulSets.
+                    description: A PVC spec to be used by the StatefulSet. The easiest
+                      way to use a volume that cannot be automatically provisioned
+                      (for whatever reason) is to use a label selector alongside manually
+                      created PersistentVolumes.
                     properties:
                       apiVersion:
                         description: 'APIVersion defines the versioned schema of this
@@ -4876,6 +4881,9 @@ spec:
                 description: TracingConfig specifies the path of the tracing configuration
                   file. When used alongside with TracingConfig, TracingConfigFile
                   takes precedence.
+                type: string
+              version:
+                description: Version of Thanos to be deployed.
                 type: string
               volumes:
                 description: Volumes allows configuration of additional volumes on

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -269,6 +269,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses
@@ -288,6 +295,7 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingressclasses
   - ingresses
   verbs:
   - list


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This PR upins jsonnet dependencies and update them to latest version.
The new version of admission-webhook library requires input of a secret name for its TLS certificate. So there is a modification on `admission-webhook.libsonnet`.