### PR TITLE
OCPBUGS-4168: Increase startupProbe for prometheus

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1710,6 +1710,16 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 
 	for i, container := range p.Spec.Containers {
 		switch container.Name {
+		case "prometheus":
+			// Increase the startup probe timeout to 1h from 15m to avoid restart failures when the WAL replay
+			// takes a long time. See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
+			// TODO (JoaoBraveCoding): Once prometheus-operator adds CRD support to configure startupProbe directly
+			// we should use that instead of using strategic merge patch
+			// See https://github.com/prometheus-operator/prometheus-operator/issues/4730
+			p.Spec.Containers[i].StartupProbe = &v1.Probe{
+				PeriodSeconds:    15,
+				FailureThreshold: 240,
+			}
 		case "prometheus-proxy":
 			p.Spec.Containers[i].Image = f.config.Images.OauthProxy
 
@@ -1977,6 +1987,16 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 
 	for i, container := range p.Spec.Containers {
 		switch container.Name {
+		case "prometheus":
+			// Increase the startup probe timeout to 1h from 15m to avoid restart failures when the WAL replay
+			// takes a long time. See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
+			// TODO (JoaoBraveCoding): Once prometheus-operator adds CRD support to configure startupProbe directly
+			// we should use that instead of using strategic merge patch
+			// See https://github.com/prometheus-operator/prometheus-operator/issues/4730
+			p.Spec.Containers[i].StartupProbe = &v1.Probe{
+				PeriodSeconds:    15,
+				FailureThreshold: 240,
+			}
 		case "kube-rbac-proxy-metrics", "kube-rbac-proxy-federate", "kube-rbac-proxy-thanos":
 			p.Spec.Containers[i].Image = f.config.Images.KubeRbacProxy
 			p.Spec.Containers[i].Args = f.setTLSSecurityConfiguration(container.Args, KubeRbacProxyTLSCipherSuitesFlag, KubeRbacProxyMinTLSVersionFlag)


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCPBUGS-4168

Problem: recently we have seen a couple of customers complaining that some startup probes are timing out due to the WAL replay that Prometheus has to perform once rebooted.

Solution: to avoid this we are doubling the startup probe, with this commit Prometheus should now have up to 30 minutes to boot


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
