### PR TITLE
OCPBUGS-2260: add alert KubePodNotScheduled to group openshift-kubernetes.rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.13
+
+- [#1830](https://github.com/openshift/cluster-monitoring-operator/pull/1830) Add alert KubePodNotScheduled
+
 ## 4.12
 - [#1624](https://github.com/openshift/cluster-monitoring-operator/pull/1624) Add option to specify TopologySpreadConstraints for Prometheus, Alertmanager, and ThanosRuler.
 - [#1752](https://github.com/openshift/cluster-monitoring-operator/pull/1752) Add option to improve consistency of prometheus-adapter CPU and RAM time series.

--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -325,6 +325,18 @@ spec:
       record: cluster:usage:openshift:kube_running_pod_ready:avg
     - expr: avg(kube_running_pod_ready{namespace!~"openshift-.*"})
       record: cluster:usage:workload:kube_running_pod_ready:avg
+    - alert: KubePodNotScheduled
+      annotations:
+        description: |-
+          Pod {{ $labels.namespace }}/{{ $labels.pod }} cannot be scheduled for more than 30 minutes.
+          Check the details of the pod with the following command:
+          oc describe -n {{ $labels.namespace }} pod {{ $labels.pod }}
+        summary: Pod cannot be scheduled.
+      expr: last_over_time(kube_pod_status_unschedulable{namespace=~"(openshift-.*|kube-.*|default)"}[5m])
+        == 1
+      for: 30m
+      labels:
+        severity: warning
   - interval: 30s
     name: kubernetes-recurring.rules
     rules:

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -428,6 +428,18 @@ function(params) {
           record: 'cluster:usage:workload:kube_running_pod_ready:avg',
           // Report the percentage (0-1) of pending or running workload (everything outside of openshift-*) pods reporting ready
         },
+        {
+          expr: 'last_over_time(kube_pod_status_unschedulable{namespace=~"(openshift-.*|kube-.*|default)"}[5m]) == 1',
+          'for': '30m',
+          alert: 'KubePodNotScheduled',
+          annotations: {
+            description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} cannot be scheduled for more than 30 minutes.\nCheck the details of the pod with the following command:\noc describe -n {{ $labels.namespace }} pod {{ $labels.pod }}',
+            summary: 'Pod cannot be scheduled.',
+          },
+          labels: {
+            severity: 'warning',
+          },
+        },
       ],
     },
     {


### PR DESCRIPTION
This PR adds alert `KubePodNotScheduled` to group `openshift-kubernetes.rules`. 
To fix the bug [OCPBUGS-2260](https://issues.redhat.com/browse/OCPBUGS-2260) we have patched the alert `KubePodNotReady` already in PR #1816 , excludingthe not schedulable pods from that alert. 
To complete the alerting on unschedulable pods, we add this new alert  `KubePodNotScheduled`. 

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.


We have also submitted [a PR to upstream](https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/801). When it is under review, we can start using this alert in CMO in conjunction with the [patched version](https://github.com/openshift/cluster-monitoring-operator/pull/1816/files#diff-9425bc6534201e7b9f2c51476ae71ce5e7c9a353c12c58ec44008c7f12d0171fR190-R204) of alert `KubePodNotReady`. 
