### PR TITLE
Remove deprecated option from kube-state-metrics args

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           --metric-denylist=
           ^kube_secret_labels$,
           ^kube_.+_annotations$
-        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]
+        - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]
         - |
           --metric-denylist=
           ^kube_.+_created$,

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -145,8 +145,7 @@ function(params)
                           ^kube_secret_labels$,
                           ^kube_.+_annotations$
                         |||,
-                        // TODO: Remove "poddisruptionbudget" once upstream KSM addresses a typo in PDB label metrics allowlist key.
-                        '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*],poddisruptionbudget=[*]',
+                        '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
The `--metric-labels-allowlist` command-line argument contained the `poddisruptionbudget[*]` string which was introduced to support older versions of kube-state-metrics.

With https://github.com/kubernetes/kube-state-metrics/pull/1826, kube-state-metrics will now refuse to start if the allow-list contains an invalid resource name.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
