### PR TITLE
OCPBUGS-2141: compute doc link in PVC not configured message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1624](https://github.com/openshift/cluster-monitoring-operator/pull/1624) Add option to specify TopologySpreadConstraints for Prometheus, Alertmanager, and ThanosRuler.
 - [#1752](https://github.com/openshift/cluster-monitoring-operator/pull/1752) Add option to improve consistency of prometheus-adapter CPU and RAM time series.
 - [#1803](https://github.com/openshift/cluster-monitoring-operator/pull/1803) Add alert TelemeterClientFailures
+- [#1836](https://github.com/openshift/cluster-monitoring-operator/pull/1836) PVC configuration link points to document specific to the cluster version
 
 ## 4.11
 - [#1652](https://github.com/openshift/cluster-monitoring-operator/pull/1652) Double scrape interval for all CMO controlled ServiceMonitors on single node deployments

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 )
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/prometheus/common v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -44,7 +45,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.44.102 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -30,7 +30,7 @@ import (
 const (
 	unavailableMessage                        string = "Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error."
 	asExpectedReason                          string = "AsExpected"
-	StorageNotConfiguredMessage                      = "Prometheus is running without persistent storage which can lead to data loss during upgrades and cluster disruptions. Please refer to the official documentation to see how to configure storage for Prometheus: https://docs.openshift.com/container-platform/4.8/monitoring/configuring-the-monitoring-stack.html"
+	StorageNotConfiguredMessage                      = "Prometheus is running without persistent storage which can lead to data loss during upgrades and cluster disruptions. Please refer to the official documentation to see how to configure storage for Prometheus: "
 	StorageNotConfiguredReason                       = "PrometheusDataPersistenceNotConfigured"
 	UserAlermanagerConfigMisconfiguredMessage        = "Misconfigured Alertmanager:  Alertmanager for user-defined alerting is enabled in the openshift-monitoring/cluster-monitoring-config configmap by setting 'enableUserAlertmanagerConfig: true' field. This conflicts with a dedicated Alertmanager instance enabled in  openshift-user-workload-monitoring/user-workload-monitoring-config. Alertmanager enabled in openshift-user-workload-monitoring takes precedence over the one in openshift-monitoring, so please remove the 'enableUserAlertmanagerConfig' field in openshift-monitoring/cluster-monitoring-config."
 	UserAlermanagerConfigMisconfiguredReason         = "UserAlertmanagerMisconfigured"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/openshift/cluster-monitoring-operator/pkg/alert"
 	"github.com/openshift/cluster-monitoring-operator/pkg/rebalancer"
 	cmostr "github.com/openshift/cluster-monitoring-operator/pkg/strings"
@@ -682,7 +683,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 
 	var degradedConditionMessage, degradedConditionReason string
 	if !config.IsStorageConfigured() {
-		degradedConditionMessage = client.StorageNotConfiguredMessage
+		degradedConditionMessage = o.storageNotConfiguredMessage()
 		degradedConditionReason = client.StorageNotConfiguredReason
 	} else if config.HasInconsistentAlertmanagerConfigurations() {
 		degradedConditionMessage = client.UserAlermanagerConfigMisconfiguredMessage
@@ -991,6 +992,33 @@ func (o *Operator) workloadsToRebalance() []rebalancer.Workload {
 		)
 	}
 	return workloads
+}
+
+// storageNotConfiguredMessage returns the message to be set if a pvc has not
+// been configured for Prometheus. This messages includes a link to the
+// documentation on configuring monitoring stack. If the current cluster
+// version can be computed, the link will point to the documentation for that
+// version, else it will point to latest documentation.
+func (o Operator) storageNotConfiguredMessage() string {
+	const docURL = "https://docs.openshift.com/container-platform/%s/monitoring/configuring-the-monitoring-stack.html"
+
+	latestDocMsg := client.StorageNotConfiguredMessage + fmt.Sprintf(docURL, "latest")
+
+	// if cluster version cannot be obtained due to any failure, point to the
+	// latest documentation
+	cv, err := o.client.GetClusterVersion(context.Background(), "version")
+	if err != nil {
+		klog.Warning("failed to find the cluster version: %s", err)
+		return latestDocMsg
+	}
+
+	v, err := semver.Make(cv.Status.Desired.Version)
+	if err != nil {
+		klog.Warning("failed to parse  cluster version: %s", err)
+		return latestDocMsg
+	}
+
+	return client.StorageNotConfiguredMessage + fmt.Sprintf(docURL, fmt.Sprintf("%d.%d", v.Major, v.Minor))
 }
 
 // stateErrorOrUnavailable converts an error to Unavailable & Degraded

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -90,7 +90,7 @@ func TestClusterMonitoringStatus(t *testing.T) {
 				f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
 				f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
 				f.AssertOperatorConditionReason(configv1.OperatorDegraded, client.StorageNotConfiguredReason)
-				f.AssertOperatorConditionMessage(configv1.OperatorDegraded, client.StorageNotConfiguredMessage)
+				f.AssertOperatorConditionMessageContains(configv1.OperatorDegraded, client.StorageNotConfiguredMessage)
 			},
 		},
 		{


### PR DESCRIPTION
Previously, when PVC is not configured for Prometheus, the CO monitoring status message for Degraded condition included a link to the documentation on configuring monitoring stack for version 4.8.

This commit fixes the link to point to doc for the current cluster version and in case of failure to compute, the cluster-version, points to the latest documentation.

JIRA: https://issues.redhat.com/browse/OCPBUGS-2141

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
