### PR TITLE
OCPBUGS-4793: fix object reference in Kubernetes events

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -68,6 +68,10 @@ spec:
         env:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: quay.io/openshift/origin-cluster-monitoring-operator:latest
         name: cluster-monitoring-operator
         resources:

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -96,6 +96,12 @@ spec:
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
+        # Inject the pod's name using the downward API to generate Kubernetes
+        # events with the correct object reference.
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: quay.io/openshift/origin-cluster-monitoring-operator:latest
         name: cluster-monitoring-operator
         resources:


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

I noticed that when CMO restarts after all monitoring components are deployed, the event recorder would use the alertmanager-main statefulset  as the object's reference in events.

For https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.13-e2e-aws-sdn-upgrade/1597573931009576960, the Loki interface shows:

`I1129 14:54:21.444741       1 event.go:285] Event(v1.ObjectReference{Kind:"StatefulSet", Namespace:"openshift-monitoring", Name:"alertmanager-main", UID:"ad2a25b2-338c-4ebb-b0b4-52f5e5eb1096", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ServiceAccountUpdated' Updated ServiceAccount/prometheus-operator -n openshift-monitoring because it changed`