### PR TITLE
OCPBUGS-2729: Node Exporter ignore virtual network device 'enP.*'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 4.13
 
 - [#1830](https://github.com/openshift/cluster-monitoring-operator/pull/1830) Add alert KubePodNotScheduled
+- [#1843](https://github.com/openshift/cluster-monitoring-operator/pull/1830) Node Exporter ignores network interface under name "enP.*".
+
 
 ## 4.12
 - [#1624](https://github.com/openshift/cluster-monitoring-operator/pull/1624) Add option to specify TopologySpreadConstraints for Prometheus, Alertmanager, and ThanosRuler.

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         - --path.udev.data=/host/root/run/udev/data
         - --no-collector.wifi
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
+        - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15}|enP.*)$
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
         - --no-collector.cpufreq

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -181,6 +181,12 @@ local inCluster =
             rateInterval: '1m',  // adjust the rate interval value to be 4 x the node_exporter's scrape interval (15s).
           },
         },
+        // NOTE: 3 patterns for virutal NICs will be ignored:
+        // 1. veth network interface associated with containers.
+        // 2. OVN renames veth.* to <rand-hex>@if<X> where X is /sys/class/net/<if>/ifindex
+        // thus [a-z0-9]{15}}
+        // 3. enP.* virtual NICs on Azure cluster.
+        ignoredNetworkDevices:: '^(veth.*|[a-f0-9]{15}|enP.*)$',
       },
       openshiftStateMetrics: {
         namespace: $.values.common.namespace,


### PR DESCRIPTION
Network interfaces named "enP.*" are virtual network interfaces on Azure cluster. We will ignore them in Node Exporter.

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
