### PR TITLE
OCPBUGS-1062: configure the admission webhook with the correct CA to verify client certificates

### DIFF
--- a/assets/admission-webhook/deployment.yaml
+++ b/assets/admission-webhook/deployment.yaml
@@ -71,6 +71,9 @@ spec:
         - mountPath: /etc/tls/private
           name: tls-certificates
           readOnly: true
+        - mountPath: /etc/tls/client
+          name: metrics-client-ca
+          readOnly: false
       priorityClassName: system-cluster-critical
       securityContext: {}
       serviceAccountName: prometheus-operator-admission-webhook
@@ -83,3 +86,6 @@ spec:
           - key: tls.key
             path: tls.key
           secretName: prometheus-operator-admission-webhook-tls
+      - configMap:
+          name: metrics-client-ca
+        name: metrics-client-ca

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -53,6 +53,13 @@ function(params)
                           scheme: 'HTTPS',
                         },
                       },
+                      volumeMounts+: [
+                        {
+                          mountPath: '/etc/tls/client',
+                          name: 'metrics-client-ca',
+                          readOnly: false,
+                        },
+                      ],
                       securityContext: {},
                       terminationMessagePolicy: 'FallbackToLogsOnError',
                     }
@@ -60,6 +67,14 @@ function(params)
                     c,
                 super.containers,
               ),
+            volumes+: [
+              {
+                name: 'metrics-client-ca',
+                configMap: {
+                  name: 'metrics-client-ca',
+                },
+              },
+            ],
           } + antiAffinity.antiaffinity(
             aw.deployment.spec.selector.matchLabels,
             aw._config.namespace,


### PR DESCRIPTION
Fixes #OCPBUGS-1062

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
