### PR TITLE
OCPBUGS-4521: check that all targets are up after certificate recreation

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -28,9 +28,7 @@ import (
 	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
 
 	"github.com/Jeffail/gabs/v2"
-	configv1 "github.com/openshift/api/config/v1"
 	statusv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -41,13 +39,12 @@ import (
 
 func TestAlertmanagerTrustedCA(t *testing.T) {
 	var (
-		factory = manifests.NewFactory("openshift-monitoring", "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{}, &configv1.Console{})
 		newCM   *v1.ConfigMap
 		lastErr error
 	)
 
 	cm := f.MustGetConfigMap(t, "alertmanager-trusted-ca-bundle", f.Ns)
-	newCM, err := factory.HashTrustedCA(cm, "alertmanager")
+	newCM, err := f.ManifestsFactory.HashTrustedCA(cm, "alertmanager")
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "no trusted CA bundle data available"))
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -28,10 +28,12 @@ import (
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	openshiftconfigclientset "github.com/openshift/client-go/config/clientset/versioned"
 	openshiftmonitoringclientset "github.com/openshift/client-go/monitoring/clientset/versioned"
 	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
 	monClient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
@@ -81,6 +83,8 @@ type Framework struct {
 	MonitoringClient             *monClient.MonitoringV1Client
 	MonitoringBetaClient         *monBetaClient.MonitoringV1beta1Client
 	Ns, UserWorkloadMonitoringNs string
+
+	ManifestsFactory *manifests.Factory
 }
 
 // New returns a new cluster monitoring operator end-to-end test framework and
@@ -165,6 +169,16 @@ func New(kubeConfigPath string) (*Framework, cleanUpFunc, error) {
 		kubeConfigPath:            kubeConfigPath,
 		SchedulingClient:          schedulingClient,
 		OpenShiftMonitoringClient: osmclient,
+		ManifestsFactory: manifests.NewFactory(
+			namespaceName,
+			userWorkloadNamespaceName,
+			nil,
+			nil,
+			nil,
+			manifests.NewAssets("../../assets"),
+			&manifests.APIServerConfig{},
+			&configv1.Console{},
+		),
 	}
 
 	cleanUp, err := f.setup()

--- a/test/e2e/prometheusadapter_test.go
+++ b/test/e2e/prometheusadapter_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -335,8 +334,7 @@ func TestPrometheusAdapterCARotation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	factory := manifests.NewFactory(f.Ns, "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{}, &configv1.Console{})
-	adapterSecret, err := factory.PrometheusAdapterSecret(tls, apiAuth)
+	adapterSecret, err := f.ManifestsFactory.PrometheusAdapterSecret(tls, apiAuth)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/thanos_querier_test.go
+++ b/test/e2e/thanos_querier_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -31,7 +29,6 @@ import (
 func TestThanosQuerierTrustedCA(t *testing.T) {
 	ctx := context.Background()
 	var (
-		factory = manifests.NewFactory("openshift-monitoring", "", nil, nil, nil, manifests.NewAssets(assetsPath), &manifests.APIServerConfig{}, &configv1.Console{})
 		newCM   *v1.ConfigMap
 		lastErr error
 	)
@@ -44,7 +41,7 @@ func TestThanosQuerierTrustedCA(t *testing.T) {
 			return false, nil
 		}
 
-		newCM, err = factory.HashTrustedCA(cm, "thanos-querier")
+		newCM, err = f.ManifestsFactory.HashTrustedCA(cm, "thanos-querier")
 		lastErr = errors.Wrap(err, "no trusted CA bundle data available")
 		if err != nil {
 			return false, nil


### PR DESCRIPTION
This change adds an end-to-end test that triggers a rotation of the TLS certificate used by prometheus-k8s pods to authenticate against targets. The rotation is simulated by deleting the existing secret.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
