### PR TITLE
WIP: [DONOTMERGE] jsonnet: Remove service.beta.openshift.io/inject-cabundle from webhook

### DIFF
--- a/assets/admission-webhook/prometheus-rule-validating-webhook.yaml
+++ b/assets/admission-webhook/prometheus-rule-validating-webhook.yaml
@@ -1,8 +1,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -93,9 +93,6 @@ function(params)
           'app.kubernetes.io/component': 'controller',
           'app.kubernetes.io/name': 'prometheus-operator',
         },
-        annotations: {
-          'service.beta.openshift.io/inject-cabundle': 'true',
-        },
       },
       webhooks: [
         {


### PR DESCRIPTION
This PR is to test if we needed `service.beta.openshift.io/inject-cabundle` on webhook

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
