### PR TITLE
OCPBUGS-5089: pkg/client: Fix nodeReadyCount filter

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -949,7 +949,8 @@ func (c *Client) WaitForDaemonSetRollout(ds *appsv1.DaemonSet) error {
 		}
 
 		var nodeReadyCount int32
-		nodeList, err := c.kclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodeList, err := c.kclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+			LabelSelector: fields.SelectorFromSet(ds.Spec.Template.Spec.NodeSelector).String()})
 		for _, node := range nodeList.Items {
 			for _, condition := range node.Status.Conditions {
 				if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {


### PR DESCRIPTION
Fixes #OCPBUGS-5089

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
