### PR TITLE
OCPBUGS-5153: Sets query.sd-dns-resolver=miekgdns for thanos-querier and thanos-ruler

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -61,6 +61,7 @@ spec:
         - --grpc-client-server-name=prometheus-grpc
         - --rule=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local
         - --target=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local
+        - --query.sd-dns-resolver=miekgdns
         env:
         - name: HOST_IP_ADDRESS
           valueFrom:

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -20,7 +20,9 @@ spec:
     key: alertmanagers.yaml
     name: thanos-ruler-alertmanagers-config
   containers:
-  - name: thanos-ruler
+  - args:
+    - --query.sd-dns-resolver=miekgdns
+    name: thanos-ruler
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -356,6 +356,10 @@ function(params)
                   '--grpc-client-server-name=prometheus-grpc',
                   '--rule=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local',
                   '--target=dnssrv+_grpc._tcp.prometheus-operated.openshift-monitoring.svc.cluster.local',
+                  // The native Go resolver fails to parse compressed responses for SRV records.
+                  // The miekgdns resolver doesn't suffer the same issue hence defaulting to it instead.
+                  // See https://bugzilla.redhat.com/show_bug.cgi?id=1953518
+                  '--query.sd-dns-resolver=miekgdns',
                 ],
                 resources: {
                   requests: {

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -385,6 +385,12 @@ function(params)
             // Note: this is performing strategic-merge-patch for thanos-ruler container.
             // Remainder of the container configuration is managed by prometheus-operator based on $.thanosRuler.spec
             name: tr.config.name,
+            args: [
+              // The native Go resolver fails to parse compressed responses for SRV records.
+              // The miekgdns resolver doesn't suffer the same issue hence defaulting to it instead.
+              // See https://bugzilla.redhat.com/show_bug.cgi?id=1953518
+              '--query.sd-dns-resolver=miekgdns',
+            ],
             terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCPBUGS-5153

Problem: a downstream commit was made to make this the default because of https://bugzilla.redhat.com/show_bug.cgi?id=1953518. However, this commit conflicts when updating the downstream repo.

Solution: migrate default to jsonnet

Signed-off-by: JoaoBraveCoding <jmarcal@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
