### PR TITLE
OCPBUGS-5864: grafana: add the Content-Security-Policy header to requests

### DIFF
--- a/assets/grafana/config.yaml
+++ b/assets/grafana/config.yaml
@@ -31,6 +31,7 @@ stringData:
     provisioning = /etc/grafana/provisioning
     [security]
     admin_user = WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000
+    content_security_policy = true
     cookie_secure = true
     [server]
     http_addr = 127.0.0.1

--- a/assets/grafana/deployment.yaml
+++ b/assets/grafana/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/grafana-config: 3d7da91f60439323422be78538e56505
+        checksum/grafana-config: a0bc2c5ab9c1e6b9f2db8a2fc575cce7
         checksum/grafana-dashboardproviders: 9ac0e8fe144a3a59f7ab62b4e733f22d
         checksum/grafana-datasources: 58dfbb3df9951f2ac8acf4c625c7173c
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -186,6 +186,7 @@ local inCluster =
               // identity that has superuser permissions in Grafana.
               admin_user: 'WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000',
               cookie_secure: true,
+              content_security_policy: true,
             },
             auth: {
               disable_login_form: true,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
