### PR TITLE
OCPBUGS-5353: unstack dashboards with limit markers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1830](https://github.com/openshift/cluster-monitoring-operator/pull/1830) Add alert KubePodNotScheduled
 - [#1843](https://github.com/openshift/cluster-monitoring-operator/pull/1843) Node Exporter ignores network interface under name "enP.*".
 - [#1860](https://github.com/openshift/cluster-monitoring-operator/pull/1860) Adds runbook for PrometheusRuleFailures
+- [#1868](https://github.com/openshift/cluster-monitoring-operator/pull/1868) In dashboards unstack diagrams with limit/quota/request.
 
 
 ## 4.12

--- a/jsonnet/components/dashboards.libsonnet
+++ b/jsonnet/components/dashboards.libsonnet
@@ -11,7 +11,72 @@ function(params)
     'grafana-dashboard-k8s-resources-workload',
   ];
 
+  // index by: data[key] - row.title - panel.title
+  local dashboardsToUnstack = {
+    'k8s-resources-pod.json': {
+      'CPU Usage': ['CPU Usage'],
+      'Memory Usage': ['Memory Usage (WSS)'],
+    },
+    'k8s-resources-namespace.json': {
+      'CPU Usage': ['CPU Usage'],
+      'Memory Usage': ['Memory Usage (w/o cache)'],
+    },
+    'k8s-resources-node.json': {
+      'CPU Usage': ['CPU Usage'],
+      'Memory Usage': ['Memory Usage (w/o cache)'],
+    },
+    'k8s-resources-workload.json': {
+      'CPU Usage': ['CPU Usage'],
+      'Memory Usage': ['Memory Usage'],
+    },
+    'k8s-resources-workloads-namespace.json': {
+      'CPU Usage': ['CPU Usage'],
+      'Memory Usage': ['Memory Usage'],
+    },
+  };
+  local shouldUnstack = function(filename, rowTitle, panelTitle)
+    if std.objectHas(dashboardsToUnstack, filename) then
+      local rowDict = dashboardsToUnstack[filename];
+      if std.objectHas(rowDict, rowTitle) then
+        local panelList = rowDict[rowTitle];
+        if std.member(panelList, panelTitle) then
+          true
+        else
+          false
+      else
+        false
+    else
+      false
+  ;
+
   local glib = kubernetesGrafana(cfg) {};
+
+  local unstackDashboards = function(dashboards)
+    std.map(
+      function(dashboard)
+        local data = { [k]: std.parseJson(dashboard.data[k]) for k in std.objectFields(dashboard.data) };
+        local updatedDashboard = dashboard {
+          data: {
+            [k]: data[k] {
+              rows: std.map(function(row)
+                row {
+                  panels: std.map(function(panel)
+                    if shouldUnstack(k, row.title, panel.title) then
+                      panel {
+                        stack: false,
+                      }
+                    else
+                      panel, row.panels),
+                }, data[k].rows),
+            }
+            for k in std.objectFields(data)
+          },
+        };
+        updatedDashboard {
+          data: { [k]: std.manifestJsonEx(updatedDashboard.data[k], '    ') for k in std.objectFields(updatedDashboard.data) },
+        },
+      dashboards
+    );
 
   {
     consoleDashboardDefinitions: {
@@ -32,7 +97,11 @@ function(params)
               } else {},
             },
           },
-        glib.dashboardDefinitions.items,
+        // Openshift Console cannot show chart with both stacked and unstacked metrics,
+        // so charts with metrics such as request/quota/limit show all metrics in
+        // an unstacked way to avoid confusion.
+        // please refer to: https://issues.redhat.com/browse/OCPBUGS-5353
+        unstackDashboards(glib.dashboardDefinitions.items),
       ),
     },
   }

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -5393,7 +5393,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -5807,7 +5807,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -7812,7 +7812,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -8207,7 +8207,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -8837,7 +8837,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -9357,7 +9357,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -10783,7 +10783,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -11160,7 +11160,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -12821,7 +12821,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {
@@ -13282,7 +13282,7 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": true,
+                        "stack": false,
                         "steppedLine": false,
                         "targets": [
                             {


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

Dashboards showing CPU / memory usage used to stack the limit markers such as limit/request/quota over other metrics create confusion for users reading the diagrams. So we unstack all metrics in the charts containing these limit markers. 

This is the result of unstacking metrics:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/6040960/213411884-17f9af32-eede-49d3-816a-7d504b82085e.png">

This is what it looks like when stacking metrics:
<img width="730" alt="image" src="https://user-images.githubusercontent.com/6040960/213416609-15e5ff0a-4260-439b-8dd7-181513e09007.png">

