### PR TITLE
OCPBUGS-2729: unify ignored network device list of Node Exporter.

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -36,11 +36,11 @@ spec:
         - --path.udev.data=/host/root/run/udev/data
         - --no-collector.wifi
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15}|enP.*)$
+        - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*)$
+        - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*)$
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
         - --no-collector.cpufreq
-        - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|tun[0-9]*|br[0-9]*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext)$
         image: quay.io/prometheus/node-exporter:v1.5.0
         name: node-exporter
         resources:

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -147,7 +147,7 @@ function(params)
                       // gather that data (especially for bare metal clusters), and
                       // add flags to collect the node_cpu_info metric + metrics
                       // from the text file.
-                      args: [a for a in c.args if (a != '--no-collector.hwmon') && !std.startsWith(a, '--collector.netclass.ignored-devices')] +
+                      args: [a for a in c.args if (a != '--no-collector.hwmon')] +
                             [
                               '--collector.cpu.info',
                               '--collector.textfile.directory=' + textfileDir,
@@ -159,9 +159,6 @@ function(params)
                               // https://bugzilla.redhat.com/show_bug.cgi?id=1972076
                               // https://github.com/prometheus/node_exporter/issues/1880
                               '--no-collector.cpufreq',
-                              // ignore OVNK network interfaces, too.
-                              // https://issues.redhat.com/browse/OCPBUGS-1321
-                              '--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|tun[0-9]*|br[0-9]*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext)$',
                             ],
                       terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts+: [{

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -182,12 +182,19 @@ local inCluster =
             fsMountpointSelector: 'mountpoint!~"/var/lib/ibmc-s3fs.*"',
           },
         },
-        // NOTE: 3 patterns for virutal NICs will be ignored:
+        // NOTE:
+        // "ignoredNetworkDevices" sets the 2 arguments "--collector.netclass.ignored-devices" and "--collector.netdev.device-exclude".
+        // 5 kinds of virtual NICs will be ignored:
         // 1. veth network interface associated with containers.
         // 2. OVN renames veth.* to <rand-hex>@if<X> where X is /sys/class/net/<if>/ifindex
         // thus [a-z0-9]{15}}
         // 3. enP.* virtual NICs on Azure cluster.
-        ignoredNetworkDevices:: '^(veth.*|[a-f0-9]{15}|enP.*)$',
+        // 4. OVN virtual interfaces ovn-k8s-mp[0-9]*
+        // 5. virtual tunnels and bridges: tun[0-9]*|br[0-9]*|br-ex|br-int|br-ext
+        // Refer to:
+        // https://issues.redhat.com/browse/OCPBUGS-1321
+        // https://issues.redhat.com/browse/OCPBUGS-2729
+        ignoredNetworkDevices:: '^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*)$',
       },
       openshiftStateMetrics: {
         namespace: $.values.common.namespace,


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR corrects a bug that in Node Exporter the list of ignored network devices for netdev collector and netclass collector is not the same. 
It complete the bugfixs for  [OCPBUGS-2729](https://issues.redhat.com/browse/OCPBUGS-2729) and [OCPBUGS-1321](https://issues.redhat.com/browse/OCPBUGS-1321).