### PR TITLE
Fix 'make run-local' target

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -199,7 +199,7 @@ func Main() int {
 
 	wg.Go(func() error { return o.Run(ctx) })
 
-	srv, err := metrics.NewServer("cluster-monitoring-operator", config, *certFile, *keyFile)
+	srv, err := metrics.NewServer("cluster-monitoring-operator", config, *kubeconfigPath, *certFile, *keyFile)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
 		return 1


### PR DESCRIPTION
When running CMO locally, the KUBECONFIG file needs to be provided to the HTTP metrics server otherwise the initialization fails.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
