### PR TITLE
OCPBUGS-4069: Prometheus Adatper takes metrics from "kubelet" job only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#1843](https://github.com/openshift/cluster-monitoring-operator/pull/1843) Node Exporter ignores network interface under name "enP.*".
 - [#1860](https://github.com/openshift/cluster-monitoring-operator/pull/1860) Adds runbook for PrometheusRuleFailures
 - [#1868](https://github.com/openshift/cluster-monitoring-operator/pull/1868) In dashboards unstack diagrams with limit/quota/request.
+- [#1875](https://github.com/openshift/cluster-monitoring-operator/pull/1875) Prometheus Adatper takes metrics from "kubelet" job only.
 
 
 ## 4.12

--- a/assets/prometheus-adapter/config-map.yaml
+++ b/assets/prometheus-adapter/config-map.yaml
@@ -7,7 +7,7 @@ data:
         "containerQuery": |
           sum by (<<.GroupBy>>) (
             irate (
-                container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[4m]
+                container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!="",job="kubelet"}[4m]
             )
           )
         "nodeQuery": |
@@ -36,7 +36,7 @@ data:
         "containerLabel": "container"
         "containerQuery": |
           sum by (<<.GroupBy>>) (
-            container_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!=""}
+            container_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!="",job="kubelet"}
           )
         "nodeQuery": |
           sum by (<<.GroupBy>>) (


### PR DESCRIPTION


* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
