### PR TITLE
[MON-2902] Add nodeExporter.collectors.tcpstat settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1868](https://github.com/openshift/cluster-monitoring-operator/pull/1868) In dashboards unstack diagrams with limit/quota/request.
 - [#1855](https://github.com/openshift/cluster-monitoring-operator/pull/1855) Add nodeExporter.collectors.cpufreq settings.
 - [#1882](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (platform)
+- [#1876](https://github.com/openshift/cluster-monitoring-operator/pull/1876) Add nodeExporter.collectors.tcpstat settings.
 
 
 ## 4.12

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -27,6 +27,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [KubeStateMetricsConfig](#kubestatemetricsconfig)
 * [NodeExporterCollectorConfig](#nodeexportercollectorconfig)
 * [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig)
+* [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig)
 * [NodeExporterConfig](#nodeexporterconfig)
 * [OpenShiftStateMetricsConfig](#openshiftstatemetricsconfig)
 * [PrometheusK8sConfig](#prometheusk8sconfig)
@@ -188,6 +189,7 @@ The `NodeExporterCollectorConfig` resource defines settings for individual colle
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | cpufreq | [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig) | Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics. Disabled by default. |
+| tcpstat | [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig) | Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default. |
 
 [Back to TOC](#table-of-contents)
 
@@ -202,7 +204,22 @@ The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for 
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| enabled | bool | A Boolean flag that enables or disables the `cpufreq` colletor. |
+| enabled | bool | A Boolean flag that enables or disables the `cpufreq` collector. |
+
+[Back to TOC](#table-of-contents)
+
+## NodeExporterCollectorTcpStatConfig
+
+#### Description
+
+The `NodeExporterCollectorTcpStatConfig` resource works as an on/off switch for the `tcpstat` collector of the `node-exporter` agent. By default, the `tcpstat` collector is disabled.
+
+
+<em>appears in: [NodeExporterCollectorConfig](#nodeexportercollectorconfig)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| enabled | bool | A Boolean flag that enables or disables the `tcpstat` collector. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -47,6 +47,7 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/kubestatemetricsconfig.adoc[KubeStateMetricsConfig]
 * link:modules/nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
 * link:modules/nodeexportercollectorcpufreqconfig.adoc[NodeExporterCollectorCpufreqConfig]
+* link:modules/nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]
 * link:modules/nodeexporterconfig.adoc[NodeExporterConfig]
 * link:modules/openshiftstatemetricsconfig.adoc[OpenShiftStateMetricsConfig]
 * link:modules/prometheusk8sconfig.adoc[PrometheusK8sConfig]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
@@ -20,6 +20,8 @@ Appears in: link:nodeexporterconfig.adoc[NodeExporterConfig]
 | Property | Type | Description 
 |cpufreq|link:nodeexportercollectorcpufreqconfig.adoc[NodeExporterCollectorCpufreqConfig]|Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics. Disabled by default.
 
+|tcpstat|link:nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]|Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorcpufreqconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorcpufreqconfig.adoc
@@ -18,7 +18,7 @@ Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
 [options="header"]
 |===
 | Property | Type | Description 
-|enabled|bool|A Boolean flag that enables or disables the `cpufreq` colletor.
+|enabled|bool|A Boolean flag that enables or disables the `cpufreq` collector.
 
 |===
 

--- a/Documentation/openshiftdocs/modules/nodeexportercollectortcpstatconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectortcpstatconfig.adoc
@@ -1,0 +1,25 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== NodeExporterCollectorTcpStatConfig
+
+=== Description
+
+The `NodeExporterCollectorTcpStatConfig` resource works as an on/off switch for the `tcpstat` collector of the `node-exporter` agent. By default, the `tcpstat` collector is disabled.
+
+
+
+Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|enabled|bool|A Boolean flag that enables or disables the `tcpstat` collector.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -809,6 +809,12 @@ func (f *Factory) updateNodeExporterArgs(args []string) []string {
 	} else {
 		args = setArg(args, "--no-collector.cpufreq", "")
 	}
+
+	if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.TcpStat.Enabled {
+		args = setArg(args, "--collector.tcpstat", "")
+	} else {
+		args = setArg(args, "--no-collector.tcpstat", "")
+	}
 	return args
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2832,10 +2832,12 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 		argsAbsent  []string
 	}{
 		{
-			name:        "default config",
-			config:      "",
-			argsPresent: []string{"--no-collector.cpufreq"},
-			argsAbsent:  []string{"--collector.cpufreq"},
+			name:   "default config",
+			config: "",
+			argsPresent: []string{"--no-collector.cpufreq",
+				"--no-collector.tcpstat"},
+			argsAbsent: []string{"--collector.cpufreq",
+				"--collector.tcpstat"},
 		},
 		{
 			name: "enable cpufreq collector",
@@ -2847,6 +2849,17 @@ nodeExporter:
 `,
 			argsPresent: []string{"--collector.cpufreq"},
 			argsAbsent:  []string{"--no-collector.cpufreq"},
+		},
+		{
+			name: "enable tcpstat collector",
+			config: `
+nodeExporter:
+  collectors:
+    tcpstat:
+      enabled: true
+`,
+			argsPresent: []string{"--collector.tcpstat"},
+			argsAbsent:  []string{"--no-collector.tcpstat"},
 		},
 	}
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -261,6 +261,9 @@ type NodeExporterCollectorConfig struct {
 	// Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics.
 	// Disabled by default.
 	CpuFreq NodeExporterCollectorCpufreqConfig `json:"cpufreq,omitempty"`
+	// Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics.
+	// Disabled by default.
+	TcpStat NodeExporterCollectorTcpStatConfig `json:"tcpstat,omitempty"`
 }
 
 // The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for
@@ -271,7 +274,15 @@ type NodeExporterCollectorConfig struct {
 // Please refer to https://github.com/prometheus/node_exporter/issues/1880 for more details.
 // A related bug: https://bugzilla.redhat.com/show_bug.cgi?id=1972076
 type NodeExporterCollectorCpufreqConfig struct {
-	// A Boolean flag that enables or disables the `cpufreq` colletor.
+	// A Boolean flag that enables or disables the `cpufreq` collector.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// The `NodeExporterCollectorTcpStatConfig` resource works as an on/off switch for
+// the `tcpstat` collector of the `node-exporter` agent.
+// By default, the `tcpstat` collector is disabled.
+type NodeExporterCollectorTcpStatConfig struct {
+	// A Boolean flag that enables or disables the `tcpstat` collector.
 	Enabled bool `json:"enabled,omitempty"`
 }
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR follows https://github.com/openshift/cluster-monitoring-operator/pull/1855
Adding enablement flag for tcpstat collector of Node Exporter. 

https://issues.redhat.com/browse/MON-2902

This PR is the base to https://github.com/openshift/cluster-monitoring-operator/pull/1888