### PR TITLE
MON-2932: jsonnet/dashboards: add role template variable to node related dashbo…

### DIFF
--- a/jsonnet/components/dashboards.libsonnet
+++ b/jsonnet/components/dashboards.libsonnet
@@ -1,4 +1,5 @@
 local kubernetesGrafana = import 'github.com/brancz/kubernetes-grafana/grafana/grafana.libsonnet';
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 
 function(params)
   local cfg = params;
@@ -49,7 +50,12 @@ function(params)
       false
   ;
 
-  local glib = kubernetesGrafana(cfg) {};
+  local nodeDashboards = [
+    'k8s-resources-node.json',
+    'node-rsrc-use.json',
+  ];
+
+  local glib = kubernetesGrafana(cfg);
 
   local unstackDashboards = function(dashboards)
     std.map(
@@ -69,6 +75,62 @@ function(params)
                       panel, row.panels),
                 }, data[k].rows),
             }
+            for k in std.objectFields(data)
+          },
+        };
+        updatedDashboard {
+          data: { [k]: std.manifestJsonEx(updatedDashboard.data[k], '    ') for k in std.objectFields(updatedDashboard.data) },
+        },
+      dashboards
+    );
+
+  local addRoleTemplate = function(templateList)
+    local template = grafana.template;
+    std.flattenArrays([
+      if std.member(['node', 'instance'], t.name) then
+        [
+          template.new(
+            name='role',
+            datasource='$datasource',
+            query='label_values(kube_node_role{%(clusterLabel)s="$cluster"}, role)' % glib._config,
+            allValues='.+',
+            current='all',
+            hide='',
+            refresh=2,
+            includeAll=true,
+            sort=1
+          ),
+          template.new(
+            name=t.name,
+            datasource='$datasource',
+            query='label_values(kube_node_info{%(clusterLabel)s="$cluster"} * on (node) group_right kube_node_role{%(clusterLabel)s="$cluster", role=~"$role"}, node)' % glib._config,
+            current='',
+            hide='',
+            refresh=2,
+            includeAll=false,
+            multi=true,
+            sort=1
+          ),
+        ]
+      else
+        [t]
+      for t in templateList
+    ]);
+
+  local nodeRoleTemplate = function(dashboards)
+    std.map(
+      function(dashboard)
+        local data = { [k]: std.parseJson(dashboard.data[k]) for k in std.objectFields(dashboard.data) };
+        local updatedDashboard = dashboard {
+          data: {
+            [k]: if std.member(nodeDashboards, k) then
+              data[k] {
+                templating: {
+                  list: addRoleTemplate(data[k].templating.list),
+                },
+              }
+            else
+              data[k]
             for k in std.objectFields(data)
           },
         };
@@ -101,7 +163,7 @@ function(params)
         // so charts with metrics such as request/quota/limit show all metrics in
         // an unstacked way to avoid confusion.
         // please refer to: https://issues.redhat.com/browse/OCPBUGS-5353
-        unstackDashboards(glib.dashboardDefinitions.items),
+        nodeRoleTemplate(unstackDashboards(glib.dashboardDefinitions.items)),
       ),
     },
   }

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -79,6 +79,10 @@ local commonConfig = {
   // TLS Cipher suite applied to every component serving HTTPS traffic
   tlsCipherSuites: 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
   prometheusAdapterMetricPrefix: 'pa_',
+  // Set label used in dashboards to identify the cluster explicitly so we can
+  // use that value in jsonnet/components/dashboard.libsonnet for our role
+  // template instead of relying on the upstream default never changing.
+  dashboardClusterLabel: 'cluster',
 };
 
 // objects deployed in openshift-monitoring namespace
@@ -159,6 +163,7 @@ local inCluster =
           for k in std.objectFields(allDashboards)
           if std.setMember(k, includeDashboards)
         },
+        clusterLabel: $.values.common.dashboardClusterLabel,
       },
       kubeStateMetrics: {
         namespace: $.values.common.namespace,
@@ -180,6 +185,7 @@ local inCluster =
             diskDeviceSelector: 'device=~"mmcblk.p.+|nvme.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"',
             rateInterval: '1m',  // adjust the rate interval value to be 4 x the node_exporter's scrape interval (15s).
             fsMountpointSelector: 'mountpoint!~"/var/lib/ibmc-s3fs.*"',
+            clusterLabel: $.values.common.dashboardClusterLabel,
           },
         },
         // NOTE:
@@ -335,6 +341,7 @@ local inCluster =
             kubeletPodLimit: 250,
             pvExcludedSelector: 'label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"',
             containerfsSelector: 'id!=""',
+            clusterLabel: $.values.common.dashboardClusterLabel,
           },
         },
         prometheusAdapterMetricPrefix: $.values.common.prometheusAdapterMetricPrefix,

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -8687,6 +8687,33 @@ data:
                     "useTags": false
                 },
                 {
+                    "allValue": ".+",
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": false,
+                    "name": "role",
+                    "options": [
+
+                    ],
+                    "query": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 1,
+                    "tagValuesQuery": "",
+                    "tags": [
+
+                    ],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
                     "allValue": null,
                     "current": {
                         "text": "",
@@ -8701,7 +8728,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(kube_node_info{cluster=\"$cluster\"}, node)",
+                    "query": "label_values(kube_node_info{cluster=\"$cluster\"} * on (node) group_right kube_node_role{cluster=\"$cluster\", role=~\"$role\"}, node)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,
@@ -18443,20 +18470,48 @@ data:
                     "useTags": false
                 },
                 {
+                    "allValue": ".+",
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": false,
+                    "name": "role",
+                    "options": [
+
+                    ],
+                    "query": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 1,
+                    "tagValuesQuery": "",
+                    "tags": [
+
+                    ],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
                     "allValue": null,
                     "current": {
-
+                        "text": "",
+                        "value": ""
                     },
                     "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
                     "label": null,
-                    "multi": false,
+                    "multi": true,
                     "name": "instance",
                     "options": [
 
                     ],
-                    "query": "label_values(node_exporter_build_info{job=\"node-exporter\", cluster=\"$cluster\"}, instance)",
+                    "query": "label_values(kube_node_info{cluster=\"$cluster\"} * on (node) group_right kube_node_role{cluster=\"$cluster\", role=~\"$role\"}, node)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,


### PR DESCRIPTION
…ards

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

This adds a new `role` template variable to the two node related dashboards. This feature allows for node role based filtering of the `node` and `instance` template variables.
I proposed this feature upstream first, but since not all k8s distributions assign node roles by default this was rejected.

For the node-rsrc-use dashboard we switch to the same template variable queries as in the k8s-resources-node dashboard (i.e. use `kube_node_info` instead of `node_exporter_build_info`. The label values that matter are the same and this avoids more jsonnet complexity, since we'd otherwise have to rewrite label names in order to match `instance` and `node` label values.

![2023-02-07-101231_1172x585](https://user-images.githubusercontent.com/458501/217203779-a343ce3b-0adc-469b-8adb-cfef38b14fe5.png)
![2023-02-07-101159_1057x605](https://user-images.githubusercontent.com/458501/217203786-71e3e7a4-c25d-4c99-a217-b967f98cb3d4.png)


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
