### PR TITLE
MON-2959: Allow configuring secrets in alertmanager (platform)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1860](https://github.com/openshift/cluster-monitoring-operator/pull/1860) Adds runbook for PrometheusRuleFailures
 - [#1868](https://github.com/openshift/cluster-monitoring-operator/pull/1868) In dashboards unstack diagrams with limit/quota/request.
 - [#1855](https://github.com/openshift/cluster-monitoring-operator/pull/1855) Add nodeExporter.collectors.cpufreq settings.
+- [#1882](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (platform)
 
 
 ## 4.12

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -78,6 +78,7 @@ The `AlertmanagerMainConfig` resource defines settings for the Alertmanager comp
 | logLevel | string | Defines the log level setting for Alertmanager. The possible values are: `error`, `warn`, `info`, `debug`. The default value is `info`. |
 | nodeSelector | map[string]string | Defines the nodes on which the Pods are scheduled. |
 | resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core) | Defines resource requests and limits for the Alertmanager container. |
+| secrets | []string | Defines a list of secrets that need to be mounted into the Alertmanager. The secrets must reside within the same namespace as the Alertmanager object. They will be added as volumes named secret-<secret-name> and mounted at /etc/alertmanager/secrets/<secret-name> within the 'alertmanager' container of the Alertmanager Pods. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core) | Defines tolerations for the pods. |
 | topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 | volumeClaimTemplate | *[monv1.EmbeddedPersistentVolumeClaim](https://github.com/prometheus-operator/prometheus-operator/blob/v0.62.0/Documentation/api.md#embeddedpersistentvolumeclaim) | Defines persistent storage for Alertmanager. Use this setting to configure the persistent volume claim, including storage class, volume size, and name. |

--- a/Documentation/openshiftdocs/modules/alertmanagermainconfig.adoc
+++ b/Documentation/openshiftdocs/modules/alertmanagermainconfig.adoc
@@ -28,6 +28,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the Alertmanager container.
 
+|secrets|[]string|Defines a list of secrets that need to be mounted into the Alertmanager. The secrets must reside within the same namespace as the Alertmanager object. They will be added as volumes named secret-<secret-name> and mounted at /etc/alertmanager/secrets/<secret-name> within the 'alertmanager' container of the Alertmanager Pods.
+
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
 |topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1235,6 +1235,16 @@ func (c *Client) WaitForSecret(ctx context.Context, s *v1.Secret) (*v1.Secret, e
 	return result, nil
 }
 
+func (c *Client) WaitForSecretByNsName(ctx context.Context, obj types.NamespacedName) (*v1.Secret, error) {
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      obj.Name,
+			Namespace: obj.Namespace,
+		},
+	}
+	return c.WaitForSecret(ctx, &secret)
+}
+
 func (c *Client) WaitForRouteReady(ctx context.Context, r *routev1.Route) (string, error) {
 	host := ""
 	var lastErr error

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -582,6 +582,10 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 		a.Spec.Resources = *f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Resources
 	}
 
+	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Secrets != nil {
+		a.Spec.Secrets = append(a.Spec.Secrets, f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Secrets...)
+	}
+
 	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.EnableUserAlertManagerConfig &&
 		!f.config.UserWorkloadConfiguration.Alertmanager.Enabled {
 		a.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -35,6 +35,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/strings/slices"
 )
 
 type fakeInfrastructureReader struct {
@@ -2596,6 +2597,9 @@ func TestAlertmanagerMainConfiguration(t *testing.T) {
     requests:
       cpu: 10m
       memory: 75Mi
+  secrets:
+  - test-secret
+  - slack-api-token
   volumeClaimTemplate:
     spec:
       resources:
@@ -2646,6 +2650,14 @@ ingress:
 	}
 	if memoryRequestPtr.String() != "75Mi" {
 		t.Fatal("Alertmanager memory request is not configured correctly:", memoryRequestPtr.String())
+	}
+
+	if !slices.Contains(a.Spec.Secrets, "test-secret") {
+		t.Fatal("Alertmanager secret `test-secret` is not configured correctly")
+	}
+
+	if !slices.Contains(a.Spec.Secrets, "slack-api-token") {
+		t.Fatal("Alertmanager secret `slack-api-token` is not configured correctly")
 	}
 
 	if a.Spec.NodeSelector["type"] != "worker" {

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -73,6 +73,12 @@ type AlertmanagerMainConfig struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines resource requests and limits for the Alertmanager container.
 	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
+	// Defines a list of secrets that need to be mounted into the Alertmanager.
+	// The secrets must reside within the same namespace as the Alertmanager object.
+	// They will be added as volumes named secret-<secret-name> and mounted at
+	// /etc/alertmanager/secrets/<secret-name> within the 'alertmanager' container of
+	// the Alertmanager Pods.
+	Secrets []string `json:"secrets,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Defines a pod's topology spread constraints.


### PR DESCRIPTION
Related-to #[MON-2798](https://issues.redhat.com//browse/MON-2798)

Signed-off-by: Jayapriya Pai <janantha@redhat.com>

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
