### PR TITLE
[WIP] MON-2901: add nodeExporter.collectors.netdev settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1868](https://github.com/openshift/cluster-monitoring-operator/pull/1868) In dashboards unstack diagrams with limit/quota/request.
 - [#1855](https://github.com/openshift/cluster-monitoring-operator/pull/1855) Add nodeExporter.collectors.cpufreq settings.
 - [#1882](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (platform)
+- [#1876](https://github.com/openshift/cluster-monitoring-operator/pull/1876) Add nodeExporter.collectors.tcpstat settings.
 
 
 ## 4.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1855](https://github.com/openshift/cluster-monitoring-operator/pull/1855) Add nodeExporter.collectors.cpufreq settings.
 - [#1882](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (platform)
 - [#1876](https://github.com/openshift/cluster-monitoring-operator/pull/1876) Add nodeExporter.collectors.tcpstat settings.
+- [#1883](https://github.com/openshift/cluster-monitoring-operator/pull/1883) Add nodeExporter.collectors.netdev settings.
 
 
 ## 4.12

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -27,6 +27,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [KubeStateMetricsConfig](#kubestatemetricsconfig)
 * [NodeExporterCollectorConfig](#nodeexportercollectorconfig)
 * [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig)
+* [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig)
 * [NodeExporterConfig](#nodeexporterconfig)
 * [OpenShiftStateMetricsConfig](#openshiftstatemetricsconfig)
 * [PrometheusK8sConfig](#prometheusk8sconfig)
@@ -188,6 +189,7 @@ The `NodeExporterCollectorConfig` resource defines settings for individual colle
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | cpufreq | [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig) | Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics. Disabled by default. |
+| tcpstat | [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig) | Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default. |
 
 [Back to TOC](#table-of-contents)
 
@@ -203,6 +205,21 @@ The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | enabled | bool | A Boolean flag that enables or disables the `cpufreq` colletor. |
+
+[Back to TOC](#table-of-contents)
+
+## NodeExporterCollectorTcpStatConfig
+
+#### Description
+
+The `NodeExporterCollectorTcpStatConfig` resource works as an on/off switch for the `tcpstat` collector of the `node-exporter` agent. By default, the `tcpstat` collector is disabled.
+
+
+<em>appears in: [NodeExporterCollectorConfig](#nodeexportercollectorconfig)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| enabled | bool | A Boolean flag that enables or disables the `tcpstat` colletor. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -74,7 +74,7 @@ The `AlertmanagerMainConfig` resource defines settings for the Alertmanager comp
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| enabled | *bool | A Boolean flag that enables or disables the main Alertmanager instance in the `openshift-monitoring` namespace. The default value is `true`. |
+| enabled | bool | A Boolean flag that enables or disables the main Alertmanager instance in the `openshift-monitoring` namespace. The default value is `true`. |
 | enableUserAlertmanagerConfig | bool | A Boolean flag that enables or disables user-defined namespaces to be selected for `AlertmanagerConfig` lookups. This setting only applies if the user workload monitoring instance of Alertmanager is not enabled. The default value is `false`. |
 | logLevel | string | Defines the log level setting for Alertmanager. The possible values are: `error`, `warn`, `info`, `debug`. The default value is `info`. |
 | nodeSelector | map[string]string | Defines the nodes on which the Pods are scheduled. |
@@ -115,15 +115,15 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| alertmanagerMain | *[AlertmanagerMainConfig](#alertmanagermainconfig) | `AlertmanagerMainConfig` defines settings for the Alertmanager component in the `openshift-monitoring` namespace. |
-| enableUserWorkload | *bool | `UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects. |
-| k8sPrometheusAdapter | *[K8sPrometheusAdapter](#k8sprometheusadapter) | `K8sPrometheusAdapter` defines settings for the Prometheus Adapter component. |
-| kubeStateMetrics | *[KubeStateMetricsConfig](#kubestatemetricsconfig) | `KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent. |
-| prometheusK8s | *[PrometheusK8sConfig](#prometheusk8sconfig) | `PrometheusK8sConfig` defines settings for the Prometheus component. |
-| prometheusOperator | *[PrometheusOperatorConfig](#prometheusoperatorconfig) | `PrometheusOperatorConfig` defines settings for the Prometheus Operator component. |
-| openshiftStateMetrics | *[OpenShiftStateMetricsConfig](#openshiftstatemetricsconfig) | `OpenShiftMetricsConfig` defines settings for the `openshift-state-metrics` agent. |
-| telemeterClient | *[TelemeterClientConfig](#telemeterclientconfig) | `TelemeterClientConfig` defines settings for the Telemeter Client component. |
-| thanosQuerier | *[ThanosQuerierConfig](#thanosquerierconfig) | `ThanosQuerierConfig` defines settings for the Thanos Querier component. |
+| alertmanagerMain | [AlertmanagerMainConfig](#alertmanagermainconfig) | `AlertmanagerMainConfig` defines settings for the Alertmanager component in the `openshift-monitoring` namespace. |
+| enableUserWorkload | bool | `UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects. |
+| k8sPrometheusAdapter | [K8sPrometheusAdapter](#k8sprometheusadapter) | `K8sPrometheusAdapter` defines settings for the Prometheus Adapter component. |
+| kubeStateMetrics | [KubeStateMetricsConfig](#kubestatemetricsconfig) | `KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent. |
+| prometheusK8s | [PrometheusK8sConfig](#prometheusk8sconfig) | `PrometheusK8sConfig` defines settings for the Prometheus component. |
+| prometheusOperator | [PrometheusOperatorConfig](#prometheusoperatorconfig) | `PrometheusOperatorConfig` defines settings for the Prometheus Operator component. |
+| openshiftStateMetrics | [OpenShiftStateMetricsConfig](#openshiftstatemetricsconfig) | `OpenShiftMetricsConfig` defines settings for the `openshift-state-metrics` agent. |
+| telemeterClient | [TelemeterClientConfig](#telemeterclientconfig) | `TelemeterClientConfig` defines settings for the Telemeter Client component. |
+| thanosQuerier | [ThanosQuerierConfig](#thanosquerierconfig) | `ThanosQuerierConfig` defines settings for the Thanos Querier component. |
 | nodeExporter | [NodeExporterConfig](#nodeexporterconfig) | `NodeExporterConfig` defines settings for the `node-exporter` agent. |
 
 [Back to TOC](#table-of-contents)
@@ -154,10 +154,10 @@ The `K8sPrometheusAdapter` resource defines settings for the Prometheus Adapter 
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| audit | *Audit | Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`. |
+| audit | Audit | Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`. |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core) | Defines tolerations for the pods. |
-| dedicatedServiceMonitors | *[DedicatedServiceMonitors](#dedicatedservicemonitors) | Defines dedicated service monitors. |
+| dedicatedServiceMonitors | [DedicatedServiceMonitors](#dedicatedservicemonitors) | Defines dedicated service monitors. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -27,6 +27,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [KubeStateMetricsConfig](#kubestatemetricsconfig)
 * [NodeExporterCollectorConfig](#nodeexportercollectorconfig)
 * [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig)
+* [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig)
 * [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig)
 * [NodeExporterConfig](#nodeexporterconfig)
 * [OpenShiftStateMetricsConfig](#openshiftstatemetricsconfig)
@@ -190,6 +191,7 @@ The `NodeExporterCollectorConfig` resource defines settings for individual colle
 | -------- | ---- | ----------- |
 | cpufreq | [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig) | Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics. Disabled by default. |
 | tcpstat | [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig) | Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default. |
+| netdev | [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig) | Defines the configuration of the `netdev` collector, which collects TCP connection statistics. Enabled by default. |
 
 [Back to TOC](#table-of-contents)
 
@@ -205,6 +207,21 @@ The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | enabled | bool | A Boolean flag that enables or disables the `cpufreq` colletor. |
+
+[Back to TOC](#table-of-contents)
+
+## NodeExporterCollectorNetDevConfig
+
+#### Description
+
+The `NodeExporterCollectorNetDevConfig` resource works as an on/off switch for the `netdev` collector of the `node-exporter` agent. By default, the `netdev` collector is enabled.
+
+
+<em>appears in: [NodeExporterCollectorConfig](#nodeexportercollectorconfig)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| enabled | bool | A Boolean flag that enables or disables the `netdev` colletor. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -47,6 +47,7 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/kubestatemetricsconfig.adoc[KubeStateMetricsConfig]
 * link:modules/nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
 * link:modules/nodeexportercollectorcpufreqconfig.adoc[NodeExporterCollectorCpufreqConfig]
+* link:modules/nodeexportercollectornetdevconfig.adoc[NodeExporterCollectorNetDevConfig]
 * link:modules/nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]
 * link:modules/nodeexporterconfig.adoc[NodeExporterConfig]
 * link:modules/openshiftstatemetricsconfig.adoc[OpenShiftStateMetricsConfig]

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -47,6 +47,7 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/kubestatemetricsconfig.adoc[KubeStateMetricsConfig]
 * link:modules/nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
 * link:modules/nodeexportercollectorcpufreqconfig.adoc[NodeExporterCollectorCpufreqConfig]
+* link:modules/nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]
 * link:modules/nodeexporterconfig.adoc[NodeExporterConfig]
 * link:modules/openshiftstatemetricsconfig.adoc[OpenShiftStateMetricsConfig]
 * link:modules/prometheusk8sconfig.adoc[PrometheusK8sConfig]

--- a/Documentation/openshiftdocs/modules/alertmanagermainconfig.adoc
+++ b/Documentation/openshiftdocs/modules/alertmanagermainconfig.adoc
@@ -18,7 +18,7 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 [options="header"]
 |===
 | Property | Type | Description 
-|enabled|*bool|A Boolean flag that enables or disables the main Alertmanager instance in the `openshift-monitoring` namespace. The default value is `true`.
+|enabled|bool|A Boolean flag that enables or disables the main Alertmanager instance in the `openshift-monitoring` namespace. The default value is `true`.
 
 |enableUserAlertmanagerConfig|bool|A Boolean flag that enables or disables user-defined namespaces to be selected for `AlertmanagerConfig` lookups. This setting only applies if the user workload monitoring instance of Alertmanager is not enabled. The default value is `false`.
 

--- a/Documentation/openshiftdocs/modules/clustermonitoringconfiguration.adoc
+++ b/Documentation/openshiftdocs/modules/clustermonitoringconfiguration.adoc
@@ -15,23 +15,23 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 [options="header"]
 |===
 | Property | Type | Description 
-|alertmanagerMain|*link:alertmanagermainconfig.adoc[AlertmanagerMainConfig]|`AlertmanagerMainConfig` defines settings for the Alertmanager component in the `openshift-monitoring` namespace.
+|alertmanagerMain|link:alertmanagermainconfig.adoc[AlertmanagerMainConfig]|`AlertmanagerMainConfig` defines settings for the Alertmanager component in the `openshift-monitoring` namespace.
 
-|enableUserWorkload|*bool|`UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects.
+|enableUserWorkload|bool|`UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects.
 
-|k8sPrometheusAdapter|*link:k8sprometheusadapter.adoc[K8sPrometheusAdapter]|`K8sPrometheusAdapter` defines settings for the Prometheus Adapter component.
+|k8sPrometheusAdapter|link:k8sprometheusadapter.adoc[K8sPrometheusAdapter]|`K8sPrometheusAdapter` defines settings for the Prometheus Adapter component.
 
-|kubeStateMetrics|*link:kubestatemetricsconfig.adoc[KubeStateMetricsConfig]|`KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent.
+|kubeStateMetrics|link:kubestatemetricsconfig.adoc[KubeStateMetricsConfig]|`KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent.
 
-|prometheusK8s|*link:prometheusk8sconfig.adoc[PrometheusK8sConfig]|`PrometheusK8sConfig` defines settings for the Prometheus component.
+|prometheusK8s|link:prometheusk8sconfig.adoc[PrometheusK8sConfig]|`PrometheusK8sConfig` defines settings for the Prometheus component.
 
-|prometheusOperator|*link:prometheusoperatorconfig.adoc[PrometheusOperatorConfig]|`PrometheusOperatorConfig` defines settings for the Prometheus Operator component.
+|prometheusOperator|link:prometheusoperatorconfig.adoc[PrometheusOperatorConfig]|`PrometheusOperatorConfig` defines settings for the Prometheus Operator component.
 
-|openshiftStateMetrics|*link:openshiftstatemetricsconfig.adoc[OpenShiftStateMetricsConfig]|`OpenShiftMetricsConfig` defines settings for the `openshift-state-metrics` agent.
+|openshiftStateMetrics|link:openshiftstatemetricsconfig.adoc[OpenShiftStateMetricsConfig]|`OpenShiftMetricsConfig` defines settings for the `openshift-state-metrics` agent.
 
-|telemeterClient|*link:telemeterclientconfig.adoc[TelemeterClientConfig]|`TelemeterClientConfig` defines settings for the Telemeter Client component.
+|telemeterClient|link:telemeterclientconfig.adoc[TelemeterClientConfig]|`TelemeterClientConfig` defines settings for the Telemeter Client component.
 
-|thanosQuerier|*link:thanosquerierconfig.adoc[ThanosQuerierConfig]|`ThanosQuerierConfig` defines settings for the Thanos Querier component.
+|thanosQuerier|link:thanosquerierconfig.adoc[ThanosQuerierConfig]|`ThanosQuerierConfig` defines settings for the Thanos Querier component.
 
 |nodeExporter|link:nodeexporterconfig.adoc[NodeExporterConfig]|`NodeExporterConfig` defines settings for the `node-exporter` agent.
 

--- a/Documentation/openshiftdocs/modules/k8sprometheusadapter.adoc
+++ b/Documentation/openshiftdocs/modules/k8sprometheusadapter.adoc
@@ -18,13 +18,13 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 [options="header"]
 |===
 | Property | Type | Description 
-|audit|*Audit|Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`.
+|audit|Audit|Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`.
 
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
-|dedicatedServiceMonitors|*link:dedicatedservicemonitors.adoc[DedicatedServiceMonitors]|Defines dedicated service monitors.
+|dedicatedServiceMonitors|link:dedicatedservicemonitors.adoc[DedicatedServiceMonitors]|Defines dedicated service monitors.
 
 |===
 

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
@@ -20,6 +20,8 @@ Appears in: link:nodeexporterconfig.adoc[NodeExporterConfig]
 | Property | Type | Description 
 |cpufreq|link:nodeexportercollectorcpufreqconfig.adoc[NodeExporterCollectorCpufreqConfig]|Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics. Disabled by default.
 
+|tcpstat|link:nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]|Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
@@ -22,6 +22,8 @@ Appears in: link:nodeexporterconfig.adoc[NodeExporterConfig]
 
 |tcpstat|link:nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]|Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default.
 
+|netdev|link:nodeexportercollectornetdevconfig.adoc[NodeExporterCollectorNetDevConfig]|Defines the configuration of the `netdev` collector, which collects TCP connection statistics. Enabled by default.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectornetdevconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectornetdevconfig.adoc
@@ -1,0 +1,25 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== NodeExporterCollectorNetDevConfig
+
+=== Description
+
+The `NodeExporterCollectorNetDevConfig` resource works as an on/off switch for the `netdev` collector of the `node-exporter` agent. By default, the `netdev` collector is enabled.
+
+
+
+Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|enabled|bool|A Boolean flag that enables or disables the `netdev` colletor.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectortcpstatconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectortcpstatconfig.adoc
@@ -1,0 +1,25 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== NodeExporterCollectorTcpStatConfig
+
+=== Description
+
+The `NodeExporterCollectorTcpStatConfig` resource works as an on/off switch for the `tcpstat` collector of the `node-exporter` agent. By default, the `tcpstat` collector is disabled.
+
+
+
+Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|enabled|bool|A Boolean flag that enables or disables the `tcpstat` colletor.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -197,6 +197,12 @@ func defaultClusterMonitoringConfiguration() *ClusterMonitoringConfiguration {
 	}
 	cmc.K8sPrometheusAdapter.Audit.Profile = auditv1.LevelMetadata
 
+	cmc.NodeExporterConfig = NodeExporterConfig{
+		Collectors: NodeExporterCollectorConfig{
+			NetDev: NodeExporterCollectorNetDevConfig{Enabled: true},
+		},
+	}
+
 	return &cmc
 }
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -816,6 +816,12 @@ func (f *Factory) updateNodeExporterArgs(args []string) []string {
 		args = setArg(args, "--no-collector.tcpstat", "")
 	}
 
+	if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.NetDev.Enabled {
+		args = setArg(args, "--collector.netdev", "")
+	} else {
+		args = setArg(args, "--no-collector.netdev", "")
+	}
+
 	return args
 }
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -815,6 +815,7 @@ func (f *Factory) updateNodeExporterArgs(args []string) []string {
 	} else {
 		args = setArg(args, "--no-collector.tcpstat", "")
 	}
+
 	return args
 }
 
@@ -1732,11 +1733,11 @@ func (f *Factory) PrometheusAdapterDeployment(apiAuthSecretName string, requesth
 	spec.Containers[0].Image = f.config.Images.K8sPrometheusAdapter
 
 	config := f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter
-	if config != nil && len(config.NodeSelector) > 0 {
+	if len(config.NodeSelector) > 0 {
 		spec.NodeSelector = config.NodeSelector
 	}
 
-	if config != nil && len(config.Tolerations) > 0 {
+	if len(config.Tolerations) > 0 {
 		spec.Tolerations = config.Tolerations
 	}
 	dep.Namespace = f.namespace

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -809,6 +809,12 @@ func (f *Factory) updateNodeExporterArgs(args []string) []string {
 	} else {
 		args = setArg(args, "--no-collector.cpufreq", "")
 	}
+
+	if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.TcpStat.Enabled {
+		args = setArg(args, "--collector.tcpstat", "")
+	} else {
+		args = setArg(args, "--no-collector.tcpstat", "")
+	}
 	return args
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2832,10 +2832,12 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 		argsAbsent  []string
 	}{
 		{
-			name:        "default config",
-			config:      "",
-			argsPresent: []string{"--no-collector.cpufreq"},
-			argsAbsent:  []string{"--collector.cpufreq"},
+			name:   "default config",
+			config: "",
+			argsPresent: []string{"--no-collector.cpufreq",
+				"--no-collector.tcpstat"},
+			argsAbsent: []string{"--collector.cpufreq",
+				"--collector.tcpstat"},
 		},
 		{
 			name: "enable cpufreq collector",
@@ -2847,6 +2849,17 @@ nodeExporter:
 `,
 			argsPresent: []string{"--collector.cpufreq"},
 			argsAbsent:  []string{"--no-collector.cpufreq"},
+		},
+		{
+			name: "enable tcpstat collector",
+			config: `
+nodeExporter:
+  collectors:
+    tcpstat:
+      enabled: true
+`,
+			argsPresent: []string{"--collector.tcpstat"},
+			argsAbsent:  []string{"--no-collector.tcpstat"},
 		},
 	}
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2836,9 +2836,11 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 			config: "",
 			argsPresent: []string{"--no-collector.cpufreq",
 				"--no-collector.tcpstat",
+				"--collector.netdev",
 			},
 			argsAbsent: []string{"--collector.cpufreq",
 				"--collector.tcpstat",
+				"--no-collector.netdev",
 			},
 		},
 		{
@@ -2862,6 +2864,17 @@ nodeExporter:
 `,
 			argsPresent: []string{"--collector.tcpstat"},
 			argsAbsent:  []string{"--no-collector.tcpstat"},
+		},
+		{
+			name: "disable netdev collector",
+			config: `
+nodeExporter:
+  collectors:
+    netdev:
+      enabled: false
+`,
+			argsPresent: []string{"--no-collector.netdev"},
+			argsAbsent:  []string{"--collector.netdev"},
 		},
 	}
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2835,9 +2835,11 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 			name:   "default config",
 			config: "",
 			argsPresent: []string{"--no-collector.cpufreq",
-				"--no-collector.tcpstat"},
+				"--no-collector.tcpstat",
+			},
 			argsAbsent: []string{"--collector.cpufreq",
-				"--collector.tcpstat"},
+				"--collector.tcpstat",
+			},
 		},
 		{
 			name: "enable cpufreq collector",

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -264,6 +264,9 @@ type NodeExporterCollectorConfig struct {
 	// Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics.
 	// Disabled by default.
 	TcpStat NodeExporterCollectorTcpStatConfig `json:"tcpstat,omitempty"`
+	// Defines the configuration of the `netdev` collector, which collects TCP connection statistics.
+	// Enabled by default.
+	NetDev NodeExporterCollectorNetDevConfig `json:"netdev,omitempty"`
 }
 
 // The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for
@@ -283,6 +286,14 @@ type NodeExporterCollectorCpufreqConfig struct {
 // By default, the `tcpstat` collector is disabled.
 type NodeExporterCollectorTcpStatConfig struct {
 	// A Boolean flag that enables or disables the `tcpstat` colletor.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// The `NodeExporterCollectorNetDevConfig` resource works as an on/off switch for
+// the `netdev` collector of the `node-exporter` agent.
+// By default, the `netdev` collector is enabled.
+type NodeExporterCollectorNetDevConfig struct {
+	// A Boolean flag that enables or disables the `netdev` colletor.
 	Enabled bool `json:"enabled,omitempty"`
 }
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -261,6 +261,9 @@ type NodeExporterCollectorConfig struct {
 	// Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics.
 	// Disabled by default.
 	CpuFreq NodeExporterCollectorCpufreqConfig `json:"cpufreq,omitempty"`
+	// Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics.
+	// Disabled by default.
+	TcpStat NodeExporterCollectorTcpStatConfig `json:"tcpstat,omitempty"`
 }
 
 // The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for
@@ -272,6 +275,14 @@ type NodeExporterCollectorConfig struct {
 // A related bug: https://bugzilla.redhat.com/show_bug.cgi?id=1972076
 type NodeExporterCollectorCpufreqConfig struct {
 	// A Boolean flag that enables or disables the `cpufreq` colletor.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// The `NodeExporterCollectorTcpStatConfig` resource works as an on/off switch for
+// the `tcpstat` collector of the `node-exporter` agent.
+// By default, the `tcpstat` collector is disabled.
+type NodeExporterCollectorTcpStatConfig struct {
+	// A Boolean flag that enables or disables the `tcpstat` colletor.
 	Enabled bool `json:"enabled,omitempty"`
 }
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -26,28 +26,28 @@ import (
 type ClusterMonitoringConfiguration struct {
 	// `AlertmanagerMainConfig` defines settings for the
 	// Alertmanager component in the `openshift-monitoring` namespace.
-	AlertmanagerMainConfig *AlertmanagerMainConfig `json:"alertmanagerMain,omitempty"`
+	AlertmanagerMainConfig AlertmanagerMainConfig `json:"alertmanagerMain,omitempty"`
 	// OmitFromDoc
-	EtcdConfig *EtcdConfig `json:"-"`
+	EtcdConfig EtcdConfig `json:"-"`
 	// `UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects.
-	UserWorkloadEnabled *bool `json:"enableUserWorkload,omitempty"`
+	UserWorkloadEnabled bool `json:"enableUserWorkload,omitempty"`
 	// OmitFromDoc
-	HTTPConfig *HTTPConfig `json:"http,omitempty"`
+	HTTPConfig HTTPConfig `json:"http,omitempty"`
 	// `K8sPrometheusAdapter` defines settings for the Prometheus Adapter component.
-	K8sPrometheusAdapter *K8sPrometheusAdapter `json:"k8sPrometheusAdapter,omitempty"`
+	K8sPrometheusAdapter K8sPrometheusAdapter `json:"k8sPrometheusAdapter,omitempty"`
 	// `KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent.
-	KubeStateMetricsConfig *KubeStateMetricsConfig `json:"kubeStateMetrics,omitempty"`
+	KubeStateMetricsConfig KubeStateMetricsConfig `json:"kubeStateMetrics,omitempty"`
 	// `PrometheusK8sConfig` defines settings for the Prometheus component.
-	PrometheusK8sConfig *PrometheusK8sConfig `json:"prometheusK8s,omitempty"`
+	PrometheusK8sConfig PrometheusK8sConfig `json:"prometheusK8s,omitempty"`
 	// `PrometheusOperatorConfig` defines settings for the Prometheus Operator component.
-	PrometheusOperatorConfig *PrometheusOperatorConfig `json:"prometheusOperator,omitempty"`
+	PrometheusOperatorConfig PrometheusOperatorConfig `json:"prometheusOperator,omitempty"`
 	// `OpenShiftMetricsConfig` defines settings for the `openshift-state-metrics` agent.
-	OpenShiftMetricsConfig *OpenShiftStateMetricsConfig `json:"openshiftStateMetrics,omitempty"`
+	OpenShiftMetricsConfig OpenShiftStateMetricsConfig `json:"openshiftStateMetrics,omitempty"`
 	// `TelemeterClientConfig` defines settings for the Telemeter Client
 	// component.
-	TelemeterClientConfig *TelemeterClientConfig `json:"telemeterClient,omitempty"`
+	TelemeterClientConfig TelemeterClientConfig `json:"telemeterClient,omitempty"`
 	// `ThanosQuerierConfig` defines settings for the Thanos Querier component.
-	ThanosQuerierConfig *ThanosQuerierConfig `json:"thanosQuerier,omitempty"`
+	ThanosQuerierConfig ThanosQuerierConfig `json:"thanosQuerier,omitempty"`
 	// `NodeExporterConfig` defines settings for the `node-exporter` agent.
 	NodeExporterConfig NodeExporterConfig `json:"nodeExporter,omitempty"`
 }
@@ -58,7 +58,7 @@ type AlertmanagerMainConfig struct {
 	// A Boolean flag that enables or disables the main Alertmanager instance
 	// in the `openshift-monitoring` namespace.
 	// The default value is `true`.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled,omitempty"`
 	// A Boolean flag that enables or disables user-defined namespaces
 	// to be selected for `AlertmanagerConfig` lookups. This setting only
 	// applies if the user workload monitoring instance of Alertmanager
@@ -94,13 +94,13 @@ type K8sPrometheusAdapter struct {
 	// Defines the audit configuration used by the Prometheus Adapter instance.
 	// Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`.
 	// The default value is `metadata`.
-	Audit *Audit `json:"audit,omitempty"`
+	Audit Audit `json:"audit,omitempty"`
 	// Defines the nodes on which the pods are scheduled.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Defines dedicated service monitors.
-	DedicatedServiceMonitors *DedicatedServiceMonitors `json:"dedicatedServiceMonitors,omitempty"`
+	DedicatedServiceMonitors DedicatedServiceMonitors `json:"dedicatedServiceMonitors,omitempty"`
 }
 
 // You can use the `DedicatedServiceMonitors` resource to configure dedicated

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -850,13 +850,13 @@ func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, e
 	// its enabled by admin via Cluster Monitoring ConfigMap.  The above
 	// loadConfig() already initializes the structs with nil values for
 	// UserWorkloadConfiguration struct.
-	if *c.ClusterMonitoringConfiguration.UserWorkloadEnabled {
+	if c.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		c.UserWorkloadConfiguration, err = o.loadUserWorkloadConfig(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
-	o.userWorkloadEnabled = *c.ClusterMonitoringConfiguration.UserWorkloadEnabled
+	o.userWorkloadEnabled = c.ClusterMonitoringConfiguration.UserWorkloadEnabled
 
 	err = c.LoadEnforcedBodySizeLimit(o.client, ctx)
 	if err != nil {
@@ -903,8 +903,7 @@ func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, e
 		certFound && len(certContent) > 0 &&
 		keyFound && len(keyContent) > 0 {
 
-		trueBool := true
-		c.ClusterMonitoringConfiguration.EtcdConfig.Enabled = &trueBool
+		c.ClusterMonitoringConfiguration.EtcdConfig.Enabled = true
 	}
 
 	return c, nil

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -165,12 +165,12 @@ func TestGetProxyReader(t *testing.T) {
 	ctx := context.Background()
 	emptyConfig := &manifests.Config{
 		ClusterMonitoringConfiguration: &manifests.ClusterMonitoringConfiguration{
-			HTTPConfig: &manifests.HTTPConfig{},
+			HTTPConfig: manifests.HTTPConfig{},
 		},
 	}
 	nonEmptyConfig := &manifests.Config{
 		ClusterMonitoringConfiguration: &manifests.ClusterMonitoringConfiguration{
-			HTTPConfig: &manifests.HTTPConfig{
+			HTTPConfig: manifests.HTTPConfig{
 				HTTPProxy: "foo",
 			},
 		},

--- a/pkg/tasks/metrics_client_ca.go
+++ b/pkg/tasks/metrics_client_ca.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ func (t *MetricsClientCATask) reconcileUWMConfigMap(ctx context.Context, apiAuth
 		return err
 	}
 
-	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
+	if t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		return t.client.CreateOrUpdateConfigMap(ctx, cm)
 	}
 

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -38,7 +38,7 @@ func NewPrometheusUserWorkloadTask(client *client.Client, factory *manifests.Fac
 }
 
 func (t *PrometheusUserWorkloadTask) Run(ctx context.Context) error {
-	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
+	if t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		return t.create(ctx)
 	}
 

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -16,6 +16,7 @@ package tasks
 
 import (
 	"context"
+
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 
@@ -37,7 +38,7 @@ func NewPrometheusOperatorUserWorkloadTask(client *client.Client, factory *manif
 }
 
 func (t *PrometheusOperatorUserWorkloadTask) Run(ctx context.Context) error {
-	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
+	if t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		return t.create(ctx)
 	}
 

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -192,7 +192,7 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 
 		dep, err := t.factory.ThanosQuerierDeployment(
 			s,
-			*t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled,
+			t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled,
 			trustedCA,
 		)
 		if err != nil {

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -39,7 +39,7 @@ func NewThanosRulerUserWorkloadTask(client *client.Client, factory *manifests.Fa
 }
 
 func (t *ThanosRulerUserWorkloadTask) Run(ctx context.Context) error {
-	if *t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
+	if t.config.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		return t.create(ctx)
 	}
 


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
