### PR TITLE
MON-2951: create Routes only with ingress operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - [#1888](https://github.com/openshift/cluster-monitoring-operator/pull/1888) Add nodeExporter.collectors.netdev settings.
 - [#1884](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (UWM)
 
-
 ## 4.12
 - [#1624](https://github.com/openshift/cluster-monitoring-operator/pull/1624) Add option to specify TopologySpreadConstraints for Prometheus, Alertmanager, and ThanosRuler.
 - [#1752](https://github.com/openshift/cluster-monitoring-operator/pull/1752) Add option to improve consistency of prometheus-adapter CPU and RAM time series.

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -191,7 +191,7 @@ function(params) {
       {
         apiGroups: ['config.openshift.io'],
         resources: ['clusteroperators', 'clusteroperators/status'],
-        verbs: ['get', 'update', 'create'],
+        verbs: ['get', 'update', 'create', 'list', 'watch'],
       },
       {
         apiGroups: ['config.openshift.io'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -111,6 +111,8 @@ rules:
   - get
   - update
   - create
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -345,6 +345,25 @@ func (c *Client) ConsoleListWatch(ctx context.Context) *cache.ListWatch {
 	}
 }
 
+func (c *Client) ClusterOperatorListWatch(ctx context.Context, name string) *cache.ListWatch {
+	ClusterOperatorInterface := c.oscclient.ConfigV1().ClusterOperators()
+
+	return &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return ClusterOperatorInterface.List(ctx,
+				metav1.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String(),
+				})
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return ClusterOperatorInterface.Watch(ctx,
+				metav1.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String(),
+				})
+		},
+	}
+}
+
 func (c *Client) EnsurePrometheusUserWorkloadConfigMapExists(ctx context.Context, cm *v1.ConfigMap) error {
 	_, err := c.CreateIfNotExistConfigMap(ctx, cm)
 	return errors.Wrapf(err, "creating empty  ConfigMap object fauled")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -364,6 +364,14 @@ func (c *Client) ClusterOperatorListWatch(ctx context.Context, name string) *cac
 	}
 }
 
+func (c *Client) HasRouteCapability(ctx context.Context) (bool, error) {
+	_, err := c.oscclient.ConfigV1().ClusterOperators().Get(ctx, "ingress", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	return true, err
+}
+
 func (c *Client) EnsurePrometheusUserWorkloadConfigMapExists(ctx context.Context, cm *v1.ConfigMap) error {
 	_, err := c.CreateIfNotExistConfigMap(ctx, cm)
 	return errors.Wrapf(err, "creating empty  ConfigMap object fauled")
@@ -513,10 +521,6 @@ func (c *Client) GetProxy(ctx context.Context, name string) (*configv1.Proxy, er
 
 func (c *Client) GetInfrastructure(ctx context.Context, name string) (*configv1.Infrastructure, error) {
 	return c.oscclient.ConfigV1().Infrastructures().Get(ctx, name, metav1.GetOptions{})
-}
-
-func (c *Client) GetClusterOperator(ctx context.Context, name string) (*configv1.ClusterOperator, error) {
-	return c.oscclient.ConfigV1().ClusterOperators().Get(ctx, name, metav1.GetOptions{})
 }
 
 func (c *Client) GetAPIServerConfig(ctx context.Context, name string) (*configv1.APIServer, error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -515,6 +515,10 @@ func (c *Client) GetInfrastructure(ctx context.Context, name string) (*configv1.
 	return c.oscclient.ConfigV1().Infrastructures().Get(ctx, name, metav1.GetOptions{})
 }
 
+func (c *Client) GetClusterOperator(ctx context.Context, name string) (*configv1.ClusterOperator, error) {
+	return c.oscclient.ConfigV1().ClusterOperators().Get(ctx, name, metav1.GetOptions{})
+}
+
 func (c *Client) GetAPIServerConfig(ctx context.Context, name string) (*configv1.APIServer, error) {
 	return c.oscclient.ConfigV1().APIServers().Get(ctx, name, metav1.GetOptions{})
 }

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -50,7 +50,11 @@ func (t *AlertmanagerTask) Run(ctx context.Context) error {
 }
 
 func (t *AlertmanagerTask) create(ctx context.Context) error {
-	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+	hasRoutes, err := t.client.HasRouteCapability(ctx)
+	if err != nil {
+		return errors.Wrap(err, "checking for Route capability failed")
+	}
+	if hasRoutes {
 		r, err := t.factory.AlertmanagerRoute()
 		if err != nil {
 			return errors.Wrap(err, "initializing Alertmanager Route failed")

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -50,19 +50,21 @@ func (t *AlertmanagerTask) Run(ctx context.Context) error {
 }
 
 func (t *AlertmanagerTask) create(ctx context.Context) error {
-	r, err := t.factory.AlertmanagerRoute()
-	if err != nil {
-		return errors.Wrap(err, "initializing Alertmanager Route failed")
-	}
+	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+		r, err := t.factory.AlertmanagerRoute()
+		if err != nil {
+			return errors.Wrap(err, "initializing Alertmanager Route failed")
+		}
 
-	err = t.client.CreateOrUpdateRoute(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Alertmanager Route failed")
-	}
+		err = t.client.CreateOrUpdateRoute(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "reconciling Alertmanager Route failed")
+		}
 
-	_, err = t.client.WaitForRouteReady(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "waiting for Alertmanager Route to become ready failed")
+		_, err = t.client.WaitForRouteReady(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "waiting for Alertmanager Route to become ready failed")
+		}
 	}
 
 	s, err := t.factory.AlertmanagerConfig()

--- a/pkg/tasks/configsharing.go
+++ b/pkg/tasks/configsharing.go
@@ -42,7 +42,11 @@ func NewConfigSharingTask(client *client.Client, factory *manifests.Factory, con
 
 func (t *ConfigSharingTask) Run(ctx context.Context) error {
 	var amURL, promURL, thanosURL *url.URL
-	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+	hasRoutes, err := t.client.HasRouteCapability(ctx)
+	if err != nil {
+		return errors.Wrap(err, "checking for Route capability failed")
+	}
+	if hasRoutes {
 		promRoute, err := t.factory.PrometheusK8sAPIRoute()
 		if err != nil {
 			return errors.Wrap(err, "initializing Prometheus Route failed")
@@ -79,7 +83,6 @@ func (t *ConfigSharingTask) Run(ctx context.Context) error {
 	var (
 		svc                  *v1.Service
 		webPort, tenancyPort int
-		err                  error
 	)
 	if t.config.UserWorkloadConfiguration.Alertmanager.Enabled {
 		// User-defined alerts are routed to the UWM Alertmanager.

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -84,7 +84,11 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "creating kubelet serving CA Bundle ConfigMap failed")
 	}
 
-	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+	hasRoutes, err := t.client.HasRouteCapability(ctx)
+	if err != nil {
+		return errors.Wrap(err, "checking for Route capability failed")
+	}
+	if hasRoutes {
 		r, err := t.factory.PrometheusK8sAPIRoute()
 		if err != nil {
 			return errors.Wrap(err, "initializing Prometheus API Route failed")

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -84,34 +84,36 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "creating kubelet serving CA Bundle ConfigMap failed")
 	}
 
-	r, err := t.factory.PrometheusK8sAPIRoute()
-	if err != nil {
-		return errors.Wrap(err, "initializing Prometheus API Route failed")
-	}
+	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+		r, err := t.factory.PrometheusK8sAPIRoute()
+		if err != nil {
+			return errors.Wrap(err, "initializing Prometheus API Route failed")
+		}
 
-	err = t.client.CreateOrUpdateRoute(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Prometheus API Route failed")
-	}
+		err = t.client.CreateOrUpdateRoute(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "reconciling Prometheus API Route failed")
+		}
 
-	_, err = t.client.WaitForRouteReady(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "waiting for Prometheus API Route to become ready failed")
-	}
+		_, err = t.client.WaitForRouteReady(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "waiting for Prometheus API Route to become ready failed")
+		}
 
-	fr, err := t.factory.PrometheusK8sFederateRoute()
-	if err != nil {
-		return errors.Wrap(err, "initializing Prometheus Federate Route failed")
-	}
+		fr, err := t.factory.PrometheusK8sFederateRoute()
+		if err != nil {
+			return errors.Wrap(err, "initializing Prometheus Federate Route failed")
+		}
 
-	err = t.client.CreateOrUpdateRoute(ctx, fr)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Prometheus Federate Route failed")
-	}
+		err = t.client.CreateOrUpdateRoute(ctx, fr)
+		if err != nil {
+			return errors.Wrap(err, "reconciling Prometheus Federate Route failed")
+		}
 
-	_, err = t.client.WaitForRouteReady(ctx, fr)
-	if err != nil {
-		return errors.Wrap(err, "waiting for Prometheus Federate Route to become ready failed")
+		_, err = t.client.WaitForRouteReady(ctx, fr)
+		if err != nil {
+			return errors.Wrap(err, "waiting for Prometheus Federate Route to become ready failed")
+		}
 	}
 
 	ps, err := t.factory.PrometheusK8sProxySecret()

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -269,19 +269,21 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling UserWorkload Thanos sidecar ServiceMonitor failed")
 	}
 
-	r, err := t.factory.PrometheusUserWorkloadFederateRoute()
-	if err != nil {
-		return errors.Wrap(err, "initializing UserWorkload Prometheus federate Route failed")
-	}
+	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+		r, err := t.factory.PrometheusUserWorkloadFederateRoute()
+		if err != nil {
+			return errors.Wrap(err, "initializing UserWorkload Prometheus federate Route failed")
+		}
 
-	err = t.client.CreateOrUpdateRoute(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "reconciling UserWorkload federate Route failed")
-	}
+		err = t.client.CreateOrUpdateRoute(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "reconciling UserWorkload federate Route failed")
+		}
 
-	_, err = t.client.WaitForRouteReady(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "waiting for UserWorkload federate Route to become ready failed")
+		_, err = t.client.WaitForRouteReady(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "waiting for UserWorkload federate Route to become ready failed")
+		}
 	}
 
 	return nil

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -269,7 +269,11 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling UserWorkload Thanos sidecar ServiceMonitor failed")
 	}
 
-	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+	hasRoutes, err := t.client.HasRouteCapability(ctx)
+	if err != nil {
+		return errors.Wrap(err, "checking for Route capability failed")
+	}
+	if hasRoutes {
 		r, err := t.factory.PrometheusUserWorkloadFederateRoute()
 		if err != nil {
 			return errors.Wrap(err, "initializing UserWorkload Prometheus federate Route failed")

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -49,7 +49,11 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Thanos Querier Service failed")
 	}
 
-	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+	hasRoutes, err := t.client.HasRouteCapability(ctx)
+	if err != nil {
+		return errors.Wrap(err, "checking for Route capability failed")
+	}
+	if hasRoutes {
 		r, err := t.factory.ThanosQuerierRoute()
 		if err != nil {
 			return errors.Wrap(err, "initializing Thanos Querier Route failed")

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -49,19 +49,21 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Thanos Querier Service failed")
 	}
 
-	r, err := t.factory.ThanosQuerierRoute()
-	if err != nil {
-		return errors.Wrap(err, "initializing Thanos Querier Route failed")
-	}
+	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+		r, err := t.factory.ThanosQuerierRoute()
+		if err != nil {
+			return errors.Wrap(err, "initializing Thanos Querier Route failed")
+		}
 
-	err = t.client.CreateOrUpdateRoute(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Thanos Querier Route failed")
-	}
+		err = t.client.CreateOrUpdateRoute(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "reconciling Thanos Querier Route failed")
+		}
 
-	_, err = t.client.WaitForRouteReady(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "waiting for Thanos Querier Route to become ready failed")
+		_, err = t.client.WaitForRouteReady(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "waiting for Thanos Querier Route to become ready failed")
+		}
 	}
 
 	s, err := t.factory.ThanosQuerierOauthCookieSecret()

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -58,7 +58,11 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Thanos Ruler Service failed")
 	}
 
-	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+	hasRoutes, err := t.client.HasRouteCapability(ctx)
+	if err != nil {
+		return errors.Wrap(err, "checking for Route capability failed")
+	}
+	if hasRoutes {
 		r, err := t.factory.ThanosRulerRoute()
 		if err != nil {
 			return errors.Wrap(err, "initializing Thanos Ruler Route failed")
@@ -218,8 +222,12 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 			return errors.Wrap(err, "error deleting expired UserWorkload Thanos Ruler GRPC TLS secret")
 		}
 
+		hasRoutes, err := t.client.HasRouteCapability(ctx)
+		if err != nil {
+			return errors.Wrap(err, "checking for Route capability failed")
+		}
 		var queryURL *url.URL
-		if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+		if hasRoutes {
 			querierRoute, err := t.factory.ThanosQuerierRoute()
 			if err != nil {
 				return errors.Wrap(err, "initializing Thanos Querier Route failed")

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -16,6 +16,7 @@ package tasks
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
@@ -57,19 +58,21 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Thanos Ruler Service failed")
 	}
 
-	r, err := t.factory.ThanosRulerRoute()
-	if err != nil {
-		return errors.Wrap(err, "initializing Thanos Ruler Route failed")
-	}
+	if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+		r, err := t.factory.ThanosRulerRoute()
+		if err != nil {
+			return errors.Wrap(err, "initializing Thanos Ruler Route failed")
+		}
 
-	err = t.client.CreateOrUpdateRoute(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "reconciling Thanos Ruler Route failed")
-	}
+		err = t.client.CreateOrUpdateRoute(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "reconciling Thanos Ruler Route failed")
+		}
 
-	_, err = t.client.WaitForRouteReady(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "waiting for Thanos Ruler Route to become ready failed")
+		_, err = t.client.WaitForRouteReady(ctx, r)
+		if err != nil {
+			return errors.Wrap(err, "waiting for Thanos Ruler Route to become ready failed")
+		}
 	}
 
 	cr, err := t.factory.ThanosRulerClusterRole()
@@ -215,11 +218,14 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 			return errors.Wrap(err, "error deleting expired UserWorkload Thanos Ruler GRPC TLS secret")
 		}
 
-		querierRoute, err := t.factory.ThanosQuerierRoute()
-		if err != nil {
-			return errors.Wrap(err, "initializing Thanos Querier Route failed")
+		var queryURL *url.URL
+		if _, err := t.client.GetClusterOperator(ctx, "ingress"); err != nil {
+			querierRoute, err := t.factory.ThanosQuerierRoute()
+			if err != nil {
+				return errors.Wrap(err, "initializing Thanos Querier Route failed")
+			}
+			queryURL, err = t.client.GetRouteURL(ctx, querierRoute)
 		}
-		queryURL, err := t.client.GetRouteURL(ctx, querierRoute)
 
 		pdb, err := t.factory.ThanosRulerPodDisruptionBudget()
 		if err != nil {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
