### PR TITLE
MON-2901: add nodeExporter.collectors.netdev settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1855](https://github.com/openshift/cluster-monitoring-operator/pull/1855) Add nodeExporter.collectors.cpufreq settings.
 - [#1882](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (platform)
 - [#1876](https://github.com/openshift/cluster-monitoring-operator/pull/1876) Add nodeExporter.collectors.tcpstat settings.
+- [#1888](https://github.com/openshift/cluster-monitoring-operator/pull/1888) Add nodeExporter.collectors.netdev settings.
 
 
 ## 4.12

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -27,6 +27,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [KubeStateMetricsConfig](#kubestatemetricsconfig)
 * [NodeExporterCollectorConfig](#nodeexportercollectorconfig)
 * [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig)
+* [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig)
 * [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig)
 * [NodeExporterConfig](#nodeexporterconfig)
 * [OpenShiftStateMetricsConfig](#openshiftstatemetricsconfig)
@@ -190,6 +191,7 @@ The `NodeExporterCollectorConfig` resource defines settings for individual colle
 | -------- | ---- | ----------- |
 | cpufreq | [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig) | Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics. Disabled by default. |
 | tcpstat | [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig) | Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default. |
+| netdev | [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig) | Defines the configuration of the `netdev` collector, which collects network devices statistics. Enabled by default. |
 
 [Back to TOC](#table-of-contents)
 
@@ -205,6 +207,21 @@ The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | enabled | bool | A Boolean flag that enables or disables the `cpufreq` collector. |
+
+[Back to TOC](#table-of-contents)
+
+## NodeExporterCollectorNetDevConfig
+
+#### Description
+
+The `NodeExporterCollectorNetDevConfig` resource works as an on/off switch for the `netdev` collector of the `node-exporter` agent. By default, the `netdev` collector is enabled. If disabled, these metrics become unavailable: `node_network_receive_bytes_total`, `node_network_receive_compressed_total`, `node_network_receive_drop_total`, `node_network_receive_errs_total`, `node_network_receive_fifo_total`, `node_network_receive_frame_total`, `node_network_receive_multicast_total`, `node_network_receive_nohandler_total`, `node_network_receive_packets_total`, `node_network_transmit_bytes_total`, `node_network_transmit_carrier_total`, `node_network_transmit_colls_total`, `node_network_transmit_compressed_total`, `node_network_transmit_drop_total`, `node_network_transmit_errs_total`, `node_network_transmit_fifo_total`, `node_network_transmit_packets_total`.
+
+
+<em>appears in: [NodeExporterCollectorConfig](#nodeexportercollectorconfig)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| enabled | bool | A Boolean flag that enables or disables the `netdev` collector. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -47,6 +47,7 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/kubestatemetricsconfig.adoc[KubeStateMetricsConfig]
 * link:modules/nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
 * link:modules/nodeexportercollectorcpufreqconfig.adoc[NodeExporterCollectorCpufreqConfig]
+* link:modules/nodeexportercollectornetdevconfig.adoc[NodeExporterCollectorNetDevConfig]
 * link:modules/nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]
 * link:modules/nodeexporterconfig.adoc[NodeExporterConfig]
 * link:modules/openshiftstatemetricsconfig.adoc[OpenShiftStateMetricsConfig]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
@@ -22,6 +22,8 @@ Appears in: link:nodeexporterconfig.adoc[NodeExporterConfig]
 
 |tcpstat|link:nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]|Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default.
 
+|netdev|link:nodeexportercollectornetdevconfig.adoc[NodeExporterCollectorNetDevConfig]|Defines the configuration of the `netdev` collector, which collects network devices statistics. Enabled by default.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectornetdevconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectornetdevconfig.adoc
@@ -1,0 +1,25 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== NodeExporterCollectorNetDevConfig
+
+=== Description
+
+The `NodeExporterCollectorNetDevConfig` resource works as an on/off switch for the `netdev` collector of the `node-exporter` agent. By default, the `netdev` collector is enabled. If disabled, these metrics become unavailable: `node_network_receive_bytes_total`, `node_network_receive_compressed_total`, `node_network_receive_drop_total`, `node_network_receive_errs_total`, `node_network_receive_fifo_total`, `node_network_receive_frame_total`, `node_network_receive_multicast_total`, `node_network_receive_nohandler_total`, `node_network_receive_packets_total`, `node_network_transmit_bytes_total`, `node_network_transmit_carrier_total`, `node_network_transmit_colls_total`, `node_network_transmit_compressed_total`, `node_network_transmit_drop_total`, `node_network_transmit_errs_total`, `node_network_transmit_fifo_total`, `node_network_transmit_packets_total`.
+
+
+
+Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|enabled|bool|A Boolean flag that enables or disables the `netdev` collector.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -188,7 +188,7 @@ func (cfg *TelemeterClientConfig) IsEnabled() bool {
 
 func NewConfig(content io.Reader) (*Config, error) {
 	c := Config{}
-	cmc := ClusterMonitoringConfiguration{}
+	cmc := defaultClusterMonitoringConfiguration()
 	err := k8syaml.NewYAMLOrJSONDecoder(content, 4096).Decode(&cmc)
 	if err != nil {
 		return nil, err
@@ -198,6 +198,18 @@ func NewConfig(content io.Reader) (*Config, error) {
 	res.applyDefaults()
 	c.UserWorkloadConfiguration = NewDefaultUserWorkloadMonitoringConfig()
 	return res, nil
+}
+
+func defaultClusterMonitoringConfiguration() ClusterMonitoringConfiguration {
+	return ClusterMonitoringConfiguration{
+		NodeExporterConfig: NodeExporterConfig{
+			Collectors: NodeExporterCollectorConfig{
+				NetDev: NodeExporterCollectorNetDevConfig{
+					Enabled: true,
+				},
+			},
+		},
+	}
 }
 
 func (c *Config) applyDefaults() {
@@ -392,7 +404,7 @@ func NewConfigFromString(content string) (*Config, error) {
 
 func NewDefaultConfig() *Config {
 	c := &Config{}
-	cmc := ClusterMonitoringConfiguration{}
+	cmc := defaultClusterMonitoringConfiguration()
 	c.ClusterMonitoringConfiguration = &cmc
 	c.UserWorkloadConfiguration = NewDefaultUserWorkloadMonitoringConfig()
 	c.applyDefaults()

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -815,6 +815,13 @@ func (f *Factory) updateNodeExporterArgs(args []string) []string {
 	} else {
 		args = setArg(args, "--no-collector.tcpstat", "")
 	}
+
+	if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.NetDev.Enabled {
+		args = setArg(args, "--collector.netdev", "")
+	} else {
+		args = setArg(args, "--no-collector.netdev", "")
+	}
+
 	return args
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2835,9 +2835,13 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 			name:   "default config",
 			config: "",
 			argsPresent: []string{"--no-collector.cpufreq",
-				"--no-collector.tcpstat"},
+				"--no-collector.tcpstat",
+				"--collector.netdev",
+			},
 			argsAbsent: []string{"--collector.cpufreq",
-				"--collector.tcpstat"},
+				"--collector.tcpstat",
+				"--no-collector.netdev",
+			},
 		},
 		{
 			name: "enable cpufreq collector",
@@ -2860,6 +2864,17 @@ nodeExporter:
 `,
 			argsPresent: []string{"--collector.tcpstat"},
 			argsAbsent:  []string{"--no-collector.tcpstat"},
+		},
+		{
+			name: "disable netdev collector",
+			config: `
+nodeExporter:
+  collectors:
+    netdev:
+      enabled: false
+`,
+			argsPresent: []string{"--no-collector.netdev"},
+			argsAbsent:  []string{"--collector.netdev"},
 		},
 	}
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -264,6 +264,9 @@ type NodeExporterCollectorConfig struct {
 	// Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics.
 	// Disabled by default.
 	TcpStat NodeExporterCollectorTcpStatConfig `json:"tcpstat,omitempty"`
+	// Defines the configuration of the `netdev` collector, which collects network devices statistics.
+	// Enabled by default.
+	NetDev NodeExporterCollectorNetDevConfig `json:"netdev,omitempty"`
 }
 
 // The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for
@@ -283,6 +286,32 @@ type NodeExporterCollectorCpufreqConfig struct {
 // By default, the `tcpstat` collector is disabled.
 type NodeExporterCollectorTcpStatConfig struct {
 	// A Boolean flag that enables or disables the `tcpstat` collector.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// The `NodeExporterCollectorNetDevConfig` resource works as an on/off switch for
+// the `netdev` collector of the `node-exporter` agent.
+// By default, the `netdev` collector is enabled.
+// If disabled, these metrics become unavailable:
+// `node_network_receive_bytes_total`,
+// `node_network_receive_compressed_total`,
+// `node_network_receive_drop_total`,
+// `node_network_receive_errs_total`,
+// `node_network_receive_fifo_total`,
+// `node_network_receive_frame_total`,
+// `node_network_receive_multicast_total`,
+// `node_network_receive_nohandler_total`,
+// `node_network_receive_packets_total`,
+// `node_network_transmit_bytes_total`,
+// `node_network_transmit_carrier_total`,
+// `node_network_transmit_colls_total`,
+// `node_network_transmit_compressed_total`,
+// `node_network_transmit_drop_total`,
+// `node_network_transmit_errs_total`,
+// `node_network_transmit_fifo_total`,
+// `node_network_transmit_packets_total`.
+type NodeExporterCollectorNetDevConfig struct {
+	// A Boolean flag that enables or disables the `netdev` collector.
 	Enabled bool `json:"enabled,omitempty"`
 }
 


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR is based on top of https://github.com/openshift/cluster-monitoring-operator/pull/1876 .

Unhold https://github.com/openshift/cluster-monitoring-operator/pull/1893 after this PR is merged.