### PR TITLE
MON-2904: add nodeExporter.collectors.buddyinfo settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#1884](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (UWM)
 - [#1893](https://github.com/openshift/cluster-monitoring-operator/pull/1893) Add nodeExporter.collectors.netclass settings.
 - [#1894](https://github.com/openshift/cluster-monitoring-operator/pull/1894) Add toggle netlink implementation of netclass collector in Node Exporter.
+- [#1891](https://github.com/openshift/cluster-monitoring-operator/pull/1891) Add nodeExporter.collectors.buddyinfo settings.
 
 ## 4.12
 - [#1624](https://github.com/openshift/cluster-monitoring-operator/pull/1624) Add option to specify TopologySpreadConstraints for Prometheus, Alertmanager, and ThanosRuler.

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -25,6 +25,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [DedicatedServiceMonitors](#dedicatedservicemonitors)
 * [K8sPrometheusAdapter](#k8sprometheusadapter)
 * [KubeStateMetricsConfig](#kubestatemetricsconfig)
+* [NodeExporterCollectorBuddyInfoConfig](#nodeexportercollectorbuddyinfoconfig)
 * [NodeExporterCollectorConfig](#nodeexportercollectorconfig)
 * [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig)
 * [NodeExporterCollectorNetClassConfig](#nodeexportercollectornetclassconfig)
@@ -180,6 +181,21 @@ The `KubeStateMetricsConfig` resource defines settings for the `kube-state-metri
 
 [Back to TOC](#table-of-contents)
 
+## NodeExporterCollectorBuddyInfoConfig
+
+#### Description
+
+The `NodeExporterCollectorBuddyInfoConfig` resource works as an on/off switch for the `buddyinfo` collector of the `node-exporter` agent. By default, the `buddyinfo` collector is disabled.
+
+
+<em>appears in: [NodeExporterCollectorConfig](#nodeexportercollectorconfig)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| enabled | bool | A Boolean flag that enables or disables the `buddyinfo` collector. |
+
+[Back to TOC](#table-of-contents)
+
 ## NodeExporterCollectorConfig
 
 #### Description
@@ -195,6 +211,7 @@ The `NodeExporterCollectorConfig` resource defines settings for individual colle
 | tcpstat | [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig) | Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default. |
 | netdev | [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig) | Defines the configuration of the `netdev` collector, which collects network devices statistics. Enabled by default. |
 | netclass | [NodeExporterCollectorNetClassConfig](#nodeexportercollectornetclassconfig) | Defines the configuration of the `netclass` collector, which collects information about network devices. Enabled by default. |
+| buddyinfo | [NodeExporterCollectorBuddyInfoConfig](#nodeexportercollectorbuddyinfoconfig) | Defines the configuration of the `buddyinfo` collector, which collects statistics about memory fragmentation from the `node_buddyinfo_blocks` metric. This metric collects data from `/proc/buddyinfo`. Disabled by default. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -45,6 +45,7 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/dedicatedservicemonitors.adoc[DedicatedServiceMonitors]
 * link:modules/k8sprometheusadapter.adoc[K8sPrometheusAdapter]
 * link:modules/kubestatemetricsconfig.adoc[KubeStateMetricsConfig]
+* link:modules/nodeexportercollectorbuddyinfoconfig.adoc[NodeExporterCollectorBuddyInfoConfig]
 * link:modules/nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
 * link:modules/nodeexportercollectorcpufreqconfig.adoc[NodeExporterCollectorCpufreqConfig]
 * link:modules/nodeexportercollectornetclassconfig.adoc[NodeExporterCollectorNetClassConfig]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorbuddyinfoconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorbuddyinfoconfig.adoc
@@ -1,0 +1,25 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== NodeExporterCollectorBuddyInfoConfig
+
+=== Description
+
+The `NodeExporterCollectorBuddyInfoConfig` resource works as an on/off switch for the `buddyinfo` collector of the `node-exporter` agent. By default, the `buddyinfo` collector is disabled.
+
+
+
+Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|enabled|bool|A Boolean flag that enables or disables the `buddyinfo` collector.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
@@ -26,6 +26,8 @@ Appears in: link:nodeexporterconfig.adoc[NodeExporterConfig]
 
 |netclass|link:nodeexportercollectornetclassconfig.adoc[NodeExporterCollectorNetClassConfig]|Defines the configuration of the `netclass` collector, which collects information about network devices. Enabled by default.
 
+|buddyinfo|link:nodeexportercollectorbuddyinfoconfig.adoc[NodeExporterCollectorBuddyInfoConfig]|Defines the configuration of the `buddyinfo` collector, which collects statistics about memory fragmentation from the `node_buddyinfo_blocks` metric. This metric collects data from `/proc/buddyinfo`. Disabled by default.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -833,6 +833,12 @@ func (f *Factory) updateNodeExporterArgs(args []string) []string {
 		args = setArg(args, "--no-collector.netclass", "")
 	}
 
+	if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.BuddyInfo.Enabled {
+		args = setArg(args, "--collector.buddyinfo", "")
+	} else {
+		args = setArg(args, "--no-collector.buddyinfo", "")
+	}
+
 	return args
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2861,11 +2861,13 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 				"--collector.netdev",
 				"--collector.netclass",
 				"--collector.netclass.netlink",
+				"--no-collector.buddyinfo",
 			},
 			argsAbsent: []string{"--collector.cpufreq",
 				"--collector.tcpstat",
 				"--no-collector.netdev",
 				"--no-collector.netclass",
+				"--collector.buddyinfo",
 			},
 		},
 		{
@@ -2924,6 +2926,17 @@ nodeExporter:
 			argsPresent: []string{"--collector.netclass"},
 			argsAbsent: []string{"--no-collector.netclass",
 				"--collector.netclass.netlink"},
+		},
+		{
+			name: "enable buddyinfo collector",
+			config: `
+nodeExporter:
+  collectors:
+    buddyinfo:
+      enabled: true
+`,
+			argsPresent: []string{"--collector.buddyinfo"},
+			argsAbsent:  []string{"--no-collector.buddyinfo"},
 		},
 	}
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -270,6 +270,9 @@ type NodeExporterCollectorConfig struct {
 	// Defines the configuration of the `netclass` collector, which collects information about network devices.
 	// Enabled by default.
 	NetClass NodeExporterCollectorNetClassConfig `json:"netclass,omitempty"`
+	// Defines the configuration of the `buddyinfo` collector, which collects statistics about memory fragmentation from the `node_buddyinfo_blocks` metric. This metric collects data from `/proc/buddyinfo`.
+	// Disabled by default.
+	BuddyInfo NodeExporterCollectorBuddyInfoConfig `json:"buddyinfo,omitempty"`
 }
 
 // The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for
@@ -349,6 +352,14 @@ type NodeExporterCollectorNetClassConfig struct {
 	// `node_network_name_assign_type`,
 	// `node_network_device_id`.
 	UseNetlink bool `json:"useNetlink,omitempty"`
+}
+
+// The `NodeExporterCollectorBuddyInfoConfig` resource works as an on/off switch for
+// the `buddyinfo` collector of the `node-exporter` agent.
+// By default, the `buddyinfo` collector is disabled.
+type NodeExporterCollectorBuddyInfoConfig struct {
+	// A Boolean flag that enables or disables the `buddyinfo` collector.
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // The `UserWorkloadConfiguration` resource defines the settings

--- a/test/e2e/node_exporter_test.go
+++ b/test/e2e/node_exporter_test.go
@@ -54,6 +54,14 @@ nodeExporter:
     tcpstat:
       enabled: true`,
 		},
+		{
+			nameCollector: "buddyinfo",
+			config: `
+nodeExporter:
+  collectors:
+    buddyinfo:
+      enabled: true`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR adds nodeExporter.collectors.buddyinfo settings, based on https://github.com/openshift/cluster-monitoring-operator/pull/1876 We should merge that before this one.