### PR TITLE
MON-2903: add nodeExporter.collectors.systemd settings.

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -34,6 +34,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [NodeExporterCollectorNetClassConfig](#nodeexportercollectornetclassconfig)
 * [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig)
 * [NodeExporterCollectorProcessesConfig](#nodeexportercollectorprocessesconfig)
+* [NodeExporterCollectorSystemdConfig](#nodeexportercollectorsystemdconfig)
 * [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig)
 * [NodeExporterConfig](#nodeexporterconfig)
 * [OpenShiftStateMetricsConfig](#openshiftstatemetricsconfig)
@@ -238,6 +239,7 @@ The `NodeExporterCollectorConfig` resource defines settings for individual colle
 | mountstats | [NodeExporterCollectorMountStatsConfig](#nodeexportercollectormountstatsconfig) | Defines the configuration of the `mountstats` collector, which collects statistics about NFS volume I/O activities. Disabled by default. |
 | ksmd | [NodeExporterCollectorKSMDConfig](#nodeexportercollectorksmdconfig) | Defines the configuration of the `ksmd` collector, which collects statistics from the kernel same-page merger daemon. Disabled by default. |
 | processes | [NodeExporterCollectorProcessesConfig](#nodeexportercollectorprocessesconfig) | Defines the configuration of the `processes` collector, which collects statistics from processes and threads running in the system. Disabled by default. |
+| systemd | [NodeExporterCollectorSystemdConfig](#nodeexportercollectorsystemdconfig) | Defines the configuration of the `systemd` collector, which collects statistics on the systemd daemon and its managed services. Disabled by default. |
 
 [Back to TOC](#table-of-contents)
 
@@ -329,6 +331,22 @@ The `NodeExporterCollectorProcessesConfig` resource works as an on/off switch fo
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | enabled | bool | A Boolean flag that enables or disables the `processes` collector. |
+
+[Back to TOC](#table-of-contents)
+
+## NodeExporterCollectorSystemdConfig
+
+#### Description
+
+The `NodeExporterCollectorSystemdConfig` resource works as an on/off switch for the `systemd` collector of the `node-exporter` agent. By default, the `systemd` collector is disabled. If enabled, the following metrics become available: `node_systemd_system_running`, `node_systemd_timer_last_trigger_seconds`, `node_systemd_units`, `node_systemd_version`. If the unit uses a socket, it also generates these 3 metrics: `node_systemd_socket_accepted_connections_total`, `node_systemd_socket_current_connections`, `node_systemd_socket_refused_connections_total`. You can use the `units` parameter to select the systemd units to be included by the `systemd` collector. The selected units are used to generate the `node_systemd_unit_state` metric, which shows the state of each systemd unit. However, this metric's cardinality might be high (at least 5 series per unit per node). If you enable this collector with a long list of selected units, closely monitor the `prometheus-k8s` deployment for excessive memory usage.
+
+
+<em>appears in: [NodeExporterCollectorConfig](#nodeexportercollectorconfig)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| enabled | bool | A Boolean flag that enables or disables the `systemd` collector. |
+| units | []string | A list of regular expression (regex) patterns that match systemd units to be included by the `systemd` collector. By default, the list is empty, so the collector exposes no metrics for systemd units. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -54,6 +54,7 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/nodeexportercollectornetclassconfig.adoc[NodeExporterCollectorNetClassConfig]
 * link:modules/nodeexportercollectornetdevconfig.adoc[NodeExporterCollectorNetDevConfig]
 * link:modules/nodeexportercollectorprocessesconfig.adoc[NodeExporterCollectorProcessesConfig]
+* link:modules/nodeexportercollectorsystemdconfig.adoc[NodeExporterCollectorSystemdConfig]
 * link:modules/nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]
 * link:modules/nodeexporterconfig.adoc[NodeExporterConfig]
 * link:modules/openshiftstatemetricsconfig.adoc[OpenShiftStateMetricsConfig]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
@@ -34,6 +34,8 @@ Appears in: link:nodeexporterconfig.adoc[NodeExporterConfig]
 
 |processes|link:nodeexportercollectorprocessesconfig.adoc[NodeExporterCollectorProcessesConfig]|Defines the configuration of the `processes` collector, which collects statistics from processes and threads running in the system. Disabled by default.
 
+|systemd|link:nodeexportercollectorsystemdconfig.adoc[NodeExporterCollectorSystemdConfig]|Defines the configuration of the `systemd` collector, which collects statistics on the systemd daemon and its managed services. Disabled by default.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorsystemdconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorsystemdconfig.adoc
@@ -1,0 +1,27 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== NodeExporterCollectorSystemdConfig
+
+=== Description
+
+The `NodeExporterCollectorSystemdConfig` resource works as an on/off switch for the `systemd` collector of the `node-exporter` agent. By default, the `systemd` collector is disabled. If enabled, the following metrics become available: `node_systemd_system_running`, `node_systemd_timer_last_trigger_seconds`, `node_systemd_units`, `node_systemd_version`. If the unit uses a socket, it also generates these 3 metrics: `node_systemd_socket_accepted_connections_total`, `node_systemd_socket_current_connections`, `node_systemd_socket_refused_connections_total`. You can use the `units` parameter to select the systemd units to be included by the `systemd` collector. The selected units are used to generate the `node_systemd_unit_state` metric, which shows the state of each systemd unit. However, this metric's cardinality might be high (at least 5 series per unit per node). If you enable this collector with a long list of selected units, closely monitor the `prometheus-k8s` deployment for excessive memory usage.
+
+
+
+Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|enabled|bool|A Boolean flag that enables or disables the `systemd` collector.
+
+|units|[]string|A list of regular expression (regex) patterns that match systemd units to be included by the `systemd` collector. By default, the list is empty, so the collector exposes no metrics for systemd units.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -54,6 +54,9 @@ spec:
           fi
           echo "ts=$(date --iso-8601=seconds) num_cpus=$NUM_CPUS gomaxprocs=$GOMAXPROCS"
           exec /bin/node_exporter "$0" "$@"
+        env:
+        - name: DBUS_SYSTEM_BUS_ADDRESS
+          value: unix:path=/host/root/var/run/dbus/system_bus_socket
         image: quay.io/prometheus/node-exporter:v1.6.0
         name: node-exporter
         resources:

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -281,6 +281,13 @@ function(params)
                       // node-exporter has issue in rolling out with security context
                       // changes in kube-prometheus hence overidding the changes
                       securityContext: {},
+                      env: [
+                        {
+                          // This is required for the systemd collector to connect to the host's dbus socket.
+                          name: 'DBUS_SYSTEM_BUS_ADDRESS',
+                          value: 'unix:path=/host/root/var/run/dbus/system_bus_socket',
+                        },
+                      ],
                     },
                 super.containers,
               ),

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -237,6 +237,9 @@ func defaultClusterMonitoringConfiguration() ClusterMonitoringConfiguration {
 					Enabled:    true,
 					UseNetlink: true,
 				},
+				Systemd: NodeExporterCollectorSystemdConfig{
+					Enabled: false,
+				},
 			},
 		},
 	}

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -317,6 +317,9 @@ type NodeExporterCollectorConfig struct {
 	// Defines the configuration of the `processes` collector, which collects statistics from processes and threads running in the system.
 	// Disabled by default.
 	Processes NodeExporterCollectorProcessesConfig `json:"processes,omitempty"`
+	// Defines the configuration of the `systemd` collector, which collects statistics on the systemd daemon and its managed services.
+	// Disabled by default.
+	Systemd NodeExporterCollectorSystemdConfig `json:"systemd,omitempty"`
 }
 
 // The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for
@@ -448,6 +451,30 @@ type NodeExporterCollectorKSMDConfig struct {
 type NodeExporterCollectorProcessesConfig struct {
 	// A Boolean flag that enables or disables the `processes` collector.
 	Enabled bool `json:"enabled,omitempty"`
+}
+
+// The `NodeExporterCollectorSystemdConfig` resource works as an on/off switch for
+// the `systemd` collector of the `node-exporter` agent.
+// By default, the `systemd` collector is disabled.
+// If enabled, the following metrics become available:
+// `node_systemd_system_running`,
+// `node_systemd_timer_last_trigger_seconds`,
+// `node_systemd_units`,
+// `node_systemd_version`.
+// If the unit uses a socket, it also generates these 3 metrics:
+// `node_systemd_socket_accepted_connections_total`,
+// `node_systemd_socket_current_connections`,
+// `node_systemd_socket_refused_connections_total`.
+// You can use the `units` parameter to select the systemd units to be included by the `systemd` collector.
+// The selected units are used to generate the `node_systemd_unit_state` metric, which shows the state of each systemd unit.
+// However, this metric's cardinality might be high (at least 5 series per unit per node).
+// If you enable this collector with a long list of selected units, closely monitor the `prometheus-k8s` deployment for excessive memory usage.
+type NodeExporterCollectorSystemdConfig struct {
+	// A Boolean flag that enables or disables the `systemd` collector.
+	Enabled bool `json:"enabled,omitempty"`
+	// A list of regular expression (regex) patterns that match systemd units to be included by the `systemd` collector.
+	// By default, the list is empty, so the collector exposes no metrics for systemd units.
+	Units []string `json:"units,omitempty"`
 }
 
 // The `UserWorkloadConfiguration` resource defines the settings


### PR DESCRIPTION
This PR is held for the moment, systems collector requires more settings, it will come together later in this PR.

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR is based on top of https://github.com/openshift/cluster-monitoring-operator/pull/1876 , we should merge that before this one.