### PR TITLE
MON-2900: add nodeExporter.collectors.netclass settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1876](https://github.com/openshift/cluster-monitoring-operator/pull/1876) Add nodeExporter.collectors.tcpstat settings.
 - [#1888](https://github.com/openshift/cluster-monitoring-operator/pull/1888) Add nodeExporter.collectors.netdev settings.
 - [#1884](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (UWM)
+- [#1893](https://github.com/openshift/cluster-monitoring-operator/pull/1893) Add nodeExporter.collectors.netclass settings.
 
 
 ## 4.12

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -27,6 +27,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [KubeStateMetricsConfig](#kubestatemetricsconfig)
 * [NodeExporterCollectorConfig](#nodeexportercollectorconfig)
 * [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig)
+* [NodeExporterCollectorNetClassConfig](#nodeexportercollectornetclassconfig)
 * [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig)
 * [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig)
 * [NodeExporterConfig](#nodeexporterconfig)
@@ -193,6 +194,7 @@ The `NodeExporterCollectorConfig` resource defines settings for individual colle
 | cpufreq | [NodeExporterCollectorCpufreqConfig](#nodeexportercollectorcpufreqconfig) | Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics. Disabled by default. |
 | tcpstat | [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig) | Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default. |
 | netdev | [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig) | Defines the configuration of the `netdev` collector, which collects network devices statistics. Enabled by default. |
+| netclass | [NodeExporterCollectorNetClassConfig](#nodeexportercollectornetclassconfig) | Defines the configuration of the `netclass` collector, which collects information about network devices. Enabled by default. |
 
 [Back to TOC](#table-of-contents)
 
@@ -208,6 +210,21 @@ The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | enabled | bool | A Boolean flag that enables or disables the `cpufreq` collector. |
+
+[Back to TOC](#table-of-contents)
+
+## NodeExporterCollectorNetClassConfig
+
+#### Description
+
+The `NodeExporterCollectorNetClassConfig` resource works as an on/off switch for the `netclass` collector of the `node-exporter` agent. By default, the `netclass` collector is enabled. If disabled, these metrics become unavailable: `node_network_info`, `node_network_address_assign_type`, `node_network_carrier`, `node_network_carrier_changes_total`, `node_network_carrier_up_changes_total`, `node_network_carrier_down_changes_total`, `node_network_device_id`, `node_network_dormant`, `node_network_flags`, `node_network_iface_id`, `node_network_iface_link`, `node_network_iface_link_mode`, `node_network_mtu_bytes`, `node_network_name_assign_type`, `node_network_net_dev_group`, `node_network_speed_bytes`, `node_network_transmit_queue_length`, `node_network_protocol_type`.
+
+
+<em>appears in: [NodeExporterCollectorConfig](#nodeexportercollectorconfig)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| enabled | bool | A Boolean flag that enables or disables the `netclass` collector. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -47,6 +47,7 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/kubestatemetricsconfig.adoc[KubeStateMetricsConfig]
 * link:modules/nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
 * link:modules/nodeexportercollectorcpufreqconfig.adoc[NodeExporterCollectorCpufreqConfig]
+* link:modules/nodeexportercollectornetclassconfig.adoc[NodeExporterCollectorNetClassConfig]
 * link:modules/nodeexportercollectornetdevconfig.adoc[NodeExporterCollectorNetDevConfig]
 * link:modules/nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]
 * link:modules/nodeexporterconfig.adoc[NodeExporterConfig]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
@@ -24,6 +24,8 @@ Appears in: link:nodeexporterconfig.adoc[NodeExporterConfig]
 
 |netdev|link:nodeexportercollectornetdevconfig.adoc[NodeExporterCollectorNetDevConfig]|Defines the configuration of the `netdev` collector, which collects network devices statistics. Enabled by default.
 
+|netclass|link:nodeexportercollectornetclassconfig.adoc[NodeExporterCollectorNetClassConfig]|Defines the configuration of the `netclass` collector, which collects information about network devices. Enabled by default.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectornetclassconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectornetclassconfig.adoc
@@ -1,0 +1,25 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== NodeExporterCollectorNetClassConfig
+
+=== Description
+
+The `NodeExporterCollectorNetClassConfig` resource works as an on/off switch for the `netclass` collector of the `node-exporter` agent. By default, the `netclass` collector is enabled. If disabled, these metrics become unavailable: `node_network_info`, `node_network_address_assign_type`, `node_network_carrier`, `node_network_carrier_changes_total`, `node_network_carrier_up_changes_total`, `node_network_carrier_down_changes_total`, `node_network_device_id`, `node_network_dormant`, `node_network_flags`, `node_network_iface_id`, `node_network_iface_link`, `node_network_iface_link_mode`, `node_network_mtu_bytes`, `node_network_name_assign_type`, `node_network_net_dev_group`, `node_network_speed_bytes`, `node_network_transmit_queue_length`, `node_network_protocol_type`.
+
+
+
+Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|enabled|bool|A Boolean flag that enables or disables the `netclass` collector.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -207,6 +207,9 @@ func defaultClusterMonitoringConfiguration() ClusterMonitoringConfiguration {
 				NetDev: NodeExporterCollectorNetDevConfig{
 					Enabled: true,
 				},
+				NetClass: NodeExporterCollectorNetClassConfig{
+					Enabled: true,
+				},
 			},
 		},
 	}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -824,6 +824,12 @@ func (f *Factory) updateNodeExporterArgs(args []string) []string {
 		args = setArg(args, "--no-collector.netdev", "")
 	}
 
+	if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.NetClass.Enabled {
+		args = setArg(args, "--collector.netclass", "")
+	} else {
+		args = setArg(args, "--no-collector.netclass", "")
+	}
+
 	return args
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2859,10 +2859,12 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 			argsPresent: []string{"--no-collector.cpufreq",
 				"--no-collector.tcpstat",
 				"--collector.netdev",
+				"--collector.netclass",
 			},
 			argsAbsent: []string{"--collector.cpufreq",
 				"--collector.tcpstat",
 				"--no-collector.netdev",
+				"--no-collector.netclass",
 			},
 		},
 		{
@@ -2897,6 +2899,17 @@ nodeExporter:
 `,
 			argsPresent: []string{"--no-collector.netdev"},
 			argsAbsent:  []string{"--collector.netdev"},
+		},
+		{
+			name: "disable netclass collector",
+			config: `
+nodeExporter:
+  collectors:
+    netclass:
+      enabled: false
+`,
+			argsPresent: []string{"--no-collector.netclass"},
+			argsAbsent:  []string{"--collector.netclass"},
 		},
 	}
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -267,6 +267,9 @@ type NodeExporterCollectorConfig struct {
 	// Defines the configuration of the `netdev` collector, which collects network devices statistics.
 	// Enabled by default.
 	NetDev NodeExporterCollectorNetDevConfig `json:"netdev,omitempty"`
+	// Defines the configuration of the `netclass` collector, which collects information about network devices.
+	// Enabled by default.
+	NetClass NodeExporterCollectorNetClassConfig `json:"netclass,omitempty"`
 }
 
 // The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for
@@ -312,6 +315,33 @@ type NodeExporterCollectorTcpStatConfig struct {
 // `node_network_transmit_packets_total`.
 type NodeExporterCollectorNetDevConfig struct {
 	// A Boolean flag that enables or disables the `netdev` collector.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// The `NodeExporterCollectorNetClassConfig` resource works as an on/off switch for
+// the `netclass` collector of the `node-exporter` agent.
+// By default, the `netclass` collector is enabled.
+// If disabled, these metrics become unavailable:
+// `node_network_info`,
+// `node_network_address_assign_type`,
+// `node_network_carrier`,
+// `node_network_carrier_changes_total`,
+// `node_network_carrier_up_changes_total`,
+// `node_network_carrier_down_changes_total`,
+// `node_network_device_id`,
+// `node_network_dormant`,
+// `node_network_flags`,
+// `node_network_iface_id`,
+// `node_network_iface_link`,
+// `node_network_iface_link_mode`,
+// `node_network_mtu_bytes`,
+// `node_network_name_assign_type`,
+// `node_network_net_dev_group`,
+// `node_network_speed_bytes`,
+// `node_network_transmit_queue_length`,
+// `node_network_protocol_type`.
+type NodeExporterCollectorNetClassConfig struct {
+	// A Boolean flag that enables or disables the `netclass` collector.
 	Enabled bool `json:"enabled,omitempty"`
 }
 

--- a/test/e2e/node_exporter_test.go
+++ b/test/e2e/node_exporter_test.go
@@ -126,6 +126,32 @@ nodeExporter:
 				"node_network_transmit_packets_total",
 			},
 		},
+		{
+			nameCollector: "netclass",
+			config: `
+nodeExporter:
+  collectors:
+    netclass:
+      enabled: false`,
+			metrics: []string{
+				"node_network_carrier",
+				"node_network_carrier_changes_total",
+				"node_network_carrier_down_changes_total",
+				"node_network_carrier_up_changes_total",
+				"node_network_dormant",
+				"node_network_flags",
+				"node_network_iface_id",
+				"node_network_iface_link",
+				"node_network_iface_link_mode",
+				"node_network_info",
+				"node_network_mtu_bytes",
+				"node_network_net_dev_group",
+				"node_network_protocol_type",
+				"node_network_speed_bytes",
+				"node_network_transmit_queue_length",
+				"node_network_up",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR adds toggle for netclass collector, based on [PR#1888](https://github.com/openshift/cluster-monitoring-operator/pull/1888). It should be merged after [PR#1888](https://github.com/openshift/cluster-monitoring-operator/pull/1888).