### PR TITLE
MON-2895: toggle netlink implementation of netclass collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#1888](https://github.com/openshift/cluster-monitoring-operator/pull/1888) Add nodeExporter.collectors.netdev settings.
 - [#1884](https://github.com/openshift/cluster-monitoring-operator/issues/1882) Allow configuring secrets in alertmanager component (UWM)
 - [#1893](https://github.com/openshift/cluster-monitoring-operator/pull/1893) Add nodeExporter.collectors.netclass settings.
+- [#1894](https://github.com/openshift/cluster-monitoring-operator/pull/1894) Add toggle netlink implementation of netclass collector in Node Exporter.
 
 
 ## 4.12

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -225,6 +225,7 @@ The `NodeExporterCollectorNetClassConfig` resource works as an on/off switch for
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | enabled | bool | A Boolean flag that enables or disables the `netclass` collector. |
+| useNetlink | bool | A Boolean flag that activates the `netlink` implementation of the `netclass` collector. This implementation improves the performance of the `netclass` collector by omitting these metrics: `node_network_address_assign_type`, `node_network_name_assign_type`, `node_network_device_id`. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/modules/nodeexportercollectornetclassconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectornetclassconfig.adoc
@@ -20,6 +20,8 @@ Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
 | Property | Type | Description 
 |enabled|bool|A Boolean flag that enables or disables the `netclass` collector.
 
+|useNetlink|bool|A Boolean flag that activates the `netlink` implementation of the `netclass` collector. This implementation improves the performance of the `netclass` collector by omitting these metrics: `node_network_address_assign_type`, `node_network_name_assign_type`, `node_network_device_id`.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -208,7 +208,8 @@ func defaultClusterMonitoringConfiguration() ClusterMonitoringConfiguration {
 					Enabled: true,
 				},
 				NetClass: NodeExporterCollectorNetClassConfig{
-					Enabled: true,
+					Enabled:    true,
+					UseNetlink: true,
 				},
 			},
 		},

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -826,6 +826,9 @@ func (f *Factory) updateNodeExporterArgs(args []string) []string {
 
 	if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.NetClass.Enabled {
 		args = setArg(args, "--collector.netclass", "")
+		if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.NetClass.UseNetlink {
+			args = setArg(args, "--collector.netclass.netlink", "")
+		}
 	} else {
 		args = setArg(args, "--no-collector.netclass", "")
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2860,6 +2860,7 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 				"--no-collector.tcpstat",
 				"--collector.netdev",
 				"--collector.netclass",
+				"--collector.netclass.netlink",
 			},
 			argsAbsent: []string{"--collector.cpufreq",
 				"--collector.tcpstat",
@@ -2910,6 +2911,19 @@ nodeExporter:
 `,
 			argsPresent: []string{"--no-collector.netclass"},
 			argsAbsent:  []string{"--collector.netclass"},
+		},
+		{
+			name: "disable netlink mode in netclass collector",
+			config: `
+nodeExporter:
+  collectors:
+    netclass:
+      enabled: true
+      useNetlink: false
+`,
+			argsPresent: []string{"--collector.netclass"},
+			argsAbsent: []string{"--no-collector.netclass",
+				"--collector.netclass.netlink"},
 		},
 	}
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -343,6 +343,12 @@ type NodeExporterCollectorNetDevConfig struct {
 type NodeExporterCollectorNetClassConfig struct {
 	// A Boolean flag that enables or disables the `netclass` collector.
 	Enabled bool `json:"enabled,omitempty"`
+	// A Boolean flag that activates the `netlink` implementation of the `netclass` collector.
+	// This implementation improves the performance of the `netclass` collector by omitting these metrics:
+	// `node_network_address_assign_type`,
+	// `node_network_name_assign_type`,
+	// `node_network_device_id`.
+	UseNetlink bool `json:"useNetlink,omitempty"`
 }
 
 // The `UserWorkloadConfiguration` resource defines the settings


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR follows https://github.com/openshift/cluster-monitoring-operator/pull/1893 . It should be merged after that one.