### PR TITLE
MON-2959: test/e2e: Add test for alertmanager secret platform

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -584,9 +584,7 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 		a.Spec.Resources = *f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Resources
 	}
 
-	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Secrets != nil {
-		a.Spec.Secrets = append(a.Spec.Secrets, f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Secrets...)
-	}
+	a.Spec.Secrets = append(a.Spec.Secrets, f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Secrets...)
 
 	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.EnableUserAlertManagerConfig &&
 		!f.config.UserWorkloadConfiguration.Alertmanager.Enabled {

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type validator interface {
+	Validate(obj runtime.Object) error
+}
+
+type genChange int64
+
+func (g genChange) Validate(obj runtime.Object) error {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	if objMeta.GetGeneration() == int64(g) {
+		ns, name := objMeta.GetNamespace(), objMeta.GetName()
+		return fmt.Errorf("%s/%s: no new generation was found after %d", ns, name, g)
+	}
+	return nil
+}


### PR DESCRIPTION
Related-to #[MON-2959](https://issues.redhat.com//browse/MON-2959)

This is followup PR of #1882 to add e2e test

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
