### PR TITLE
OCPBUGS-7391: wait for service CA secrets

### DIFF
--- a/pkg/tasks/prometheusadapter.go
+++ b/pkg/tasks/prometheusadapter.go
@@ -3,10 +3,12 @@ package tasks
 import (
 	"context"
 
-	"github.com/openshift/cluster-monitoring-operator/pkg/client"
-	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 )
 
 type PrometheusAdapterTask struct {
@@ -183,14 +185,14 @@ func (t *PrometheusAdapterTask) Run(ctx context.Context) error {
 			cmName = cm.Name
 		}
 
-		tlsSecret, err := t.client.GetSecret(ctx, t.namespace, "prometheus-adapter-tls")
+		tlsSecret, err := t.client.WaitForSecretByNsName(ctx, types.NamespacedName{Namespace: t.namespace, Name: "prometheus-adapter-tls"})
 		if err != nil {
-			return errors.Wrap(err, "failed to load prometheus-adapter-tls secret")
+			return errors.Wrap(err, "failed to wait for prometheus-adapter-tls secret")
 		}
 
-		apiAuthConfigmap, err := t.client.GetConfigmap(ctx, "kube-system", "extension-apiserver-authentication")
+		apiAuthConfigmap, err := t.client.WaitForConfigMapByNsName(ctx, types.NamespacedName{Namespace: "kube-system", Name: "extension-apiserver-authentication"})
 		if err != nil {
-			return errors.Wrap(err, "failed to load kube-system/extension-apiserver-authentication configmap")
+			return errors.Wrap(err, "failed to wait for kube-system/extension-apiserver-authentication configmap")
 		}
 
 		secret, err := t.factory.PrometheusAdapterSecret(tlsSecret, apiAuthConfigmap)


### PR DESCRIPTION
The Prometheus adapter and control plane tasks would exit immediately if they couldn't find the TLS secrets generated by the service CA operator.

With this change, the tasks are waiting up to 5 minutes for the secrets to appear which should speed up a bit the reconciliation (no need to run another attempt).

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
