### PR TITLE
MON-3229: Remove the dependency on the apiserver auth

### DIFF
--- a/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
@@ -20,9 +20,4 @@ stringData:
         "user":
           "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
         "verb": "get"
-      - "path": "/federate"
-        "resourceRequest": false
-        "user":
-          "name": "system:serviceaccount:openshift-monitoring:telemeter-client"
-        "verb": "get"
 type: Opaque

--- a/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
@@ -15,4 +15,9 @@ stringData:
         "user":
           "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
         "verb": "get"
+      - "path": "/federate"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
+        "verb": "get"
 type: Opaque

--- a/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
@@ -20,4 +20,9 @@ stringData:
         "user":
           "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
         "verb": "get"
+      - "path": "/federate"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:telemeter-client"
+        "verb": "get"
 type: Opaque

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -82,7 +82,7 @@ spec:
   - args:
     - --secure-listen-address=0.0.0.0:9092
     - --upstream=http://127.0.0.1:9090
-    - --allow-paths=/metrics
+    - --allow-paths=/metrics,/federate
     - --config-file=/etc/kube-rbac-proxy/config.yaml
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -210,19 +210,9 @@ function(params)
       {
         authorization+: {
           static+: [
-            // prometheus-k8s is needed for mTLS due to cert is signed with this SA
-            // instead for token auth telemeter-client SA is required
             {
               user: {
                 name: 'system:serviceaccount:openshift-monitoring:prometheus-k8s',
-              },
-              verb: 'get',
-              path: '/federate',
-              resourceRequest: false,
-            },
-            {
-              user: {
-                name: 'system:serviceaccount:openshift-monitoring:telemeter-client',
               },
               verb: 'get',
               path: '/federate',
@@ -432,7 +422,6 @@ function(params)
               '--client-ca-file=/etc/tls/client/client-ca.crt',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
               '--logtostderr=true',
-              '--v=10',
             ],
             terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -210,9 +210,19 @@ function(params)
       {
         authorization+: {
           static+: [
+            // prometheus-k8s is needed for mTLS due to cert is signed with this SA
+            // instead for token auth telemeter-client SA is required
             {
               user: {
                 name: 'system:serviceaccount:openshift-monitoring:prometheus-k8s',
+              },
+              verb: 'get',
+              path: '/federate',
+              resourceRequest: false,
+            },
+            {
+              user: {
+                name: 'system:serviceaccount:openshift-monitoring:telemeter-client',
               },
               verb: 'get',
               path: '/federate',
@@ -422,6 +432,7 @@ function(params)
               '--client-ca-file=/etc/tls/client/client-ca.crt',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
               '--logtostderr=true',
+              '--v=10',
             ],
             terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [

--- a/jsonnet/utils/generate-secret.libsonnet
+++ b/jsonnet/utils/generate-secret.libsonnet
@@ -1,5 +1,5 @@
 {
-  staticAuthSecret(cfgNamespace, cfgCommonLabels, cfgName):: {
+  staticAuthSecret(cfgNamespace, cfgCommonLabels, cfgName, additionalConfig={}):: {
     apiVersion: 'v1',
     kind: 'Secret',
     metadata: {
@@ -23,7 +23,7 @@
             },
           ],
         },
-      },),
+      } + additionalConfig),
     },
   },
 }

--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -121,7 +121,7 @@ func TestTelemeterClient(t *testing.T) {
 			`federate_samples{job="telemeter-client"}`,
 			func(v float64) error {
 				if v < 10 {
-					return fmt.Errorf("expecting federate samples from telemeter client more than 10 but got %f", v)
+					return fmt.Errorf("expecting federate samples from telemeter client greater than or equal to 10 but got %f", v)
 				}
 				return nil
 			},

--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -97,4 +98,33 @@ func TestTelemeterRemoteWrite(t *testing.T) {
 			return nil
 		},
 	)
+}
+
+// TestTelemeterClient verifies that the telemeter client can collect metrics from the monitoring stack and forward them to the telemeter server.
+func TestTelemeterClient(t *testing.T) {
+	{
+		f.PrometheusK8sClient.WaitForQueryReturn(
+			t,
+			5*time.Minute,
+			`metricsclient_request_send{client="federate_to",job="telemeter-client",status_code="200"}`,
+			func(v float64) error {
+				if v == 0 {
+					return fmt.Errorf("expecting metricsclient request send more than 0 but got none")
+				}
+				return nil
+			},
+		)
+
+		f.PrometheusK8sClient.WaitForQueryReturn(
+			t,
+			5*time.Minute,
+			`federate_samples{job="telemeter-client"}`,
+			func(v float64) error {
+				if v < 10 {
+					return fmt.Errorf("expecting federate samples from telemeter client more than 10 but got %f", v)
+				}
+				return nil
+			},
+		)
+	}
 }


### PR DESCRIPTION
## Description

When the control plane nodes are under pressure or the apiserver is just not available, no telemetry data is emitted by the monitoring stack 

## Solution 

Remove the dependency on the apiserver would be to use mTLS communication between telemeter-client and the Prometheus pods.

Add /federate endpoint to rbac proxy and allow telemeter-client to authenticate via mTLS to reach Prometheus metrics.

Add mTLS auth to telemeter-client https://github.com/openshift/telemeter/pull/455

## Type of change

- [X] Remove the dependency on the apiserver auth
- [X] kube-rbac-proxy exposing the /federate endpoint
- [X] Add tests
- [X] No user facing changes, so no entry in CHANGELOG was needed.
