### PR TITLE
OCPBUGS-7282: Node Exporter ignores network interface under name "cali[a-f0-9]*"

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -36,8 +36,8 @@ spec:
         - --path.udev.data=/host/root/run/udev/data
         - --no-collector.wifi
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*)$
-        - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*)$
+        - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$
+        - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
         image: quay.io/prometheus/node-exporter:v1.5.0

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -190,17 +190,19 @@ local inCluster =
         },
         // NOTE:
         // "ignoredNetworkDevices" sets the 2 arguments "--collector.netclass.ignored-devices" and "--collector.netdev.device-exclude".
-        // 5 kinds of virtual NICs will be ignored:
+        // 6 kinds of virtual NICs will be ignored:
         // 1. veth network interface associated with containers.
         // 2. OVN renames veth.* to <rand-hex>@if<X> where X is /sys/class/net/<if>/ifindex
-        // thus [a-z0-9]{15}}
+        // thus [a-z0-9]{15}
         // 3. enP.* virtual NICs on Azure cluster.
         // 4. OVN virtual interfaces ovn-k8s-mp[0-9]*
         // 5. virtual tunnels and bridges: tun[0-9]*|br[0-9]*|br-ex|br-int|br-ext
+        // 6. Calico Virtual NICs cali[a-f0-9]*
         // Refer to:
         // https://issues.redhat.com/browse/OCPBUGS-1321
         // https://issues.redhat.com/browse/OCPBUGS-2729
-        ignoredNetworkDevices:: '^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*)$',
+        // https://issues.redhat.com/browse/OCPBUGS-7282
+        ignoredNetworkDevices:: '^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$',
       },
       openshiftStateMetrics: {
         namespace: $.values.common.namespace,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR resolves https://issues.redhat.com/browse/OCPBUGS-7282 .
The issue is similar to https://issues.redhat.com/browse/OCPBUGS-2729 .