### PR TITLE
MON-2973: test/e2e: Add cleanup func for alertmanager uwm secret test

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -915,6 +915,10 @@ func TestAlertmanagerUWMSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	t.Cleanup(func() {
+		f.OperatorClient.DeleteSecret(ctx, amSecret)
+	})
+
 	for _, tc := range []struct {
 		name               string
 		config             string


### PR DESCRIPTION
Related-to #[MON-2973](https://issues.redhat.com//browse/MON-2973)

This cleanup of secret was missed in https://github.com/openshift/cluster-monitoring-operator/pull/1884 hence adding it here

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
