### PR TITLE
OCPBUGS-8215: bugfix in Node Exporter argument setting

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2209,7 +2209,8 @@ func (f *Factory) setTLSSecurityConfiguration(args []string, tlsCipherSuitesArg 
 func setArg(args []string, argName string, argValue string) []string {
 	found := false
 	for i, arg := range args {
-		if strings.HasPrefix(arg, argName) {
+		if arg == argName ||
+			(argName[len(argName)-1] == '=' && strings.HasPrefix(arg, argName)) {
 			args[i] = argName + argValue
 			found = true
 		}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -4151,6 +4151,79 @@ enableUserWorkload: true
 	}
 }
 
+func TestSetArg(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		expectedArgs []string
+		argName      string
+		argValue     string
+	}{
+		{
+			name: "shared prefix",
+			args: []string{
+				"--collector.netclass",
+				"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
+			},
+			expectedArgs: []string{
+				"--collector.netclass",
+				"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
+			},
+			argName:  "--collector.netclass",
+			argValue: "",
+		},
+		{
+			name: "modify value",
+			args: []string{
+				"--collector.netclass",
+				"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
+			},
+			expectedArgs: []string{
+				"--collector.netclass",
+				"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$",
+			},
+			argName:  "--collector.netclass.ignored-devices=",
+			argValue: "^(veth.*|[a-f0-9]{15})$",
+		},
+		{
+			name: "append flag",
+			args: []string{
+				"--collector.netclass",
+				"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
+			},
+			expectedArgs: []string{
+				"--collector.netclass",
+				"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
+				"--collector.netdev",
+			},
+			argName:  "--collector.netdev",
+			argValue: "",
+		},
+		{
+			name: "append argument with value",
+			args: []string{
+				"--collector.netclass",
+			},
+			expectedArgs: []string{
+				"--collector.netclass",
+				"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
+			},
+			argName:  "--collector.netclass.ignored-devices=",
+			argValue: "^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			newArgs := setArg(test.args, test.argName, test.argValue)
+			if !reflect.DeepEqual(test.expectedArgs, newArgs) {
+				t.Fatalf("expecting: %v get: %v ", test.expectedArgs, newArgs)
+			}
+		})
+	}
+
+}
+
 func volumeConfigured(volumes []v1.Volume, volumeName string) bool {
 	for _, volume := range volumes {
 		if volume.Name == volumeName {

--- a/test/e2e/node_exporter_test.go
+++ b/test/e2e/node_exporter_test.go
@@ -155,7 +155,6 @@ nodeExporter:
 				"node_network_mtu_bytes",
 				"node_network_net_dev_group",
 				"node_network_protocol_type",
-				"node_network_speed_bytes",
 				"node_network_transmit_queue_length",
 				"node_network_up",
 			},


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This is the fix to the bug found by @juzhao  in https://github.com/openshift/cluster-monitoring-operator/pull/1905#issuecomment-1451186414
