### PR TITLE
OCPBUGS-7694: add startup probe for prometheus-adapter

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -58,7 +58,6 @@ spec:
             path: /livez
             port: https
             scheme: HTTPS
-          initialDelaySeconds: 30
           periodSeconds: 5
         name: prometheus-adapter
         ports:
@@ -70,7 +69,6 @@ spec:
             path: /readyz
             port: https
             scheme: HTTPS
-          initialDelaySeconds: 30
           periodSeconds: 5
         resources:
           requests:
@@ -82,6 +80,13 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 18
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -131,8 +131,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "c5360561fa3cb52297b652c263794ca474a0ab73",
-      "sum": "RDIIadGPJcRu2ENkju7BtYrjxn2+aj9B7N8Z4knB2no="
+      "version": "274d5856c72932d93c4fee5eea335e2d99134ff7",
+      "sum": "f7GllMNkhsfGwxxu2D2Kze7RLQChv4rfb/WlHL4uAMs="
     },
     {
       "source": {


### PR DESCRIPTION
The startup probe prevents that kubelet kills the prometheus-adapter pod on clusters with many CRDs and/or slow API because it might take some time for prometheus-adapter to discover the available API resources and the /livez endpoint only becomes available once this discovery phase is completed.

The startup probe will wait 3m30s before failing which should be enough even in most unfavorable cases.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
