### PR TITLE
OCPBUGS-10895: add startup probe for prometheus-adapter

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             path: /livez
             port: https
             scheme: HTTPS
-          initialDelaySeconds: 30
+          initialDelaySeconds: 0
           periodSeconds: 5
         name: prometheus-adapter
         ports:
@@ -70,7 +70,7 @@ spec:
             path: /readyz
             port: https
             scheme: HTTPS
-          initialDelaySeconds: 30
+          initialDelaySeconds: 0
           periodSeconds: 5
         resources:
           requests:
@@ -82,6 +82,13 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 18
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -132,6 +132,27 @@ function(params)
                           '--secure-port=6443',
                           '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                         ],
+                        // OCPBUGS-10895: configure a startup probe to prevent
+                        // the container from being killed by kubelet in case
+                        // the prometheus-adapter initialization takes more
+                        // time than usual which can happen on clusters with
+                        // lots of CRDs and/or high Kube API latencies.
+                        // We also reset the initial delay for the other probes.
+                        livenessProbe+: {
+                          initialDelaySeconds: 0,
+                        },
+                        readinessProbe+: {
+                          initialDelaySeconds: 0,
+                        },
+                        startupProbe: {
+                          httpGet: {
+                            path: '/livez',
+                            port: 'https',
+                            scheme: 'HTTPS',
+                          },
+                          periodSeconds: 10,
+                          failureThreshold: 18,
+                        },
                         terminationMessagePolicy: 'FallbackToLogsOnError',
                         volumeMounts: [
                           {


### PR DESCRIPTION
This is the backport of commit 90585d11.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
