### PR TITLE
OCPBUGS-10387: label for infra nodes for metric cluster:capacity_cpu_cores:sum

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -93,6 +93,13 @@ spec:
             )
           )
           or on(node) (
+            label_replace(cluster:infra_nodes, "label_node_role_kubernetes_io", "infra", "", "")
+            * on(node) group_left() max by(node)
+            (
+              kube_node_status_capacity{resource="cpu",unit="core"}
+            )
+          )
+          or on(node) (
             max without(endpoint, instance, job, pod, service)
             (
               kube_node_labels

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -121,6 +121,13 @@ function(params) {
                 )
               )
               or on(node) (
+                label_replace(cluster:infra_nodes, "label_node_role_kubernetes_io", "infra", "", "")
+                * on(node) group_left() max by(node)
+                (
+                  kube_node_status_capacity{resource="cpu",unit="core"}
+                )
+              )
+              or on(node) (
                 max without(endpoint, instance, job, pod, service)
                 (
                   kube_node_labels

--- a/test/rules/cluster_capacity_cpu.yaml
+++ b/test/rules/cluster_capacity_cpu.yaml
@@ -1,5 +1,5 @@
 # Tests for cluster:capacity_cpu_cores:sum
-# Verifying basic logic and infra nodes are correctly labeled.
+# Verifying basic logic and check infra & master nodes are correctly labeled.
 
 rule_files:
   - rules.yaml
@@ -37,9 +37,7 @@ tests:
         exp_samples:
           - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
             value: 6
-  # infra node capacity is listed in the same series as workers
-  # This behavior of labeling infra node without label_node_role_kubernetes_io in cluster:capacity_cpu_cores:sum is reported as a bug:
-  # https://issues.redhat.com//browse/OCPBUGS-10387
+  # infra node capacity is listed as different series than workers.
   - interval: 1m
     input_series:
       - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
@@ -64,9 +62,11 @@ tests:
       - expr: cluster:capacity_cpu_cores:sum
         eval_time: 1m
         exp_samples:
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io="infra",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 1
           - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
-            value: 7
-  # master node capacity is listed as separate series
+            value: 6
+  # master node capacity is listed as distinct series
   - interval: 1m
     input_series:
       - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
@@ -122,9 +122,7 @@ tests:
             value: 5
           - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
             value: 4
-  # node with both worker and infra role is counted as worker.
-  # This behavior of labeling infra node without label_node_role_kubernetes_io in cluster:capacity_cpu_cores:sum is reported as a bug:
-  # https://issues.redhat.com//browse/OCPBUGS-10387
+  # node with both worker and infra role is counted as infra.
   - interval: 1m
     input_series:
       - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
@@ -161,5 +159,36 @@ tests:
         exp_samples:
           - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io="master",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
             value: 5
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 4
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io="infra",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 4
+  # node without the role "master" or "infra" but only custom roles ("ai-worker" in the test) is counted as worker.
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="worker-1",role="worker"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="ai-worker-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_role{node="ai-worker-1",role="ai-worker"}'
+        values: "1"
+      - series: 'kube_node_labels{node="ai-worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="master-1",resource="cpu",unit="core"}'
+        values: "3"
+      - series: 'kube_node_labels{node="master-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="master-1",role="master"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:capacity_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io="master",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 3
           - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
             value: 8

--- a/test/rules/cluster_capacity_cpu.yaml
+++ b/test/rules/cluster_capacity_cpu.yaml
@@ -1,0 +1,165 @@
+# Tests for cluster:capacity_cpu_cores:sum
+# Verifying basic logic and infra nodes are correctly labeled.
+
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+  # worker capacity is the only series (hypershift-style)
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:capacity_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 4
+  # multiple worker capacity buckets
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="worker-2",resource="cpu",unit="core"}'
+        values: "2"
+      - series: 'kube_node_labels{node="worker-2",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:capacity_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 6
+  # infra node capacity is listed in the same series as workers
+  # This behavior of labeling infra node without label_node_role_kubernetes_io in cluster:capacity_cpu_cores:sum is reported as a bug:
+  # https://issues.redhat.com//browse/OCPBUGS-10387
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="worker-1",role="worker"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="worker-2",resource="cpu",unit="core"}'
+        values: "2"
+      - series: 'kube_node_labels{node="worker-2",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="worker-2",role="worker"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="infra-1",resource="cpu",unit="core"}'
+        values: "1"
+      - series: 'kube_node_labels{node="infra-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="infra-1",role="infra"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:capacity_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 7
+  # master node capacity is listed as separate series
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="master-1",resource="cpu",unit="core"}'
+        values: "2"
+      - series: 'kube_node_role{node="master-1",role="master"}'
+        values: "1"
+      - series: 'kube_node_role{node="master-1",role="control-plane"}'
+        values: "1"
+      - series: 'kube_node_labels{node="master-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:capacity_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io="master",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 2
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 4
+  # node with both master and infra role is counted as master.
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="master-1",resource="cpu",unit="core"}'
+        values: "3"
+      - series: 'kube_node_role{node="master-1",role="master"}'
+        values: "1"
+      - series: 'kube_node_role{node="master-1",role="control-plane"}'
+        values: "1"
+      - series: 'kube_node_labels{node="master-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="master-infra-1",resource="cpu",unit="core"}'
+        values: "2"
+      - series: 'kube_node_role{node="master-infra-1",role="master"}'
+        values: "1"
+      - series: 'kube_node_role{node="master-infra-1",role="control-plane"}'
+        values: "1"
+      - series: 'kube_node_role{node="master-infra-1",role="infra"}'
+        values: "1"
+      - series: 'kube_node_labels{node="master-infra-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:capacity_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io="master",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 5
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 4
+  # node with both worker and infra role is counted as worker.
+  # This behavior of labeling infra node without label_node_role_kubernetes_io in cluster:capacity_cpu_cores:sum is reported as a bug:
+  # https://issues.redhat.com//browse/OCPBUGS-10387
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_capacity{node="worker-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="worker-1",role="worker"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="worker-infra-1",resource="cpu",unit="core"}'
+        values: "4"
+      - series: 'kube_node_role{node="worker-infra-1",role="worker"}'
+        values: "1"
+      - series: 'kube_node_role{node="worker-infra-1",role="infra"}'
+        values: "1"
+      - series: 'kube_node_labels{node="worker-infra-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="master-1",resource="cpu",unit="core"}'
+        values: "3"
+      - series: 'kube_node_labels{node="master-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="master-1",role="master"}'
+        values: "1"
+      - series: 'kube_node_status_capacity{node="master-infra-1",resource="cpu",unit="core"}'
+        values: "2"
+      - series: 'kube_node_role{node="master-infra-1",role="master"}'
+        values: "1"
+      - series: 'kube_node_role{node="master-infra-1",role="infra"}'
+        values: "1"
+      - series: 'kube_node_labels{node="master-infra-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:capacity_cpu_cores:sum
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io="master",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 5
+          - labels: 'cluster:capacity_cpu_cores:sum{label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+            value: 8

--- a/test/rules/node_role.yaml
+++ b/test/rules/node_role.yaml
@@ -1,0 +1,57 @@
+# Test rules about role of node
+
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+  # cluster:master_nodes contains all nodes with kube_node_role{role="master"}.
+  # 2 labels are generated for each node:
+  # - label_node_role_kubernetes_io="master"
+  # - label_node_role_kubernetes_io_master="true"
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="worker-1",role="worker"}'
+        values: "1"
+      - series: 'kube_node_labels{node="worker-2",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="worker-2",role="worker"}'
+        values: "1"
+      - series: 'kube_node_labels{node="master-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="master-1",role="master"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:master_nodes
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:master_nodes{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io="master",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos",label_node_role_kubernetes_io_master="true", node="master-1"}'
+            value: 1
+  # cluster:infra_nodes contains all nodes with kube_node_role{role="infra"}.
+  # Only 1 label is generated for each node:
+  # - label_node_role_kubernetes_io_infra="true"
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_labels{node="worker-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="worker-1",role="worker"}'
+        values: "1"
+      - series: 'kube_node_labels{node="infra-1",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="infra-1",role="infra"}'
+        values: "1"
+      - series: 'kube_node_labels{node="infra-2",label_beta_kubernetes_io_instance_type="e2-standard-4",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos"}'
+        values: "1"
+      - series: 'kube_node_role{node="infra-2",role="infra"}'
+        values: "1"
+    promql_expr_test:
+      - expr: cluster:infra_nodes
+        eval_time: 1m
+        exp_samples:
+          - labels: 'cluster:infra_nodes{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io_infra="true",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos", node="infra-1"}'
+            value: 1
+          - labels: 'cluster:infra_nodes{label_beta_kubernetes_io_instance_type="e2-standard-4",label_node_role_kubernetes_io_infra="true",label_kubernetes_io_arch="amd64",label_node_openshift_io_os_id="rhcos", node="infra-2"}'
+            value: 1


### PR DESCRIPTION
As stated in [OCPBUGS-10387](https://issues.redhat.com/browse/OCPBUGS-10387), certain clusters do not label their infra nodes in the metric `cluster:capacity_cpu_cores:sum`, due to lack of label `label_node_role_kubernetes_io="infra"` in the metric `kube_node_labels`.
This PR add logic to automatically add a label  `label_node_role_kubernetes_io="infra"` to infra nodes when generating the metric `metric cluster:capacity_cpu_cores:sum`.

This PR is based on the PR https://github.com/openshift/cluster-monitoring-operator/pull/1926 that adds unit tests for the current recording rule of  `cluster:capacity_cpu_cores:sum`.

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
