### PR TITLE
OCPBUGS-11434: node-exporter: disable btrfs collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.14
+
+- [#1937](https://github.com/openshift/cluster-monitoring-operator/pull/1937) Disables btrfs collector
+
 ## 4.13
 
 - [#1785](https://github.com/openshift/cluster-monitoring-operator/pull/1785) Adds support for CollectionProfiles TechPreview

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
+        - --no-collector.btrfs
         image: quay.io/prometheus/node-exporter:v1.5.0
         name: node-exporter
         resources:

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -207,10 +207,12 @@ function(params)
                       // gather that data (especially for bare metal clusters), and
                       // add flags to collect the node_cpu_info metric + metrics
                       // from the text file.
+                      // Disable btrfs collector as btrfs is not included in RHEL kernels
                       args: [a for a in c.args if (a != '--no-collector.hwmon')] +
                             [
                               '--collector.cpu.info',
                               '--collector.textfile.directory=' + textfileDir,
+                              '--no-collector.btrfs',
                             ],
                       terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts+: [{


### PR DESCRIPTION
[Profiling](https://pprof.me/9802ad7/) shows that node-exporter is using ~16% of CPU time on updating btrfs details. This FS is not included in RHEL kernels, so it can be safely disabled

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
