### PR TITLE
[release-4.10]  OCPBUGS-11579: jsonnet: Add prometheus container in UWM prometheus asset file

### DIFF
--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -147,6 +147,7 @@ spec:
       requests:
         cpu: 1m
         memory: 10Mi
+  - name: prometheus
   enableFeatures: []
   enforcedNamespaceLabel: namespace
   externalLabels: {}

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -464,6 +464,9 @@ function(params)
               },
             },
           },
+          {
+            name: 'prometheus',
+          },
         ],
       },
     },


### PR DESCRIPTION
openshift#1824 increased the
startupProbe timeout from 15m to 1h for both platform and uwm proemetheus. But it didn't take effect on UWM prometheus because in assets file it didn't have a container named `prometheus` on UWM prometheus pod so CMO never entered the code path that was added in openshift#1824
since it uses strategic merge patch.

Hence this commit adds a `prometheus` container in uwm prometheus jsonnet file so it gets added
in assets file.

Fixes #OCPBUGS-10690

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
