### PR TITLE
jsonnet: add comment why empty prometheus container needed

### DIFF
--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -499,6 +499,10 @@ function(params)
               },
             },
           },
+
+          // NOTE: It is important to have the container - prometheus specified
+          // so that CMO will apply all the required customizations.
+          // See e.g pkg/manifests/manifests.go where the startup probe is added
           {
             name: 'prometheus',
           },


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
