### PR TITLE
[release-4.12] OCPBUGS-11623: node-exporter: disable btrfs collector

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
         - --no-collector.cpufreq
         - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|tun[0-9]*|br[0-9]*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext)$
         - --path.udev.data=/host/root/run/udev/data
+        - --no-collector.btrfs
         image: quay.io/prometheus/node-exporter:v1.4.0
         name: node-exporter
         resources:

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -181,6 +181,8 @@ function(params)
                               // https://issues.redhat.com/browse/OCPBUGS-1321
                               '--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|tun[0-9]*|br[0-9]*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext)$',
                               '--path.udev.data=/host/root/run/udev/data',
+                              // Disable btrfs collector as btrfs is not included in RHEL kernels
+                              '--no-collector.btrfs',
                             ],
                       terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts+: [{


### PR DESCRIPTION
[Profiling](https://pprof.me/9802ad7/) shows that node-exporter is using ~16% of CPU time on updating btrfs details. This FS is not included in RHEL kernels, so it can be safely disabled

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

Cherry-pick of https://github.com/openshift/cluster-monitoring-operator/pull/1941 on release-4.12