### PR TITLE
OCPBUGS-11889: disable CORS headers on Thanos querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1937](https://github.com/openshift/cluster-monitoring-operator/pull/1937) Disables btrfs collector
 - [#1910](https://github.com/openshift/cluster-monitoring-operator/pull/1910) Add new web console usage metrics
+- [#1950](https://github.com/openshift/cluster-monitoring-operator/pull/1950) Disable CORS headers on Thanos querier by defaut and add a flag to enable them back.
 
 ## 4.13
 

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -466,6 +466,7 @@ The `ThanosQuerierConfig` resource defines settings for the Thanos Querier compo
 | -------- | ---- | ----------- |
 | enableRequestLogging | bool | A Boolean flag that enables or disables request logging. The default value is `false`. |
 | logLevel | string | Defines the log level setting for Thanos Querier. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`. |
+| enableCORS | bool | A Boolean flag that enables setting CORS headers. The headers would allow access from any origin. The default value is `false`. |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core) | Defines resource requests and limits for the Thanos Querier container. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core) | Defines tolerations for the pods. |

--- a/Documentation/openshiftdocs/modules/thanosquerierconfig.adoc
+++ b/Documentation/openshiftdocs/modules/thanosquerierconfig.adoc
@@ -22,6 +22,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 
 |logLevel|string|Defines the log level setting for Thanos Querier. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
 
+|enableCORS|bool|A Boolean flag that enables setting CORS headers. The headers would allow access from any origin. The default value is `false`.
+
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the Thanos Querier container.

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2621,6 +2621,11 @@ func (f *Factory) ThanosQuerierDeployment(grpcTLS *v1.Secret, enableUserWorkload
 				)
 			}
 
+			if !f.config.ClusterMonitoringConfiguration.ThanosQuerierConfig.EnableCORS {
+				d.Spec.Template.Spec.Containers[i].Args = append(
+					d.Spec.Template.Spec.Containers[i].Args, "--web.disable-cors")
+			}
+
 		case "prom-label-proxy":
 			d.Spec.Template.Spec.Containers[i].Image = f.config.Images.PromLabelProxy
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3277,7 +3277,8 @@ func TestThanosQuerierConfiguration(t *testing.T) {
       cpu: 3m
       memory: 4Mi
   logLevel: debug
-  enableRequestLogging: true`, false)
+  enableRequestLogging: true
+  enableCORS: true`, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -3397,6 +3398,19 @@ grpc:
 				}
 				if got.value != expectResult {
 					t.Fatalf("unexpected flag value for Thanos query, wanted %s but got %s", expectResult, got.value)
+				}
+			}
+
+			{
+				// test CORS headers flag
+				const (
+					disableCORSFlag = "--web.disable-cors"
+				)
+
+				_, ok := getArgValue(c, disableCORSFlag)
+				if ok {
+					// For now this "index out of range" prior to this if the flag is set
+					t.Fatalf("CORS headers should be enabled on Thanos query")
 				}
 			}
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -258,6 +258,10 @@ type ThanosQuerierConfig struct {
 	// The possible values are `error`, `warn`, `info`, and `debug`.
 	// The default value is `info`.
 	LogLevel string `json:"logLevel,omitempty"`
+	// A Boolean flag that enables setting CORS headers.
+	// The headers would allow access from any origin.
+	// The default value is `false`.
+	EnableCORS bool `json:"enableCORS,omitempty"`
 	// Defines the nodes on which the pods are scheduled.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines resource requests and limits for the Thanos Querier container.

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -560,6 +560,7 @@ func TestClusterMonitorThanosQuerierConfig(t *testing.T) {
 				[]framework.PodAssertion{
 					expectCatchAllToleration(),
 					expectMatchingRequests("*", containerName, mem, cpu),
+					expectContainerArg("--web.disable-cors", containerName),
 				},
 			),
 		},


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

* [x] Change commit message + changelog entry
* [ ] Backport to 4.12/4.13?