### PR TITLE
OCPBUGS-12525: fallback Thanos to 0.30.2.

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -205,10 +205,10 @@ spec:
       openshift.io/cluster-monitoring: "true"
   serviceMonitorSelector: {}
   thanos:
-    image: quay.io/thanos/thanos:v0.31.0
+    image: quay.io/thanos/thanos:v0.30.2
     resources:
       requests:
         cpu: 1m
         memory: 100Mi
-    version: 0.31.0
+    version: 0.30.2
   version: 2.43.0

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -247,10 +247,10 @@ spec:
       - "false"
   serviceMonitorSelector: {}
   thanos:
-    image: quay.io/thanos/thanos:v0.31.0
+    image: quay.io/thanos/thanos:v0.30.2
     resources:
       requests:
         cpu: 1m
         memory: 100Mi
-    version: 0.31.0
+    version: 0.30.2
   version: 2.43.0

--- a/assets/thanos-querier/cluster-role-binding.yaml
+++ b/assets/thanos-querier/cluster-role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/thanos-querier/cluster-role.yaml
+++ b/assets/thanos-querier/cluster-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
 rules:
 - apiGroups:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: thanos-query
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 0.31.0
+        app.kubernetes.io/version: 0.30.2
     spec:
       affinity:
         podAntiAffinity:
@@ -66,7 +66,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: quay.io/thanos/thanos:v0.31.0
+        image: quay.io/thanos/thanos:v0.30.2
         imagePullPolicy: IfNotPresent
         name: thanos-query
         ports:

--- a/assets/thanos-querier/grpc-tls-secret.yaml
+++ b/assets/thanos-querier/grpc-tls-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-grpc-tls
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/thanos-querier/kube-rbac-proxy-rules-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-rules-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-kube-rbac-proxy-rules
   namespace: openshift-monitoring
 stringData:

--- a/assets/thanos-querier/kube-rbac-proxy-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-kube-rbac-proxy
   namespace: openshift-monitoring
 stringData:

--- a/assets/thanos-querier/oauth-cookie-secret.yaml
+++ b/assets/thanos-querier/oauth-cookie-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-oauth-cookie
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/thanos-querier/pod-disruption-budget.yaml
+++ b/assets/thanos-querier/pod-disruption-budget.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-pdb
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/route.yaml
+++ b/assets/thanos-querier/route.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/service-account.yaml
+++ b/assets/thanos-querier/service-account.yaml
@@ -8,6 +8,6 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring

--- a/assets/thanos-querier/service-monitor.yaml
+++ b/assets/thanos-querier/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/service.yaml
+++ b/assets/thanos-querier/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-ruler/service-account.yaml
+++ b/assets/thanos-ruler/service-account.yaml
@@ -8,6 +8,6 @@ metadata:
     app.kubernetes.io/instance: thanos-ruler
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring

--- a/assets/thanos-ruler/service-monitor.yaml
+++ b/assets/thanos-ruler/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-ruler
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/thanos-ruler/service.yaml
+++ b/assets/thanos-ruler/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: thanos-ruler
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -113,7 +113,7 @@ spec:
     caFile: /etc/tls/grpc/ca.crt
     certFile: /etc/tls/grpc/server.crt
     keyFile: /etc/tls/grpc/server.key
-  image: quay.io/thanos/thanos:v0.31.0
+  image: quay.io/thanos/thanos:v0.30.2
   listenLocal: true
   podMetadata:
     annotations:

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -21,4 +21,4 @@ versions:
   prometheus: 2.43.0
   prometheusAdapter: 0.10.0
   prometheusOperator: 0.63.0
-  thanos: 0.31.0
+  thanos: 0.30.2


### PR DESCRIPTION
Thanos 0.31 has some issues when deduplicating the metric series. We are going to stay on version 0.30.2 when searching for a better solution. 