### PR TITLE
OCPBUGS-14561: Prevent ci/prow/versions from failing on PR against release-xxx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,11 @@ jsonnet/crds/alertrelabelconfigs-custom-resource-definition.json: vendor/github.
 versions: $(GOJSONTOYAML_BIN)
 	./hack/generate-versions.sh
 
+.PHONY: check-versions
+check-versions: VERSION_FILE=jsonnet/versions.yaml
+check-versions:
+	export VERSION_FILE=$(VERSION_FILE) && $(MAKE) versions && git diff --exit-code -- ${VERSION_FILE}
+
 .PHONY: docs
 docs: $(EMBEDMD_BIN) $(DOCGEN_BIN) Documentation/telemetry/telemeter_query
 	$(EMBEDMD_BIN) -w `find Documentation -name "*.md"`

--- a/assets/alertmanager-user-workload/alertmanager.yaml
+++ b/assets/alertmanager-user-workload/alertmanager.yaml
@@ -30,7 +30,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --logtostderr=true
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: alertmanager-proxy
     ports:
     - containerPort: 9095
@@ -56,7 +56,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --logtostderr=true
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: tenancy-proxy
     ports:
     - containerPort: 9092
@@ -86,7 +86,7 @@ spec:
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --logtostderr=true
     - --allow-paths=/metrics
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: kube-rbac-proxy-metric
     ports:
     - containerPort: 9097

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -72,7 +72,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --logtostderr=true
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: kube-rbac-proxy
     ports:
     - containerPort: 9092
@@ -97,7 +97,7 @@ spec:
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --logtostderr=true
     - --allow-paths=/metrics
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: kube-rbac-proxy-metric
     ports:
     - containerPort: 9097

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -103,7 +103,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -76,7 +76,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100

--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --config-file=/etc/kube-rbac-policy/config.yaml
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -62,7 +62,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --config-file=/etc/kube-rbac-policy/config.yaml
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -89,7 +89,7 @@ spec:
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --logtostderr=true
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: kube-rbac-proxy
     ports:
     - containerPort: 9092
@@ -122,7 +122,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: kube-rbac-proxy-thanos
     ports:
     - containerPort: 10902
@@ -205,10 +205,10 @@ spec:
       openshift.io/cluster-monitoring: "true"
   serviceMonitorSelector: {}
   thanos:
-    image: quay.io/thanos/thanos:v0.31.0
+    image: quay.io/thanos/thanos:v0.30.2
     resources:
       requests:
         cpu: 1m
         memory: 100Mi
-    version: 0.31.0
+    version: 0.30.2
   version: 2.43.0

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --config-file=/etc/kube-rbac-policy/config.yaml
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -48,7 +48,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: kube-rbac-proxy-federate
     ports:
     - containerPort: 9092
@@ -80,7 +80,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: kube-rbac-proxy-metrics
     ports:
     - containerPort: 9091
@@ -118,7 +118,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+    image: quay.io/brancz/kube-rbac-proxy:v0.14.1
     name: kube-rbac-proxy-thanos
     ports:
     - containerPort: 10902
@@ -247,10 +247,10 @@ spec:
       - "false"
   serviceMonitorSelector: {}
   thanos:
-    image: quay.io/thanos/thanos:v0.31.0
+    image: quay.io/thanos/thanos:v0.30.2
     resources:
       requests:
         cpu: 1m
         memory: 100Mi
-    version: 0.31.0
+    version: 0.30.2
   version: 2.43.0

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --config-file=/etc/kube-rbac-policy/config.yaml
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/thanos-querier/cluster-role-binding.yaml
+++ b/assets/thanos-querier/cluster-role-binding.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/thanos-querier/cluster-role.yaml
+++ b/assets/thanos-querier/cluster-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
 rules:
 - apiGroups:

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/managed-by: cluster-monitoring-operator
         app.kubernetes.io/name: thanos-query
         app.kubernetes.io/part-of: openshift-monitoring
-        app.kubernetes.io/version: 0.31.0
+        app.kubernetes.io/version: 0.30.2
     spec:
       affinity:
         podAntiAffinity:
@@ -66,7 +66,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: quay.io/thanos/thanos:v0.31.0
+        image: quay.io/thanos/thanos:v0.30.2
         imagePullPolicy: IfNotPresent
         name: thanos-query
         ports:
@@ -148,7 +148,7 @@ spec:
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
         - --allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values,/api/v1/series
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 9092
@@ -195,7 +195,7 @@ spec:
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
         - --allow-paths=/api/v1/rules
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy-rules
         ports:
         - containerPort: 9093
@@ -225,7 +225,7 @@ spec:
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --logtostderr=true
         - --allow-paths=/metrics
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy-metrics
         ports:
         - containerPort: 9094

--- a/assets/thanos-querier/grpc-tls-secret.yaml
+++ b/assets/thanos-querier/grpc-tls-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-grpc-tls
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/thanos-querier/kube-rbac-proxy-rules-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-rules-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-kube-rbac-proxy-rules
   namespace: openshift-monitoring
 stringData:

--- a/assets/thanos-querier/kube-rbac-proxy-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-kube-rbac-proxy
   namespace: openshift-monitoring
 stringData:

--- a/assets/thanos-querier/oauth-cookie-secret.yaml
+++ b/assets/thanos-querier/oauth-cookie-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-oauth-cookie
   namespace: openshift-monitoring
 type: Opaque

--- a/assets/thanos-querier/pod-disruption-budget.yaml
+++ b/assets/thanos-querier/pod-disruption-budget.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier-pdb
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/route.yaml
+++ b/assets/thanos-querier/route.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/service-account.yaml
+++ b/assets/thanos-querier/service-account.yaml
@@ -8,6 +8,6 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring

--- a/assets/thanos-querier/service-monitor.yaml
+++ b/assets/thanos-querier/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-querier/service.yaml
+++ b/assets/thanos-querier/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: thanos-querier
     app.kubernetes.io/name: thanos-query
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-querier
   namespace: openshift-monitoring
 spec:

--- a/assets/thanos-ruler/service-account.yaml
+++ b/assets/thanos-ruler/service-account.yaml
@@ -8,6 +8,6 @@ metadata:
     app.kubernetes.io/instance: thanos-ruler
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring

--- a/assets/thanos-ruler/service-monitor.yaml
+++ b/assets/thanos-ruler/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: thanos-ruler
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/thanos-ruler/service.yaml
+++ b/assets/thanos-ruler/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: thanos-ruler
     app.kubernetes.io/name: thanos-rule
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.31.0
+    app.kubernetes.io/version: 0.30.2
   name: thanos-ruler
   namespace: openshift-user-workload-monitoring
 spec:

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -113,7 +113,7 @@ spec:
     caFile: /etc/tls/grpc/ca.crt
     certFile: /etc/tls/grpc/server.crt
     keyFile: /etc/tls/grpc/server.key
-  image: quay.io/thanos/thanos:v0.31.0
+  image: quay.io/thanos/thanos:v0.30.2
   listenLocal: true
   podMetadata:
     annotations:

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -14,11 +14,11 @@ repos:
   thanos: openshift/thanos
 versions:
   alertmanager: 0.25.0
-  kubeRbacProxy: 0.14.0
+  kubeRbacProxy: 0.14.1
   kubeStateMetrics: 2.8.2
   nodeExporter: 1.5.0
   promLabelProxy: 0.6.0
   prometheus: 2.43.0
   prometheusAdapter: 0.10.0
   prometheusOperator: 0.63.0
-  thanos: 0.31.0
+  thanos: 0.30.2


### PR DESCRIPTION
…implify.

Make hack/generate-versions.sh do nothing on PR that are not against the main branch as the components versions are only updated on the main branch (on release-xx branches, components kepp their versions when fixed)

Add a 'make check-versions' target to run the versions check. CI jobs will be updated to use this.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
