### PR TITLE
OCPBUGS-13939: Extend remote write test timeout

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -289,7 +289,7 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 func remoteWriteCheckMetrics(ctx context.Context, t *testing.T, promClient *framework.PrometheusClient, tests []remoteWriteTest) {
 	for _, test := range tests {
 		promClient.WaitForQueryReturn(
-			t, 4*time.Minute, test.query,
+			t, 6*time.Minute, test.query,
 			func(v float64) error {
 				if !test.expected(v) {
 					return fmt.Errorf(test.description)


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
