### PR TITLE
OCPBUGS-14007: test/e2e: don't fail on telemeter remote write failed samples

### DIFF
--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -94,19 +93,6 @@ func TestTelemeterRemoteWrite(t *testing.T) {
 		func(v float64) error {
 			if v == 0 {
 				return errors.New("expecting samples to be sent via Prometheus remote write but got none")
-			}
-			return nil
-		},
-	)
-
-	// Check that the Telemeter server returns no error.
-	f.PrometheusK8sClient.WaitForQueryReturn(
-		t,
-		5*time.Minute,
-		`max without(pod,instance) (rate(prometheus_remote_storage_samples_failed_total{job="prometheus-k8s",url=~"https://infogw.api.openshift.com.+"}[5m]))`,
-		func(v float64) error {
-			if v > 0 {
-				return fmt.Errorf("expecting Prometheus remote write to see no failed samples but got %f", v)
 			}
 			return nil
 		},


### PR DESCRIPTION
This test adds a lot of flakiness. Assuming 0 failed samples is too strict for determining that remote write is working. This commit removes the check for failed samples so that we consider telemetry via remote write successful as long as some samples are send.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
