### PR TITLE
Add minimal golangci-lint linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,26 @@
+run:
+  timeout: 5m
+  tests: false
+  skip-dirs:
+    - vendor
+    - test
+  modules-download-mode: vendor
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - bodyclose
+    - exportloopref
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - nosprintfhostport
+    - staticcheck
+    - tenv
+    - typecheck
+    - unconvert
+    - unused
+    - wastedassign
+    - whitespace

--- a/.yamllint
+++ b/.yamllint
@@ -1,10 +1,10 @@
 ---
 extends: default
-ignore: | 
+ignore: |
  vendor/
  manifests/cluster-monitoring-operator-role.yaml
 
-rules: 
+rules:
   indentation:
     spaces: 2
     indent-sequences: consistent


### PR DESCRIPTION
## Add minimalgolangci-lint linters

This commit adds a new makefile target `golangci-lint` which allows the
usage of it for linting.

It also adds a default configuration including
static checking and fixes its staticcheck violations.
In order to do so, it also updates go mod vendoring.

This PR slims down the original one in order to fully test the CI run.

