### PR TITLE
OCPBUGS-14380: Fix golangcilint whitespace violations

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -923,7 +923,6 @@ func (c *Client) WaitForPrometheus(ctx context.Context, p *monv1.Prometheus) err
 // validatePrometheusResource is a helper method for ValidatePrometheus.
 // NOTE: this function is refactored out of wait.Poll for testing
 func (c Client) validatePrometheusResource(ctx context.Context, prom types.NamespacedName) (bool, []error) {
-
 	p, err := c.mclient.MonitoringV1().Prometheuses(prom.Namespace).Get(ctx, prom.Name, metav1.GetOptions{})
 	if err != nil {
 		// failing to get Prometheus -> Degraded: Unknown & Unavailable: Unknown
@@ -951,7 +950,6 @@ func (c Client) validatePrometheusResource(ctx context.Context, prom types.Names
 			klog.V(4).Info("validate prometheus failed to get prometheus reconciled condition: ", err)
 			// failing to get Prometheus.Status.Condtion -> Degraded: Unknown
 			return false, []error{NewUnknownDegradedError(err.Error())}
-
 		} else if reconciled.Status != monv1.PrometheusConditionTrue {
 			klog.V(4).Info("validate prometheus failed reconciled condition: ", reconciled.Status)
 			msg := fmt.Sprintf("%s: %s", reconciled.Reason, reconciled.Message)
@@ -1762,7 +1760,6 @@ func (c *Client) CreateOrUpdateAPIService(ctx context.Context, apiService *apire
 	}
 	_, err = apsc.Update(ctx, required, metav1.UpdateOptions{})
 	return errors.Wrap(err, "updating APIService object failed")
-
 }
 
 func (c *Client) WaitForCRDReady(ctx context.Context, crd *extensionsobj.CustomResourceDefinition) error {

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -411,7 +411,6 @@ func (c *Config) LoadEnforcedBodySizeLimit(pcr PodCapacityReader, ctx context.Co
 	}
 
 	return poperator.ValidateSizeField(c.ClusterMonitoringConfiguration.PrometheusK8sConfig.EnforcedBodySizeLimit)
-
 }
 
 func calculateBodySizeLimit(podCapacity int) string {

--- a/pkg/promqlgen/promqlgen.go
+++ b/pkg/promqlgen/promqlgen.go
@@ -78,7 +78,6 @@ func GroupLabelSelectors(matches []string) (string, error) {
 				newLabelSet[lm.Name] = []string{lm.Value}
 			}
 		}
-
 	}
 
 	keys := make([]string, 0, len(newLabelSet))

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -336,7 +336,6 @@ func (t *AlertmanagerTask) destroy(ctx context.Context) error {
 
 		if err := t.client.DeleteConfigMap(ctx, trustedCA); err != nil {
 			return errors.Wrap(err, "deleting Alertmanager trusted CA bundle failed")
-
 		}
 
 		a, err := t.factory.AlertmanagerMain(trustedCA)

--- a/pkg/tasks/alertmanager_user_workload.go
+++ b/pkg/tasks/alertmanager_user_workload.go
@@ -277,7 +277,6 @@ func (t *AlertmanagerUserWorkloadTask) destroy(ctx context.Context) error {
 
 		if err := t.client.DeleteConfigMap(ctx, trustedCA); err != nil {
 			return errors.Wrap(err, "deleting Alertmanager User Workload trusted CA bundle failed")
-
 		}
 
 		a, err := t.factory.AlertmanagerUserWorkload(trustedCA)

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -41,7 +41,6 @@ func NewPrometheusTask(client *client.Client, factory *manifests.Factory, config
 }
 
 func (t *PrometheusTask) Run(ctx context.Context) error {
-
 	errs := []error{}
 
 	err := t.create(ctx)

--- a/pkg/tasks/prometheus_validation.go
+++ b/pkg/tasks/prometheus_validation.go
@@ -36,7 +36,6 @@ func NewPrometheusValidationTask(client *client.Client, factory *manifests.Facto
 }
 
 func (t *PrometheusValidationTask) Run(ctx context.Context) error {
-
 	prom, err := t.factory.NewPrometheusK8s()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixes whitespace violations as per the new makefile target for
golangci-lint.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>