### PR TITLE
OCPBUGS-14375: Fix golangci-lint gosimple violations

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -181,7 +181,7 @@ func (cfg *TelemeterClientConfig) IsEnabled() bool {
 		return false
 	}
 
-	if (cfg.Enabled != nil && *cfg.Enabled == false) ||
+	if (cfg.Enabled != nil && !*cfg.Enabled) ||
 		cfg.ClusterID == "" ||
 		cfg.Token == "" {
 		return false

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3017,7 +3017,7 @@ func (f *Factory) mountThanosRulerAlertmanagerSecrets(t *monv1.ThanosRuler) {
 	}
 
 	t.Spec.Volumes = append(t.Spec.Volumes, volumes...)
-	for i, _ := range t.Spec.Containers {
+	for i := range t.Spec.Containers {
 		containerName := t.Spec.Containers[i].Name
 		if containerName == "thanos-ruler" {
 			t.Spec.Containers[i].VolumeMounts = append(t.Spec.Containers[i].VolumeMounts, volumeMounts...)
@@ -3031,7 +3031,7 @@ func (f *Factory) injectThanosRulerAlertmanagerDigest(t *monv1.ThanosRuler, aler
 	}
 	digestBytes := md5.Sum([]byte(alertmanagerConfig.StringData["alertmanagers.yaml"]))
 	digest := fmt.Sprintf("%x", digestBytes)
-	for i, _ := range t.Spec.Containers {
+	for i := range t.Spec.Containers {
 		containerName := t.Spec.Containers[i].Name
 		if containerName == "thanos-ruler" {
 			// Thanos ruler does not refresh its config when the alertmanagers secret changes.


### PR DESCRIPTION
This PR fixes gosimple violations as per the new makefile target for
golangci-lint.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>