### PR TITLE
OCPBUGS-14376: Fix golangci-lint ineffassign violations

### DIFF
--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -275,6 +275,7 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Metrics Client Certs secret failed")
 	}
 
+	//nolint:ineffassign
 	metricsCerts, err = t.client.WaitForSecret(ctx, metricsCerts)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Metrics Client Certs secret failed")

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -335,6 +335,10 @@ func (t *PrometheusUserWorkloadTask) destroy(ctx context.Context) error {
 		"server.key", string(grpcTLS.Data["prometheus-server.key"]),
 	)
 
+	if err != nil {
+		return errors.Wrap(err, "error hashing TLS secrets")
+	}
+
 	pdb, err := t.factory.PrometheusUserWorkloadPodDisruptionBudget()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus PodDisruptionBudget object failed")

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -233,6 +233,9 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 				return errors.Wrap(err, "initializing Thanos Querier Route failed")
 			}
 			queryURL, err = t.client.GetRouteURL(ctx, querierRoute)
+			if err != nil {
+				return errors.Wrap(err, "error getting Thanos Querier Route url")
+			}
 		}
 
 		pdb, err := t.factory.ThanosRulerPodDisruptionBudget()


### PR DESCRIPTION
This PR fixes golangci-lint ineffassign violations as per the new
Makefile option.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>