### PR TITLE
Fix golangci-lint unconvert violations

### DIFF
--- a/pkg/tasks/helpers.go
+++ b/pkg/tasks/helpers.go
@@ -83,7 +83,7 @@ func (cbs *caBundleSyncer) syncTrustedCABundle(ctx context.Context, trustedCA *v
 		ctx,
 		trustedCA.GetNamespace(),
 		cbs.prefix,
-		string(hashedCM.Labels["monitoring.openshift.io/hash"]),
+		hashedCM.Labels["monitoring.openshift.io/hash"],
 	)
 	return hashedCM, errors.Wrap(err, "deleting old trusted CA bundle configmaps failed")
 }

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -313,7 +313,7 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 		ctx,
 		s.GetNamespace(),
 		"prometheus-k8s-grpc-tls",
-		string(s.Labels["monitoring.openshift.io/hash"]),
+		s.Labels["monitoring.openshift.io/hash"],
 	)
 	if err != nil {
 		return errors.Wrap(err, "error creating Prometheus Client GRPC TLS secret")

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -183,7 +183,7 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 		ctx,
 		s.GetNamespace(),
 		"prometheus-user-workload-grpc-tls",
-		string(s.Labels["monitoring.openshift.io/hash"]),
+		s.Labels["monitoring.openshift.io/hash"],
 	)
 	if err != nil {
 		return errors.Wrap(err, "error creating UserWorkload Prometheus Client GRPC TLS secret")

--- a/pkg/tasks/prometheusadapter.go
+++ b/pkg/tasks/prometheusadapter.go
@@ -200,7 +200,7 @@ func (t *PrometheusAdapterTask) Run(ctx context.Context) error {
 			return errors.Wrap(err, "failed to create prometheus adapter secret")
 		}
 
-		err = t.deleteOldPrometheusAdapterSecrets(string(secret.Labels["monitoring.openshift.io/hash"]))
+		err = t.deleteOldPrometheusAdapterSecrets(secret.Labels["monitoring.openshift.io/hash"])
 		if err != nil {
 			return errors.Wrap(err, "deleting old prometheus adapter secrets failed")
 		}

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -173,7 +173,7 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 		ctx,
 		s.GetNamespace(),
 		"thanos-querier-grpc-tls",
-		string(s.Labels["monitoring.openshift.io/hash"]),
+		s.Labels["monitoring.openshift.io/hash"],
 	)
 	if err != nil {
 		return errors.Wrap(err, "error creating Thanos Querier Client GRPC TLS secret")

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -216,7 +216,7 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 			ctx,
 			grpcSecret.GetNamespace(),
 			"thanos-ruler-grpc-tls",
-			string(grpcSecret.Labels["monitoring.openshift.io/hash"]),
+			grpcSecret.Labels["monitoring.openshift.io/hash"],
 		)
 		if err != nil {
 			return errors.Wrap(err, "error deleting expired UserWorkload Thanos Ruler GRPC TLS secret")


### PR DESCRIPTION
This PR fixes unnecesary conversions as per the new golangci-lint
Makefile target.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>