### PR TITLE
OCPBUGS-14379: Skip specific govet violation on operator main.go

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -82,6 +82,7 @@ type telemetryConfig struct {
 	Matches []string `json:"matches"`
 }
 
+//nolint:govet
 func Main() int {
 	flagset := flag.CommandLine
 	klog.InitFlags(flagset)


### PR DESCRIPTION
This commit skips the warning of unbuffered os.Signal channel due to its explicitly wanted use
as per to do graceful shutdown.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>