### PR TITLE
OCPBUGS-14606: Remove remaining staticcheck violations

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -207,7 +207,7 @@ func Main() int {
 	}
 	wg.Go(func() error { return srv.Run(ctx) })
 
-	term := make(chan os.Signal)
+	term := make(chan os.Signal, 1)
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 
 	select {

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -274,8 +274,7 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "initializing Metrics Client Certs secret failed")
 	}
 
-	//nolint:ineffassign
-	metricsCerts, err = t.client.WaitForSecret(ctx, metricsCerts)
+	_, err = t.client.WaitForSecret(ctx, metricsCerts)
 	if err != nil {
 		return errors.Wrap(err, "waiting for Metrics Client Certs secret failed")
 	}


### PR DESCRIPTION
This PR removes remaining static check violations in the CMO that
showed up after fixing all the other issues.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>