### PR TITLE
OCPBUGS-14123: make TestBodySizeLimit less flaky

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Jeffail/gabs/v2 v2.6.1
 	github.com/blang/semver/v4 v4.0.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-kit/log v0.2.1
 	github.com/imdario/mergo v0.3.13
 	github.com/openshift/api v0.0.0-20230120195050-6ba31fa438f2
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
@@ -62,7 +63,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/client_metrics.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/client_metrics.go
@@ -1,0 +1,175 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/tools/metrics"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const workqueueMetricsNamespace = metricsNamespace + "_workqueue"
+
+var (
+	// Metrics for client-go's HTTP requests.
+	clientGoRequestResultMetricVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "http_request_total",
+			Help:      "Total number of HTTP requests to the Kubernetes API by status code.",
+		},
+		[]string{"status_code"},
+	)
+	clientGoRequestLatencyMetricVec = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace:  metricsNamespace,
+			Name:       "http_request_duration_seconds",
+			Help:       "Summary of latencies for HTTP requests to the Kubernetes API by endpoint.",
+			Objectives: map[float64]float64{},
+		},
+		[]string{"endpoint"},
+	)
+
+	// Definition of metrics for client-go workflow metrics provider
+	clientGoWorkqueueDepthMetricVec = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: workqueueMetricsNamespace,
+			Name:      "depth",
+			Help:      "Current depth of the work queue.",
+		},
+		[]string{"queue_name"},
+	)
+	clientGoWorkqueueAddsMetricVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: workqueueMetricsNamespace,
+			Name:      "items_total",
+			Help:      "Total number of items added to the work queue.",
+		},
+		[]string{"queue_name"},
+	)
+	clientGoWorkqueueLatencyMetricVec = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace:  workqueueMetricsNamespace,
+			Name:       "latency_seconds",
+			Help:       "How long an item stays in the work queue.",
+			Objectives: map[float64]float64{},
+		},
+		[]string{"queue_name"},
+	)
+	clientGoWorkqueueUnfinishedWorkSecondsMetricVec = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: workqueueMetricsNamespace,
+			Name:      "unfinished_work_seconds",
+			Help:      "How long an item has remained unfinished in the work queue.",
+		},
+		[]string{"queue_name"},
+	)
+	clientGoWorkqueueLongestRunningProcessorMetricVec = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: workqueueMetricsNamespace,
+			Name:      "longest_running_processor_seconds",
+			Help:      "Duration of the longest running processor in the work queue.",
+		},
+		[]string{"queue_name"},
+	)
+	clientGoWorkqueueWorkDurationMetricVec = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace:  workqueueMetricsNamespace,
+			Name:       "work_duration_seconds",
+			Help:       "How long processing an item from the work queue takes.",
+			Objectives: map[float64]float64{},
+		},
+		[]string{"queue_name"},
+	)
+)
+
+// Definition of dummy metric used as a placeholder if we don't want to observe some data.
+type noopMetric struct{}
+
+func (noopMetric) Inc()            {}
+func (noopMetric) Dec()            {}
+func (noopMetric) Observe(float64) {}
+func (noopMetric) Set(float64)     {}
+
+// Definition of client-go metrics adapters for HTTP requests observation
+type clientGoRequestMetricAdapter struct{}
+
+func (f *clientGoRequestMetricAdapter) Register(registerer prometheus.Registerer) {
+	metrics.Register(
+		metrics.RegisterOpts{
+			RequestLatency: f,
+			RequestResult:  f,
+		},
+	)
+	registerer.MustRegister(
+		clientGoRequestResultMetricVec,
+		clientGoRequestLatencyMetricVec,
+	)
+}
+
+func (clientGoRequestMetricAdapter) Increment(ctx context.Context, code, method, host string) {
+	clientGoRequestResultMetricVec.WithLabelValues(code).Inc()
+}
+
+func (clientGoRequestMetricAdapter) Observe(ctx context.Context, verb string, u url.URL, latency time.Duration) {
+	clientGoRequestLatencyMetricVec.WithLabelValues(u.EscapedPath()).Observe(latency.Seconds())
+}
+
+// Definition of client-go workqueue metrics provider definition
+type clientGoWorkqueueMetricsProvider struct{}
+
+func (f *clientGoWorkqueueMetricsProvider) Register(registerer prometheus.Registerer) {
+	workqueue.SetProvider(f)
+	registerer.MustRegister(
+		clientGoWorkqueueDepthMetricVec,
+		clientGoWorkqueueAddsMetricVec,
+		clientGoWorkqueueLatencyMetricVec,
+		clientGoWorkqueueWorkDurationMetricVec,
+		clientGoWorkqueueUnfinishedWorkSecondsMetricVec,
+		clientGoWorkqueueLongestRunningProcessorMetricVec,
+	)
+}
+
+func (f *clientGoWorkqueueMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return clientGoWorkqueueDepthMetricVec.WithLabelValues(name)
+}
+
+func (f *clientGoWorkqueueMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	return clientGoWorkqueueAddsMetricVec.WithLabelValues(name)
+}
+
+func (f *clientGoWorkqueueMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	return clientGoWorkqueueLatencyMetricVec.WithLabelValues(name)
+}
+
+func (f *clientGoWorkqueueMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	return clientGoWorkqueueWorkDurationMetricVec.WithLabelValues(name)
+}
+
+func (f *clientGoWorkqueueMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return clientGoWorkqueueUnfinishedWorkSecondsMetricVec.WithLabelValues(name)
+}
+
+func (f *clientGoWorkqueueMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return clientGoWorkqueueLongestRunningProcessorMetricVec.WithLabelValues(name)
+}
+
+func (clientGoWorkqueueMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	// Retries are not used so the metric is omitted.
+	return noopMetric{}
+}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/endpoints.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/endpoints.go
@@ -1,0 +1,469 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+var (
+	epAddCount    = eventCount.WithLabelValues("endpoints", "add")
+	epUpdateCount = eventCount.WithLabelValues("endpoints", "update")
+	epDeleteCount = eventCount.WithLabelValues("endpoints", "delete")
+)
+
+// Endpoints discovers new endpoint targets.
+type Endpoints struct {
+	logger log.Logger
+
+	endpointsInf     cache.SharedIndexInformer
+	serviceInf       cache.SharedInformer
+	podInf           cache.SharedInformer
+	nodeInf          cache.SharedInformer
+	withNodeMetadata bool
+
+	podStore       cache.Store
+	endpointsStore cache.Store
+	serviceStore   cache.Store
+
+	queue *workqueue.Type
+}
+
+// NewEndpoints returns a new endpoints discovery.
+func NewEndpoints(l log.Logger, eps cache.SharedIndexInformer, svc, pod, node cache.SharedInformer) *Endpoints {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+	e := &Endpoints{
+		logger:           l,
+		endpointsInf:     eps,
+		endpointsStore:   eps.GetStore(),
+		serviceInf:       svc,
+		serviceStore:     svc.GetStore(),
+		podInf:           pod,
+		podStore:         pod.GetStore(),
+		nodeInf:          node,
+		withNodeMetadata: node != nil,
+		queue:            workqueue.NewNamed("endpoints"),
+	}
+
+	_, err := e.endpointsInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			epAddCount.Inc()
+			e.enqueue(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			epUpdateCount.Inc()
+			e.enqueue(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			epDeleteCount.Inc()
+			e.enqueue(o)
+		},
+	})
+	if err != nil {
+		level.Error(l).Log("msg", "Error adding endpoints event handler.", "err", err)
+	}
+
+	serviceUpdate := func(o interface{}) {
+		svc, err := convertToService(o)
+		if err != nil {
+			level.Error(e.logger).Log("msg", "converting to Service object failed", "err", err)
+			return
+		}
+
+		ep := &apiv1.Endpoints{}
+		ep.Namespace = svc.Namespace
+		ep.Name = svc.Name
+		obj, exists, err := e.endpointsStore.Get(ep)
+		if exists && err == nil {
+			e.enqueue(obj.(*apiv1.Endpoints))
+		}
+
+		if err != nil {
+			level.Error(e.logger).Log("msg", "retrieving endpoints failed", "err", err)
+		}
+	}
+	_, err = e.serviceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		// TODO(fabxc): potentially remove add and delete event handlers. Those should
+		// be triggered via the endpoint handlers already.
+		AddFunc: func(o interface{}) {
+			svcAddCount.Inc()
+			serviceUpdate(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			svcUpdateCount.Inc()
+			serviceUpdate(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			svcDeleteCount.Inc()
+			serviceUpdate(o)
+		},
+	})
+	if err != nil {
+		level.Error(l).Log("msg", "Error adding services event handler.", "err", err)
+	}
+	if e.withNodeMetadata {
+		_, err = e.nodeInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(o interface{}) {
+				node := o.(*apiv1.Node)
+				e.enqueueNode(node.Name)
+			},
+			UpdateFunc: func(_, o interface{}) {
+				node := o.(*apiv1.Node)
+				e.enqueueNode(node.Name)
+			},
+			DeleteFunc: func(o interface{}) {
+				node := o.(*apiv1.Node)
+				e.enqueueNode(node.Name)
+			},
+		})
+		if err != nil {
+			level.Error(l).Log("msg", "Error adding nodes event handler.", "err", err)
+		}
+	}
+
+	return e
+}
+
+func (e *Endpoints) enqueueNode(nodeName string) {
+	endpoints, err := e.endpointsInf.GetIndexer().ByIndex(nodeIndex, nodeName)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Error getting endpoints for node", "node", nodeName, "err", err)
+		return
+	}
+
+	for _, endpoint := range endpoints {
+		e.enqueue(endpoint)
+	}
+}
+
+func (e *Endpoints) enqueue(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	e.queue.Add(key)
+}
+
+// Run implements the Discoverer interface.
+func (e *Endpoints) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer e.queue.ShutDown()
+
+	cacheSyncs := []cache.InformerSynced{e.endpointsInf.HasSynced, e.serviceInf.HasSynced, e.podInf.HasSynced}
+	if e.withNodeMetadata {
+		cacheSyncs = append(cacheSyncs, e.nodeInf.HasSynced)
+	}
+
+	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			level.Error(e.logger).Log("msg", "endpoints informer unable to sync cache")
+		}
+		return
+	}
+
+	go func() {
+		for e.process(ctx, ch) {
+		}
+	}()
+
+	// Block until the target provider is explicitly canceled.
+	<-ctx.Done()
+}
+
+func (e *Endpoints) process(ctx context.Context, ch chan<- []*targetgroup.Group) bool {
+	keyObj, quit := e.queue.Get()
+	if quit {
+		return false
+	}
+	defer e.queue.Done(keyObj)
+	key := keyObj.(string)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "splitting key failed", "key", key)
+		return true
+	}
+
+	o, exists, err := e.endpointsStore.GetByKey(key)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "getting object from store failed", "key", key)
+		return true
+	}
+	if !exists {
+		send(ctx, ch, &targetgroup.Group{Source: endpointsSourceFromNamespaceAndName(namespace, name)})
+		return true
+	}
+	eps, err := convertToEndpoints(o)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "converting to Endpoints object failed", "err", err)
+		return true
+	}
+	send(ctx, ch, e.buildEndpoints(eps))
+	return true
+}
+
+func convertToEndpoints(o interface{}) (*apiv1.Endpoints, error) {
+	endpoints, ok := o.(*apiv1.Endpoints)
+	if ok {
+		return endpoints, nil
+	}
+
+	return nil, fmt.Errorf("received unexpected object: %v", o)
+}
+
+func endpointsSource(ep *apiv1.Endpoints) string {
+	return endpointsSourceFromNamespaceAndName(ep.Namespace, ep.Name)
+}
+
+func endpointsSourceFromNamespaceAndName(namespace, name string) string {
+	return "endpoints/" + namespace + "/" + name
+}
+
+const (
+	endpointsLabelPrefix           = metaLabelPrefix + "endpoints_label_"
+	endpointsLabelPresentPrefix    = metaLabelPrefix + "endpoints_labelpresent_"
+	endpointsNameLabel             = metaLabelPrefix + "endpoints_name"
+	endpointNodeName               = metaLabelPrefix + "endpoint_node_name"
+	endpointHostname               = metaLabelPrefix + "endpoint_hostname"
+	endpointReadyLabel             = metaLabelPrefix + "endpoint_ready"
+	endpointPortNameLabel          = metaLabelPrefix + "endpoint_port_name"
+	endpointPortProtocolLabel      = metaLabelPrefix + "endpoint_port_protocol"
+	endpointAddressTargetKindLabel = metaLabelPrefix + "endpoint_address_target_kind"
+	endpointAddressTargetNameLabel = metaLabelPrefix + "endpoint_address_target_name"
+)
+
+func (e *Endpoints) buildEndpoints(eps *apiv1.Endpoints) *targetgroup.Group {
+	tg := &targetgroup.Group{
+		Source: endpointsSource(eps),
+	}
+	tg.Labels = model.LabelSet{
+		namespaceLabel:     lv(eps.Namespace),
+		endpointsNameLabel: lv(eps.Name),
+	}
+	e.addServiceLabels(eps.Namespace, eps.Name, tg)
+	// Add endpoints labels metadata.
+	for k, v := range eps.Labels {
+		ln := strutil.SanitizeLabelName(k)
+		tg.Labels[model.LabelName(endpointsLabelPrefix+ln)] = lv(v)
+		tg.Labels[model.LabelName(endpointsLabelPresentPrefix+ln)] = presentValue
+	}
+
+	type podEntry struct {
+		pod          *apiv1.Pod
+		servicePorts []apiv1.EndpointPort
+	}
+	seenPods := map[string]*podEntry{}
+
+	add := func(addr apiv1.EndpointAddress, port apiv1.EndpointPort, ready string) {
+		a := net.JoinHostPort(addr.IP, strconv.FormatUint(uint64(port.Port), 10))
+
+		target := model.LabelSet{
+			model.AddressLabel:        lv(a),
+			endpointPortNameLabel:     lv(port.Name),
+			endpointPortProtocolLabel: lv(string(port.Protocol)),
+			endpointReadyLabel:        lv(ready),
+		}
+
+		if addr.TargetRef != nil {
+			target[model.LabelName(endpointAddressTargetKindLabel)] = lv(addr.TargetRef.Kind)
+			target[model.LabelName(endpointAddressTargetNameLabel)] = lv(addr.TargetRef.Name)
+		}
+
+		if addr.NodeName != nil {
+			target[model.LabelName(endpointNodeName)] = lv(*addr.NodeName)
+		}
+		if addr.Hostname != "" {
+			target[model.LabelName(endpointHostname)] = lv(addr.Hostname)
+		}
+
+		if e.withNodeMetadata {
+			target = addNodeLabels(target, e.nodeInf, e.logger, addr.NodeName)
+		}
+
+		pod := e.resolvePodRef(addr.TargetRef)
+		if pod == nil {
+			// This target is not a Pod, so don't continue with Pod specific logic.
+			tg.Targets = append(tg.Targets, target)
+			return
+		}
+		s := pod.Namespace + "/" + pod.Name
+
+		sp, ok := seenPods[s]
+		if !ok {
+			sp = &podEntry{pod: pod}
+			seenPods[s] = sp
+		}
+
+		// Attach standard pod labels.
+		target = target.Merge(podLabels(pod))
+
+		// Attach potential container port labels matching the endpoint port.
+		for _, c := range pod.Spec.Containers {
+			for _, cport := range c.Ports {
+				if port.Port == cport.ContainerPort {
+					ports := strconv.FormatUint(uint64(port.Port), 10)
+
+					target[podContainerNameLabel] = lv(c.Name)
+					target[podContainerImageLabel] = lv(c.Image)
+					target[podContainerPortNameLabel] = lv(cport.Name)
+					target[podContainerPortNumberLabel] = lv(ports)
+					target[podContainerPortProtocolLabel] = lv(string(port.Protocol))
+					break
+				}
+			}
+		}
+
+		// Add service port so we know that we have already generated a target
+		// for it.
+		sp.servicePorts = append(sp.servicePorts, port)
+		tg.Targets = append(tg.Targets, target)
+	}
+
+	for _, ss := range eps.Subsets {
+		for _, port := range ss.Ports {
+			for _, addr := range ss.Addresses {
+				add(addr, port, "true")
+			}
+			// Although this generates the same target again, as it was generated in
+			// the loop above, it causes the ready meta label to be overridden.
+			for _, addr := range ss.NotReadyAddresses {
+				add(addr, port, "false")
+			}
+		}
+	}
+
+	v := eps.Labels[apiv1.EndpointsOverCapacity]
+	if v == "truncated" {
+		level.Warn(e.logger).Log("msg", "Number of endpoints in one Endpoints object exceeds 1000 and has been truncated, please use \"role: endpointslice\" instead", "endpoint", eps.Name)
+	}
+	if v == "warning" {
+		level.Warn(e.logger).Log("msg", "Number of endpoints in one Endpoints object exceeds 1000, please use \"role: endpointslice\" instead", "endpoint", eps.Name)
+	}
+
+	// For all seen pods, check all container ports. If they were not covered
+	// by one of the service endpoints, generate targets for them.
+	for _, pe := range seenPods {
+		for _, c := range pe.pod.Spec.Containers {
+			for _, cport := range c.Ports {
+				hasSeenPort := func() bool {
+					for _, eport := range pe.servicePorts {
+						if cport.ContainerPort == eport.Port {
+							return true
+						}
+					}
+					return false
+				}
+				if hasSeenPort() {
+					continue
+				}
+
+				a := net.JoinHostPort(pe.pod.Status.PodIP, strconv.FormatUint(uint64(cport.ContainerPort), 10))
+				ports := strconv.FormatUint(uint64(cport.ContainerPort), 10)
+
+				target := model.LabelSet{
+					model.AddressLabel:            lv(a),
+					podContainerNameLabel:         lv(c.Name),
+					podContainerImageLabel:        lv(c.Image),
+					podContainerPortNameLabel:     lv(cport.Name),
+					podContainerPortNumberLabel:   lv(ports),
+					podContainerPortProtocolLabel: lv(string(cport.Protocol)),
+				}
+				tg.Targets = append(tg.Targets, target.Merge(podLabels(pe.pod)))
+			}
+		}
+	}
+
+	return tg
+}
+
+func (e *Endpoints) resolvePodRef(ref *apiv1.ObjectReference) *apiv1.Pod {
+	if ref == nil || ref.Kind != "Pod" {
+		return nil
+	}
+	p := &apiv1.Pod{}
+	p.Namespace = ref.Namespace
+	p.Name = ref.Name
+
+	obj, exists, err := e.podStore.Get(p)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "resolving pod ref failed", "err", err)
+		return nil
+	}
+	if !exists {
+		return nil
+	}
+	return obj.(*apiv1.Pod)
+}
+
+func (e *Endpoints) addServiceLabels(ns, name string, tg *targetgroup.Group) {
+	svc := &apiv1.Service{}
+	svc.Namespace = ns
+	svc.Name = name
+
+	obj, exists, err := e.serviceStore.Get(svc)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "retrieving service failed", "err", err)
+		return
+	}
+	if !exists {
+		return
+	}
+	svc = obj.(*apiv1.Service)
+
+	tg.Labels = tg.Labels.Merge(serviceLabels(svc))
+}
+
+func addNodeLabels(tg model.LabelSet, nodeInf cache.SharedInformer, logger log.Logger, nodeName *string) model.LabelSet {
+	if nodeName == nil {
+		return tg
+	}
+
+	obj, exists, err := nodeInf.GetStore().GetByKey(*nodeName)
+	if err != nil {
+		level.Error(logger).Log("msg", "Error getting node", "node", *nodeName, "err", err)
+		return tg
+	}
+
+	if !exists {
+		return tg
+	}
+
+	node := obj.(*apiv1.Node)
+	// Allocate one target label for the node name,
+	// and two target labels for each node label.
+	nodeLabelset := make(model.LabelSet, 1+2*len(node.GetLabels()))
+	nodeLabelset[nodeNameLabel] = lv(*nodeName)
+	for k, v := range node.GetLabels() {
+		ln := strutil.SanitizeLabelName(k)
+		nodeLabelset[model.LabelName(nodeLabelPrefix+ln)] = lv(v)
+		nodeLabelset[model.LabelName(nodeLabelPresentPrefix+ln)] = presentValue
+	}
+	return tg.Merge(nodeLabelset)
+}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/endpointslice.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/endpointslice.go
@@ -1,0 +1,468 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/discovery/v1"
+	"k8s.io/api/discovery/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+var (
+	epslAddCount    = eventCount.WithLabelValues("endpointslice", "add")
+	epslUpdateCount = eventCount.WithLabelValues("endpointslice", "update")
+	epslDeleteCount = eventCount.WithLabelValues("endpointslice", "delete")
+)
+
+// EndpointSlice discovers new endpoint targets.
+type EndpointSlice struct {
+	logger log.Logger
+
+	endpointSliceInf cache.SharedIndexInformer
+	serviceInf       cache.SharedInformer
+	podInf           cache.SharedInformer
+	nodeInf          cache.SharedInformer
+	withNodeMetadata bool
+
+	podStore           cache.Store
+	endpointSliceStore cache.Store
+	serviceStore       cache.Store
+
+	queue *workqueue.Type
+}
+
+// NewEndpointSlice returns a new endpointslice discovery.
+func NewEndpointSlice(l log.Logger, eps cache.SharedIndexInformer, svc, pod, node cache.SharedInformer) *EndpointSlice {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+	e := &EndpointSlice{
+		logger:             l,
+		endpointSliceInf:   eps,
+		endpointSliceStore: eps.GetStore(),
+		serviceInf:         svc,
+		serviceStore:       svc.GetStore(),
+		podInf:             pod,
+		podStore:           pod.GetStore(),
+		nodeInf:            node,
+		withNodeMetadata:   node != nil,
+		queue:              workqueue.NewNamed("endpointSlice"),
+	}
+
+	_, err := e.endpointSliceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			epslAddCount.Inc()
+			e.enqueue(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			epslUpdateCount.Inc()
+			e.enqueue(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			epslDeleteCount.Inc()
+			e.enqueue(o)
+		},
+	})
+	if err != nil {
+		level.Error(l).Log("msg", "Error adding endpoint slices event handler.", "err", err)
+	}
+
+	serviceUpdate := func(o interface{}) {
+		svc, err := convertToService(o)
+		if err != nil {
+			level.Error(e.logger).Log("msg", "converting to Service object failed", "err", err)
+			return
+		}
+
+		// TODO(brancz): use cache.Indexer to index endpoints by
+		// disv1beta1.LabelServiceName so this operation doesn't have to
+		// iterate over all endpoint objects.
+		for _, obj := range e.endpointSliceStore.List() {
+			esa, err := e.getEndpointSliceAdaptor(obj)
+			if err != nil {
+				level.Error(e.logger).Log("msg", "converting to EndpointSlice object failed", "err", err)
+				continue
+			}
+			if lv, exists := esa.labels()[esa.labelServiceName()]; exists && lv == svc.Name {
+				e.enqueue(esa.get())
+			}
+		}
+	}
+	_, err = e.serviceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			svcAddCount.Inc()
+			serviceUpdate(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			svcUpdateCount.Inc()
+			serviceUpdate(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			svcDeleteCount.Inc()
+			serviceUpdate(o)
+		},
+	})
+	if err != nil {
+		level.Error(l).Log("msg", "Error adding services event handler.", "err", err)
+	}
+
+	if e.withNodeMetadata {
+		_, err = e.nodeInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(o interface{}) {
+				node := o.(*apiv1.Node)
+				e.enqueueNode(node.Name)
+			},
+			UpdateFunc: func(_, o interface{}) {
+				node := o.(*apiv1.Node)
+				e.enqueueNode(node.Name)
+			},
+			DeleteFunc: func(o interface{}) {
+				node := o.(*apiv1.Node)
+				e.enqueueNode(node.Name)
+			},
+		})
+		if err != nil {
+			level.Error(l).Log("msg", "Error adding nodes event handler.", "err", err)
+		}
+	}
+
+	return e
+}
+
+func (e *EndpointSlice) enqueueNode(nodeName string) {
+	endpoints, err := e.endpointSliceInf.GetIndexer().ByIndex(nodeIndex, nodeName)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Error getting endpoints for node", "node", nodeName, "err", err)
+		return
+	}
+
+	for _, endpoint := range endpoints {
+		e.enqueue(endpoint)
+	}
+}
+
+func (e *EndpointSlice) enqueue(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	e.queue.Add(key)
+}
+
+// Run implements the Discoverer interface.
+func (e *EndpointSlice) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer e.queue.ShutDown()
+
+	cacheSyncs := []cache.InformerSynced{e.endpointSliceInf.HasSynced, e.serviceInf.HasSynced, e.podInf.HasSynced}
+	if e.withNodeMetadata {
+		cacheSyncs = append(cacheSyncs, e.nodeInf.HasSynced)
+	}
+	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
+		if ctx.Err() != context.Canceled {
+			level.Error(e.logger).Log("msg", "endpointslice informer unable to sync cache")
+		}
+		return
+	}
+
+	go func() {
+		for e.process(ctx, ch) {
+		}
+	}()
+
+	// Block until the target provider is explicitly canceled.
+	<-ctx.Done()
+}
+
+func (e *EndpointSlice) process(ctx context.Context, ch chan<- []*targetgroup.Group) bool {
+	keyObj, quit := e.queue.Get()
+	if quit {
+		return false
+	}
+	defer e.queue.Done(keyObj)
+	key := keyObj.(string)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "splitting key failed", "key", key)
+		return true
+	}
+
+	o, exists, err := e.endpointSliceStore.GetByKey(key)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "getting object from store failed", "key", key)
+		return true
+	}
+	if !exists {
+		send(ctx, ch, &targetgroup.Group{Source: endpointSliceSourceFromNamespaceAndName(namespace, name)})
+		return true
+	}
+
+	esa, err := e.getEndpointSliceAdaptor(o)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "converting to EndpointSlice object failed", "err", err)
+		return true
+	}
+
+	send(ctx, ch, e.buildEndpointSlice(esa))
+	return true
+}
+
+func (e *EndpointSlice) getEndpointSliceAdaptor(o interface{}) (endpointSliceAdaptor, error) {
+	switch endpointSlice := o.(type) {
+	case *v1.EndpointSlice:
+		return newEndpointSliceAdaptorFromV1(endpointSlice), nil
+	case *v1beta1.EndpointSlice:
+		return newEndpointSliceAdaptorFromV1beta1(endpointSlice), nil
+	default:
+		return nil, fmt.Errorf("received unexpected object: %v", o)
+	}
+}
+
+func endpointSliceSource(ep endpointSliceAdaptor) string {
+	return endpointSliceSourceFromNamespaceAndName(ep.namespace(), ep.name())
+}
+
+func endpointSliceSourceFromNamespaceAndName(namespace, name string) string {
+	return "endpointslice/" + namespace + "/" + name
+}
+
+const (
+	endpointSliceNameLabel                          = metaLabelPrefix + "endpointslice_name"
+	endpointSliceAddressTypeLabel                   = metaLabelPrefix + "endpointslice_address_type"
+	endpointSlicePortNameLabel                      = metaLabelPrefix + "endpointslice_port_name"
+	endpointSlicePortProtocolLabel                  = metaLabelPrefix + "endpointslice_port_protocol"
+	endpointSlicePortLabel                          = metaLabelPrefix + "endpointslice_port"
+	endpointSlicePortAppProtocol                    = metaLabelPrefix + "endpointslice_port_app_protocol"
+	endpointSliceEndpointConditionsReadyLabel       = metaLabelPrefix + "endpointslice_endpoint_conditions_ready"
+	endpointSliceEndpointHostnameLabel              = metaLabelPrefix + "endpointslice_endpoint_hostname"
+	endpointSliceAddressTargetKindLabel             = metaLabelPrefix + "endpointslice_address_target_kind"
+	endpointSliceAddressTargetNameLabel             = metaLabelPrefix + "endpointslice_address_target_name"
+	endpointSliceEndpointTopologyLabelPrefix        = metaLabelPrefix + "endpointslice_endpoint_topology_"
+	endpointSliceEndpointTopologyLabelPresentPrefix = metaLabelPrefix + "endpointslice_endpoint_topology_present_"
+)
+
+func (e *EndpointSlice) buildEndpointSlice(eps endpointSliceAdaptor) *targetgroup.Group {
+	tg := &targetgroup.Group{
+		Source: endpointSliceSource(eps),
+	}
+	tg.Labels = model.LabelSet{
+		namespaceLabel:                lv(eps.namespace()),
+		endpointSliceNameLabel:        lv(eps.name()),
+		endpointSliceAddressTypeLabel: lv(eps.addressType()),
+	}
+	e.addServiceLabels(eps, tg)
+
+	type podEntry struct {
+		pod          *apiv1.Pod
+		servicePorts []endpointSlicePortAdaptor
+	}
+	seenPods := map[string]*podEntry{}
+
+	add := func(addr string, ep endpointSliceEndpointAdaptor, port endpointSlicePortAdaptor) {
+		a := addr
+		if port.port() != nil {
+			a = net.JoinHostPort(addr, strconv.FormatUint(uint64(*port.port()), 10))
+		}
+
+		target := model.LabelSet{
+			model.AddressLabel: lv(a),
+		}
+
+		if port.name() != nil {
+			target[endpointSlicePortNameLabel] = lv(*port.name())
+		}
+
+		if port.protocol() != nil {
+			target[endpointSlicePortProtocolLabel] = lv(string(*port.protocol()))
+		}
+
+		if port.port() != nil {
+			target[endpointSlicePortLabel] = lv(strconv.FormatUint(uint64(*port.port()), 10))
+		}
+
+		if port.appProtocol() != nil {
+			target[endpointSlicePortAppProtocol] = lv(*port.appProtocol())
+		}
+
+		if ep.conditions().ready() != nil {
+			target[endpointSliceEndpointConditionsReadyLabel] = lv(strconv.FormatBool(*ep.conditions().ready()))
+		}
+
+		if ep.hostname() != nil {
+			target[endpointSliceEndpointHostnameLabel] = lv(*ep.hostname())
+		}
+
+		if ep.targetRef() != nil {
+			target[model.LabelName(endpointSliceAddressTargetKindLabel)] = lv(ep.targetRef().Kind)
+			target[model.LabelName(endpointSliceAddressTargetNameLabel)] = lv(ep.targetRef().Name)
+		}
+
+		for k, v := range ep.topology() {
+			ln := strutil.SanitizeLabelName(k)
+			target[model.LabelName(endpointSliceEndpointTopologyLabelPrefix+ln)] = lv(v)
+			target[model.LabelName(endpointSliceEndpointTopologyLabelPresentPrefix+ln)] = presentValue
+		}
+
+		if e.withNodeMetadata {
+			target = addNodeLabels(target, e.nodeInf, e.logger, ep.nodename())
+		}
+
+		pod := e.resolvePodRef(ep.targetRef())
+		if pod == nil {
+			// This target is not a Pod, so don't continue with Pod specific logic.
+			tg.Targets = append(tg.Targets, target)
+			return
+		}
+		s := pod.Namespace + "/" + pod.Name
+
+		sp, ok := seenPods[s]
+		if !ok {
+			sp = &podEntry{pod: pod}
+			seenPods[s] = sp
+		}
+
+		// Attach standard pod labels.
+		target = target.Merge(podLabels(pod))
+
+		// Attach potential container port labels matching the endpoint port.
+		for _, c := range pod.Spec.Containers {
+			for _, cport := range c.Ports {
+				if port.port() == nil {
+					continue
+				}
+				if *port.port() == cport.ContainerPort {
+					ports := strconv.FormatUint(uint64(*port.port()), 10)
+
+					target[podContainerNameLabel] = lv(c.Name)
+					target[podContainerImageLabel] = lv(c.Image)
+					target[podContainerPortNameLabel] = lv(cport.Name)
+					target[podContainerPortNumberLabel] = lv(ports)
+					target[podContainerPortProtocolLabel] = lv(string(cport.Protocol))
+					break
+				}
+			}
+		}
+
+		// Add service port so we know that we have already generated a target
+		// for it.
+		sp.servicePorts = append(sp.servicePorts, port)
+		tg.Targets = append(tg.Targets, target)
+	}
+
+	for _, ep := range eps.endpoints() {
+		for _, port := range eps.ports() {
+			for _, addr := range ep.addresses() {
+				add(addr, ep, port)
+			}
+		}
+	}
+
+	// For all seen pods, check all container ports. If they were not covered
+	// by one of the service endpoints, generate targets for them.
+	for _, pe := range seenPods {
+		for _, c := range pe.pod.Spec.Containers {
+			for _, cport := range c.Ports {
+				hasSeenPort := func() bool {
+					for _, eport := range pe.servicePorts {
+						if eport.port() == nil {
+							continue
+						}
+						if cport.ContainerPort == *eport.port() {
+							return true
+						}
+					}
+					return false
+				}
+				if hasSeenPort() {
+					continue
+				}
+
+				a := net.JoinHostPort(pe.pod.Status.PodIP, strconv.FormatUint(uint64(cport.ContainerPort), 10))
+				ports := strconv.FormatUint(uint64(cport.ContainerPort), 10)
+
+				target := model.LabelSet{
+					model.AddressLabel:            lv(a),
+					podContainerNameLabel:         lv(c.Name),
+					podContainerImageLabel:        lv(c.Image),
+					podContainerPortNameLabel:     lv(cport.Name),
+					podContainerPortNumberLabel:   lv(ports),
+					podContainerPortProtocolLabel: lv(string(cport.Protocol)),
+				}
+				tg.Targets = append(tg.Targets, target.Merge(podLabels(pe.pod)))
+			}
+		}
+	}
+
+	return tg
+}
+
+func (e *EndpointSlice) resolvePodRef(ref *apiv1.ObjectReference) *apiv1.Pod {
+	if ref == nil || ref.Kind != "Pod" {
+		return nil
+	}
+	p := &apiv1.Pod{}
+	p.Namespace = ref.Namespace
+	p.Name = ref.Name
+
+	obj, exists, err := e.podStore.Get(p)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "resolving pod ref failed", "err", err)
+		return nil
+	}
+	if !exists {
+		return nil
+	}
+	return obj.(*apiv1.Pod)
+}
+
+func (e *EndpointSlice) addServiceLabels(esa endpointSliceAdaptor, tg *targetgroup.Group) {
+	var (
+		svc   = &apiv1.Service{}
+		found bool
+	)
+	svc.Namespace = esa.namespace()
+
+	// Every EndpointSlice object has the Service they belong to in the
+	// kubernetes.io/service-name label.
+	svc.Name, found = esa.labels()[esa.labelServiceName()]
+	if !found {
+		return
+	}
+
+	obj, exists, err := e.serviceStore.Get(svc)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "retrieving service failed", "err", err)
+		return
+	}
+	if !exists {
+		return
+	}
+	svc = obj.(*apiv1.Service)
+
+	tg.Labels = tg.Labels.Merge(serviceLabels(svc))
+}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/endpointslice_adaptor.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/endpointslice_adaptor.go
@@ -1,0 +1,288 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/discovery/v1"
+	"k8s.io/api/discovery/v1beta1"
+)
+
+// endpointSliceAdaptor is an adaptor for the different EndpointSlice versions
+type endpointSliceAdaptor interface {
+	get() interface{}
+	name() string
+	namespace() string
+	addressType() string
+	endpoints() []endpointSliceEndpointAdaptor
+	ports() []endpointSlicePortAdaptor
+	labels() map[string]string
+	labelServiceName() string
+}
+
+type endpointSlicePortAdaptor interface {
+	name() *string
+	port() *int32
+	protocol() *string
+	appProtocol() *string
+}
+
+type endpointSliceEndpointAdaptor interface {
+	addresses() []string
+	hostname() *string
+	nodename() *string
+	conditions() endpointSliceEndpointConditionsAdaptor
+	targetRef() *corev1.ObjectReference
+	topology() map[string]string
+}
+
+type endpointSliceEndpointConditionsAdaptor interface {
+	ready() *bool
+}
+
+// Adaptor for k8s.io/api/discovery/v1
+type endpointSliceAdaptorV1 struct {
+	endpointSlice *v1.EndpointSlice
+}
+
+func newEndpointSliceAdaptorFromV1(endpointSlice *v1.EndpointSlice) endpointSliceAdaptor {
+	return &endpointSliceAdaptorV1{endpointSlice: endpointSlice}
+}
+
+func (e *endpointSliceAdaptorV1) get() interface{} {
+	return e.endpointSlice
+}
+
+func (e *endpointSliceAdaptorV1) name() string {
+	return e.endpointSlice.ObjectMeta.Name
+}
+
+func (e *endpointSliceAdaptorV1) namespace() string {
+	return e.endpointSlice.ObjectMeta.Namespace
+}
+
+func (e *endpointSliceAdaptorV1) addressType() string {
+	return string(e.endpointSlice.AddressType)
+}
+
+func (e *endpointSliceAdaptorV1) endpoints() []endpointSliceEndpointAdaptor {
+	eps := make([]endpointSliceEndpointAdaptor, 0, len(e.endpointSlice.Endpoints))
+	for i := 0; i < len(e.endpointSlice.Endpoints); i++ {
+		eps = append(eps, newEndpointSliceEndpointAdaptorFromV1(e.endpointSlice.Endpoints[i]))
+	}
+	return eps
+}
+
+func (e *endpointSliceAdaptorV1) ports() []endpointSlicePortAdaptor {
+	ports := make([]endpointSlicePortAdaptor, 0, len(e.endpointSlice.Ports))
+	for i := 0; i < len(e.endpointSlice.Ports); i++ {
+		ports = append(ports, newEndpointSlicePortAdaptorFromV1(e.endpointSlice.Ports[i]))
+	}
+	return ports
+}
+
+func (e *endpointSliceAdaptorV1) labels() map[string]string {
+	return e.endpointSlice.Labels
+}
+
+func (e *endpointSliceAdaptorV1) labelServiceName() string {
+	return v1.LabelServiceName
+}
+
+// Adaptor for k8s.io/api/discovery/v1beta1
+type endpointSliceAdaptorV1Beta1 struct {
+	endpointSlice *v1beta1.EndpointSlice
+}
+
+func newEndpointSliceAdaptorFromV1beta1(endpointSlice *v1beta1.EndpointSlice) endpointSliceAdaptor {
+	return &endpointSliceAdaptorV1Beta1{endpointSlice: endpointSlice}
+}
+
+func (e *endpointSliceAdaptorV1Beta1) get() interface{} {
+	return e.endpointSlice
+}
+
+func (e *endpointSliceAdaptorV1Beta1) name() string {
+	return e.endpointSlice.Name
+}
+
+func (e *endpointSliceAdaptorV1Beta1) namespace() string {
+	return e.endpointSlice.Namespace
+}
+
+func (e *endpointSliceAdaptorV1Beta1) addressType() string {
+	return string(e.endpointSlice.AddressType)
+}
+
+func (e *endpointSliceAdaptorV1Beta1) endpoints() []endpointSliceEndpointAdaptor {
+	eps := make([]endpointSliceEndpointAdaptor, 0, len(e.endpointSlice.Endpoints))
+	for i := 0; i < len(e.endpointSlice.Endpoints); i++ {
+		eps = append(eps, newEndpointSliceEndpointAdaptorFromV1beta1(e.endpointSlice.Endpoints[i]))
+	}
+	return eps
+}
+
+func (e *endpointSliceAdaptorV1Beta1) ports() []endpointSlicePortAdaptor {
+	ports := make([]endpointSlicePortAdaptor, 0, len(e.endpointSlice.Ports))
+	for i := 0; i < len(e.endpointSlice.Ports); i++ {
+		ports = append(ports, newEndpointSlicePortAdaptorFromV1beta1(e.endpointSlice.Ports[i]))
+	}
+	return ports
+}
+
+func (e *endpointSliceAdaptorV1Beta1) labels() map[string]string {
+	return e.endpointSlice.Labels
+}
+
+func (e *endpointSliceAdaptorV1Beta1) labelServiceName() string {
+	return v1beta1.LabelServiceName
+}
+
+type endpointSliceEndpointAdaptorV1 struct {
+	endpoint v1.Endpoint
+}
+
+func newEndpointSliceEndpointAdaptorFromV1(endpoint v1.Endpoint) endpointSliceEndpointAdaptor {
+	return &endpointSliceEndpointAdaptorV1{endpoint: endpoint}
+}
+
+func (e *endpointSliceEndpointAdaptorV1) addresses() []string {
+	return e.endpoint.Addresses
+}
+
+func (e *endpointSliceEndpointAdaptorV1) hostname() *string {
+	return e.endpoint.Hostname
+}
+
+func (e *endpointSliceEndpointAdaptorV1) nodename() *string {
+	return e.endpoint.NodeName
+}
+
+func (e *endpointSliceEndpointAdaptorV1) conditions() endpointSliceEndpointConditionsAdaptor {
+	return newEndpointSliceEndpointConditionsAdaptorFromV1(e.endpoint.Conditions)
+}
+
+func (e *endpointSliceEndpointAdaptorV1) targetRef() *corev1.ObjectReference {
+	return e.endpoint.TargetRef
+}
+
+func (e *endpointSliceEndpointAdaptorV1) topology() map[string]string {
+	return e.endpoint.DeprecatedTopology
+}
+
+type endpointSliceEndpointConditionsAdaptorV1 struct {
+	endpointConditions v1.EndpointConditions
+}
+
+func newEndpointSliceEndpointConditionsAdaptorFromV1(endpointConditions v1.EndpointConditions) endpointSliceEndpointConditionsAdaptor {
+	return &endpointSliceEndpointConditionsAdaptorV1{endpointConditions: endpointConditions}
+}
+
+func (e *endpointSliceEndpointConditionsAdaptorV1) ready() *bool {
+	return e.endpointConditions.Ready
+}
+
+type endpointSliceEndpointAdaptorV1beta1 struct {
+	endpoint v1beta1.Endpoint
+}
+
+func newEndpointSliceEndpointAdaptorFromV1beta1(endpoint v1beta1.Endpoint) endpointSliceEndpointAdaptor {
+	return &endpointSliceEndpointAdaptorV1beta1{endpoint: endpoint}
+}
+
+func (e *endpointSliceEndpointAdaptorV1beta1) addresses() []string {
+	return e.endpoint.Addresses
+}
+
+func (e *endpointSliceEndpointAdaptorV1beta1) hostname() *string {
+	return e.endpoint.Hostname
+}
+
+func (e *endpointSliceEndpointAdaptorV1beta1) nodename() *string {
+	return e.endpoint.NodeName
+}
+
+func (e *endpointSliceEndpointAdaptorV1beta1) conditions() endpointSliceEndpointConditionsAdaptor {
+	return newEndpointSliceEndpointConditionsAdaptorFromV1beta1(e.endpoint.Conditions)
+}
+
+func (e *endpointSliceEndpointAdaptorV1beta1) targetRef() *corev1.ObjectReference {
+	return e.endpoint.TargetRef
+}
+
+func (e *endpointSliceEndpointAdaptorV1beta1) topology() map[string]string {
+	return e.endpoint.Topology
+}
+
+type endpointSliceEndpointConditionsAdaptorV1beta1 struct {
+	endpointConditions v1beta1.EndpointConditions
+}
+
+func newEndpointSliceEndpointConditionsAdaptorFromV1beta1(endpointConditions v1beta1.EndpointConditions) endpointSliceEndpointConditionsAdaptor {
+	return &endpointSliceEndpointConditionsAdaptorV1beta1{endpointConditions: endpointConditions}
+}
+
+func (e *endpointSliceEndpointConditionsAdaptorV1beta1) ready() *bool {
+	return e.endpointConditions.Ready
+}
+
+type endpointSlicePortAdaptorV1 struct {
+	endpointPort v1.EndpointPort
+}
+
+func newEndpointSlicePortAdaptorFromV1(port v1.EndpointPort) endpointSlicePortAdaptor {
+	return &endpointSlicePortAdaptorV1{endpointPort: port}
+}
+
+func (e *endpointSlicePortAdaptorV1) name() *string {
+	return e.endpointPort.Name
+}
+
+func (e *endpointSlicePortAdaptorV1) port() *int32 {
+	return e.endpointPort.Port
+}
+
+func (e *endpointSlicePortAdaptorV1) protocol() *string {
+	val := string(*e.endpointPort.Protocol)
+	return &val
+}
+
+func (e *endpointSlicePortAdaptorV1) appProtocol() *string {
+	return e.endpointPort.AppProtocol
+}
+
+type endpointSlicePortAdaptorV1beta1 struct {
+	endpointPort v1beta1.EndpointPort
+}
+
+func newEndpointSlicePortAdaptorFromV1beta1(port v1beta1.EndpointPort) endpointSlicePortAdaptor {
+	return &endpointSlicePortAdaptorV1beta1{endpointPort: port}
+}
+
+func (e *endpointSlicePortAdaptorV1beta1) name() *string {
+	return e.endpointPort.Name
+}
+
+func (e *endpointSlicePortAdaptorV1beta1) port() *int32 {
+	return e.endpointPort.Port
+}
+
+func (e *endpointSlicePortAdaptorV1beta1) protocol() *string {
+	val := string(*e.endpointPort.Protocol)
+	return &val
+}
+
+func (e *endpointSlicePortAdaptorV1beta1) appProtocol() *string {
+	return e.endpointPort.AppProtocol
+}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/ingress.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/ingress.go
@@ -1,0 +1,254 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+var (
+	ingressAddCount    = eventCount.WithLabelValues("ingress", "add")
+	ingressUpdateCount = eventCount.WithLabelValues("ingress", "update")
+	ingressDeleteCount = eventCount.WithLabelValues("ingress", "delete")
+)
+
+// Ingress implements discovery of Kubernetes ingress.
+type Ingress struct {
+	logger   log.Logger
+	informer cache.SharedInformer
+	store    cache.Store
+	queue    *workqueue.Type
+}
+
+// NewIngress returns a new ingress discovery.
+func NewIngress(l log.Logger, inf cache.SharedInformer) *Ingress {
+	s := &Ingress{logger: l, informer: inf, store: inf.GetStore(), queue: workqueue.NewNamed("ingress")}
+	_, err := s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			ingressAddCount.Inc()
+			s.enqueue(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			ingressDeleteCount.Inc()
+			s.enqueue(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			ingressUpdateCount.Inc()
+			s.enqueue(o)
+		},
+	})
+	if err != nil {
+		level.Error(l).Log("msg", "Error adding ingresses event handler.", "err", err)
+	}
+	return s
+}
+
+func (i *Ingress) enqueue(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	i.queue.Add(key)
+}
+
+// Run implements the Discoverer interface.
+func (i *Ingress) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer i.queue.ShutDown()
+
+	if !cache.WaitForCacheSync(ctx.Done(), i.informer.HasSynced) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			level.Error(i.logger).Log("msg", "ingress informer unable to sync cache")
+		}
+		return
+	}
+
+	go func() {
+		for i.process(ctx, ch) {
+		}
+	}()
+
+	// Block until the target provider is explicitly canceled.
+	<-ctx.Done()
+}
+
+func (i *Ingress) process(ctx context.Context, ch chan<- []*targetgroup.Group) bool {
+	keyObj, quit := i.queue.Get()
+	if quit {
+		return false
+	}
+	defer i.queue.Done(keyObj)
+	key := keyObj.(string)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return true
+	}
+
+	o, exists, err := i.store.GetByKey(key)
+	if err != nil {
+		return true
+	}
+	if !exists {
+		send(ctx, ch, &targetgroup.Group{Source: ingressSourceFromNamespaceAndName(namespace, name)})
+		return true
+	}
+
+	var ia ingressAdaptor
+	switch ingress := o.(type) {
+	case *v1.Ingress:
+		ia = newIngressAdaptorFromV1(ingress)
+	case *v1beta1.Ingress:
+		ia = newIngressAdaptorFromV1beta1(ingress)
+	default:
+		level.Error(i.logger).Log("msg", "converting to Ingress object failed", "err",
+			fmt.Errorf("received unexpected object: %v", o))
+		return true
+	}
+	send(ctx, ch, i.buildIngress(ia))
+	return true
+}
+
+func ingressSource(s ingressAdaptor) string {
+	return ingressSourceFromNamespaceAndName(s.namespace(), s.name())
+}
+
+func ingressSourceFromNamespaceAndName(namespace, name string) string {
+	return "ingress/" + namespace + "/" + name
+}
+
+const (
+	ingressNameLabel               = metaLabelPrefix + "ingress_name"
+	ingressLabelPrefix             = metaLabelPrefix + "ingress_label_"
+	ingressLabelPresentPrefix      = metaLabelPrefix + "ingress_labelpresent_"
+	ingressAnnotationPrefix        = metaLabelPrefix + "ingress_annotation_"
+	ingressAnnotationPresentPrefix = metaLabelPrefix + "ingress_annotationpresent_"
+	ingressSchemeLabel             = metaLabelPrefix + "ingress_scheme"
+	ingressHostLabel               = metaLabelPrefix + "ingress_host"
+	ingressPathLabel               = metaLabelPrefix + "ingress_path"
+	ingressClassNameLabel          = metaLabelPrefix + "ingress_class_name"
+)
+
+func ingressLabels(ingress ingressAdaptor) model.LabelSet {
+	// Each label and annotation will create two key-value pairs in the map.
+	ls := make(model.LabelSet, 2*(len(ingress.labels())+len(ingress.annotations()))+2)
+	ls[ingressNameLabel] = lv(ingress.name())
+	ls[namespaceLabel] = lv(ingress.namespace())
+	if cls := ingress.ingressClassName(); cls != nil {
+		ls[ingressClassNameLabel] = lv(*cls)
+	}
+
+	for k, v := range ingress.labels() {
+		ln := strutil.SanitizeLabelName(k)
+		ls[model.LabelName(ingressLabelPrefix+ln)] = lv(v)
+		ls[model.LabelName(ingressLabelPresentPrefix+ln)] = presentValue
+	}
+
+	for k, v := range ingress.annotations() {
+		ln := strutil.SanitizeLabelName(k)
+		ls[model.LabelName(ingressAnnotationPrefix+ln)] = lv(v)
+		ls[model.LabelName(ingressAnnotationPresentPrefix+ln)] = presentValue
+	}
+	return ls
+}
+
+func pathsFromIngressPaths(ingressPaths []string) []string {
+	if ingressPaths == nil {
+		return []string{"/"}
+	}
+	paths := make([]string, len(ingressPaths))
+	for n, p := range ingressPaths {
+		path := p
+		if p == "" {
+			path = "/"
+		}
+		paths[n] = path
+	}
+	return paths
+}
+
+func (i *Ingress) buildIngress(ingress ingressAdaptor) *targetgroup.Group {
+	tg := &targetgroup.Group{
+		Source: ingressSource(ingress),
+	}
+	tg.Labels = ingressLabels(ingress)
+
+	for _, rule := range ingress.rules() {
+		scheme := "http"
+		paths := pathsFromIngressPaths(rule.paths())
+
+	out:
+		for _, pattern := range ingress.tlsHosts() {
+			if matchesHostnamePattern(pattern, rule.host()) {
+				scheme = "https"
+				break out
+			}
+		}
+
+		for _, path := range paths {
+			tg.Targets = append(tg.Targets, model.LabelSet{
+				model.AddressLabel: lv(rule.host()),
+				ingressSchemeLabel: lv(scheme),
+				ingressHostLabel:   lv(rule.host()),
+				ingressPathLabel:   lv(path),
+			})
+		}
+	}
+
+	return tg
+}
+
+// matchesHostnamePattern returns true if the host matches a wildcard DNS
+// pattern or pattern and host are equal.
+func matchesHostnamePattern(pattern, host string) bool {
+	if pattern == host {
+		return true
+	}
+
+	patternParts := strings.Split(pattern, ".")
+	hostParts := strings.Split(host, ".")
+
+	// If the first element of the pattern is not a wildcard, give up.
+	if len(patternParts) == 0 || patternParts[0] != "*" {
+		return false
+	}
+
+	// A wildcard match require the pattern to have the same length as the host
+	// path.
+	if len(patternParts) != len(hostParts) {
+		return false
+	}
+
+	for i := 1; i < len(patternParts); i++ {
+		if patternParts[i] != hostParts[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/ingress_adaptor.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/ingress_adaptor.go
@@ -1,0 +1,141 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/api/networking/v1beta1"
+)
+
+// ingressAdaptor is an adaptor for the different Ingress versions
+type ingressAdaptor interface {
+	name() string
+	namespace() string
+	labels() map[string]string
+	annotations() map[string]string
+	tlsHosts() []string
+	ingressClassName() *string
+	rules() []ingressRuleAdaptor
+}
+
+type ingressRuleAdaptor interface {
+	paths() []string
+	host() string
+}
+
+// Adaptor for networking.k8s.io/v1
+type ingressAdaptorV1 struct {
+	ingress *v1.Ingress
+}
+
+func newIngressAdaptorFromV1(ingress *v1.Ingress) ingressAdaptor {
+	return &ingressAdaptorV1{ingress: ingress}
+}
+
+func (i *ingressAdaptorV1) name() string                   { return i.ingress.Name }
+func (i *ingressAdaptorV1) namespace() string              { return i.ingress.Namespace }
+func (i *ingressAdaptorV1) labels() map[string]string      { return i.ingress.Labels }
+func (i *ingressAdaptorV1) annotations() map[string]string { return i.ingress.Annotations }
+func (i *ingressAdaptorV1) ingressClassName() *string      { return i.ingress.Spec.IngressClassName }
+
+func (i *ingressAdaptorV1) tlsHosts() []string {
+	var hosts []string
+	for _, tls := range i.ingress.Spec.TLS {
+		hosts = append(hosts, tls.Hosts...)
+	}
+	return hosts
+}
+
+func (i *ingressAdaptorV1) rules() []ingressRuleAdaptor {
+	var rules []ingressRuleAdaptor
+	for _, rule := range i.ingress.Spec.Rules {
+		rules = append(rules, newIngressRuleAdaptorFromV1(rule))
+	}
+	return rules
+}
+
+type ingressRuleAdaptorV1 struct {
+	rule v1.IngressRule
+}
+
+func newIngressRuleAdaptorFromV1(rule v1.IngressRule) ingressRuleAdaptor {
+	return &ingressRuleAdaptorV1{rule: rule}
+}
+
+func (i *ingressRuleAdaptorV1) paths() []string {
+	rv := i.rule.IngressRuleValue
+	if rv.HTTP == nil {
+		return nil
+	}
+	paths := make([]string, len(rv.HTTP.Paths))
+	for n, p := range rv.HTTP.Paths {
+		paths[n] = p.Path
+	}
+	return paths
+}
+
+func (i *ingressRuleAdaptorV1) host() string { return i.rule.Host }
+
+// Adaptor for networking.k8s.io/v1beta1
+type ingressAdaptorV1Beta1 struct {
+	ingress *v1beta1.Ingress
+}
+
+func newIngressAdaptorFromV1beta1(ingress *v1beta1.Ingress) ingressAdaptor {
+	return &ingressAdaptorV1Beta1{ingress: ingress}
+}
+
+func (i *ingressAdaptorV1Beta1) name() string                   { return i.ingress.Name }
+func (i *ingressAdaptorV1Beta1) namespace() string              { return i.ingress.Namespace }
+func (i *ingressAdaptorV1Beta1) labels() map[string]string      { return i.ingress.Labels }
+func (i *ingressAdaptorV1Beta1) annotations() map[string]string { return i.ingress.Annotations }
+func (i *ingressAdaptorV1Beta1) ingressClassName() *string      { return i.ingress.Spec.IngressClassName }
+
+func (i *ingressAdaptorV1Beta1) tlsHosts() []string {
+	var hosts []string
+	for _, tls := range i.ingress.Spec.TLS {
+		hosts = append(hosts, tls.Hosts...)
+	}
+	return hosts
+}
+
+func (i *ingressAdaptorV1Beta1) rules() []ingressRuleAdaptor {
+	var rules []ingressRuleAdaptor
+	for _, rule := range i.ingress.Spec.Rules {
+		rules = append(rules, newIngressRuleAdaptorFromV1Beta1(rule))
+	}
+	return rules
+}
+
+type ingressRuleAdaptorV1Beta1 struct {
+	rule v1beta1.IngressRule
+}
+
+func newIngressRuleAdaptorFromV1Beta1(rule v1beta1.IngressRule) ingressRuleAdaptor {
+	return &ingressRuleAdaptorV1Beta1{rule: rule}
+}
+
+func (i *ingressRuleAdaptorV1Beta1) paths() []string {
+	rv := i.rule.IngressRuleValue
+	if rv.HTTP == nil {
+		return nil
+	}
+	paths := make([]string, len(rv.HTTP.Paths))
+	for n, p := range rv.HTTP.Paths {
+		paths[n] = p.Path
+	}
+	return paths
+}
+
+func (i *ingressRuleAdaptorV1Beta1) host() string { return i.rule.Host }

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go
@@ -1,0 +1,825 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	disv1beta1 "k8s.io/api/discovery/v1beta1"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/version"
+	apiv1 "k8s.io/api/core/v1"
+	disv1 "k8s.io/api/discovery/v1"
+	networkv1 "k8s.io/api/networking/v1"
+	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+
+	// Required to get the GCP auth provider working.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+const (
+	// metaLabelPrefix is the meta prefix used for all meta labels.
+	// in this discovery.
+	metaLabelPrefix  = model.MetaLabelPrefix + "kubernetes_"
+	namespaceLabel   = metaLabelPrefix + "namespace"
+	metricsNamespace = "prometheus_sd_kubernetes"
+	presentValue     = model.LabelValue("true")
+)
+
+var (
+	// Http header
+	userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+	// Custom events metric
+	eventCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "events_total",
+			Help:      "The number of Kubernetes events handled.",
+		},
+		[]string{"role", "event"},
+	)
+	// DefaultSDConfig is the default Kubernetes SD configuration
+	DefaultSDConfig = SDConfig{
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
+	}
+)
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+	prometheus.MustRegister(eventCount)
+	// Initialize metric vectors.
+	for _, role := range []string{"endpointslice", "endpoints", "node", "pod", "service", "ingress"} {
+		for _, evt := range []string{"add", "delete", "update"} {
+			eventCount.WithLabelValues(role, evt)
+		}
+	}
+	(&clientGoRequestMetricAdapter{}).Register(prometheus.DefaultRegisterer)
+	(&clientGoWorkqueueMetricsProvider{}).Register(prometheus.DefaultRegisterer)
+}
+
+// Role is role of the service in Kubernetes.
+type Role string
+
+// The valid options for Role.
+const (
+	RoleNode          Role = "node"
+	RolePod           Role = "pod"
+	RoleService       Role = "service"
+	RoleEndpoint      Role = "endpoints"
+	RoleEndpointSlice Role = "endpointslice"
+	RoleIngress       Role = "ingress"
+)
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	if err := unmarshal((*string)(c)); err != nil {
+		return err
+	}
+	switch *c {
+	case RoleNode, RolePod, RoleService, RoleEndpoint, RoleEndpointSlice, RoleIngress:
+		return nil
+	default:
+		return fmt.Errorf("unknown Kubernetes SD role %q", *c)
+	}
+}
+
+// SDConfig is the configuration for Kubernetes service discovery.
+type SDConfig struct {
+	APIServer          config.URL              `yaml:"api_server,omitempty"`
+	Role               Role                    `yaml:"role"`
+	KubeConfig         string                  `yaml:"kubeconfig_file"`
+	HTTPClientConfig   config.HTTPClientConfig `yaml:",inline"`
+	NamespaceDiscovery NamespaceDiscovery      `yaml:"namespaces,omitempty"`
+	Selectors          []SelectorConfig        `yaml:"selectors,omitempty"`
+	AttachMetadata     AttachMetadataConfig    `yaml:"attach_metadata,omitempty"`
+}
+
+// Name returns the name of the Config.
+func (*SDConfig) Name() string { return "kubernetes" }
+
+// NewDiscoverer returns a Discoverer for the Config.
+func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return New(opts.Logger, c)
+}
+
+// SetDirectory joins any relative file paths with dir.
+func (c *SDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+	c.KubeConfig = config.JoinDir(dir, c.KubeConfig)
+}
+
+type roleSelector struct {
+	node          resourceSelector
+	pod           resourceSelector
+	service       resourceSelector
+	endpoints     resourceSelector
+	endpointslice resourceSelector
+	ingress       resourceSelector
+}
+
+type SelectorConfig struct {
+	Role  Role   `yaml:"role,omitempty"`
+	Label string `yaml:"label,omitempty"`
+	Field string `yaml:"field,omitempty"`
+}
+
+type resourceSelector struct {
+	label string
+	field string
+}
+
+// AttachMetadataConfig is the configuration for attaching additional metadata
+// coming from nodes on which the targets are scheduled.
+type AttachMetadataConfig struct {
+	Node bool `yaml:"node"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultSDConfig
+	type plain SDConfig
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
+	if c.Role == "" {
+		return fmt.Errorf("role missing (one of: pod, service, endpoints, endpointslice, node, ingress)")
+	}
+	err = c.HTTPClientConfig.Validate()
+	if err != nil {
+		return err
+	}
+	if c.APIServer.URL != nil && c.KubeConfig != "" {
+		// Api-server and kubeconfig_file are mutually exclusive
+		return fmt.Errorf("cannot use 'kubeconfig_file' and 'api_server' simultaneously")
+	}
+	if c.KubeConfig != "" && !reflect.DeepEqual(c.HTTPClientConfig, config.DefaultHTTPClientConfig) {
+		// Kubeconfig_file and custom http config are mutually exclusive
+		return fmt.Errorf("cannot use a custom HTTP client configuration together with 'kubeconfig_file'")
+	}
+	if c.APIServer.URL == nil && !reflect.DeepEqual(c.HTTPClientConfig, config.DefaultHTTPClientConfig) {
+		return fmt.Errorf("to use custom HTTP client configuration please provide the 'api_server' URL explicitly")
+	}
+	if c.APIServer.URL != nil && c.NamespaceDiscovery.IncludeOwnNamespace {
+		return fmt.Errorf("cannot use 'api_server' and 'namespaces.own_namespace' simultaneously")
+	}
+	if c.KubeConfig != "" && c.NamespaceDiscovery.IncludeOwnNamespace {
+		return fmt.Errorf("cannot use 'kubeconfig_file' and 'namespaces.own_namespace' simultaneously")
+	}
+
+	foundSelectorRoles := make(map[Role]struct{})
+	allowedSelectors := map[Role][]string{
+		RolePod:           {string(RolePod)},
+		RoleService:       {string(RoleService)},
+		RoleEndpointSlice: {string(RolePod), string(RoleService), string(RoleEndpointSlice)},
+		RoleEndpoint:      {string(RolePod), string(RoleService), string(RoleEndpoint)},
+		RoleNode:          {string(RoleNode)},
+		RoleIngress:       {string(RoleIngress)},
+	}
+
+	for _, selector := range c.Selectors {
+		if _, ok := foundSelectorRoles[selector.Role]; ok {
+			return fmt.Errorf("duplicated selector role: %s", selector.Role)
+		}
+		foundSelectorRoles[selector.Role] = struct{}{}
+
+		if _, ok := allowedSelectors[c.Role]; !ok {
+			return fmt.Errorf("invalid role: %q, expecting one of: pod, service, endpoints, endpointslice, node or ingress", c.Role)
+		}
+		var allowed bool
+		for _, role := range allowedSelectors[c.Role] {
+			if role == string(selector.Role) {
+				allowed = true
+				break
+			}
+		}
+
+		if !allowed {
+			return fmt.Errorf("%s role supports only %s selectors", c.Role, strings.Join(allowedSelectors[c.Role], ", "))
+		}
+
+		_, err := fields.ParseSelector(selector.Field)
+		if err != nil {
+			return err
+		}
+		_, err = labels.Parse(selector.Label)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NamespaceDiscovery is the configuration for discovering
+// Kubernetes namespaces.
+type NamespaceDiscovery struct {
+	IncludeOwnNamespace bool     `yaml:"own_namespace"`
+	Names               []string `yaml:"names"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *NamespaceDiscovery) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = NamespaceDiscovery{}
+	type plain NamespaceDiscovery
+	return unmarshal((*plain)(c))
+}
+
+// Discovery implements the discoverer interface for discovering
+// targets from Kubernetes.
+type Discovery struct {
+	sync.RWMutex
+	client             kubernetes.Interface
+	role               Role
+	logger             log.Logger
+	namespaceDiscovery *NamespaceDiscovery
+	discoverers        []discovery.Discoverer
+	selectors          roleSelector
+	ownNamespace       string
+	attachMetadata     AttachMetadataConfig
+}
+
+func (d *Discovery) getNamespaces() []string {
+	namespaces := d.namespaceDiscovery.Names
+	includeOwnNamespace := d.namespaceDiscovery.IncludeOwnNamespace
+
+	if len(namespaces) == 0 && !includeOwnNamespace {
+		return []string{apiv1.NamespaceAll}
+	}
+
+	if includeOwnNamespace && d.ownNamespace != "" {
+		return append(namespaces, d.ownNamespace)
+	}
+
+	return namespaces
+}
+
+// New creates a new Kubernetes discovery for the given role.
+func New(l log.Logger, conf *SDConfig) (*Discovery, error) {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+	var (
+		kcfg         *rest.Config
+		err          error
+		ownNamespace string
+	)
+	if conf.KubeConfig != "" {
+		kcfg, err = clientcmd.BuildConfigFromFlags("", conf.KubeConfig)
+		if err != nil {
+			return nil, err
+		}
+	} else if conf.APIServer.URL == nil {
+		// Use the Kubernetes provided pod service account
+		// as described in https://kubernetes.io/docs/admin/service-accounts-admin/
+		kcfg, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		if conf.NamespaceDiscovery.IncludeOwnNamespace {
+			ownNamespaceContents, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+			if err != nil {
+				return nil, fmt.Errorf("could not determine the pod's namespace: %w", err)
+			}
+			if len(ownNamespaceContents) == 0 {
+				return nil, errors.New("could not read own namespace name (empty file)")
+			}
+			ownNamespace = string(ownNamespaceContents)
+		}
+
+		level.Info(l).Log("msg", "Using pod service account via in-cluster config")
+	} else {
+		rt, err := config.NewRoundTripperFromConfig(conf.HTTPClientConfig, "kubernetes_sd")
+		if err != nil {
+			return nil, err
+		}
+		kcfg = &rest.Config{
+			Host:      conf.APIServer.String(),
+			Transport: rt,
+		}
+	}
+
+	kcfg.UserAgent = userAgent
+	kcfg.ContentType = "application/vnd.kubernetes.protobuf"
+
+	c, err := kubernetes.NewForConfig(kcfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Discovery{
+		client:             c,
+		logger:             l,
+		role:               conf.Role,
+		namespaceDiscovery: &conf.NamespaceDiscovery,
+		discoverers:        make([]discovery.Discoverer, 0),
+		selectors:          mapSelector(conf.Selectors),
+		ownNamespace:       ownNamespace,
+		attachMetadata:     conf.AttachMetadata,
+	}, nil
+}
+
+func mapSelector(rawSelector []SelectorConfig) roleSelector {
+	rs := roleSelector{}
+	for _, resourceSelectorRaw := range rawSelector {
+		switch resourceSelectorRaw.Role {
+		case RoleEndpointSlice:
+			rs.endpointslice.field = resourceSelectorRaw.Field
+			rs.endpointslice.label = resourceSelectorRaw.Label
+		case RoleEndpoint:
+			rs.endpoints.field = resourceSelectorRaw.Field
+			rs.endpoints.label = resourceSelectorRaw.Label
+		case RoleIngress:
+			rs.ingress.field = resourceSelectorRaw.Field
+			rs.ingress.label = resourceSelectorRaw.Label
+		case RoleNode:
+			rs.node.field = resourceSelectorRaw.Field
+			rs.node.label = resourceSelectorRaw.Label
+		case RolePod:
+			rs.pod.field = resourceSelectorRaw.Field
+			rs.pod.label = resourceSelectorRaw.Label
+		case RoleService:
+			rs.service.field = resourceSelectorRaw.Field
+			rs.service.label = resourceSelectorRaw.Label
+		}
+	}
+	return rs
+}
+
+const resyncPeriod = 10 * time.Minute
+
+// Run implements the discoverer interface.
+func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	d.Lock()
+	namespaces := d.getNamespaces()
+
+	switch d.role {
+	case RoleEndpointSlice:
+		// Check "networking.k8s.io/v1" availability with retries.
+		// If "v1" is not available, use "networking.k8s.io/v1beta1" for backward compatibility
+		var v1Supported bool
+		if retryOnError(ctx, 10*time.Second,
+			func() (err error) {
+				v1Supported, err = checkDiscoveryV1Supported(d.client)
+				if err != nil {
+					level.Error(d.logger).Log("msg", "Failed to check networking.k8s.io/v1 availability", "err", err)
+				}
+				return err
+			},
+		) {
+			d.Unlock()
+			return
+		}
+
+		for _, namespace := range namespaces {
+			var informer cache.SharedIndexInformer
+			if v1Supported {
+				e := d.client.DiscoveryV1().EndpointSlices(namespace)
+				elw := &cache.ListWatch{
+					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+						options.FieldSelector = d.selectors.endpointslice.field
+						options.LabelSelector = d.selectors.endpointslice.label
+						return e.List(ctx, options)
+					},
+					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+						options.FieldSelector = d.selectors.endpointslice.field
+						options.LabelSelector = d.selectors.endpointslice.label
+						return e.Watch(ctx, options)
+					},
+				}
+				informer = d.newEndpointSlicesByNodeInformer(elw, &disv1.EndpointSlice{})
+			} else {
+				e := d.client.DiscoveryV1beta1().EndpointSlices(namespace)
+				elw := &cache.ListWatch{
+					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+						options.FieldSelector = d.selectors.endpointslice.field
+						options.LabelSelector = d.selectors.endpointslice.label
+						return e.List(ctx, options)
+					},
+					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+						options.FieldSelector = d.selectors.endpointslice.field
+						options.LabelSelector = d.selectors.endpointslice.label
+						return e.Watch(ctx, options)
+					},
+				}
+				informer = d.newEndpointSlicesByNodeInformer(elw, &disv1beta1.EndpointSlice{})
+			}
+
+			s := d.client.CoreV1().Services(namespace)
+			slw := &cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.service.field
+					options.LabelSelector = d.selectors.service.label
+					return s.List(ctx, options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.service.field
+					options.LabelSelector = d.selectors.service.label
+					return s.Watch(ctx, options)
+				},
+			}
+			p := d.client.CoreV1().Pods(namespace)
+			plw := &cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.pod.field
+					options.LabelSelector = d.selectors.pod.label
+					return p.List(ctx, options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.pod.field
+					options.LabelSelector = d.selectors.pod.label
+					return p.Watch(ctx, options)
+				},
+			}
+			var nodeInf cache.SharedInformer
+			if d.attachMetadata.Node {
+				nodeInf = d.newNodeInformer(context.Background())
+				go nodeInf.Run(ctx.Done())
+			}
+			eps := NewEndpointSlice(
+				log.With(d.logger, "role", "endpointslice"),
+				informer,
+				cache.NewSharedInformer(slw, &apiv1.Service{}, resyncPeriod),
+				cache.NewSharedInformer(plw, &apiv1.Pod{}, resyncPeriod),
+				nodeInf,
+			)
+			d.discoverers = append(d.discoverers, eps)
+			go eps.endpointSliceInf.Run(ctx.Done())
+			go eps.serviceInf.Run(ctx.Done())
+			go eps.podInf.Run(ctx.Done())
+		}
+	case RoleEndpoint:
+		for _, namespace := range namespaces {
+			e := d.client.CoreV1().Endpoints(namespace)
+			elw := &cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.endpoints.field
+					options.LabelSelector = d.selectors.endpoints.label
+					return e.List(ctx, options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.endpoints.field
+					options.LabelSelector = d.selectors.endpoints.label
+					return e.Watch(ctx, options)
+				},
+			}
+			s := d.client.CoreV1().Services(namespace)
+			slw := &cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.service.field
+					options.LabelSelector = d.selectors.service.label
+					return s.List(ctx, options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.service.field
+					options.LabelSelector = d.selectors.service.label
+					return s.Watch(ctx, options)
+				},
+			}
+			p := d.client.CoreV1().Pods(namespace)
+			plw := &cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.pod.field
+					options.LabelSelector = d.selectors.pod.label
+					return p.List(ctx, options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.pod.field
+					options.LabelSelector = d.selectors.pod.label
+					return p.Watch(ctx, options)
+				},
+			}
+			var nodeInf cache.SharedInformer
+			if d.attachMetadata.Node {
+				nodeInf = d.newNodeInformer(ctx)
+				go nodeInf.Run(ctx.Done())
+			}
+
+			eps := NewEndpoints(
+				log.With(d.logger, "role", "endpoint"),
+				d.newEndpointsByNodeInformer(elw),
+				cache.NewSharedInformer(slw, &apiv1.Service{}, resyncPeriod),
+				cache.NewSharedInformer(plw, &apiv1.Pod{}, resyncPeriod),
+				nodeInf,
+			)
+			d.discoverers = append(d.discoverers, eps)
+			go eps.endpointsInf.Run(ctx.Done())
+			go eps.serviceInf.Run(ctx.Done())
+			go eps.podInf.Run(ctx.Done())
+		}
+	case RolePod:
+		var nodeInformer cache.SharedInformer
+		if d.attachMetadata.Node {
+			nodeInformer = d.newNodeInformer(ctx)
+			go nodeInformer.Run(ctx.Done())
+		}
+
+		for _, namespace := range namespaces {
+			p := d.client.CoreV1().Pods(namespace)
+			plw := &cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.pod.field
+					options.LabelSelector = d.selectors.pod.label
+					return p.List(ctx, options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.pod.field
+					options.LabelSelector = d.selectors.pod.label
+					return p.Watch(ctx, options)
+				},
+			}
+			pod := NewPod(
+				log.With(d.logger, "role", "pod"),
+				d.newPodsByNodeInformer(plw),
+				nodeInformer,
+			)
+			d.discoverers = append(d.discoverers, pod)
+			go pod.podInf.Run(ctx.Done())
+		}
+	case RoleService:
+		for _, namespace := range namespaces {
+			s := d.client.CoreV1().Services(namespace)
+			slw := &cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.service.field
+					options.LabelSelector = d.selectors.service.label
+					return s.List(ctx, options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.service.field
+					options.LabelSelector = d.selectors.service.label
+					return s.Watch(ctx, options)
+				},
+			}
+			svc := NewService(
+				log.With(d.logger, "role", "service"),
+				cache.NewSharedInformer(slw, &apiv1.Service{}, resyncPeriod),
+			)
+			d.discoverers = append(d.discoverers, svc)
+			go svc.informer.Run(ctx.Done())
+		}
+	case RoleIngress:
+		// Check "networking.k8s.io/v1" availability with retries.
+		// If "v1" is not available, use "networking.k8s.io/v1beta1" for backward compatibility
+		var v1Supported bool
+		if retryOnError(ctx, 10*time.Second,
+			func() (err error) {
+				v1Supported, err = checkNetworkingV1Supported(d.client)
+				if err != nil {
+					level.Error(d.logger).Log("msg", "Failed to check networking.k8s.io/v1 availability", "err", err)
+				}
+				return err
+			},
+		) {
+			d.Unlock()
+			return
+		}
+
+		for _, namespace := range namespaces {
+			var informer cache.SharedInformer
+			if v1Supported {
+				i := d.client.NetworkingV1().Ingresses(namespace)
+				ilw := &cache.ListWatch{
+					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+						options.FieldSelector = d.selectors.ingress.field
+						options.LabelSelector = d.selectors.ingress.label
+						return i.List(ctx, options)
+					},
+					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+						options.FieldSelector = d.selectors.ingress.field
+						options.LabelSelector = d.selectors.ingress.label
+						return i.Watch(ctx, options)
+					},
+				}
+				informer = cache.NewSharedInformer(ilw, &networkv1.Ingress{}, resyncPeriod)
+			} else {
+				i := d.client.NetworkingV1beta1().Ingresses(namespace)
+				ilw := &cache.ListWatch{
+					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+						options.FieldSelector = d.selectors.ingress.field
+						options.LabelSelector = d.selectors.ingress.label
+						return i.List(ctx, options)
+					},
+					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+						options.FieldSelector = d.selectors.ingress.field
+						options.LabelSelector = d.selectors.ingress.label
+						return i.Watch(ctx, options)
+					},
+				}
+				informer = cache.NewSharedInformer(ilw, &v1beta1.Ingress{}, resyncPeriod)
+			}
+			ingress := NewIngress(
+				log.With(d.logger, "role", "ingress"),
+				informer,
+			)
+			d.discoverers = append(d.discoverers, ingress)
+			go ingress.informer.Run(ctx.Done())
+		}
+	case RoleNode:
+		nodeInformer := d.newNodeInformer(ctx)
+		node := NewNode(log.With(d.logger, "role", "node"), nodeInformer)
+		d.discoverers = append(d.discoverers, node)
+		go node.informer.Run(ctx.Done())
+	default:
+		level.Error(d.logger).Log("msg", "unknown Kubernetes discovery kind", "role", d.role)
+	}
+
+	var wg sync.WaitGroup
+	for _, dd := range d.discoverers {
+		wg.Add(1)
+		go func(d discovery.Discoverer) {
+			defer wg.Done()
+			d.Run(ctx, ch)
+		}(dd)
+	}
+
+	d.Unlock()
+
+	wg.Wait()
+	<-ctx.Done()
+}
+
+func lv(s string) model.LabelValue {
+	return model.LabelValue(s)
+}
+
+func send(ctx context.Context, ch chan<- []*targetgroup.Group, tg *targetgroup.Group) {
+	if tg == nil {
+		return
+	}
+	select {
+	case <-ctx.Done():
+	case ch <- []*targetgroup.Group{tg}:
+	}
+}
+
+func retryOnError(ctx context.Context, interval time.Duration, f func() error) (canceled bool) {
+	var err error
+	err = f()
+	for {
+		if err == nil {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return true
+		case <-time.After(interval):
+			err = f()
+		}
+	}
+}
+
+func checkNetworkingV1Supported(client kubernetes.Interface) (bool, error) {
+	k8sVer, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return false, err
+	}
+	semVer, err := utilversion.ParseSemantic(k8sVer.String())
+	if err != nil {
+		return false, err
+	}
+	// networking.k8s.io/v1 is available since Kubernetes v1.19
+	// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md
+	return semVer.Major() >= 1 && semVer.Minor() >= 19, nil
+}
+
+func (d *Discovery) newNodeInformer(ctx context.Context) cache.SharedInformer {
+	nlw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = d.selectors.node.field
+			options.LabelSelector = d.selectors.node.label
+			return d.client.CoreV1().Nodes().List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = d.selectors.node.field
+			options.LabelSelector = d.selectors.node.label
+			return d.client.CoreV1().Nodes().Watch(ctx, options)
+		},
+	}
+	return cache.NewSharedInformer(nlw, &apiv1.Node{}, resyncPeriod)
+}
+
+func (d *Discovery) newPodsByNodeInformer(plw *cache.ListWatch) cache.SharedIndexInformer {
+	indexers := make(map[string]cache.IndexFunc)
+	if d.attachMetadata.Node {
+		indexers[nodeIndex] = func(obj interface{}) ([]string, error) {
+			pod, ok := obj.(*apiv1.Pod)
+			if !ok {
+				return nil, fmt.Errorf("object is not a pod")
+			}
+			return []string{pod.Spec.NodeName}, nil
+		}
+	}
+
+	return cache.NewSharedIndexInformer(plw, &apiv1.Pod{}, resyncPeriod, indexers)
+}
+
+func (d *Discovery) newEndpointsByNodeInformer(plw *cache.ListWatch) cache.SharedIndexInformer {
+	indexers := make(map[string]cache.IndexFunc)
+	if !d.attachMetadata.Node {
+		return cache.NewSharedIndexInformer(plw, &apiv1.Endpoints{}, resyncPeriod, indexers)
+	}
+
+	indexers[nodeIndex] = func(obj interface{}) ([]string, error) {
+		e, ok := obj.(*apiv1.Endpoints)
+		if !ok {
+			return nil, fmt.Errorf("object is not a pod")
+		}
+		var nodes []string
+		for _, target := range e.Subsets {
+			for _, addr := range target.Addresses {
+				if addr.NodeName == nil {
+					continue
+				}
+				nodes = append(nodes, *addr.NodeName)
+			}
+		}
+		return nodes, nil
+	}
+
+	return cache.NewSharedIndexInformer(plw, &apiv1.Endpoints{}, resyncPeriod, indexers)
+}
+
+func (d *Discovery) newEndpointSlicesByNodeInformer(plw *cache.ListWatch, object runtime.Object) cache.SharedIndexInformer {
+	indexers := make(map[string]cache.IndexFunc)
+	if !d.attachMetadata.Node {
+		cache.NewSharedIndexInformer(plw, &disv1.EndpointSlice{}, resyncPeriod, indexers)
+	}
+
+	indexers[nodeIndex] = func(obj interface{}) ([]string, error) {
+		var nodes []string
+		switch e := obj.(type) {
+		case *disv1.EndpointSlice:
+			for _, target := range e.Endpoints {
+				if target.NodeName == nil {
+					continue
+				}
+				nodes = append(nodes, *target.NodeName)
+			}
+		case *disv1beta1.EndpointSlice:
+			for _, target := range e.Endpoints {
+				if target.NodeName == nil {
+					continue
+				}
+				nodes = append(nodes, *target.NodeName)
+			}
+		default:
+			return nil, fmt.Errorf("object is not an endpointslice")
+		}
+
+		return nodes, nil
+	}
+
+	return cache.NewSharedIndexInformer(plw, object, resyncPeriod, indexers)
+}
+
+func checkDiscoveryV1Supported(client kubernetes.Interface) (bool, error) {
+	k8sVer, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return false, err
+	}
+	semVer, err := utilversion.ParseSemantic(k8sVer.String())
+	if err != nil {
+		return false, err
+	}
+	// The discovery.k8s.io/v1beta1 API version of EndpointSlice will no longer be served in v1.25.
+	// discovery.k8s.io/v1 is available since Kubernetes v1.21
+	// https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25
+	return semVer.Major() >= 1 && semVer.Minor() >= 21, nil
+}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/node.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/node.go
@@ -1,0 +1,246 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+const (
+	NodeLegacyHostIP = "LegacyHostIP"
+)
+
+var (
+	nodeAddCount    = eventCount.WithLabelValues("node", "add")
+	nodeUpdateCount = eventCount.WithLabelValues("node", "update")
+	nodeDeleteCount = eventCount.WithLabelValues("node", "delete")
+)
+
+// Node discovers Kubernetes nodes.
+type Node struct {
+	logger   log.Logger
+	informer cache.SharedInformer
+	store    cache.Store
+	queue    *workqueue.Type
+}
+
+// NewNode returns a new node discovery.
+func NewNode(l log.Logger, inf cache.SharedInformer) *Node {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+	n := &Node{logger: l, informer: inf, store: inf.GetStore(), queue: workqueue.NewNamed("node")}
+	_, err := n.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			nodeAddCount.Inc()
+			n.enqueue(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			nodeDeleteCount.Inc()
+			n.enqueue(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			nodeUpdateCount.Inc()
+			n.enqueue(o)
+		},
+	})
+	if err != nil {
+		level.Error(l).Log("msg", "Error adding nodes event handler.", "err", err)
+	}
+	return n
+}
+
+func (n *Node) enqueue(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	n.queue.Add(key)
+}
+
+// Run implements the Discoverer interface.
+func (n *Node) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer n.queue.ShutDown()
+
+	if !cache.WaitForCacheSync(ctx.Done(), n.informer.HasSynced) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			level.Error(n.logger).Log("msg", "node informer unable to sync cache")
+		}
+		return
+	}
+
+	go func() {
+		for n.process(ctx, ch) {
+		}
+	}()
+
+	// Block until the target provider is explicitly canceled.
+	<-ctx.Done()
+}
+
+func (n *Node) process(ctx context.Context, ch chan<- []*targetgroup.Group) bool {
+	keyObj, quit := n.queue.Get()
+	if quit {
+		return false
+	}
+	defer n.queue.Done(keyObj)
+	key := keyObj.(string)
+
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return true
+	}
+
+	o, exists, err := n.store.GetByKey(key)
+	if err != nil {
+		return true
+	}
+	if !exists {
+		send(ctx, ch, &targetgroup.Group{Source: nodeSourceFromName(name)})
+		return true
+	}
+	node, err := convertToNode(o)
+	if err != nil {
+		level.Error(n.logger).Log("msg", "converting to Node object failed", "err", err)
+		return true
+	}
+	send(ctx, ch, n.buildNode(node))
+	return true
+}
+
+func convertToNode(o interface{}) (*apiv1.Node, error) {
+	node, ok := o.(*apiv1.Node)
+	if ok {
+		return node, nil
+	}
+
+	return nil, fmt.Errorf("received unexpected object: %v", o)
+}
+
+func nodeSource(n *apiv1.Node) string {
+	return nodeSourceFromName(n.Name)
+}
+
+func nodeSourceFromName(name string) string {
+	return "node/" + name
+}
+
+const (
+	nodeNameLabel               = metaLabelPrefix + "node_name"
+	nodeProviderIDLabel         = metaLabelPrefix + "node_provider_id"
+	nodeLabelPrefix             = metaLabelPrefix + "node_label_"
+	nodeLabelPresentPrefix      = metaLabelPrefix + "node_labelpresent_"
+	nodeAnnotationPrefix        = metaLabelPrefix + "node_annotation_"
+	nodeAnnotationPresentPrefix = metaLabelPrefix + "node_annotationpresent_"
+	nodeAddressPrefix           = metaLabelPrefix + "node_address_"
+)
+
+func nodeLabels(n *apiv1.Node) model.LabelSet {
+	// Each label and annotation will create two key-value pairs in the map.
+	ls := make(model.LabelSet, 2*(len(n.Labels)+len(n.Annotations))+1)
+
+	ls[nodeNameLabel] = lv(n.Name)
+	ls[nodeProviderIDLabel] = lv(n.Spec.ProviderID)
+
+	for k, v := range n.Labels {
+		ln := strutil.SanitizeLabelName(k)
+		ls[model.LabelName(nodeLabelPrefix+ln)] = lv(v)
+		ls[model.LabelName(nodeLabelPresentPrefix+ln)] = presentValue
+	}
+
+	for k, v := range n.Annotations {
+		ln := strutil.SanitizeLabelName(k)
+		ls[model.LabelName(nodeAnnotationPrefix+ln)] = lv(v)
+		ls[model.LabelName(nodeAnnotationPresentPrefix+ln)] = presentValue
+	}
+	return ls
+}
+
+func (n *Node) buildNode(node *apiv1.Node) *targetgroup.Group {
+	tg := &targetgroup.Group{
+		Source: nodeSource(node),
+	}
+	tg.Labels = nodeLabels(node)
+
+	addr, addrMap, err := nodeAddress(node)
+	if err != nil {
+		level.Warn(n.logger).Log("msg", "No node address found", "err", err)
+		return nil
+	}
+	addr = net.JoinHostPort(addr, strconv.FormatInt(int64(node.Status.DaemonEndpoints.KubeletEndpoint.Port), 10))
+
+	t := model.LabelSet{
+		model.AddressLabel:  lv(addr),
+		model.InstanceLabel: lv(node.Name),
+	}
+
+	for ty, a := range addrMap {
+		ln := strutil.SanitizeLabelName(nodeAddressPrefix + string(ty))
+		t[model.LabelName(ln)] = lv(a[0])
+	}
+	tg.Targets = append(tg.Targets, t)
+
+	return tg
+}
+
+// nodeAddresses returns the provided node's address, based on the priority:
+// 1. NodeInternalIP
+// 2. NodeInternalDNS
+// 3. NodeExternalIP
+// 4. NodeExternalDNS
+// 5. NodeLegacyHostIP
+// 6. NodeHostName
+//
+// Derived from k8s.io/kubernetes/pkg/util/node/node.go
+func nodeAddress(node *apiv1.Node) (string, map[apiv1.NodeAddressType][]string, error) {
+	m := map[apiv1.NodeAddressType][]string{}
+	for _, a := range node.Status.Addresses {
+		m[a.Type] = append(m[a.Type], a.Address)
+	}
+
+	if addresses, ok := m[apiv1.NodeInternalIP]; ok {
+		return addresses[0], m, nil
+	}
+	if addresses, ok := m[apiv1.NodeInternalDNS]; ok {
+		return addresses[0], m, nil
+	}
+	if addresses, ok := m[apiv1.NodeExternalIP]; ok {
+		return addresses[0], m, nil
+	}
+	if addresses, ok := m[apiv1.NodeExternalDNS]; ok {
+		return addresses[0], m, nil
+	}
+	if addresses, ok := m[apiv1.NodeAddressType(NodeLegacyHostIP)]; ok {
+		return addresses[0], m, nil
+	}
+	if addresses, ok := m[apiv1.NodeHostName]; ok {
+		return addresses[0], m, nil
+	}
+	return "", m, errors.New("host address unknown")
+}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/pod.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/pod.go
@@ -1,0 +1,330 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+const nodeIndex = "node"
+
+var (
+	podAddCount    = eventCount.WithLabelValues("pod", "add")
+	podUpdateCount = eventCount.WithLabelValues("pod", "update")
+	podDeleteCount = eventCount.WithLabelValues("pod", "delete")
+)
+
+// Pod discovers new pod targets.
+type Pod struct {
+	podInf           cache.SharedIndexInformer
+	nodeInf          cache.SharedInformer
+	withNodeMetadata bool
+	store            cache.Store
+	logger           log.Logger
+	queue            *workqueue.Type
+}
+
+// NewPod creates a new pod discovery.
+func NewPod(l log.Logger, pods cache.SharedIndexInformer, nodes cache.SharedInformer) *Pod {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+
+	p := &Pod{
+		podInf:           pods,
+		nodeInf:          nodes,
+		withNodeMetadata: nodes != nil,
+		store:            pods.GetStore(),
+		logger:           l,
+		queue:            workqueue.NewNamed("pod"),
+	}
+	_, err := p.podInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			podAddCount.Inc()
+			p.enqueue(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			podDeleteCount.Inc()
+			p.enqueue(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			podUpdateCount.Inc()
+			p.enqueue(o)
+		},
+	})
+	if err != nil {
+		level.Error(l).Log("msg", "Error adding pods event handler.", "err", err)
+	}
+
+	if p.withNodeMetadata {
+		_, err = p.nodeInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(o interface{}) {
+				node := o.(*apiv1.Node)
+				p.enqueuePodsForNode(node.Name)
+			},
+			UpdateFunc: func(_, o interface{}) {
+				node := o.(*apiv1.Node)
+				p.enqueuePodsForNode(node.Name)
+			},
+			DeleteFunc: func(o interface{}) {
+				node := o.(*apiv1.Node)
+				p.enqueuePodsForNode(node.Name)
+			},
+		})
+		if err != nil {
+			level.Error(l).Log("msg", "Error adding pods event handler.", "err", err)
+		}
+	}
+
+	return p
+}
+
+func (p *Pod) enqueue(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	p.queue.Add(key)
+}
+
+// Run implements the Discoverer interface.
+func (p *Pod) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer p.queue.ShutDown()
+
+	cacheSyncs := []cache.InformerSynced{p.podInf.HasSynced}
+	if p.withNodeMetadata {
+		cacheSyncs = append(cacheSyncs, p.nodeInf.HasSynced)
+	}
+
+	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			level.Error(p.logger).Log("msg", "pod informer unable to sync cache")
+		}
+		return
+	}
+
+	go func() {
+		for p.process(ctx, ch) {
+		}
+	}()
+
+	// Block until the target provider is explicitly canceled.
+	<-ctx.Done()
+}
+
+func (p *Pod) process(ctx context.Context, ch chan<- []*targetgroup.Group) bool {
+	keyObj, quit := p.queue.Get()
+	if quit {
+		return false
+	}
+	defer p.queue.Done(keyObj)
+	key := keyObj.(string)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return true
+	}
+
+	o, exists, err := p.store.GetByKey(key)
+	if err != nil {
+		return true
+	}
+	if !exists {
+		send(ctx, ch, &targetgroup.Group{Source: podSourceFromNamespaceAndName(namespace, name)})
+		return true
+	}
+	pod, err := convertToPod(o)
+	if err != nil {
+		level.Error(p.logger).Log("msg", "converting to Pod object failed", "err", err)
+		return true
+	}
+	send(ctx, ch, p.buildPod(pod))
+	return true
+}
+
+func convertToPod(o interface{}) (*apiv1.Pod, error) {
+	pod, ok := o.(*apiv1.Pod)
+	if ok {
+		return pod, nil
+	}
+
+	return nil, fmt.Errorf("received unexpected object: %v", o)
+}
+
+const (
+	podNameLabel                  = metaLabelPrefix + "pod_name"
+	podIPLabel                    = metaLabelPrefix + "pod_ip"
+	podContainerNameLabel         = metaLabelPrefix + "pod_container_name"
+	podContainerImageLabel        = metaLabelPrefix + "pod_container_image"
+	podContainerPortNameLabel     = metaLabelPrefix + "pod_container_port_name"
+	podContainerPortNumberLabel   = metaLabelPrefix + "pod_container_port_number"
+	podContainerPortProtocolLabel = metaLabelPrefix + "pod_container_port_protocol"
+	podContainerIsInit            = metaLabelPrefix + "pod_container_init"
+	podReadyLabel                 = metaLabelPrefix + "pod_ready"
+	podPhaseLabel                 = metaLabelPrefix + "pod_phase"
+	podLabelPrefix                = metaLabelPrefix + "pod_label_"
+	podLabelPresentPrefix         = metaLabelPrefix + "pod_labelpresent_"
+	podAnnotationPrefix           = metaLabelPrefix + "pod_annotation_"
+	podAnnotationPresentPrefix    = metaLabelPrefix + "pod_annotationpresent_"
+	podNodeNameLabel              = metaLabelPrefix + "pod_node_name"
+	podHostIPLabel                = metaLabelPrefix + "pod_host_ip"
+	podUID                        = metaLabelPrefix + "pod_uid"
+	podControllerKind             = metaLabelPrefix + "pod_controller_kind"
+	podControllerName             = metaLabelPrefix + "pod_controller_name"
+)
+
+// GetControllerOf returns a pointer to a copy of the controllerRef if controllee has a controller
+// https://github.com/kubernetes/apimachinery/blob/cd2cae2b39fa57e8063fa1f5f13cfe9862db3d41/pkg/apis/meta/v1/controller_ref.go
+func GetControllerOf(controllee metav1.Object) *metav1.OwnerReference {
+	for _, ref := range controllee.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			return &ref
+		}
+	}
+	return nil
+}
+
+func podLabels(pod *apiv1.Pod) model.LabelSet {
+	ls := model.LabelSet{
+		podNameLabel:     lv(pod.ObjectMeta.Name),
+		podIPLabel:       lv(pod.Status.PodIP),
+		podReadyLabel:    podReady(pod),
+		podPhaseLabel:    lv(string(pod.Status.Phase)),
+		podNodeNameLabel: lv(pod.Spec.NodeName),
+		podHostIPLabel:   lv(pod.Status.HostIP),
+		podUID:           lv(string(pod.ObjectMeta.UID)),
+	}
+
+	createdBy := GetControllerOf(pod)
+	if createdBy != nil {
+		if createdBy.Kind != "" {
+			ls[podControllerKind] = lv(createdBy.Kind)
+		}
+		if createdBy.Name != "" {
+			ls[podControllerName] = lv(createdBy.Name)
+		}
+	}
+
+	for k, v := range pod.Labels {
+		ln := strutil.SanitizeLabelName(k)
+		ls[model.LabelName(podLabelPrefix+ln)] = lv(v)
+		ls[model.LabelName(podLabelPresentPrefix+ln)] = presentValue
+	}
+
+	for k, v := range pod.Annotations {
+		ln := strutil.SanitizeLabelName(k)
+		ls[model.LabelName(podAnnotationPrefix+ln)] = lv(v)
+		ls[model.LabelName(podAnnotationPresentPrefix+ln)] = presentValue
+	}
+
+	return ls
+}
+
+func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+	tg := &targetgroup.Group{
+		Source: podSource(pod),
+	}
+	// PodIP can be empty when a pod is starting or has been evicted.
+	if len(pod.Status.PodIP) == 0 {
+		return tg
+	}
+
+	tg.Labels = podLabels(pod)
+	tg.Labels[namespaceLabel] = lv(pod.Namespace)
+	if p.withNodeMetadata {
+		tg.Labels = addNodeLabels(tg.Labels, p.nodeInf, p.logger, &pod.Spec.NodeName)
+	}
+
+	containers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
+	for i, c := range containers {
+		isInit := i >= len(pod.Spec.Containers)
+
+		// If no ports are defined for the container, create an anonymous
+		// target per container.
+		if len(c.Ports) == 0 {
+			// We don't have a port so we just set the address label to the pod IP.
+			// The user has to add a port manually.
+			tg.Targets = append(tg.Targets, model.LabelSet{
+				model.AddressLabel:     lv(pod.Status.PodIP),
+				podContainerNameLabel:  lv(c.Name),
+				podContainerImageLabel: lv(c.Image),
+				podContainerIsInit:     lv(strconv.FormatBool(isInit)),
+			})
+			continue
+		}
+		// Otherwise create one target for each container/port combination.
+		for _, port := range c.Ports {
+			ports := strconv.FormatUint(uint64(port.ContainerPort), 10)
+			addr := net.JoinHostPort(pod.Status.PodIP, ports)
+
+			tg.Targets = append(tg.Targets, model.LabelSet{
+				model.AddressLabel:            lv(addr),
+				podContainerNameLabel:         lv(c.Name),
+				podContainerImageLabel:        lv(c.Image),
+				podContainerPortNumberLabel:   lv(ports),
+				podContainerPortNameLabel:     lv(port.Name),
+				podContainerPortProtocolLabel: lv(string(port.Protocol)),
+				podContainerIsInit:            lv(strconv.FormatBool(isInit)),
+			})
+		}
+	}
+
+	return tg
+}
+
+func (p *Pod) enqueuePodsForNode(nodeName string) {
+	pods, err := p.podInf.GetIndexer().ByIndex(nodeIndex, nodeName)
+	if err != nil {
+		level.Error(p.logger).Log("msg", "Error getting pods for node", "node", nodeName, "err", err)
+		return
+	}
+
+	for _, pod := range pods {
+		p.enqueue(pod.(*apiv1.Pod))
+	}
+}
+
+func podSource(pod *apiv1.Pod) string {
+	return podSourceFromNamespaceAndName(pod.Namespace, pod.Name)
+}
+
+func podSourceFromNamespaceAndName(namespace, name string) string {
+	return "pod/" + namespace + "/" + name
+}
+
+func podReady(pod *apiv1.Pod) model.LabelValue {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == apiv1.PodReady {
+			return lv(strings.ToLower(string(cond.Status)))
+		}
+	}
+	return lv(strings.ToLower(string(apiv1.ConditionUnknown)))
+}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/service.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/service.go
@@ -1,0 +1,216 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+var (
+	svcAddCount    = eventCount.WithLabelValues("service", "add")
+	svcUpdateCount = eventCount.WithLabelValues("service", "update")
+	svcDeleteCount = eventCount.WithLabelValues("service", "delete")
+)
+
+// Service implements discovery of Kubernetes services.
+type Service struct {
+	logger   log.Logger
+	informer cache.SharedInformer
+	store    cache.Store
+	queue    *workqueue.Type
+}
+
+// NewService returns a new service discovery.
+func NewService(l log.Logger, inf cache.SharedInformer) *Service {
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+	s := &Service{logger: l, informer: inf, store: inf.GetStore(), queue: workqueue.NewNamed("service")}
+	_, err := s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o interface{}) {
+			svcAddCount.Inc()
+			s.enqueue(o)
+		},
+		DeleteFunc: func(o interface{}) {
+			svcDeleteCount.Inc()
+			s.enqueue(o)
+		},
+		UpdateFunc: func(_, o interface{}) {
+			svcUpdateCount.Inc()
+			s.enqueue(o)
+		},
+	})
+	if err != nil {
+		level.Error(l).Log("msg", "Error adding services event handler.", "err", err)
+	}
+	return s
+}
+
+func (s *Service) enqueue(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	s.queue.Add(key)
+}
+
+// Run implements the Discoverer interface.
+func (s *Service) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer s.queue.ShutDown()
+
+	if !cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			level.Error(s.logger).Log("msg", "service informer unable to sync cache")
+		}
+		return
+	}
+
+	go func() {
+		for s.process(ctx, ch) {
+		}
+	}()
+
+	// Block until the target provider is explicitly canceled.
+	<-ctx.Done()
+}
+
+func (s *Service) process(ctx context.Context, ch chan<- []*targetgroup.Group) bool {
+	keyObj, quit := s.queue.Get()
+	if quit {
+		return false
+	}
+	defer s.queue.Done(keyObj)
+	key := keyObj.(string)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return true
+	}
+
+	o, exists, err := s.store.GetByKey(key)
+	if err != nil {
+		return true
+	}
+	if !exists {
+		send(ctx, ch, &targetgroup.Group{Source: serviceSourceFromNamespaceAndName(namespace, name)})
+		return true
+	}
+	eps, err := convertToService(o)
+	if err != nil {
+		level.Error(s.logger).Log("msg", "converting to Service object failed", "err", err)
+		return true
+	}
+	send(ctx, ch, s.buildService(eps))
+	return true
+}
+
+func convertToService(o interface{}) (*apiv1.Service, error) {
+	service, ok := o.(*apiv1.Service)
+	if ok {
+		return service, nil
+	}
+	return nil, fmt.Errorf("received unexpected object: %v", o)
+}
+
+func serviceSource(s *apiv1.Service) string {
+	return serviceSourceFromNamespaceAndName(s.Namespace, s.Name)
+}
+
+func serviceSourceFromNamespaceAndName(namespace, name string) string {
+	return "svc/" + namespace + "/" + name
+}
+
+const (
+	serviceNameLabel               = metaLabelPrefix + "service_name"
+	serviceLabelPrefix             = metaLabelPrefix + "service_label_"
+	serviceLabelPresentPrefix      = metaLabelPrefix + "service_labelpresent_"
+	serviceAnnotationPrefix        = metaLabelPrefix + "service_annotation_"
+	serviceAnnotationPresentPrefix = metaLabelPrefix + "service_annotationpresent_"
+	servicePortNameLabel           = metaLabelPrefix + "service_port_name"
+	servicePortNumberLabel         = metaLabelPrefix + "service_port_number"
+	servicePortProtocolLabel       = metaLabelPrefix + "service_port_protocol"
+	serviceClusterIPLabel          = metaLabelPrefix + "service_cluster_ip"
+	serviceLoadBalancerIP          = metaLabelPrefix + "service_loadbalancer_ip"
+	serviceExternalNameLabel       = metaLabelPrefix + "service_external_name"
+	serviceType                    = metaLabelPrefix + "service_type"
+)
+
+func serviceLabels(svc *apiv1.Service) model.LabelSet {
+	// Each label and annotation will create two key-value pairs in the map.
+	ls := make(model.LabelSet, 2*(len(svc.Labels)+len(svc.Annotations))+2)
+
+	ls[serviceNameLabel] = lv(svc.Name)
+	ls[namespaceLabel] = lv(svc.Namespace)
+
+	for k, v := range svc.Labels {
+		ln := strutil.SanitizeLabelName(k)
+		ls[model.LabelName(serviceLabelPrefix+ln)] = lv(v)
+		ls[model.LabelName(serviceLabelPresentPrefix+ln)] = presentValue
+	}
+
+	for k, v := range svc.Annotations {
+		ln := strutil.SanitizeLabelName(k)
+		ls[model.LabelName(serviceAnnotationPrefix+ln)] = lv(v)
+		ls[model.LabelName(serviceAnnotationPresentPrefix+ln)] = presentValue
+	}
+	return ls
+}
+
+func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
+	tg := &targetgroup.Group{
+		Source: serviceSource(svc),
+	}
+	tg.Labels = serviceLabels(svc)
+
+	for _, port := range svc.Spec.Ports {
+		addr := net.JoinHostPort(svc.Name+"."+svc.Namespace+".svc", strconv.FormatInt(int64(port.Port), 10))
+
+		labelSet := model.LabelSet{
+			model.AddressLabel:       lv(addr),
+			servicePortNameLabel:     lv(port.Name),
+			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
+			servicePortProtocolLabel: lv(string(port.Protocol)),
+			serviceType:              lv(string(svc.Spec.Type)),
+		}
+
+		if svc.Spec.Type == apiv1.ServiceTypeExternalName {
+			labelSet[serviceExternalNameLabel] = lv(svc.Spec.ExternalName)
+		} else {
+			labelSet[serviceClusterIPLabel] = lv(svc.Spec.ClusterIP)
+		}
+
+		if svc.Spec.Type == apiv1.ServiceTypeLoadBalancer {
+			labelSet[serviceLoadBalancerIP] = lv(svc.Spec.LoadBalancerIP)
+		}
+
+		tg.Targets = append(tg.Targets, labelSet)
+	}
+
+	return tg
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/version/doc.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/version/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version provides utilities for version number comparisons
+package version // import "k8s.io/apimachinery/pkg/util/version"

--- a/vendor/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/version/version.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Version is an opaque representation of a version number
+type Version struct {
+	components    []uint
+	semver        bool
+	preRelease    string
+	buildMetadata string
+}
+
+var (
+	// versionMatchRE splits a version string into numeric and "extra" parts
+	versionMatchRE = regexp.MustCompile(`^\s*v?([0-9]+(?:\.[0-9]+)*)(.*)*$`)
+	// extraMatchRE splits the "extra" part of versionMatchRE into semver pre-release and build metadata; it does not validate the "no leading zeroes" constraint for pre-release
+	extraMatchRE = regexp.MustCompile(`^(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?\s*$`)
+)
+
+func parse(str string, semver bool) (*Version, error) {
+	parts := versionMatchRE.FindStringSubmatch(str)
+	if parts == nil {
+		return nil, fmt.Errorf("could not parse %q as version", str)
+	}
+	numbers, extra := parts[1], parts[2]
+
+	components := strings.Split(numbers, ".")
+	if (semver && len(components) != 3) || (!semver && len(components) < 2) {
+		return nil, fmt.Errorf("illegal version string %q", str)
+	}
+
+	v := &Version{
+		components: make([]uint, len(components)),
+		semver:     semver,
+	}
+	for i, comp := range components {
+		if (i == 0 || semver) && strings.HasPrefix(comp, "0") && comp != "0" {
+			return nil, fmt.Errorf("illegal zero-prefixed version component %q in %q", comp, str)
+		}
+		num, err := strconv.ParseUint(comp, 10, 0)
+		if err != nil {
+			return nil, fmt.Errorf("illegal non-numeric version component %q in %q: %v", comp, str, err)
+		}
+		v.components[i] = uint(num)
+	}
+
+	if semver && extra != "" {
+		extraParts := extraMatchRE.FindStringSubmatch(extra)
+		if extraParts == nil {
+			return nil, fmt.Errorf("could not parse pre-release/metadata (%s) in version %q", extra, str)
+		}
+		v.preRelease, v.buildMetadata = extraParts[1], extraParts[2]
+
+		for _, comp := range strings.Split(v.preRelease, ".") {
+			if _, err := strconv.ParseUint(comp, 10, 0); err == nil {
+				if strings.HasPrefix(comp, "0") && comp != "0" {
+					return nil, fmt.Errorf("illegal zero-prefixed version component %q in %q", comp, str)
+				}
+			}
+		}
+	}
+
+	return v, nil
+}
+
+// ParseGeneric parses a "generic" version string. The version string must consist of two
+// or more dot-separated numeric fields (the first of which can't have leading zeroes),
+// followed by arbitrary uninterpreted data (which need not be separated from the final
+// numeric field by punctuation). For convenience, leading and trailing whitespace is
+// ignored, and the version can be preceded by the letter "v". See also ParseSemantic.
+func ParseGeneric(str string) (*Version, error) {
+	return parse(str, false)
+}
+
+// MustParseGeneric is like ParseGeneric except that it panics on error
+func MustParseGeneric(str string) *Version {
+	v, err := ParseGeneric(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// ParseSemantic parses a version string that exactly obeys the syntax and semantics of
+// the "Semantic Versioning" specification (http://semver.org/) (although it ignores
+// leading and trailing whitespace, and allows the version to be preceded by "v"). For
+// version strings that are not guaranteed to obey the Semantic Versioning syntax, use
+// ParseGeneric.
+func ParseSemantic(str string) (*Version, error) {
+	return parse(str, true)
+}
+
+// MustParseSemantic is like ParseSemantic except that it panics on error
+func MustParseSemantic(str string) *Version {
+	v, err := ParseSemantic(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// Major returns the major release number
+func (v *Version) Major() uint {
+	return v.components[0]
+}
+
+// Minor returns the minor release number
+func (v *Version) Minor() uint {
+	return v.components[1]
+}
+
+// Patch returns the patch release number if v is a Semantic Version, or 0
+func (v *Version) Patch() uint {
+	if len(v.components) < 3 {
+		return 0
+	}
+	return v.components[2]
+}
+
+// BuildMetadata returns the build metadata, if v is a Semantic Version, or ""
+func (v *Version) BuildMetadata() string {
+	return v.buildMetadata
+}
+
+// PreRelease returns the prerelease metadata, if v is a Semantic Version, or ""
+func (v *Version) PreRelease() string {
+	return v.preRelease
+}
+
+// Components returns the version number components
+func (v *Version) Components() []uint {
+	return v.components
+}
+
+// WithMajor returns copy of the version object with requested major number
+func (v *Version) WithMajor(major uint) *Version {
+	result := *v
+	result.components = []uint{major, v.Minor(), v.Patch()}
+	return &result
+}
+
+// WithMinor returns copy of the version object with requested minor number
+func (v *Version) WithMinor(minor uint) *Version {
+	result := *v
+	result.components = []uint{v.Major(), minor, v.Patch()}
+	return &result
+}
+
+// WithPatch returns copy of the version object with requested patch number
+func (v *Version) WithPatch(patch uint) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), patch}
+	return &result
+}
+
+// WithPreRelease returns copy of the version object with requested prerelease
+func (v *Version) WithPreRelease(preRelease string) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), v.Patch()}
+	result.preRelease = preRelease
+	return &result
+}
+
+// WithBuildMetadata returns copy of the version object with requested buildMetadata
+func (v *Version) WithBuildMetadata(buildMetadata string) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), v.Patch()}
+	result.buildMetadata = buildMetadata
+	return &result
+}
+
+// String converts a Version back to a string; note that for versions parsed with
+// ParseGeneric, this will not include the trailing uninterpreted portion of the version
+// number.
+func (v *Version) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+	var buffer bytes.Buffer
+
+	for i, comp := range v.components {
+		if i > 0 {
+			buffer.WriteString(".")
+		}
+		buffer.WriteString(fmt.Sprintf("%d", comp))
+	}
+	if v.preRelease != "" {
+		buffer.WriteString("-")
+		buffer.WriteString(v.preRelease)
+	}
+	if v.buildMetadata != "" {
+		buffer.WriteString("+")
+		buffer.WriteString(v.buildMetadata)
+	}
+
+	return buffer.String()
+}
+
+// compareInternal returns -1 if v is less than other, 1 if it is greater than other, or 0
+// if they are equal
+func (v *Version) compareInternal(other *Version) int {
+
+	vLen := len(v.components)
+	oLen := len(other.components)
+	for i := 0; i < vLen && i < oLen; i++ {
+		switch {
+		case other.components[i] < v.components[i]:
+			return 1
+		case other.components[i] > v.components[i]:
+			return -1
+		}
+	}
+
+	// If components are common but one has more items and they are not zeros, it is bigger
+	switch {
+	case oLen < vLen && !onlyZeros(v.components[oLen:]):
+		return 1
+	case oLen > vLen && !onlyZeros(other.components[vLen:]):
+		return -1
+	}
+
+	if !v.semver || !other.semver {
+		return 0
+	}
+
+	switch {
+	case v.preRelease == "" && other.preRelease != "":
+		return 1
+	case v.preRelease != "" && other.preRelease == "":
+		return -1
+	case v.preRelease == other.preRelease: // includes case where both are ""
+		return 0
+	}
+
+	vPR := strings.Split(v.preRelease, ".")
+	oPR := strings.Split(other.preRelease, ".")
+	for i := 0; i < len(vPR) && i < len(oPR); i++ {
+		vNum, err := strconv.ParseUint(vPR[i], 10, 0)
+		if err == nil {
+			oNum, err := strconv.ParseUint(oPR[i], 10, 0)
+			if err == nil {
+				switch {
+				case oNum < vNum:
+					return 1
+				case oNum > vNum:
+					return -1
+				default:
+					continue
+				}
+			}
+		}
+		if oPR[i] < vPR[i] {
+			return 1
+		} else if oPR[i] > vPR[i] {
+			return -1
+		}
+	}
+
+	switch {
+	case len(oPR) < len(vPR):
+		return 1
+	case len(oPR) > len(vPR):
+		return -1
+	}
+
+	return 0
+}
+
+// returns false if array contain any non-zero element
+func onlyZeros(array []uint) bool {
+	for _, num := range array {
+		if num != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// AtLeast tests if a version is at least equal to a given minimum version. If both
+// Versions are Semantic Versions, this will use the Semantic Version comparison
+// algorithm. Otherwise, it will compare only the numeric components, with non-present
+// components being considered "0" (ie, "1.4" is equal to "1.4.0").
+func (v *Version) AtLeast(min *Version) bool {
+	return v.compareInternal(min) != -1
+}
+
+// LessThan tests if a version is less than a given version. (It is exactly the opposite
+// of AtLeast, for situations where asking "is v too old?" makes more sense than asking
+// "is v new enough?".)
+func (v *Version) LessThan(other *Version) bool {
+	return v.compareInternal(other) == -1
+}
+
+// Compare compares v against a version string (which will be parsed as either Semantic
+// or non-Semantic depending on v). On success it returns -1 if v is less than other, 1 if
+// it is greater than other, or 0 if they are equal.
+func (v *Version) Compare(other string) (int, error) {
+	ov, err := parse(other, v.semver)
+	if err != nil {
+		return 0, err
+	}
+	return v.compareInternal(ov), nil
+}

--- a/vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_stub.go
+++ b/vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_stub.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcp
+
+import (
+	"errors"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	if err := rest.RegisterAuthProviderPlugin("gcp", newGCPAuthProvider); err != nil {
+		klog.Fatalf("Failed to register gcp auth plugin: %v", err)
+	}
+}
+
+func newGCPAuthProvider(_ string, _ map[string]string, _ rest.AuthProviderConfigPersister) (rest.AuthProvider, error) {
+	return nil, errors.New(`The gcp auth plugin has been removed.
+Please use the "gke-gcloud-auth-plugin" kubectl/client-go credential plugin instead.
+See https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke for further details`)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -553,6 +553,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit; go 1.18
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
+github.com/prometheus/prometheus/discovery/kubernetes
 github.com/prometheus/prometheus/discovery/targetgroup
 github.com/prometheus/prometheus/model/exemplar
 github.com/prometheus/prometheus/model/histogram
@@ -1035,6 +1036,7 @@ k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/validation/field
+k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/util/waitgroup
 k8s.io/apimachinery/pkg/util/yaml
@@ -1465,6 +1467,7 @@ k8s.io/client-go/pkg/apis/clientauthentication/v1
 k8s.io/client-go/pkg/apis/clientauthentication/v1beta1
 k8s.io/client-go/pkg/version
 k8s.io/client-go/plugin/pkg/client/auth/exec
+k8s.io/client-go/plugin/pkg/client/auth/gcp
 k8s.io/client-go/rest
 k8s.io/client-go/rest/fake
 k8s.io/client-go/rest/watch


### PR DESCRIPTION
TestBodySizeLimit checks Prometheus config file instead of the metric "prometheus_target_scrapes_exceeded_body_size_limit_total".

The package "github.com/prometheus/prometheus/discovery/kubernetes" is added to `vendor/` to parse the field `kubernetes_sd_configs` in the config file. 