### PR TITLE
OCPBUGS-14816: Add misspell target in Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [#1937](https://github.com/openshift/cluster-monitoring-operator/pull/1937) Disables btrfs collector
 - [#1910](https://github.com/openshift/cluster-monitoring-operator/pull/1910) Add new web console usage metrics
-- [#1950](https://github.com/openshift/cluster-monitoring-operator/pull/1950) Disable CORS headers on Thanos querier by defaut and add a flag to enable them back.
+- [#1950](https://github.com/openshift/cluster-monitoring-operator/pull/1950) Disable CORS headers on Thanos querier by default and add a flag to enable them back.
 
 ## 4.13
 
@@ -73,7 +73,7 @@
 - [#1308](https://github.com/openshift/cluster-monitoring-operator/pull/1308) Expose remote_write to user for in-cluster deployment and UWM.
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Add config option to disable Grafana deployment.
 - [#1278](https://github.com/openshift/cluster-monitoring-operator/pull/1278) Add EnforcedTargetLimit option for user-workload Prometheus.
-- [#1291](https://github.com/openshift/cluster-monitoring-operator/pull/1291) Drop high caredinality cAdvisor metrics via [kube-prometheus #1250](https://github.com/prometheus-operator/kube-prometheus/pull/1250)
+- [#1291](https://github.com/openshift/cluster-monitoring-operator/pull/1291) Drop high cardinality cAdvisor metrics via [kube-prometheus #1250](https://github.com/prometheus-operator/kube-prometheus/pull/1250)
 - [#1270](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Show a message in the degraded condition when Platform Monitoring Prometheus runs without persistent storage.
 - [#1241](https://github.com/openshift/cluster-monitoring-operator/pull/1241) Allow configuring additional Alertmanagers in User Workload Prometheus and Thanos Ruler.
 - [#1293](https://github.com/openshift/cluster-monitoring-operator/pull/1270) Allow disabling the local Alertmanager.
@@ -125,13 +125,13 @@
 - [#854](https://github.com/openshift/cluster-monitoring-operator/pull/854) Change KubeQuotaExceeded to KubeQuotaFullyUsed.
 - [#859](https://github.com/openshift/cluster-monitoring-operator/pull/859) Remove the `hostport` parameter from the configuration.
 - [#859](https://github.com/openshift/cluster-monitoring-operator/pull/865) Allow users to configure EnforcedSampleLimit for User workload monitoring Prometheus tenant.
-- [#894](https://github.com/openshift/cluster-monitoring-operator/pull/894) Bump jsonnet depdencies:
-  - kubernetes-mixin: https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/475: alerts: adjust error message accrodingly to recent change
+- [#894](https://github.com/openshift/cluster-monitoring-operator/pull/894) Bump jsonnet dependencies:
+  - kubernetes-mixin: https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/475: alerts: adjust error message accordingly to recent change
   - prometheus-operator: https://github.com/coreos/kube-prometheus/pull/610: Add PrometheusOperatorListErrors and fix PrometheusOperatorWatchErrors threshold
   - etcd: https://github.com/etcd-io/etcd/pull/12122: Documentation/etcd-mixin: Reformulate alerting rules to use `without` rather than `by`
   - kubelet: https://github.com/coreos/kube-prometheus/pull/623: Add scraping of endpoint for kubelet probe metrics
   - thanos: https://github.com/thanos-io/thanos/pull/2374: mixin: Added critical Rules alerts.
-- [#898](https://github.com/openshift/cluster-monitoring-operator/pull/898) Bump jsonnet depdencies for kube-mixin:
+- [#898](https://github.com/openshift/cluster-monitoring-operator/pull/898) Bump jsonnet dependencies for kube-mixin:
   - Adjusts severity levels of many alerts from critical to warning as they were cause based alerts
   - Adjusts KubeStatefulSetUpdateNotRolledOut, KubeDaemonSetRolloutStuck
   - Removes KubeAPILatencyHigh and KubeAPIErrorsHigh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This document was created by the Linux Kernel community and is a simple statemen
 # Notes
 Cluster Monitoring Operator is part of OpenShift and therefore follows the [OpenShift Life Cycle](https://access.redhat.com/support/policy/updates/openshift)
 
-You should keep this in mind when decding in which release you want your feature or fix.
+You should keep this in mind when deciding in which release you want your feature or fix.
 
 # Contribution Flow
 Before you get started, you have to perform the following **mandatory** steps:
@@ -115,9 +115,9 @@ This targets needs `docker` to be installed on host and was not tested with othe
 Supposing $KUBECONFIG is set to the config file of a Kubernetes cluster running the codes to test. We can run all tests by using this command `make test`.
 
 The testing consist of 3 aspects:
-- unit tests, can be run seperately by `make test-unit`.
-- Prometheus rule tests, can be run seperately by `make test-rules`.
-- end to end tests, can be run seperately by `make test-e2e`.
+- unit tests, can be run separately by `make test-unit`.
+- Prometheus rule tests, can be run separately by `make test-rules`.
+- end to end tests, can be run separately by `make test-e2e`.
 
 If we need to run a specific test case of the E2E test, we can use the following command.
 ```bash
@@ -127,7 +127,7 @@ Attention that we have to pass a valid $KUBECONFIG explicitly `--kubeconfig $KUB
 
 To run a specific test case of unit tests, we can use the command `go test -v $PACKAGE_DIR -run $TEST_FUNC_NAME`.
 The `$PACKAGE_DIR` is where the source files of a Go package lives. The `$TEST_FUNC_NAME` is the test function whose name always starts with "Test" (regex pattern `TEST\w+`).
-For example, we have a test function `TestImageParsing` in package `manifests`.The source file `./pkg/manifests/image_test.go` and other source code files of this package lives in `./pkg/manifests`. So we can use the following commnad to run the test function `TestImageParsing` in package `manifests`.
+For example, we have a test function `TestImageParsing` in package `manifests`.The source file `./pkg/manifests/image_test.go` and other source code files of this package lives in `./pkg/manifests`. So we can use the following command to run the test function `TestImageParsing` in package `manifests`.
 ```bash
 go test -v ./pkg/manifests -run TestImageParsing
 ```

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/brancz/gojsontoyaml v0.0.0-20201216083616-202f76bf8c1f
 	github.com/campoy/embedmd v1.0.0
+	github.com/client9/misspell v0.3.4
 	github.com/google/go-jsonnet v0.17.1-0.20210520122306-7373f5b60678
 	github.com/jsonnet-bundler/jsonnet-bundler v0.4.0
 	github.com/prometheus/prometheus v1.8.2-0.20210701133801-b0944590a1c9

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -184,6 +184,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -22,6 +22,7 @@ package tools
 import (
 	_ "github.com/brancz/gojsontoyaml"
 	_ "github.com/campoy/embedmd"
+	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/google/go-jsonnet/cmd/jsonnet"
 	_ "github.com/google/go-jsonnet/cmd/jsonnetfmt"
 	_ "github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb"


### PR DESCRIPTION
This PR adds a new misspell target in makefile to sort out common
misspells in markdown files. It explicitly ignores some autogenerated files.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>