### PR TITLE
OCPBUGS-12903: Fix console metrics doc typo

### DIFF
--- a/Documentation/data-collection.md
+++ b/Documentation/data-collection.md
@@ -425,20 +425,20 @@ data:
     # owners: (@openshift/hybrid-application-console-maintainers)
     # cluster:console_auth_login_successes_total:sum gives the total number of successful logins initiated from the web console.
     # Labels:
-    # * `role`, one of `kubeadmin`, `cluster-admin` or `developer`. The value is based whether or not the logged-in user can list all namespaces.
+    # * `role`, one of `kubeadmin`, `cluster-admin` or `developer`. The value is based on whether or not the logged-in user can list all namespaces.
     #
     - '{__name__="cluster:console_auth_login_successes_total:sum"}'
     #
     # owners: (@openshift/hybrid-application-console-maintainers)
     # cluster:console_auth_login_failures_total:sum gives the total number of login failures initiated from the web console.
-    # This might include canceled OAuth logins depenending on the user OAuth provider/configuration.
+    # This might include canceled OAuth logins depending on the user OAuth provider/configuration.
     # Labels:
     # * `reason`, currently always `unknown`
     #
     - '{__name__="cluster:console_auth_login_failures_total:sum"}'
     #
     # owners: (@openshift/hybrid-application-console-maintainers)
-    # cluster:console_auth_logout_requests_total:sum gives the total number of logout requests send from the web console.
+    # cluster:console_auth_logout_requests_total:sum gives the total number of logout requests sent from the web console.
     # Labels:
     # * `reason`, currently always `unknown`
     #
@@ -447,7 +447,7 @@ data:
     # owners: (@openshift/hybrid-application-console-maintainers)
     # cluster:console_usage_users:max contains the number of web console users splitten into the roles.
     # Labels:
-    # * `role`: `kubeadmin`, `cluster-admin` or `developer`. The value is based whether or not the user can list all namespaces.
+    # * `role`: `kubeadmin`, `cluster-admin` or `developer`. The value is based on whether or not the user can list all namespaces.
     #
     - '{__name__="cluster:console_usage_users:max"}'
     #

--- a/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
@@ -417,20 +417,20 @@ data:
     # owners: (@openshift/hybrid-application-console-maintainers)
     # cluster:console_auth_login_successes_total:sum gives the total number of successful logins initiated from the web console.
     # Labels:
-    # * `role`, one of `kubeadmin`, `cluster-admin` or `developer`. The value is based whether or not the logged-in user can list all namespaces.
+    # * `role`, one of `kubeadmin`, `cluster-admin` or `developer`. The value is based on whether or not the logged-in user can list all namespaces.
     #
     - '{__name__="cluster:console_auth_login_successes_total:sum"}'
     #
     # owners: (@openshift/hybrid-application-console-maintainers)
     # cluster:console_auth_login_failures_total:sum gives the total number of login failures initiated from the web console.
-    # This might include canceled OAuth logins depenending on the user OAuth provider/configuration.
+    # This might include canceled OAuth logins depending on the user OAuth provider/configuration.
     # Labels:
     # * `reason`, currently always `unknown`
     #
     - '{__name__="cluster:console_auth_login_failures_total:sum"}'
     #
     # owners: (@openshift/hybrid-application-console-maintainers)
-    # cluster:console_auth_logout_requests_total:sum gives the total number of logout requests send from the web console.
+    # cluster:console_auth_logout_requests_total:sum gives the total number of logout requests sent from the web console.
     # Labels:
     # * `reason`, currently always `unknown`
     #
@@ -439,7 +439,7 @@ data:
     # owners: (@openshift/hybrid-application-console-maintainers)
     # cluster:console_usage_users:max contains the number of web console users splitten into the roles.
     # Labels:
-    # * `role`: `kubeadmin`, `cluster-admin` or `developer`. The value is based whether or not the user can list all namespaces.
+    # * `role`: `kubeadmin`, `cluster-admin` or `developer`. The value is based on whether or not the user can list all namespaces.
     #
     - '{__name__="cluster:console_usage_users:max"}'
     #


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This is a follow-up on #1910 to fix some typos @juzhao mentioned in the 4.13 backport https://github.com/openshift/cluster-monitoring-operator/pull/1976#pullrequestreview-1468917977, so that master and 4.13 are aligned here.

The backport will contain these changes already.