### PR TITLE
Log as cmo service account in make run-local script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ clean:
 
 .PHONY: run-local
 run-local: build
+	PATH="$(PATH):$(BIN_DIR)" KUBECONFIG=$(KUBECONFIG) ./hack/local-cmo.sh --no-cmo-login
+
+.PHONY: run-local-as-cmo
+run-local-as-cmo: build
 	PATH="$(PATH):$(BIN_DIR)" KUBECONFIG=$(KUBECONFIG) ./hack/local-cmo.sh
 
 .PHONY: build

--- a/hack/local-cmo.sh
+++ b/hack/local-cmo.sh
@@ -1,11 +1,35 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+cmo_login='true'
+
 # Script will:
 # 1. Patch CVO to exclude CMO from being managed
 # 2. Scale in-cluster CMO to 0
 # 3. Try to run CMO locally (CMO needs to be built before starting)
 
+
+echo "script starting"
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      echo "local_cmo [options]"
+      echo " "
+      echo "options:"
+      echo "-h, --help                show brief help"
+      echo "-n, --no-cmo-login        run script as kube:admin"
+      exit 0
+      ;;
+    -n|--no-cmo-login)
+      cmo_login='false'
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 validate() {
   local ret=0
@@ -78,6 +102,29 @@ images_from_deployment() {
   kc get deployment cluster-monitoring-operator -o json | jq -r '.spec.template.spec.containers[] | select(.name=="cluster-monitoring-operator") | .args[] | select(.|test("\\-images.*"))'
 }
 
+#log as cmo sa in order to be the correct user
+login_as_cmo() {
+	local cmo_sa="system:serviceaccount:openshift-monitoring:cluster-monitoring-operator"
+  local tmp_dir="tmp/cmo_token"
+	local token="$tmp_dir/cmo-token"
+
+	# use while to break out
+	while [[ -f "$token" ]]; do
+		oc login -u "$cmo_sa" || {
+			rm -f "$token"
+			break
+		}
+		oc get prometheus -n openshift-monitoring && return 0
+	done
+
+	echo "create a new cmo token -> $token"
+	mkdir -p "$tmp_dir"
+	oc create -n openshift-monitoring token cluster-monitoring-operator >"$token"
+  oc login --token="$(cat "$token")"
+	oc project openshift-monitoring
+	oc whoami
+}
+
 run() {
   echo "Running: $*"
   "$@"
@@ -88,6 +135,7 @@ main(){
   cd "$(git rev-parse --show-cdup)"
 
   validate || exit 1
+  oc login -u system:admin
   disable_managed_cmo
 
   local operator_config=manifests/0000_50_cluster-monitoring-operator_04-config.yaml
@@ -99,6 +147,12 @@ main(){
   # NOTE: can't use readarray as it is missing in OSX
   local -a images
   while read -r img; do images+=( "$img" ); done < <(images_from_deployment)
+
+  if [ $cmo_login == 'true' ]; then
+    echo "loggin as cmo sa"
+    echo "run: oc login -u system:admin when finished in order to continue as admin"
+    login_as_cmo
+  fi
 
   run ./operator "${images[@]}" \
     -assets assets/ \


### PR DESCRIPTION
After some issues with cert creation:
 {[{Denied True CSRDenied CSR "system:openshift:openshift-monitoring-dvpqj" was created by an unexpected user: "system:admin"

This change allows correct cmo sa to test changes in local: make run-local

Add: 
make run-local-as-cmo

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
