### PR TITLE
MON-3249: Update telemeter-client to allow TLS through rbac proxy

### DIFF
--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -125,7 +125,7 @@ spec:
           secretName: telemeter-client
       - name: telemeter-client-tls
         secret:
-          secretName: telemeter-client-certs
+          secretName: telemeter-client-tls
       - name: federate-client-tls
         secret:
           secretName: federate-client-certs

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -29,6 +29,8 @@ spec:
         - /usr/bin/telemeter-client
         - --id=$(ID)
         - --from=$(FROM)
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
         - --from-ca-file=/etc/serving-certs-ca-bundle/service-ca.crt
         - --from-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
         - --to=$(TO)
@@ -40,7 +42,7 @@ spec:
         - name: ANONYMIZE_LABELS
           value: ""
         - name: FROM
-          value: https://prometheus-k8s.openshift-monitoring.svc:9091
+          value: https://prometheus-k8s.openshift-monitoring.svc:9092
         - name: ID
           value: ""
         - name: TO
@@ -66,6 +68,9 @@ spec:
           readOnly: false
         - mountPath: /etc/telemeter
           name: secret-telemeter-client
+          readOnly: false
+        - mountPath: /etc/tls/private
+          name: federate-client-tls
           readOnly: false
       - args:
         - --reload-url=http://localhost:8080/-/reload
@@ -120,7 +125,10 @@ spec:
           secretName: telemeter-client
       - name: telemeter-client-tls
         secret:
-          secretName: telemeter-client-tls
+          secretName: telemeter-client-certs
+      - name: federate-client-tls
+        secret:
+          secretName: federate-client-certs
       - name: secret-telemeter-client-kube-rbac-proxy-config
         secret:
           secretName: telemeter-client-kube-rbac-proxy-config

--- a/assets/telemeter-client/service.yaml
+++ b/assets/telemeter-client/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: telemeter-client-tls
+    service.beta.openshift.io/serving-cert-secret-name: telemeter-client-certs
   labels:
     k8s-app: telemeter-client
   name: telemeter-client

--- a/assets/telemeter-client/service.yaml
+++ b/assets/telemeter-client/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: telemeter-client-certs
+    service.beta.openshift.io/serving-cert-secret-name: telemeter-client-tls
   labels:
     k8s-app: telemeter-client
   name: telemeter-client

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -120,8 +120,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "f89e6dc822513285ba010fdc8bff13939bbc62e5",
-      "sum": "CGBrF6OtNwal33cdS+hUvgQa0slORIJVnuG65KcfhtA=",
+      "version": "9d50dd68b8b26316770db5fb1188bdcfe5a5b20e",
+      "sum": "J6AvgvLAMOdprhPQ3Z/hRDgyzDBeUhiZcpu+neY8MKc=",
       "name": "telemeter-client"
     },
     {

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -120,8 +120,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "9d50dd68b8b26316770db5fb1188bdcfe5a5b20e",
-      "sum": "J6AvgvLAMOdprhPQ3Z/hRDgyzDBeUhiZcpu+neY8MKc=",
+      "version": "a8eaf7c6f0112888870a3599fccb731d16421360",
+      "sum": "q5Ks8a8hGq/KsttHxnIrWnJNY7s4pN1NCDmjGp+/QQM=",
       "name": "telemeter-client"
     },
     {


### PR DESCRIPTION
Update telemeter-client deployment to work with new feature TLS.

Update telemeter branch to get updated json
Generate new jsonnetfile with new branch
Make generate to update deployment.yaml



Depends on:
https://github.com/openshift/cluster-monitoring-operator/pull/1904 
https://github.com/openshift/telemeter/pull/455

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
