### PR TITLE
test/e2e: validate CMO and UWM configs

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -108,35 +108,13 @@ enableUserWorkload: true`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cm := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterMonitorConfigMapName,
-					Namespace: f.Ns,
-					Labels: map[string]string{
-						framework.E2eTestLabelName: framework.E2eTestLabelValue,
-					},
-				},
-				Data: map[string]string{
-					"config.yaml": tc.config,
-				},
-			}
+			cm := f.BuildCMOConfigMap(t, tc.config)
 			f.MustCreateOrUpdateConfigMap(t, cm)
 			t.Cleanup(func() {
 				f.MustDeleteConfigMap(t, cm)
 			})
 
-			uwmConfigMap := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      userWorkloadMonitorConfigMapName,
-					Namespace: f.UserWorkloadMonitoringNs,
-					Labels: map[string]string{
-						framework.E2eTestLabelName: framework.E2eTestLabelValue,
-					},
-				},
-				Data: map[string]string{
-					"config.yaml": tc.userWorkloadConfig,
-				},
-			}
+			uwmConfigMap := f.BuildUserWorkloadConfigMap(t, tc.userWorkloadConfig)
 			f.MustCreateOrUpdateConfigMap(t, uwmConfigMap)
 			t.Cleanup(func() {
 				f.MustDeleteConfigMap(t, uwmConfigMap)
@@ -453,7 +431,7 @@ func TestAlertmanagerDataReplication(t *testing.T) {
 	data := fmt.Sprintf(`alertmanagerMain:
   logLevel: warn
 `)
-	f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, data))
+	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, data))
 
 	for _, test := range []scenario{
 		{
@@ -537,20 +515,7 @@ func TestAlertmanagerOAuthProxy(t *testing.T) {
 
 // Users should be able to disable Alertmanager through the cluster-monitoring-config
 func TestAlertmanagerDisabling(t *testing.T) {
-	// Disable alertmanager
-	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterMonitorConfigMapName,
-			Namespace: f.Ns,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `alertmanagerMain: { enabled: false }`,
-		},
-	}
-	f.MustCreateOrUpdateConfigMap(t, cm)
+	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, "alertmanagerMain: { enabled: false }"))
 
 	assertions := []struct {
 		name      string
@@ -705,35 +670,13 @@ enableUserWorkload: true`,
 				wr.tearDown(t, f)
 			})
 
-			cm := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterMonitorConfigMapName,
-					Namespace: f.Ns,
-					Labels: map[string]string{
-						framework.E2eTestLabelName: framework.E2eTestLabelValue,
-					},
-				},
-				Data: map[string]string{
-					"config.yaml": tc.config,
-				},
-			}
+			cm := f.BuildCMOConfigMap(t, tc.config)
 			f.MustCreateOrUpdateConfigMap(t, cm)
 			t.Cleanup(func() {
 				f.MustDeleteConfigMap(t, cm)
 			})
 
-			uwmConfigMap := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      userWorkloadMonitorConfigMapName,
-					Namespace: f.UserWorkloadMonitoringNs,
-					Labels: map[string]string{
-						framework.E2eTestLabelName: framework.E2eTestLabelValue,
-					},
-				},
-				Data: map[string]string{
-					"config.yaml": tc.userWorkloadConfig,
-				},
-			}
+			uwmConfigMap := f.BuildUserWorkloadConfigMap(t, tc.userWorkloadConfig)
 			f.MustCreateOrUpdateConfigMap(t, uwmConfigMap)
 			t.Cleanup(func() {
 				f.MustDeleteConfigMap(t, uwmConfigMap)
@@ -942,20 +885,9 @@ func TestAlertmanagerPlatformSecrets(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cm := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterMonitorConfigMapName,
-					Namespace: f.Ns,
-					Labels: map[string]string{
-						framework.E2eTestLabelName: framework.E2eTestLabelValue,
-					},
-				},
-				Data: map[string]string{
-					"config.yaml": tc.config,
-				},
-			}
-
 			amGeneration := testAlertmanagerReady(t, tc.amName, tc.amNamespace).GetGeneration()
+
+			cm := f.BuildCMOConfigMap(t, tc.config)
 			f.MustCreateOrUpdateConfigMap(t, cm)
 			t.Cleanup(func() {
 				f.MustDeleteConfigMap(t, cm)
@@ -1041,18 +973,7 @@ func TestAlertmanagerUWMSecrets(t *testing.T) {
 				f.MustDeleteConfigMap(t, cm)
 			})
 
-			uwmConfigMap := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      userWorkloadMonitorConfigMapName,
-					Namespace: f.UserWorkloadMonitoringNs,
-					Labels: map[string]string{
-						framework.E2eTestLabelName: framework.E2eTestLabelValue,
-					},
-				},
-				Data: map[string]string{
-					"config.yaml": tc.userWorkloadConfig,
-				},
-			}
+			uwmConfigMap := f.BuildUserWorkloadConfigMap(t, tc.userWorkloadConfig)
 			f.MustCreateOrUpdateConfigMap(t, uwmConfigMap)
 			t.Cleanup(func() {
 				f.MustDeleteConfigMap(t, uwmConfigMap)

--- a/test/e2e/image_registry_test.go
+++ b/test/e2e/image_registry_test.go
@@ -5,9 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestImageRegistryPods(t *testing.T) {
@@ -51,16 +49,8 @@ func TestImageRegistryPods(t *testing.T) {
 	}
 
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
-	uwmCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWorkloadMonitorConfigMapName,
-			Namespace: f.UserWorkloadMonitoringNs,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `prometheus:
+	uwmCM := f.BuildUserWorkloadConfigMap(t,
+		`prometheus:
   enforcedTargetLimit: 10
   volumeClaimTemplate:
     spec:
@@ -68,9 +58,7 @@ func TestImageRegistryPods(t *testing.T) {
         requests:
           storage: 2Gi
 `,
-		},
-	}
-
+	)
 	f.MustCreateOrUpdateConfigMap(t, uwmCM)
 	defer f.MustDeleteConfigMap(t, uwmCM)
 

--- a/test/e2e/node_exporter_test.go
+++ b/test/e2e/node_exporter_test.go
@@ -18,20 +18,11 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	corev1 "k8s.io/api/core/v1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNodeExporterCollectorEnablement(t *testing.T) {
 	t.Cleanup(func() {
-		f.MustDeleteConfigMap(t, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      clusterMonitorConfigMapName,
-				Namespace: f.Ns,
-			},
-		})
+		f.MustDeleteConfigMap(t, f.BuildCMOConfigMap(t, ""))
 	})
 
 	tests := []struct {
@@ -92,7 +83,7 @@ nodeExporter:
 				},
 			)
 
-			f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, test.config))
+			f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, test.config))
 
 			f.PrometheusK8sClient.WaitForQueryReturn(
 				t, 5*time.Minute, fmt.Sprintf(`min(node_scrape_collector_success{collector="%s"})`, test.nameCollector),
@@ -110,12 +101,7 @@ nodeExporter:
 
 func TestNodeExporterCollectorDisablement(t *testing.T) {
 	t.Cleanup(func() {
-		f.MustDeleteConfigMap(t, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      clusterMonitorConfigMapName,
-				Namespace: f.Ns,
-			},
-		})
+		f.MustDeleteConfigMap(t, f.BuildCMOConfigMap(t, ""))
 	})
 
 	tests := []struct {
@@ -193,7 +179,7 @@ nodeExporter:
 				f.PrometheusK8sClient.WaitForQueryReturnEmpty(t, 5*time.Minute, fmt.Sprintf(`absent(%s)`, metric))
 			}
 
-			f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, test.config))
+			f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, test.config))
 
 			f.PrometheusK8sClient.WaitForQueryReturn(
 				t, 5*time.Minute, fmt.Sprintf(`absent_over_time(node_scrape_collector_success{collector="%s"}[1m])`, test.nameCollector),
@@ -211,12 +197,7 @@ nodeExporter:
 // This test ensures neccessary collectors stay operational after changing generic options in Node Exporter.
 func TestNodeExporterGenericOptions(t *testing.T) {
 	t.Cleanup(func() {
-		f.MustDeleteConfigMap(t, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      clusterMonitorConfigMapName,
-				Namespace: f.Ns,
-			},
-		})
+		f.MustDeleteConfigMap(t, f.BuildCMOConfigMap(t, ""))
 	})
 
 	collectorsToCheck := []string{
@@ -255,7 +236,7 @@ nodeExporter:
 
 	for _, test := range tests {
 		t.Run(test.name, func(st *testing.T) {
-			f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, test.config))
+			f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, test.config))
 
 			for _, nameCollector := range collectorsToCheck {
 

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -282,7 +282,7 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, cmoConfigMap))
+			f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, cmoConfigMap))
 
 			f.AssertOperatorCondition(osConfigv1.OperatorDegraded, osConfigv1.ConditionFalse)(t)
 			f.AssertOperatorCondition(osConfigv1.OperatorProgressing, osConfigv1.ConditionFalse)(t)
@@ -318,7 +318,7 @@ func TestBodySizeLimit(t *testing.T) {
 		prometheusConfigSecretName = "prometheus-k8s"
 	)
 
-	cm := f.MustGetConfigMap(t, clusterMonitorConfigMapName, f.Ns)
+	cm := f.MustGetConfigMap(t, framework.ClusterMonitorConfigMapName, f.Ns)
 	cmBackup := cm.DeepCopy()
 	cmBackup.ObjectMeta.ResourceVersion = ""
 	cmBackup.ObjectMeta.UID = ""
@@ -345,7 +345,7 @@ func TestBodySizeLimit(t *testing.T) {
   logLevel: debug
   enforcedBodySizeLimit: %s
 `, bodySizeLimitSmall)
-	f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, data))
+	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, data))
 
 	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		prometheusConfig, err := getPrometheusConfig(t, prometheusConfigSecretName)
@@ -364,7 +364,6 @@ func TestBodySizeLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func getPrometheusConfig(t *testing.T, prometheusConfigSecretName string) (*promConfig.Config, error) {

--- a/test/e2e/prometheusadapter_test.go
+++ b/test/e2e/prometheusadapter_test.go
@@ -79,7 +79,7 @@ func TestMetricsAPIAvailability(t *testing.T) {
 `,
 		},
 	} {
-		f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, tc.cmoConfig))
+		f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, tc.cmoConfig))
 
 		f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
 		f.AssertOperatorCondition(configv1.OperatorProgressing, configv1.ConditionFalse)(t)
@@ -133,7 +133,7 @@ func TestNodeMetricsPresence(t *testing.T) {
 `,
 		},
 	} {
-		f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, tc.cmoConfig))
+		f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, tc.cmoConfig))
 
 		f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
 		f.AssertOperatorCondition(configv1.OperatorProgressing, configv1.ConditionFalse)(t)
@@ -202,7 +202,7 @@ func TestPodMetricsPresence(t *testing.T) {
 `,
 		},
 	} {
-		f.MustCreateOrUpdateConfigMap(t, configMapWithData(t, tc.cmoConfig))
+		f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, tc.cmoConfig))
 
 		f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
 		f.AssertOperatorCondition(configv1.OperatorProgressing, configv1.ConditionFalse)(t)

--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -30,19 +28,9 @@ import (
 // TestTelemeterRemoteWrite verifies that the monitoring stack can send data to
 // the telemeter server using the native Prometheus remote write endpoint.
 func TestTelemeterRemoteWrite(t *testing.T) {
-	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterMonitorConfigMapName,
-			Namespace: f.Ns,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": "{}",
-		},
-	}
+	cm := f.BuildCMOConfigMap(t, "{}")
 	f.MustCreateOrUpdateConfigMap(t, cm)
+
 	t.Cleanup(func() {
 		f.MustDeleteConfigMap(t, cm)
 	})

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -10,30 +10,20 @@ import (
 
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestUserWorkloadThanosRulerWithAdditionalAlertmanagers(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
-	uwmCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWorkloadMonitorConfigMapName,
-			Namespace: f.UserWorkloadMonitoringNs,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `thanosRuler:
+	uwmCM := f.BuildUserWorkloadConfigMap(t,
+		`thanosRuler:
   additionalAlertmanagerConfigs:
   - scheme: http
     apiVersion: v2
     staticConfigs: ["dnssrv+_web._tcp.alertmanager-operated.openshift-user-workload-monitoring.svc"]
 `,
-		},
-	}
+	)
 	f.MustCreateOrUpdateConfigMap(t, uwmCM)
 	t.Cleanup(func() {
 		deleteAlertmanager(t)

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -45,16 +45,8 @@ type scenario struct {
 func TestUserWorkloadMonitoringMetrics(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
-	uwmCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWorkloadMonitorConfigMapName,
-			Namespace: f.UserWorkloadMonitoringNs,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `prometheus:
+	uwmCM := f.BuildUserWorkloadConfigMap(t,
+		`prometheus:
   enforcedTargetLimit: 10
   volumeClaimTemplate:
     spec:
@@ -62,9 +54,7 @@ func TestUserWorkloadMonitoringMetrics(t *testing.T) {
         requests:
           storage: 2Gi
 `,
-		},
-	}
-
+	)
 	f.MustCreateOrUpdateConfigMap(t, uwmCM)
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
@@ -112,16 +102,8 @@ func TestUserWorkloadMonitoringMetrics(t *testing.T) {
 func TestUserWorkloadMonitoringAlerting(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
-	uwmCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWorkloadMonitorConfigMapName,
-			Namespace: f.UserWorkloadMonitoringNs,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `prometheus:
+	uwmCM := f.BuildUserWorkloadConfigMap(t,
+		`prometheus:
   enforcedTargetLimit: 10
   volumeClaimTemplate:
     spec:
@@ -129,9 +111,7 @@ func TestUserWorkloadMonitoringAlerting(t *testing.T) {
         requests:
           storage: 2Gi
 `,
-		},
-	}
-
+	)
 	f.MustCreateOrUpdateConfigMap(t, uwmCM)
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
@@ -166,16 +146,8 @@ func TestUserWorkloadMonitoringAlerting(t *testing.T) {
 func TestUserWorkloadMonitoringOptOut(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
-	uwmCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWorkloadMonitorConfigMapName,
-			Namespace: f.UserWorkloadMonitoringNs,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `prometheus:
+	uwmCM := f.BuildUserWorkloadConfigMap(t,
+		`prometheus:
   enforcedTargetLimit: 10
   volumeClaimTemplate:
     spec:
@@ -183,9 +155,7 @@ func TestUserWorkloadMonitoringOptOut(t *testing.T) {
         requests:
           storage: 2Gi
 `,
-		},
-	}
-
+	)
 	f.MustCreateOrUpdateConfigMap(t, uwmCM)
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
@@ -205,13 +175,8 @@ func TestUserWorkloadMonitoringOptOut(t *testing.T) {
 func TestUserWorkloadMonitoringGrpcSecrets(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
-	uwmCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWorkloadMonitorConfigMapName,
-			Namespace: f.UserWorkloadMonitoringNs,
-		},
-		Data: map[string]string{
-			"config.yaml": `prometheus:
+	uwmCM := f.BuildUserWorkloadConfigMap(t,
+		`prometheus:
   enforcedTargetLimit: 10
   volumeClaimTemplate:
     spec:
@@ -219,9 +184,7 @@ func TestUserWorkloadMonitoringGrpcSecrets(t *testing.T) {
         requests:
           storage: 2Gi
 `,
-		},
-	}
-
+	)
 	f.MustCreateOrUpdateConfigMap(t, uwmCM)
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
@@ -242,16 +205,8 @@ func TestUserWorkloadMonitoringWithAdditionalAlertmanagerConfigs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	uwmCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWorkloadMonitorConfigMapName,
-			Namespace: f.UserWorkloadMonitoringNs,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `prometheus:
+	uwmCM := f.BuildUserWorkloadConfigMap(t,
+		`prometheus:
   additionalAlertmanagerConfigs:
   - scheme: https
     pathPrefix: /prefix
@@ -269,8 +224,7 @@ func TestUserWorkloadMonitoringWithAdditionalAlertmanagerConfigs(t *testing.T) {
         key: tls.ca
     staticConfigs: ["127.0.0.1", "127.0.0.2"]
 `,
-		},
-	}
+	)
 	f.MustCreateOrUpdateConfigMap(t, uwmCM)
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
@@ -397,18 +351,7 @@ func assertAlertmanagerInstancesDiscovered(expectedInstances int) func(_ *testin
 
 func disableAdditionalAlertmanagerConfigs(t *testing.T) {
 	ctx := context.Background()
-	uwmCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWorkloadMonitorConfigMapName,
-			Namespace: f.UserWorkloadMonitoringNs,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `prometheus: {}`,
-		},
-	}
+	uwmCM := f.BuildUserWorkloadConfigMap(t, `prometheus: {}`)
 
 	if err := f.OperatorClient.CreateOrUpdateConfigMap(ctx, uwmCM); err != nil {
 		t.Fatal(err)

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -27,19 +27,8 @@ var (
 // getUserWorkloadEnabledConfigMap returns a config map with uwm enabled
 func getUserWorkloadEnabledConfigMap(t *testing.T, f *framework.Framework) *v1.ConfigMap {
 	t.Helper()
-	return &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      framework.ClusterMonitorConfigMapName,
-			Namespace: f.Ns,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": `enableUserWorkload: true
-`,
-		},
-	}
+
+	return f.BuildCMOConfigMap(t, "enableUserWorkload: true")
 }
 
 // setupUserWorkloadAssets enables UWM via the config map and asserts resources are up and running


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
