### PR TITLE
OCPBUGS-15210: manifest: rename TP roleBinding to cluster-monitoring-operator-alert-…

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_03-role-binding.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_03-role-binding.yaml
@@ -65,7 +65,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cluster-monitoring-operator-techpreview-only
+  name: cluster-monitoring-operator-alert-customization
   namespace: openshift-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"


### PR DESCRIPTION
…customization

Problem: When the alertoverrides feature was promoted to v1, I failed to rename a RoleBinding accordingly. This caused CVO to fail to progress through an update since it had to modify an existing RoleBinding (cannot change RoleRef).

Solution: Rename the RoleBinding object in manifests/. We don't need to mark the old object for deletion, since it was behind a tech-preview flag, and tech-preview cluster are not supported to upgrade. So from the upgrade process this is simply a new resource.

Links: https://issues.redhat.com/browse/OCPBUGS-15210

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
