### PR TITLE
OCPBUGS-14922: skip console-plugin installation if console CO is absent

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -181,7 +181,7 @@ function(params) {
       {
         apiGroups: ['config.openshift.io'],
         resources: ['clusterversions'],
-        verbs: ['get'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['config.openshift.io'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -78,6 +78,8 @@ rules:
   - clusterversions
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:


### PR DESCRIPTION
This PR fixes the failure to upgrade from OpenShift version 4.13 to 4.14 in environments (such as telco) where `console` ClusterOperator is disabled. The upgrade fails happens when CMO executes the console-plugin task which fails due to missing ConsolePlugin.

The fix checks for the presence of `console` ClusterOperator and bails out (with a log message) if it is absent.
