### PR TITLE
MON-3180: Expose and propagate TopologySpreadConstraints for telemeter-client

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2911,6 +2911,10 @@ func (f *Factory) TelemeterClientDeployment(proxyCABundleCM *v1.ConfigMap, s *v1
 	if len(f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.Tolerations) > 0 {
 		d.Spec.Template.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.Tolerations
 	}
+	if len(f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.TopologySpreadConstraints) > 0 {
+		d.Spec.Template.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.TopologySpreadConstraints
+	}
 	d.Namespace = f.namespace
 	return d, nil
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3471,7 +3471,16 @@ grpc:
 }
 
 func TestTelemeterConfiguration(t *testing.T) {
-	c, err := NewConfigFromString(``, false)
+	config := (`telemeterClient:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar`)
+
+	c, err := NewConfigFromString(config, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3520,6 +3529,14 @@ func TestTelemeterConfiguration(t *testing.T) {
 		KubeRbacProxyMinTLSVersionFlag, APIServerDefaultMinTLSVersion)
 	if expectedKubeRbacProxyMinTLSVersionArg != kubeRbacProxyMinTLSVersionArg {
 		t.Fatalf("incorrect TLS version \n got %s, \nwant %s", kubeRbacProxyMinTLSVersionArg, expectedKubeRbacProxyMinTLSVersionArg)
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Telemeter ruler topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Telemeter ruler topology spread contraints WhenUnsatisfiable not configured correctly")
 	}
 }
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -248,6 +248,8 @@ type TelemeterClientConfig struct {
 	Token string `json:"token,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
 // The `ThanosQuerierConfig` resource defines settings for the Thanos Querier


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the TelemeterClientConfig field and propagate this to the pod that is created.