### PR TITLE
MON-3180: Expose and propagate TopologySpreadConstraints for telemeter-client

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -522,6 +522,7 @@ The `TLSConfig` resource configures the settings for TLS connections.
 | -------- | ---- | ----------- |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
+| topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/modules/telemeterclientconfig.adoc
+++ b/Documentation/openshiftdocs/modules/telemeterclientconfig.adoc
@@ -25,6 +25,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2944,6 +2944,10 @@ func (f *Factory) TelemeterClientDeployment(proxyCABundleCM *v1.ConfigMap, s *v1
 	if len(f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.Tolerations) > 0 {
 		d.Spec.Template.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.Tolerations
 	}
+	if len(f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.TopologySpreadConstraints) > 0 {
+		d.Spec.Template.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.TopologySpreadConstraints
+	}
 	d.Namespace = f.namespace
 	return d, nil
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3514,7 +3514,16 @@ grpc:
 }
 
 func TestTelemeterConfiguration(t *testing.T) {
-	c, err := NewConfigFromString(``, false)
+	config := (`telemeterClient:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar`)
+
+	c, err := NewConfigFromString(config, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3563,6 +3572,14 @@ func TestTelemeterConfiguration(t *testing.T) {
 		KubeRbacProxyMinTLSVersionFlag, APIServerDefaultMinTLSVersion)
 	if expectedKubeRbacProxyMinTLSVersionArg != kubeRbacProxyMinTLSVersionArg {
 		t.Fatalf("incorrect TLS version \n got %s, \nwant %s", kubeRbacProxyMinTLSVersionArg, expectedKubeRbacProxyMinTLSVersionArg)
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Telemeter topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Telemeter topology spread contraints WhenUnsatisfiable not configured correctly")
 	}
 }
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -248,6 +248,8 @@ type TelemeterClientConfig struct {
 	Token string `json:"token,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
 // The `ThanosQuerierConfig` resource defines settings for the Thanos Querier


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the TelemeterClientConfig field and propagate this to the pod that is created.
