### PR TITLE
OCPBUGS-15440: fix CMO to apply console-plugin pod.spec config

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2621,8 +2621,8 @@ func (f *Factory) MonitoringPluginDeployment() (*appsv1.Deployment, error) {
 
 	// ensure console-plugin container is present even if config isn't defined so that,
 	// we validate that deployment has the expected container name. Thereby avoiding
-	// any suprises should user add config later.
-	podSpec := d.Spec.Template.Spec
+	// any surprises should user add config later.
+	podSpec := &d.Spec.Template.Spec
 	containers := podSpec.Containers
 	idx := slices.IndexFunc(containers, containerNameEquals(MonitoringPluginDeploymentContainer))
 	if idx < 0 {


### PR DESCRIPTION
The console-plugin's deployment configs that need to applied to the deployment.spec.template.spec weren't getting applied because the changes were made to the copy of the object instead of the original object itself. The tests didn't catch the issue because the pod assertions didn't validate if any pods were found for the combination of namespace and label-selector

This commit fixes both by refering (pointer) to the original spec instead of the copy and by fixing the assertions fail if it fails to find any pods.
