### PR TITLE
OCPBUGS-15469: Limit the value of GOMAXPROCS on node-exporter to 4.

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -41,6 +41,19 @@ spec:
         - --collector.cpu.info
         - --collector.textfile.directory=/var/node_exporter/textfile
         - --no-collector.btrfs
+        command:
+        - /bin/sh
+        - -c
+        - |
+          export GOMAXPROCS=4
+          # We don't take CPU affinity into account as the container doesn't have integer CPU requests.
+          # In case of error, fallback to the default value.
+          NUM_CPUS=$(grep -c '^processor' "/proc/cpuinfo" 2>/dev/null || echo "0")
+          if [ "$NUM_CPUS" -lt "$GOMAXPROCS" ]; then
+            export GOMAXPROCS="$NUM_CPUS"
+          fi
+          echo "ts=$(date --iso-8601=seconds) num_cpus=$NUM_CPUS gomaxprocs=$GOMAXPROCS"
+          exec /bin/node_exporter "$0" "$@"
         image: quay.io/prometheus/node-exporter:v1.5.0
         name: node-exporter
         resources:


### PR DESCRIPTION
On nodes with multiple CPU cores, this should help avoid lock contentions without having any side effects, see the ticket for more details.

node-exporter versions that have "--runtime.gomaxprocs" can still override this: the flag has precedence over this automatic setting.

Make the entrypoint set the env var before runnning the process. Get the CPU count from /proc/cpuinfo without taking CPU affinity (via cpuset) into account as the container's CPU requests is not an integer, thus no affinity is applied.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
