### PR TITLE
MON-3176: Expose and propagate TopologySpreadConstraints for prometheus-adapter

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -166,6 +166,7 @@ The `K8sPrometheusAdapter` resource defines settings for the Prometheus Adapter 
 | audit | *Audit | Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`. |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
+| topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 | dedicatedServiceMonitors | *[DedicatedServiceMonitors](#dedicatedservicemonitors) | Defines dedicated service monitors. |
 
 [Back to TOC](#table-of-contents)

--- a/Documentation/openshiftdocs/modules/k8sprometheusadapter.adoc
+++ b/Documentation/openshiftdocs/modules/k8sprometheusadapter.adoc
@@ -24,6 +24,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
 |dedicatedServiceMonitors|*link:dedicatedservicemonitors.adoc[DedicatedServiceMonitors]|Defines dedicated service monitors.
 
 |===

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1904,6 +1904,11 @@ func (f *Factory) PrometheusAdapterDeployment(apiAuthSecretName string, requesth
 	if config != nil && len(config.Tolerations) > 0 {
 		spec.Tolerations = config.Tolerations
 	}
+
+	if len(f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.TopologySpreadConstraints) > 0 {
+		spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.TopologySpreadConstraints
+	}
 	dep.Namespace = f.namespace
 
 	r := newErrMapReader(requestheader)

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2530,11 +2530,19 @@ expected:
 }
 
 func TestK8sPrometheusAdapterConfiguration(t *testing.T) {
-	c, err := NewConfigFromString(`
+	config := (`
 k8sPrometheusAdapter:
   nodeSelector:
     test: value
-`, false)
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar`)
+
+	c, err := NewConfigFromString(config, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2556,6 +2564,15 @@ k8sPrometheusAdapter:
 	if d.Spec.Template.Spec.Containers[0].Image != "docker.io/openshift/origin-k8s-prometheus-adapter:latest" {
 		t.Fatal("k8s-prometheus-adapter image is not configured correctly")
 	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("k8s-prometheus-adapter topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("k8s-prometheus-adapter topology spread contraints WhenUnsatisfiable not configured correctly")
+	}
+
 	expected := map[string]string{"test": "value"}
 	if !reflect.DeepEqual(d.Spec.Template.Spec.NodeSelector, expected) {
 		t.Fatalf("k8s-prometheus-adapter nodeSelector is not configured correctly\n\ngot:\n\n%#+v\n\nexpected:\n\n%#+v\n", d.Spec.Template.Spec.NodeSelector, expected)

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -111,6 +111,8 @@ type K8sPrometheusAdapter struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// Defines dedicated service monitors.
 	DedicatedServiceMonitors *DedicatedServiceMonitors `json:"dedicatedServiceMonitors,omitempty"`
 }


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the K8sPrometheusAdapter field and propagate this to the pod that is created.
