### PR TITLE
MON-3177: Expose and propagate TopologySpreadConstraints for kube state metrics

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -183,6 +183,7 @@ The `KubeStateMetricsConfig` resource defines settings for the `kube-state-metri
 | -------- | ---- | ----------- |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
+| topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/modules/kubestatemetricsconfig.adoc
+++ b/Documentation/openshiftdocs/modules/kubestatemetricsconfig.adoc
@@ -22,6 +22,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -758,6 +758,10 @@ func (f *Factory) KubeStateMetricsDeployment() (*appsv1.Deployment, error) {
 		d.Spec.Template.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.KubeStateMetricsConfig.Tolerations
 	}
 
+	if len(f.config.ClusterMonitoringConfiguration.KubeStateMetricsConfig.TopologySpreadConstraints) > 0 {
+		d.Spec.Template.Spec.TopologySpreadConstraints = f.config.ClusterMonitoringConfiguration.KubeStateMetricsConfig.TopologySpreadConstraints
+	}
+
 	return d, nil
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3171,7 +3171,17 @@ nodeExporter:
 }
 
 func TestKubeStateMetrics(t *testing.T) {
-	c, err := NewConfigFromString(``, false)
+	config :=
+		(`kubeStateMetrics:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar`)
+
+	c, err := NewConfigFromString(config, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3217,6 +3227,14 @@ func TestKubeStateMetrics(t *testing.T) {
 		KubeRbacProxyMinTLSVersionFlag, APIServerDefaultMinTLSVersion)
 	if expectedKubeRbacProxyMinTLSVersionArg != kubeRbacProxyMinTLSVersionArg {
 		t.Fatalf("incorrect TLS version \n got %s, \nwant %s", kubeRbacProxyMinTLSVersionArg, expectedKubeRbacProxyMinTLSVersionArg)
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("kube-state-metrics topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("kube-state-metrics topology spread contraints WhenUnsatisfiable not configured correctly")
 	}
 
 	d2, err := f.KubeStateMetricsDeployment()

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -137,6 +137,8 @@ type KubeStateMetricsConfig struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
 // The `PrometheusK8sConfig` resource defines settings for the Prometheus


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the kubeStateMetrcisConfig field and propagate this to the pod that is created.
