### PR TITLE
Add new alert for kube-api degraded

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -475,6 +475,16 @@ spec:
       for: 15m
       labels:
         severity: critical
+    - alert: KubeAPIDegraded
+      annotations:
+        description: KubeAPI is degraded.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeAPIDegraded.md
+        summary: Kubernetes API is in degraded state.
+      expr: |
+        cluster_operator_conditions{condition="Degraded",name="kube-apiserver"}==1
+      for: 15m
+      labels:
+        severity: warning
     - alert: KubeAPITerminatedRequests
       annotations:
         description: The kubernetes apiserver has terminated {{ $value | humanizePercentage

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -379,6 +379,7 @@ local includeRunbooks = {
   ClusterOperatorDegraded: openShiftRunbookCMO('ClusterOperatorDegraded.md'),
   ClusterOperatorDown: openShiftRunbookCMO('ClusterOperatorDown.md'),
   KubeAPIDown: openShiftRunbookCMO('KubeAPIDown.md'),
+  #KubeAPIDegraded: openShiftRunBookCMO('KubeAPIDegraded.md'),
   KubeDeploymentReplicasMismatch: openShiftRunbookCMO('KubeDeploymentReplicasMismatch.md'),
   KubeJobFailed: openShiftRunbookCMO('KubeJobFailed.md'),
   KubeNodeNotReady: openShiftRunbookCMO('KubeNodeNotReady.md'),


### PR DESCRIPTION
This PR adds a new alert for kube-api-server been in degraded state.
Signed-off-by: Daniel Mellado <dmellado@redhat.com>