### PR TITLE
MON-3269: add nodeExporter.collectors.processes settings.

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -33,6 +33,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [NodeExporterCollectorMountStatsConfig](#nodeexportercollectormountstatsconfig)
 * [NodeExporterCollectorNetClassConfig](#nodeexportercollectornetclassconfig)
 * [NodeExporterCollectorNetDevConfig](#nodeexportercollectornetdevconfig)
+* [NodeExporterCollectorProcessesConfig](#nodeexportercollectorprocessesconfig)
 * [NodeExporterCollectorTcpStatConfig](#nodeexportercollectortcpstatconfig)
 * [NodeExporterConfig](#nodeexporterconfig)
 * [OpenShiftStateMetricsConfig](#openshiftstatemetricsconfig)
@@ -236,6 +237,7 @@ The `NodeExporterCollectorConfig` resource defines settings for individual colle
 | buddyinfo | [NodeExporterCollectorBuddyInfoConfig](#nodeexportercollectorbuddyinfoconfig) | Defines the configuration of the `buddyinfo` collector, which collects statistics about memory fragmentation from the `node_buddyinfo_blocks` metric. This metric collects data from `/proc/buddyinfo`. Disabled by default. |
 | mountstats | [NodeExporterCollectorMountStatsConfig](#nodeexportercollectormountstatsconfig) | Defines the configuration of the `mountstats` collector, which collects statistics about NFS volume I/O activities. Disabled by default. |
 | ksmd | [NodeExporterCollectorKSMDConfig](#nodeexportercollectorksmdconfig) | Defines the configuration of the `ksmd` collector, which collects statistics from the kernel same-page merger daemon. Disabled by default. |
+| processes | [NodeExporterCollectorProcessesConfig](#nodeexportercollectorprocessesconfig) | Defines the configuration of the `processes` collector, which collects statistics from processes and threads running in the system. Disabled by default. |
 
 [Back to TOC](#table-of-contents)
 
@@ -312,6 +314,21 @@ The `NodeExporterCollectorNetDevConfig` resource works as an on/off switch for t
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | enabled | bool | A Boolean flag that enables or disables the `netdev` collector. |
+
+[Back to TOC](#table-of-contents)
+
+## NodeExporterCollectorProcessesConfig
+
+#### Description
+
+The `NodeExporterCollectorProcessesConfig` resource works as an on/off switch for the `processes` collector of the `node-exporter` agent. If enabled, these metrics become available: `node_processes_max_processes`, `node_processes_pids`, `node_processes_state`, `node_processes_threads`, `node_processes_threads_state`. The metric `node_processes_state` and `node_processes_threads_state` can have up to 5 series each, depending on the state of the processes and threads. The possible states of a process or a thread are: 'D' (UNINTERRUPTABLE_SLEEP), 'R' (RUNNING & RUNNABLE), 'S' (INTERRRUPTABLE_SLEEP), 'T' (STOPPED), 'Z' (ZOMBIE). By default, the `processes` collector is disabled.
+
+
+<em>appears in: [NodeExporterCollectorConfig](#nodeexportercollectorconfig)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| enabled | bool | A Boolean flag that enables or disables the `processes` collector. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -53,6 +53,7 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/nodeexportercollectormountstatsconfig.adoc[NodeExporterCollectorMountStatsConfig]
 * link:modules/nodeexportercollectornetclassconfig.adoc[NodeExporterCollectorNetClassConfig]
 * link:modules/nodeexportercollectornetdevconfig.adoc[NodeExporterCollectorNetDevConfig]
+* link:modules/nodeexportercollectorprocessesconfig.adoc[NodeExporterCollectorProcessesConfig]
 * link:modules/nodeexportercollectortcpstatconfig.adoc[NodeExporterCollectorTcpStatConfig]
 * link:modules/nodeexporterconfig.adoc[NodeExporterConfig]
 * link:modules/openshiftstatemetricsconfig.adoc[OpenShiftStateMetricsConfig]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorconfig.adoc
@@ -32,6 +32,8 @@ Appears in: link:nodeexporterconfig.adoc[NodeExporterConfig]
 
 |ksmd|link:nodeexportercollectorksmdconfig.adoc[NodeExporterCollectorKSMDConfig]|Defines the configuration of the `ksmd` collector, which collects statistics from the kernel same-page merger daemon. Disabled by default.
 
+|processes|link:nodeexportercollectorprocessesconfig.adoc[NodeExporterCollectorProcessesConfig]|Defines the configuration of the `processes` collector, which collects statistics from processes and threads running in the system. Disabled by default.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/nodeexportercollectorprocessesconfig.adoc
+++ b/Documentation/openshiftdocs/modules/nodeexportercollectorprocessesconfig.adoc
@@ -1,0 +1,25 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== NodeExporterCollectorProcessesConfig
+
+=== Description
+
+The `NodeExporterCollectorProcessesConfig` resource works as an on/off switch for the `processes` collector of the `node-exporter` agent. If enabled, these metrics become available: `node_processes_max_processes`, `node_processes_pids`, `node_processes_state`, `node_processes_threads`, `node_processes_threads_state`. The metric `node_processes_state` and `node_processes_threads_state` can have up to 5 series each, depending on the state of the processes and threads. The possible states of a process or a thread are: 'D' (UNINTERRUPTABLE_SLEEP), 'R' (RUNNING & RUNNABLE), 'S' (INTERRRUPTABLE_SLEEP), 'T' (STOPPED), 'Z' (ZOMBIE). By default, the `processes` collector is disabled.
+
+
+
+Appears in: link:nodeexportercollectorconfig.adoc[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|enabled|bool|A Boolean flag that enables or disables the `processes` collector.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -901,6 +901,12 @@ func (f *Factory) updateNodeExporterArgs(args []string) ([]string, error) {
 		args = setArg(args, "--no-collector.ksmd", "")
 	}
 
+	if f.config.ClusterMonitoringConfiguration.NodeExporterConfig.Collectors.Processes.Enabled {
+		args = setArg(args, "--collector.processes", "")
+	} else {
+		args = setArg(args, "--no-collector.processes", "")
+	}
+
 	return args, nil
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2921,6 +2921,7 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 				"--collector.netclass.netlink",
 				"--no-collector.buddyinfo",
 				"--no-collector.ksmd",
+				"--no-collector.processes",
 				"--collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
 				"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15}|enP.*|ovn-k8s-mp[0-9]*|br-ex|br-int|br-ext|br[0-9]*|tun[0-9]*|cali[a-f0-9]*)$",
 			},
@@ -2930,6 +2931,7 @@ func TestNodeExporterCollectorSettings(t *testing.T) {
 				"--no-collector.netclass",
 				"--collector.buddyinfo",
 				"--collector.ksmd",
+				"--collector.processes",
 			},
 		},
 		{
@@ -3021,6 +3023,17 @@ nodeExporter:
 `,
 			argsPresent: []string{"--collector.ksmd"},
 			argsAbsent:  []string{"--no-collector.ksmd"},
+		},
+		{
+			name: "enable processes collector",
+			config: `
+nodeExporter:
+  collectors:
+    processes:
+      enabled: true
+`,
+			argsPresent: []string{"--collector.processes"},
+			argsAbsent:  []string{"--no-collector.processes"},
 		},
 		{
 			name: "configure network interfaces exclusion",

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -314,6 +314,9 @@ type NodeExporterCollectorConfig struct {
 	// Defines the configuration of the `ksmd` collector, which collects statistics from the kernel same-page merger daemon.
 	// Disabled by default.
 	Ksmd NodeExporterCollectorKSMDConfig `json:"ksmd,omitempty"`
+	// Defines the configuration of the `processes` collector, which collects statistics from processes and threads running in the system.
+	// Disabled by default.
+	Processes NodeExporterCollectorProcessesConfig `json:"processes,omitempty"`
 }
 
 // The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for
@@ -422,6 +425,28 @@ type NodeExporterCollectorMountStatsConfig struct {
 // By default, the `ksmd` collector is disabled.
 type NodeExporterCollectorKSMDConfig struct {
 	// A Boolean flag that enables or disables the `ksmd` collector.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// The `NodeExporterCollectorProcessesConfig` resource works as an on/off switch for
+// the `processes` collector of the `node-exporter` agent.
+// If enabled, these metrics become available:
+// `node_processes_max_processes`,
+// `node_processes_pids`,
+// `node_processes_state`,
+// `node_processes_threads`,
+// `node_processes_threads_state`.
+// The metric `node_processes_state` and `node_processes_threads_state` can have up to 5 series each,
+// depending on the state of the processes and threads.
+// The possible states of a process or a thread are:
+// 'D' (UNINTERRUPTABLE_SLEEP),
+// 'R' (RUNNING & RUNNABLE),
+// 'S' (INTERRRUPTABLE_SLEEP),
+// 'T' (STOPPED),
+// 'Z' (ZOMBIE).
+// By default, the `processes` collector is disabled.
+type NodeExporterCollectorProcessesConfig struct {
+	// A Boolean flag that enables or disables the `processes` collector.
 	Enabled bool `json:"enabled,omitempty"`
 }
 

--- a/test/e2e/node_exporter_test.go
+++ b/test/e2e/node_exporter_test.go
@@ -69,6 +69,14 @@ nodeExporter:
     ksmd:
       enabled: true`,
 		},
+		{
+			nameCollector: "processes",
+			config: `
+nodeExporter:
+  collectors:
+    processes:
+      enabled: true`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

This PR is similar to #1931 , adding an on/off switch to `processes` collector.
