### PR TITLE
MON-3178: Expose and propagate TopologySpreadConstraints for prometheus-operator

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -422,6 +422,7 @@ The `PrometheusOperatorConfig` resource defines settings for the Prometheus Oper
 | logLevel | string | Defines the log level settings for Prometheus Operator. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`. |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
+| topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/modules/prometheusoperatorconfig.adoc
+++ b/Documentation/openshiftdocs/modules/prometheusoperatorconfig.adoc
@@ -25,6 +25,8 @@ link:userworkloadconfiguration.adoc[UserWorkloadConfiguration]
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2171,6 +2171,11 @@ func (f *Factory) PrometheusOperatorDeployment() (*appsv1.Deployment, error) {
 		d.Spec.Template.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.PrometheusOperatorConfig.Tolerations
 	}
 
+	if len(f.config.ClusterMonitoringConfiguration.PrometheusOperatorConfig.TopologySpreadConstraints) > 0 {
+		d.Spec.Template.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.PrometheusOperatorConfig.TopologySpreadConstraints
+	}
+
 	for i, container := range d.Spec.Template.Spec.Containers {
 		switch container.Name {
 		case "kube-rbac-proxy":

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -222,6 +222,8 @@ type PrometheusOperatorConfig struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
 // The `OpenShiftStateMetricsConfig` resource defines settings for the


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the prometheus-operator field and propagate this to the pod that is created.
