### PR TITLE
MON-3179: Expose and propagate TopologySpreadConstraints for openshift state metrics

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -377,6 +377,7 @@ The `OpenShiftStateMetricsConfig` resource defines settings for the `openshift-s
 | -------- | ---- | ----------- |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
+| topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/modules/openshiftstatemetricsconfig.adoc
+++ b/Documentation/openshiftdocs/modules/openshiftstatemetricsconfig.adoc
@@ -22,6 +22,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -812,6 +812,10 @@ func (f *Factory) OpenShiftStateMetricsDeployment() (*appsv1.Deployment, error) 
 	if len(f.config.ClusterMonitoringConfiguration.OpenShiftMetricsConfig.Tolerations) > 0 {
 		d.Spec.Template.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.OpenShiftMetricsConfig.Tolerations
 	}
+	if len(f.config.ClusterMonitoringConfiguration.OpenShiftMetricsConfig.TopologySpreadConstraints) > 0 {
+		d.Spec.Template.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.OpenShiftMetricsConfig.TopologySpreadConstraints
+	}
 	d.Namespace = f.namespace
 
 	return d, nil

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3230,7 +3230,18 @@ func TestKubeStateMetrics(t *testing.T) {
 }
 
 func TestOpenShiftStateMetrics(t *testing.T) {
-	c, err := NewConfigFromString(``, false)
+	config := (`
+openShiftStateMetrics:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar`)
+
+	c, err := NewConfigFromString(config, false)
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3276,6 +3287,14 @@ func TestOpenShiftStateMetrics(t *testing.T) {
 		KubeRbacProxyMinTLSVersionFlag, APIServerDefaultMinTLSVersion)
 	if expectedKubeRbacProxyMinTLSVersionArg != kubeRbacProxyMinTLSVersionArg {
 		t.Fatalf("incorrect TLS version \n got %s, \nwant %s", kubeRbacProxyMinTLSVersionArg, expectedKubeRbacProxyMinTLSVersionArg)
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("openShiftStateMetrics topology spread contraints MaxSkew not configured correctly")
+	}
+
+	if d.Spec.Template.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("openShiftStateMetrics topology spread contraints WhenUnsatisfiable not configured correctly")
 	}
 
 	d2, err := f.OpenShiftStateMetricsDeployment()

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -231,6 +231,8 @@ type OpenShiftStateMetricsConfig struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
 // `TelemeterClientConfig` defines settings for the Telemeter Client


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the openshiftStateMetrics field and propagate this to the pod that is created.
