### PR TITLE
MON-3181: Expose and propagate TopologySpreadConstraints for thanos-querier

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -542,6 +542,7 @@ The `ThanosQuerierConfig` resource defines settings for the Thanos Querier compo
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | Defines resource requests and limits for the Thanos Querier container. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
+| topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/modules/thanosquerierconfig.adoc
+++ b/Documentation/openshiftdocs/modules/thanosquerierconfig.adoc
@@ -30,6 +30,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2799,6 +2799,10 @@ func (f *Factory) ThanosQuerierDeployment(grpcTLS *v1.Secret, enableUserWorkload
 	if len(f.config.ClusterMonitoringConfiguration.ThanosQuerierConfig.Tolerations) > 0 {
 		d.Spec.Template.Spec.Tolerations = f.config.ClusterMonitoringConfiguration.ThanosQuerierConfig.Tolerations
 	}
+	if len(f.config.ClusterMonitoringConfiguration.ThanosQuerierConfig.TopologySpreadConstraints) > 0 {
+		d.Spec.Template.Spec.TopologySpreadConstraints =
+			f.config.ClusterMonitoringConfiguration.ThanosQuerierConfig.TopologySpreadConstraints
+	}
 
 	return d, nil
 }

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -270,6 +270,8 @@ type ThanosQuerierConfig struct {
 	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
 // The `NodeExporterConfig` resource defines settings for the `node-exporter` agent.


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the ThanosQuerier field and propagate this to the pod that is created.