### PR TITLE
MON-3183:  Expose and propagate TopologySpreadConstraints for UWM prometheus

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1705,6 +1705,11 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 		p.Spec.Tolerations = f.config.UserWorkloadConfiguration.Prometheus.Tolerations
 	}
 
+	if len(f.config.UserWorkloadConfiguration.Prometheus.TopologySpreadConstraints) > 0 {
+		p.Spec.TopologySpreadConstraints =
+			f.config.UserWorkloadConfiguration.Prometheus.TopologySpreadConstraints
+	}
+
 	if f.config.UserWorkloadConfiguration.Prometheus.ExternalLabels != nil {
 		p.Spec.ExternalLabels = f.config.UserWorkloadConfiguration.Prometheus.ExternalLabels
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1608,6 +1608,39 @@ ingress:
 	}
 }
 
+func TestPrometheusUserWorkloadConfiguration(t *testing.T) {
+	c, err := NewConfigFromString(``, false)
+	uwc, err := NewUserConfigFromString(`prometheus:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: type
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar`)
+
+	c.UserWorkloadConfiguration = uwc
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+	p, err := f.PrometheusUserWorkload(
+		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.UserWorkloadConfiguration.Prometheus.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Fatal("Prometheus UWM spread contraints MaxSkew not configured correctly")
+	}
+
+	if p.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
+		t.Fatal("Prometheus UWM spread contraints WhenUnsatisfiable not configured correctly")
+	}
+}
+
 func TestPrometheusQueryLogFileConfig(t *testing.T) {
 	for _, tc := range []struct {
 		name             string

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -586,6 +586,8 @@ type PrometheusRestrictedConfig struct {
 	RetentionSize string `json:"retentionSize,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// Defines persistent storage for Prometheus. Use this setting to
 	// configure the storage class and size of a volume.
 	VolumeClaimTemplate *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the PrometheusRestrictedConfig field and propagate this to the pod that is created.
