### PR TITLE
MON-3182: Expose and propagate TopologySpreadConstraints for UWM alertmanager 

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -111,6 +111,7 @@ The `AlertmanagerUserWorkloadConfig` resource defines the settings for the Alert
 | secrets | []string | Defines a list of secrets that need to be mounted into the Alertmanager. The secrets must reside within the same namespace as the Alertmanager object. They will be added as volumes named secret-<secret-name> and mounted at /etc/alertmanager/secrets/<secret-name> within the 'alertmanager' container of the Alertmanager Pods. |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
+| topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 | volumeClaimTemplate | *[monv1.EmbeddedPersistentVolumeClaim](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#embeddedpersistentvolumeclaim) | Defines persistent storage for Alertmanager. Use this setting to configure the persistent volume claim, including storage class, volume size and name. |
 
 [Back to TOC](#table-of-contents)

--- a/Documentation/openshiftdocs/modules/alertmanageruserworkloadconfig.adoc
+++ b/Documentation/openshiftdocs/modules/alertmanageruserworkloadconfig.adoc
@@ -32,6 +32,8 @@ Appears in: link:userworkloadconfiguration.adoc[UserWorkloadConfiguration]
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
 |volumeClaimTemplate|*monv1.EmbeddedPersistentVolumeClaim|Defines persistent storage for Alertmanager. Use this setting to configure the persistent volume claim, including storage class, volume size and name.
 
 |===

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -519,6 +519,11 @@ func (f *Factory) AlertmanagerUserWorkload(trustedCABundleCM *v1.ConfigMap) (*mo
 		a.Spec.Tolerations = alertmanagerConfig.Tolerations
 	}
 
+	if len(alertmanagerConfig.TopologySpreadConstraints) > 0 {
+		a.Spec.TopologySpreadConstraints =
+			alertmanagerConfig.TopologySpreadConstraints
+	}
+
 	for i, c := range a.Spec.Containers {
 		switch c.Name {
 		case "alertmanager-proxy", "tenancy-proxy", "kube-rbac-proxy-metric":

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -500,6 +500,8 @@ type AlertmanagerUserWorkloadConfig struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// Defines persistent storage for Alertmanager. Use this setting to
 	// configure the persistent volume claim, including storage class,
 	// volume size and name.


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the AlertmanagerUserWorkloadConfig field and propagate this to the pod that is created.