### PR TITLE
MON-3183: Expose and propagate TopologySpreadConstraints for UWM prometheus

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -451,6 +451,7 @@ The `PrometheusRestrictedConfig` resource defines the settings for the Prometheu
 | retention | string | Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`. |
 | retentionSize | string | Defines the maximum amount of disk space used by data blocks plus the write-ahead log (WAL). Supported values are `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`, `EB`, and `EiB`. The default value is `nil`. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
+| topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 | volumeClaimTemplate | *[monv1.EmbeddedPersistentVolumeClaim](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#embeddedpersistentvolumeclaim) | Defines persistent storage for Prometheus. Use this setting to configure the storage class and size of a volume. |
 
 [Back to TOC](#table-of-contents)

--- a/Documentation/openshiftdocs/modules/prometheusrestrictedconfig.adoc
+++ b/Documentation/openshiftdocs/modules/prometheusrestrictedconfig.adoc
@@ -48,6 +48,8 @@ Appears in: link:userworkloadconfiguration.adoc[UserWorkloadConfiguration]
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
 |volumeClaimTemplate|*monv1.EmbeddedPersistentVolumeClaim|Defines persistent storage for Prometheus. Use this setting to configure the storage class and size of a volume.
 
 |===

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1705,6 +1705,11 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 		p.Spec.Tolerations = f.config.UserWorkloadConfiguration.Prometheus.Tolerations
 	}
 
+	if len(f.config.UserWorkloadConfiguration.Prometheus.TopologySpreadConstraints) > 0 {
+		p.Spec.TopologySpreadConstraints =
+			f.config.UserWorkloadConfiguration.Prometheus.TopologySpreadConstraints
+	}
+
 	if f.config.UserWorkloadConfiguration.Prometheus.ExternalLabels != nil {
 		p.Spec.ExternalLabels = f.config.UserWorkloadConfiguration.Prometheus.ExternalLabels
 	}

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -586,6 +586,8 @@ type PrometheusRestrictedConfig struct {
 	RetentionSize string `json:"retentionSize,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines a pod's topology spread constraints.
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// Defines persistent storage for Prometheus. Use this setting to
 	// configure the storage class and size of a volume.
 	VolumeClaimTemplate *monv1.EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`


### PR DESCRIPTION
Give users a TopologySpreadConstraints field in the PrometheusRestrictedConfig field and propagate this to the pod that is created.