### PR TITLE
[release-4.12] OCPBUGS-16028: Add the trusted CA bundle in UWM Prometheus pods

### DIFF
--- a/assets/prometheus-user-workload/trusted-ca-bundle.yaml
+++ b/assets/prometheus-user-workload/trusted-ca-bundle.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: prometheus-user-workload-trusted-ca-bundle
+  namespace: openshift-user-workload-monitoring

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -20,6 +20,8 @@ function(params)
     serviceMonitorCoreDNS:: {},
     secretEtcdCerts:: {},
 
+    trustedCaBundle: generateCertInjection.trustedCNOCaBundleCM(cfg.namespace, 'prometheus-user-workload-trusted-ca-bundle'),
+
     grpcTlsSecret: {
       apiVersion: 'v1',
       kind: 'Secret',

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1999,6 +1999,25 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 		return nil, err
 	}
 
+	var trustedCABundleVolumeName string
+	if trustedCABundleCM != nil {
+		trustedCABundleVolumeName = "prometheus-user-workload-trusted-ca-bundle"
+		volume := trustedCABundleVolume(trustedCABundleCM.Name, trustedCABundleVolumeName)
+		volume.VolumeSource.ConfigMap.Items = append(volume.VolumeSource.ConfigMap.Items, v1.KeyToPath{
+			Key:  TrustedCABundleKey,
+			Path: "tls-ca-bundle.pem",
+		})
+		p.Spec.Volumes = append(p.Spec.Volumes, volume)
+	}
+	p.Spec.Volumes = append(p.Spec.Volumes, v1.Volume{
+		Name: "secret-grpc-tls",
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: grpcTLS.GetName(),
+			},
+		},
+	})
+
 	for i, container := range p.Spec.Containers {
 		switch container.Name {
 		case "prometheus":
@@ -2010,6 +2029,13 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 			p.Spec.Containers[i].StartupProbe = &v1.Probe{
 				PeriodSeconds:    15,
 				FailureThreshold: 240,
+			}
+			// Support CA bundles for Prometheus UWM.
+			if trustedCABundleVolumeName != "" {
+				p.Spec.Containers[i].VolumeMounts = append(
+					p.Spec.Containers[i].VolumeMounts,
+					trustedCABundleVolumeMount(trustedCABundleVolumeName),
+				)
 			}
 		case "kube-rbac-proxy-metrics", "kube-rbac-proxy-federate", "kube-rbac-proxy-thanos":
 			p.Spec.Containers[i].Image = f.config.Images.KubeRbacProxy
@@ -2023,15 +2049,6 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 		setupAlerting(p, platformAlertmanagerService, f.namespace)
 	}
 
-	p.Spec.Volumes = append(p.Spec.Volumes, v1.Volume{
-		Name: "secret-grpc-tls",
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
-				SecretName: grpcTLS.GetName(),
-			},
-		},
-	})
-
 	alertManagerConfigs := f.config.AdditionalAlertmanagerConfigsForPrometheusUserWorkload()
 	if len(alertManagerConfigs) > 0 {
 		p.Spec.AdditionalAlertManagerConfigs = &v1.SecretKeySelector{
@@ -2041,27 +2058,6 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 			},
 		}
 		p.Spec.Secrets = append(p.Spec.Secrets, getAdditionalAlertmanagerSecrets(alertManagerConfigs)...)
-	}
-
-	if trustedCABundleCM != nil {
-		volumeName := "prometheus-user-workload-trusted-ca-bundle"
-		volume := trustedCABundleVolume(trustedCABundleCM.Name, volumeName)
-		volume.VolumeSource.ConfigMap.Items = append(volume.VolumeSource.ConfigMap.Items, v1.KeyToPath{
-			Key:  TrustedCABundleKey,
-			Path: "tls-ca-bundle.pem",
-		})
-		p.Spec.Volumes = append(p.Spec.Volumes, volume)
-
-		// we only need the trusted CA bundle in:
-		// 1. Prometheus, because users might want to configure external remote write.
-		for i, container := range p.Spec.Containers {
-			if container.Name == "prometheus" {
-				p.Spec.Containers[i].VolumeMounts = append(
-					p.Spec.Containers[i].VolumeMounts,
-					trustedCABundleVolumeMount(volumeName),
-				)
-			}
-		}
 	}
 
 	return p, nil

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -505,7 +505,10 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.PrometheusUserWorkload(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	_, err = f.PrometheusUserWorkload(
+		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3392,6 +3395,7 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 			getSpec: func(f *Factory) (spec, error) {
 				p, err := f.PrometheusUserWorkload(
 					&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+					&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				)
 				if err != nil {
 					return spec{}, err

--- a/pkg/tasks/helpers.go
+++ b/pkg/tasks/helpers.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/openshift/cluster-monitoring-operator/pkg/client"
-	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 )
 
 type caBundleSyncer struct {
@@ -83,7 +84,7 @@ func (cbs *caBundleSyncer) syncTrustedCABundle(ctx context.Context, trustedCA *v
 		ctx,
 		trustedCA.GetNamespace(),
 		cbs.prefix,
-		string(hashedCM.Labels["monitoring.openshift.io/hash"]),
+		hashedCM.Labels["monitoring.openshift.io/hash"],
 	)
 	return hashedCM, errors.Wrap(err, "deleting old trusted CA bundle configmaps failed")
 }

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -17,10 +17,11 @@ package tasks
 import (
 	"context"
 
-	"github.com/openshift/cluster-monitoring-operator/pkg/client"
-	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 )
 
 type PrometheusUserWorkloadTask struct {
@@ -209,6 +210,22 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "creating or updating UserWorkload Prometheus RBAC federate endpoint Secret failed")
 	}
 
+	trustedCA, err := t.factory.PrometheusUserWorkloadTrustedCABundle()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload CA bundle ConfigMap failed")
+	}
+
+	cbs := &caBundleSyncer{
+		client:  t.client,
+		factory: t.factory,
+		prefix:  "prometheus-user-workload",
+	}
+
+	trustedCA, err = cbs.syncTrustedCABundle(ctx, trustedCA)
+	if err != nil {
+		return errors.Wrap(err, "syncing UserWorkload trusted CA bundle ConfigMap failed")
+	}
+
 	secret, err := t.factory.PrometheusUserWorkloadAdditionalAlertManagerConfigsSecret()
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus additionalAlertmanagerConfigs secret failed")
@@ -232,7 +249,7 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 	}
 
 	klog.V(4).Info("initializing UserWorkload Prometheus object")
-	p, err := t.factory.PrometheusUserWorkload(s)
+	p, err := t.factory.PrometheusUserWorkload(s, trustedCA)
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus object failed")
 	}
@@ -341,7 +358,33 @@ func (t *PrometheusUserWorkloadTask) destroy(ctx context.Context) error {
 		}
 	}
 
-	p, err := t.factory.PrometheusUserWorkload(s)
+	trustedCA, err := t.factory.PrometheusUserWorkloadTrustedCABundle()
+	if err != nil {
+		return errors.Wrap(err, "initializing UserWorkload CA bundle ConfigMap failed")
+	}
+
+	cbs := &caBundleSyncer{
+		client:  t.client,
+		factory: t.factory,
+		prefix:  "prometheus-user-workload",
+	}
+
+	hashedTrustedCA, err := cbs.syncTrustedCABundle(ctx, trustedCA)
+	if err != nil {
+		return errors.Wrap(err, "syncing UserWorkload trusted CA bundle ConfigMap failed")
+	}
+
+	err = t.client.DeleteConfigMap(ctx, trustedCA)
+	if err != nil {
+		return errors.Wrap(err, "deleting UserWorkload trusted CA Bundle ConfigMap failed")
+	}
+
+	err = t.client.DeleteConfigMap(ctx, hashedTrustedCA)
+	if err != nil {
+		return errors.Wrap(err, "deleting UserWorkload trusted CA Bundle ConfigMap failed")
+	}
+
+	p, err := t.factory.PrometheusUserWorkload(s, nil)
 	if err != nil {
 		return errors.Wrap(err, "initializing UserWorkload Prometheus object failed")
 	}

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -363,23 +363,12 @@ func (t *PrometheusUserWorkloadTask) destroy(ctx context.Context) error {
 		return errors.Wrap(err, "initializing UserWorkload CA bundle ConfigMap failed")
 	}
 
-	cbs := &caBundleSyncer{
-		client:  t.client,
-		factory: t.factory,
-		prefix:  "prometheus-user-workload",
-	}
-
-	hashedTrustedCA, err := cbs.syncTrustedCABundle(ctx, trustedCA)
-	if err != nil {
-		return errors.Wrap(err, "syncing UserWorkload trusted CA bundle ConfigMap failed")
-	}
-
 	err = t.client.DeleteConfigMap(ctx, trustedCA)
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload trusted CA Bundle ConfigMap failed")
 	}
 
-	err = t.client.DeleteHashedConfigMap(ctx, hashedTrustedCA.GetNamespace(), "prometheus-user-workload", hashedTrustedCA.Labels["monitoring.openshift.io/hash"])
+	err = t.client.DeleteHashedConfigMap(ctx, trustedCA.GetNamespace(), "prometheus-user-workload", "")
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload trusted CA Bundle ConfigMap failed")
 	}

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -379,7 +379,7 @@ func (t *PrometheusUserWorkloadTask) destroy(ctx context.Context) error {
 		return errors.Wrap(err, "deleting UserWorkload trusted CA Bundle ConfigMap failed")
 	}
 
-	err = t.client.DeleteConfigMap(ctx, hashedTrustedCA)
+	err = t.client.DeleteHashedConfigMap(ctx, hashedTrustedCA.GetNamespace(), "prometheus-user-workload", hashedTrustedCA.Labels["monitoring.openshift.io/hash"])
 	if err != nil {
 		return errors.Wrap(err, "deleting UserWorkload trusted CA Bundle ConfigMap failed")
 	}


### PR DESCRIPTION
Add the trusted CA bundle in UWM Prometheus pods, so users can secure
the remote-write endpoint, in response to [OCPBUGS-11958](https://issues.redhat.com/browse/OCPBUGS-11958).

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
***
_This is the 4.12 backport of #1970._