### PR TITLE
Add telemeter client SA to rbac proxy

### DIFF
--- a/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
+++ b/assets/prometheus-k8s/kube-rbac-proxy-secret.yaml
@@ -20,4 +20,9 @@ stringData:
         "user":
           "name": "system:serviceaccount:openshift-monitoring:prometheus-k8s"
         "verb": "get"
+      - "path": "/federate"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-monitoring:telemeter-client"
+        "verb": "get"
 type: Opaque

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -218,6 +218,14 @@ function(params)
               path: '/federate',
               resourceRequest: false,
             },
+            {
+              user: {
+                name: 'system:serviceaccount:openshift-monitoring:telemeter-client',
+              },
+              verb: 'get',
+              path: '/federate',
+              resourceRequest: false,
+            },
           ],
         },
       },


### PR DESCRIPTION
After change oauth proxy to rbac proxy https://github.com/openshift/cluster-monitoring-operator/pull/2005

When mTLS does not work and auth from telemeter-client and prometheus is done via token, telemter-client SA needs to be allowed.
