### PR TITLE
OCPBUGS-17125: backport metrics collection profiles selector logic to prevent users from double scraping when they upgrade from 4.12 to 4.13

### DIFF
--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1691,6 +1691,46 @@ func TestPrometheusQueryLogFileConfig(t *testing.T) {
 	}
 }
 
+func TestPrometheusCollectionProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		collectionProfile     CollectionProfile
+		expectedLabelSelector *metav1.LabelSelector
+	}{
+		{
+			name: "full_collection_profile",
+			expectedLabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "monitoring.openshift.io/collection-profile",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"minimal"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewDefaultConfig()
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+			p, err := f.PrometheusK8s(
+				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			)
+			if err != nil {
+				t.Fatalf("Unexpected error but got %v", err)
+			}
+
+			if !reflect.DeepEqual(p.Spec.ServiceMonitorSelector, tc.expectedLabelSelector) {
+				t.Fatalf("Label selector for service monitor is not configured correctly, got %v, expected %v", p.Spec.ServiceMonitorSelector, tc.expectedLabelSelector)
+			}
+			if !reflect.DeepEqual(p.Spec.PodMonitorSelector, tc.expectedLabelSelector) {
+				t.Fatalf("Label selector for pod monitor is not configured correctly, got %v, expected %v", p.Spec.PodMonitorSelector, tc.expectedLabelSelector)
+			}
+		})
+	}
+}
+
 func TestPrometheusRetentionConfigs(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -19,6 +19,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+type CollectionProfile string
+type CollectionProfiles []CollectionProfile
+
+const (
+	FullCollectionProfile    = "full"
+	MinimalCollectionProfile = "minimal"
+)
+
+var SupportedCollectionProfiles = CollectionProfiles{FullCollectionProfile, MinimalCollectionProfile}
+
 // The `ClusterMonitoringConfiguration` resource defines settings that
 // customize the default platform monitoring stack through the
 // `cluster-monitoring-config` config map in the `openshift-monitoring`


### PR DESCRIPTION
Part of https://github.com/openshift/enhancements/pull/1298

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
