### PR TITLE
OCPBUGS-10699: remove Kube*QuotaOvercommit alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#1910](https://github.com/openshift/cluster-monitoring-operator/pull/1910) Add new web console usage metrics
 - [#1950](https://github.com/openshift/cluster-monitoring-operator/pull/1950) Disable CORS headers on Thanos querier by default and add a flag to enable them back.
 - [#1963](https://github.com/openshift/cluster-monitoring-operator/pull/1963) Add nodeExporter settings for network devices list.
+- [#2049](https://github.com/openshift/cluster-monitoring-operator/pull/2049) Remove Kube*QuotaOvercommit alerts.
 
 ## 4.13
 

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -241,30 +241,6 @@ spec:
       labels:
         namespace: kube-system
         severity: warning
-    - alert: KubeCPUQuotaOvercommit
-      annotations:
-        description: Cluster has overcommitted CPU resource requests for Namespaces.
-        summary: Cluster has overcommitted CPU resource requests.
-      expr: |
-        sum(min without(resource) (kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
-          /
-        sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
-          > 1.5
-      for: 5m
-      labels:
-        severity: warning
-    - alert: KubeMemoryQuotaOvercommit
-      annotations:
-        description: Cluster has overcommitted memory resource requests for Namespaces.
-        summary: Cluster has overcommitted memory resource requests.
-      expr: |
-        sum(min without(resource) (kube_resourcequota{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
-          /
-        sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
-          > 1.5
-      for: 5m
-      labels:
-        severity: warning
     - alert: KubeQuotaAlmostFull
       annotations:
         description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -50,6 +50,10 @@ local excludedRules = [
     rules: [
       // Removing CPUThrottlingHigh alert as per https://bugzilla.redhat.com/show_bug.cgi?id=1843346
       { alert: 'CPUThrottlingHigh' },
+      // Removing Kube*QuotaOvercommit alerts since quotas should not be defined
+      // for system namespaces. Refer OCPBUGS-10699 for more details.
+      { alert: 'KubeCPUQuotaOvercommit' },
+      { alert: 'KubeMemoryQuotaOvercommit' },
     ],
   },
   {


### PR DESCRIPTION
Quota alerts should not be defined for system namespaces.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
