### PR TITLE
OCPBUGS-17191: add namespace label to alerting rules

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -459,6 +459,7 @@ spec:
         ) > 0.95
       for: 15m
       labels:
+        namespace: kube-system
         severity: info
     - alert: KubeNodeReadinessFlapping
       annotations:
@@ -468,6 +469,7 @@ spec:
         sum(changes(kube_node_status_condition{job="kube-state-metrics",status="true",condition="Ready"}[15m])) by (cluster, node) > 2
       for: 15m
       labels:
+        namespace: kube-system
         severity: warning
     - alert: KubeletPlegDurationHigh
       annotations:
@@ -477,6 +479,7 @@ spec:
         node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile="0.99"} >= 10
       for: 5m
       labels:
+        namespace: kube-system
         severity: warning
     - alert: KubeletPodStartUpLatencyHigh
       annotations:
@@ -486,6 +489,7 @@ spec:
         histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (cluster, instance, le)) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"} > 60
       for: 15m
       labels:
+        namespace: kube-system
         severity: warning
     - alert: KubeletClientCertificateRenewalErrors
       annotations:

--- a/assets/kube-state-metrics/prometheus-rule.yaml
+++ b/assets/kube-state-metrics/prometheus-rule.yaml
@@ -26,6 +26,7 @@ spec:
         > 0.01
       for: 15m
       labels:
+        namespace: openshift-monitoring
         severity: warning
     - alert: KubeStateMetricsWatchErrors
       annotations:
@@ -38,4 +39,5 @@ spec:
         > 0.01
       for: 15m
       labels:
+        namespace: openshift-monitoring
         severity: warning

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -243,6 +243,33 @@ local patchedRules = [
           namespace: 'kube-system',
         },
       },
+      // All OpenShift alerts should include a namespace label.
+      //
+      // See https://issues.redhat.com/browse/OCPBUGS-17191
+      {
+        alert: 'KubeletTooManyPods',
+        labels: {
+          namespace: 'kube-system',
+        },
+      },
+      {
+        alert: 'KubeletPlegDurationHigh',
+        labels: {
+          namespace: 'kube-system',
+        },
+      },
+      {
+        alert: 'KubeletPodStartUpLatencyHigh',
+        labels: {
+          namespace: 'kube-system',
+        },
+      },
+      {
+        alert: 'KubeNodeReadinessFlapping',
+        labels: {
+          namespace: 'kube-system',
+        },
+      },
     ],
   },
   {
@@ -252,12 +279,20 @@ local patchedRules = [
         alert: 'KubeStateMetricsListErrors',
         labels: {
           severity: 'warning',
+          // All OpenShift alerts should include a namespace label.
+          //
+          // See https://issues.redhat.com/browse/OCPBUGS-17191
+          namespace: 'openshift-monitoring',
         },
       },
       {
         alert: 'KubeStateMetricsWatchErrors',
         labels: {
           severity: 'warning',
+          // All OpenShift alerts should include a namespace label.
+          //
+          // See https://issues.redhat.com/browse/OCPBUGS-17191
+          namespace: 'openshift-monitoring',
         },
       },
     ],


### PR DESCRIPTION
The following alerting rules were missing a namespace label:
* KubeStateMetricsListErrors
* KubeStateMetricsWatchErrors
* KubeletPlegDurationHigh
* KubeletTooManyPods
* KubeNodeReadinessFlapping
* KubeletPodStartUpLatencyHigh

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
