### PR TITLE
Remove deprecated visual_web_terminal_sessions metric

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
@@ -689,12 +689,6 @@ data:
     # and per volume type (filesystem/block)
     - '{__name__="cluster:kube_persistentvolume_plugin_type_counts:sum"}'
     #
-    # owners: (https://github.com/open-cluster-management, @open-cluster-management/squad-kui-admins)
-    #
-    # visual_web_terminal_sessions_total is the count of Visual Web Terminal sessions created
-    # on the hub cluster.
-    - '{__name__="visual_web_terminal_sessions_total"}'
-    #
     # owners: (https://github.com/open-cluster-management, @open-cluster-management/cluster-lifecycle-admin)
     #
     # acm_managed_cluster_info provides Subscription watch and other information for the managed clusters for an ACM Hub cluster.


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ x ] No user facing changes, so no entry in CHANGELOG was needed.
