### PR TITLE
OCPBUGS-17346: Avoid recreating some resources, created by prometheus-operator, during 4.13->4.14 upgrade

### DIFF
--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -40,7 +40,6 @@ spec:
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
         - --web.listen-address=127.0.0.1:8080
-        - --labels=app.kubernetes.io/part-of=openshift-monitoring
         image: quay.io/prometheus-operator/prometheus-operator:v0.67.1
         name: prometheus-operator
         ports: []

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -41,7 +41,6 @@ spec:
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
         - --web.listen-address=127.0.0.1:8080
-        - --labels=app.kubernetes.io/part-of=openshift-monitoring
         image: quay.io/prometheus-operator/prometheus-operator:v0.67.1
         name: prometheus-operator
         ports: []

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -3,7 +3,6 @@ local tlsVolumeName = 'prometheus-operator-user-workload-tls';
 local operator = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet';
 local generateSecret = import '../utils/generate-secret.libsonnet';
 local rbac = import '../utils/rbac.libsonnet';
-local labelsAsString = (import '../utils/add-labels.libsonnet').labelsAsString;
 
 function(params)
   local po = operator(params);
@@ -97,7 +96,6 @@ function(params)
                         '--config-reloader-cpu-request=1m',
                         '--config-reloader-memory-request=10Mi',
                         '--web.listen-address=127.0.0.1:8080',
-                        '--labels=' + labelsAsString(params.commonLabels),
                       ],
                       ports: [],
                       resources: {

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -5,7 +5,6 @@ local operator = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/
 local conversionWebhook = import 'github.com/prometheus-operator/prometheus-operator/jsonnet/prometheus-operator/conversion.libsonnet';
 local generateSecret = import '../utils/generate-secret.libsonnet';
 local rbac = import '../utils/rbac.libsonnet';
-local labelsAsString = (import '../utils/add-labels.libsonnet').labelsAsString;
 
 function(params)
   local po = operator(params);
@@ -75,7 +74,6 @@ function(params)
                         '--config-reloader-cpu-request=1m',
                         '--config-reloader-memory-request=10Mi',
                         '--web.listen-address=127.0.0.1:8080',
-                        '--labels=' + labelsAsString(params.commonLabels),
                       ],
                       ports: [],
                       resources: {

--- a/jsonnet/utils/add-labels.libsonnet
+++ b/jsonnet/utils/add-labels.libsonnet
@@ -12,8 +12,4 @@
     [k]: o[k] + if o[k].kind != 'ConfigMapList' then { metadata+: { labels+: labels { 'app.kubernetes.io/managed-by': managedBy(o[k]) } } } else {}
     for k in std.objectFields(o)
   },
-
-  labelsAsString(o)::
-    local parts = [k + '=' + o[k] for k in std.objectFields(o)];
-    std.join(',', parts),
 }


### PR DESCRIPTION

The option --labels was set to the prometheus-operator in https://github.com/openshift/cluster-monitoring-operator/pull/1986
to make it add the label "app.kubernetes.io/part-of: openshift-monitoring" to resources it creates.

prometheus-operator adds the labels to some controllers matchLabels as well (to the prometheus statefulset e.g.)
which makes the prometheus-operator recreate the statefulset as matchLabels is an immutable field.

Recreating the statefulset leads to downtime as the prometheus-operator run the deletion in a foreground mode, check
https://github.com/prometheus-operator/prometheus-operator/issues/3875 for the whys.

We consider that adding the ownership labels is not worth the downtime, and we'll be thinking of a way to avoid it.

Of course, this will lead to the recreation of these resources if https://github.com/openshift/cluster-monitoring-operator/pull/1986

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
