### PR TITLE
OCPBUGS-17113: pkg/client: Only update Prometheus if we have changes to push

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-kit/log v0.2.1
+	github.com/google/go-cmp v0.5.9
 	github.com/imdario/mergo v0.3.13
 	github.com/openshift/api v0.0.0-20230417092139-1b2161d23365
 	github.com/openshift/client-go v0.0.0-20230419131419-497c7032c581
@@ -76,7 +77,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/cel-go v0.12.6 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd // indirect


### PR DESCRIPTION
Following the pattern we've used in `CreateOrUpdateDeployment` since 675a7ed490 (#103). This saves some network traffic and Kubernetes API service load. There's a bit of dancing as I copy `Status` (which is irrelevant for this use-case) and `ObjectMeta` (except for merged `annotations` and `labels`) over from `existing` to `required`, but that sets up a convenient `DeepEqual` for "did anything we care about change?".

It also makes it easier to see from the Kube API server logs when the Prometheus resources are actually being updates, while before this commit:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-ovn-serial/1685027676433158144/artifacts/e2e-aws-ovn-serial/gather-audit-logs/artifacts/audit-logs.tar | tar -xz --strip-components=2
$ zgrep -h '"resource":"prometheuses"' kube-apiserver/*.log.gz | jq -r 'select(.verb == "update" and .objectRef.subresource != "status") | .stageTimestamp + " " + (.responseStatus.code | tostring) + " " + .user.username' | sort
```

would find traffic like:

```
2023-07-28T21:10:30.455712Z 200 system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
2023-07-28T21:11:39.629004Z 200 system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
2023-07-28T21:11:58.727870Z 200 system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
2023-07-28T21:13:24.616877Z 200 system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
2023-07-28T21:13:43.859596Z 200 system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
2023-07-28T21:14:51.770214Z 200 system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
2023-07-28T21:15:10.524179Z 200 system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
...
```

* [x] No user facing changes, so no entry in CHANGELOG was needed.
