### PR TITLE
OCPBUGS-17487: fix typo for ThanosRulerConfig.Resources

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -585,7 +585,7 @@ The `ThanosRulerConfig` resource defines configuration for the Thanos Ruler inst
 | additionalAlertmanagerConfigs | [][AdditionalAlertmanagerConfig](#additionalalertmanagerconfig) | Configures how the Thanos Ruler component communicates with additional Alertmanager instances. The default value is `nil`. |
 | logLevel | string | Defines the log level setting for Thanos Ruler. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`. |
 | nodeSelector | map[string]string | Defines the nodes on which the Pods are scheduled. |
-| resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | Defines resource requests and limits for the Alertmanager container. |
+| resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | Defines resource requests and limits for the Thanos Ruler container. |
 | retention | string | Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core) | Defines tolerations for the pods. |
 | topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines topology spread constraints for the pods. |

--- a/Documentation/openshiftdocs/modules/thanosrulerconfig.adoc
+++ b/Documentation/openshiftdocs/modules/thanosrulerconfig.adoc
@@ -24,7 +24,7 @@ Appears in: link:userworkloadconfiguration.adoc[UserWorkloadConfiguration]
 
 |nodeSelector|map[string]string|Defines the nodes on which the Pods are scheduled.
 
-|resources|*v1.ResourceRequirements|Defines resource requests and limits for the Alertmanager container.
+|resources|*v1.ResourceRequirements|Defines resource requests and limits for the Thanos Ruler container.
 
 |retention|string|Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`.
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -645,7 +645,7 @@ type ThanosRulerConfig struct {
 	LogLevel string `json:"logLevel,omitempty"`
 	// Defines the nodes on which the Pods are scheduled.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
-	// Defines resource requests and limits for the Alertmanager container.
+	// Defines resource requests and limits for the Thanos Ruler container.
 	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 	// Defines the duration for which Prometheus retains data.
 	// This definition must be specified using the following regular


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
