### PR TITLE
MON-988: remove alert "MultipleContainersOOMKilled"

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -256,15 +256,6 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: MultipleContainersOOMKilled
-      annotations:
-        description: Multiple containers were out of memory killed within the past 15 minutes. There are many potential causes of OOM errors, however issues on a specific node or containers breaching their limits is common.
-        summary: Containers are being killed due to OOM
-      expr: sum(max by(namespace, container, pod) (increase(kube_pod_container_status_restarts_total[12m])) and max by(namespace, container, pod) (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}) == 1) > 5
-      for: 15m
-      labels:
-        namespace: kube-system
-        severity: info
     - expr: avg_over_time((((count((max by (node) (up{job="kubelet",metrics_path="/metrics"} == 1) and max by (node) (kube_node_status_condition{condition="Ready",status="true"} == 1) and min by (node) (kube_node_spec_unschedulable == 0))) / scalar(count(min by (node) (kube_node_spec_unschedulable == 0))))))[5m:1s])
       record: cluster:usage:kube_schedulable_node_ready_reachable:avg5m
     - expr: avg_over_time((count(max by (node) (kube_node_status_condition{condition="Ready",status="true"} == 1)) / scalar(count(max by (node) (kube_node_status_condition{condition="Ready",status="true"}))))[5m:1s])

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -385,21 +385,6 @@ function(params) {
           },
         },
         {
-          expr: 'sum(max by(namespace, container, pod) (increase(kube_pod_container_status_restarts_total[12m])) and max by(namespace, container, pod) (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}) == 1) > 5',
-          alert: 'MultipleContainersOOMKilled',
-          'for': '15m',
-          annotations: {
-            summary: 'Containers are being killed due to OOM',
-            description: 'Multiple containers were out of memory killed within the past 15 minutes. There are many potential causes of OOM errors, however issues on a specific node or containers breaching their limits is common.',
-          },
-          labels: {
-            severity: 'info',
-            // All OpenShift alerts should have a namespace label.
-            // See: https://issues.redhat.com/browse/MON-939
-            namespace: 'kube-system',
-          },
-        },
-        {
           expr: 'avg_over_time((((count((max by (node) (up{job="kubelet",metrics_path="/metrics"} == 1) and max by (node) (kube_node_status_condition{condition="Ready",status="true"} == 1) and min by (node) (kube_node_spec_unschedulable == 0))) / scalar(count(min by (node) (kube_node_spec_unschedulable == 0))))))[5m:1s])',
           record: 'cluster:usage:kube_schedulable_node_ready_reachable:avg5m',
           // Report a 5m rolling average of the number of schedulable nodes that are ready and reachable to be scraped by metrics. This is


### PR DESCRIPTION
The alert `MultipleContainersOOMKilled` is removed. 
The metric `container_runtime_crio_containers_oom_total` is available in OCP now.
Moreover, the alert  `MultipleContainersOOMKilled` is almost always accompanied by the alert `SystemMemoryExceedsReservation` of warning level from [MachineConfigOperator](https://github.com/openshift/machine-config-operator/blob/4048c667b54967ecd62b1e2bed886b4f54b78732/install/0000_90_machine-config-operator_01_prometheus-rules.yaml#L91). 
<img width="881" alt="image" src="https://github.com/openshift/cluster-monitoring-operator/assets/6040960/9266af77-5cfb-46cc-b6aa-a3c331bd3056">

