### PR TITLE
OCPBUGS-17691: replace outdated repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It contains the following components:
 * [Alertmanager](https://github.com/prometheus/alertmanager) cluster for cluster and application level alerting
 * [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)
 * [node_exporter](https://github.com/prometheus/node_exporter)
-* [prometheus-adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter)
+* [prometheus-adapter](https://github.com/kubernetes-sigs/prometheus-adapter)
 
 The deployed Prometheus instance (`prometheus-k8s`) is responsible for monitoring and alerting on cluster and OpenShift components; it should not be extended to monitor user applications. Users interested in leveraging Prometheus for application monitoring on OpenShift should consider enabling [User Workload Monitoring](https://docs.openshift.com/container-platform/4.5/monitoring/monitoring-your-own-services.html) to easily setup new Prometheus instances to monitor and alert on their applications.
 

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc:9091
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        image: directxman12/k8s-prometheus-adapter:v0.10.0
+        image: kubernetes-sigs/prometheus-adapter:v0.10.0
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -63,7 +63,7 @@ local commonConfig = {
     prometheus: 'quay.io/prometheus/prometheus:v' + $.versions.prometheus,
     kubeStateMetrics: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v' + $.versions.kubeStateMetrics,
     nodeExporter: 'quay.io/prometheus/node-exporter:v' + $.versions.nodeExporter,
-    prometheusAdapter: 'directxman12/k8s-prometheus-adapter:v' + $.versions.prometheusAdapter,
+    prometheusAdapter: 'kubernetes-sigs/prometheus-adapter:v' + $.versions.prometheusAdapter,
     prometheusOperator: 'quay.io/prometheus-operator/prometheus-operator:v' + $.versions.prometheusOperator,
     prometheusOperatorReloader: 'quay.io/prometheus-operator/prometheus-config-reloader:v' + $.versions.prometheusOperator,
     prometheusOperatorAdmissionWebhook: 'quay.io/prometheus-operator/admission-webhook:v' + $.versions.prometheusOperator,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
