### PR TITLE
OCPBUGS-17690: remove deprecated argument

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -46,7 +46,6 @@ spec:
       - args:
         - --prometheus-auth-config=/etc/prometheus-config/prometheus-config.yaml
         - --config=/etc/adapter/config.yaml
-        - --logtostderr=true
         - --metrics-relist-interval=1m
         - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc:9091
         - --secure-port=6443

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -126,7 +126,6 @@ function(params)
                           // '--prometheus-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token',
                           '--prometheus-auth-config=%s/%s' % [prometheusAdapterPrometheusConfigPath, 'prometheus-config.yaml'],
                           '--config=/etc/adapter/config.yaml',
-                          '--logtostderr=true',
                           '--metrics-relist-interval=1m',
                           '--prometheus-url=' + cfg.prometheusURL,
                           '--secure-port=6443',


### PR DESCRIPTION
The `--logtostderr` argument has been deprecated in prometheus-adapter v0.10.0 and removed in v0.11.0.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
