### PR TITLE
MON-2642: Improve e2e tests for alertrelabelconfigs CRD

### DIFF
--- a/examples/alert-relabel-config.yaml
+++ b/examples/alert-relabel-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: monitoring.openshift.io/v1alpha1
+apiVersion: monitoring.openshift.io/v1
 kind: AlertRelabelConfig
 metadata:
   name: watchdog

--- a/examples/alerting-rule.yaml
+++ b/examples/alerting-rule.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: monitoring.openshift.io/v1alpha1
+apiVersion: monitoring.openshift.io/v1
 kind: AlertingRule
 metadata:
   name: example


### PR DESCRIPTION
Check on Prometheus config secret instead of relabelConfig secret to test more things/parts.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
