### PR TITLE
OCPBUGS-18390: jsonnet/rules: exclude -1 from etcd objects count

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -194,9 +194,9 @@ spec:
           )
         )
       record: cluster:kubelet_volume_stats_used_bytes:provisioner:sum
-    - expr: sum by (instance) (apiserver_storage_objects)
+    - expr: sum by (instance) (apiserver_storage_objects != -1)
       record: instance:etcd_object_counts:sum
-    - expr: topk(500, max by(resource) (apiserver_storage_objects))
+    - expr: topk(500, max by(resource) (apiserver_storage_objects != -1))
       record: cluster:usage:resources:sum
     - expr: count(count (kube_pod_restart_policy{type!="Always",namespace!~"openshift-.+"}) by (namespace,pod))
       record: cluster:usage:pods:terminal:workload:sum

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -284,11 +284,18 @@ function(params) {
           // This recording rule was based on the now deprecated
           // etcd_object_counts metric which explains the name.
           // TODO: rename the recording rule and add it to the telemetry allow-list.
-          expr: 'sum by (instance) (apiserver_storage_objects)',
+          //
+          // This recording rule doesn't expose objects count of -1 as it
+          // indicates issues between the kube-apiserver and etcd and pollutes
+          // the data in telemetry.
+          expr: 'sum by (instance) (apiserver_storage_objects != -1)',
           record: 'instance:etcd_object_counts:sum',
         },
         {
-          expr: 'topk(500, max by(resource) (apiserver_storage_objects))',
+          // This recording rule doesn't expose objects count of -1 as it
+          // indicates issues between the kube-apiserver and etcd and pollutes
+          // the data in telemetry.
+          expr: 'topk(500, max by(resource) (apiserver_storage_objects != -1))',
           record: 'cluster:usage:resources:sum',
         },
         {


### PR DESCRIPTION
The apiserver_storage_objects metric can take -1 values when there are
communication issues between the kube-apiserver and etcd. In such case,
the kube-apiserver can't get objects count from etcd and as such exposes
a metric value denoting the issue. However, this is polluting the data
exported to telemetry so they should be skipped. Doing that will not
cause the lose of the etcd issue information since we have alerts that
would trigger in such scenarios.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
