### PR TITLE
MON-3383: Remove weak cryptograhic primitive usage

### DIFF
--- a/pkg/alert/rule_controller.go
+++ b/pkg/alert/rule_controller.go
@@ -16,7 +16,7 @@ package alert
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -315,7 +315,7 @@ func (rc *RuleController) sync(ctx context.Context, key string) error {
 // AlertingRule namespace, name, and UID.
 func (rc *RuleController) promRuleName(namespace, name string, uid types.UID) string {
 	data := fmt.Sprintf("%s-%s-%s", namespace, name, uid)
-	hash := md5.Sum([]byte(data))
+	hash := sha256.Sum224([]byte(data))
 	hexString := hex.EncodeToString(hash[:])
 
 	return fmt.Sprintf("%s-%s", name, hexString[:6])

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -15,7 +15,6 @@
 package manifests
 
 import (
-	"crypto/md5"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
@@ -3205,7 +3204,7 @@ func (f *Factory) injectThanosRulerAlertmanagerDigest(t *monv1.ThanosRuler, aler
 	if alertmanagerConfig == nil {
 		return
 	}
-	digestBytes := md5.Sum([]byte(alertmanagerConfig.StringData["alertmanagers.yaml"]))
+	digestBytes := sha256.Sum224([]byte(alertmanagerConfig.StringData["alertmanagers.yaml"]))
 	digest := fmt.Sprintf("%x", digestBytes)
 	for i := range t.Spec.Containers {
 		containerName := t.Spec.Containers[i].Name


### PR DESCRIPTION
This commit replaces md5 usage for sha256 as a method for cryptographic
primitive and replaces it for sha256.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>