### PR TITLE
OCPBUGS-19059: Enable ipv6 on monitoring-plugin nginx

### DIFF
--- a/assets/monitoring-plugin/config-map.yaml
+++ b/assets/monitoring-plugin/config-map.yaml
@@ -9,6 +9,7 @@ data:
       keepalive_timeout  65;
       server {
         listen              9443 ssl;
+        listen              [::]:9443 ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /usr/share/nginx/html;

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -23,6 +23,7 @@ function(params)
       keepalive_timeout  65;
       server {
         listen              %(nginxPort)d ssl;
+        listen              [::]:%(nginxPort)d ssl;
         ssl_certificate     %(tlsPath)s/tls.crt;
         ssl_certificate_key %(tlsPath)s/tls.key;
         root                /usr/share/nginx/html;


### PR DESCRIPTION
This commit modifies the monitoring-plugin configmap so nginx listens on
both ipv4 and ipv6 addresses. The nginx image used supported ipv6 but it
wasn't enabled on the endpoint config.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>