### PR TITLE
add bearertoken

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3600,6 +3600,7 @@ func addRemoteWriteConfigs(clusterID string, rw []monv1.RemoteWriteSpec, rwTarge
 			WriteRelabelConfigs: writeRelabelConfigs,
 			BasicAuth:           target.BasicAuth,
 			BearerTokenFile:     target.BearerTokenFile,
+			BearerToken:     target.BearerToken,
 			Sigv4:               target.Sigv4,
 			ProxyURL:            target.ProxyURL,
 			MetadataConfig:      target.MetadataConfig,

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1393,6 +1393,21 @@ func TestRemoteWriteAuthorizationConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "bearerToken authentication configuration",
+			config: `prometheusK8s:
+  remoteWrite:
+  - url: "https://bearerTokenFile.remotewrite.com/api/write"
+    bearerToken: "password"
+`,
+			checkFn: []func(*testing.T, monv1.RemoteWriteSpec){
+				func(t *testing.T, target monv1.RemoteWriteSpec) {
+					if target.BearerToken != "password" {
+						t.Fatalf("BearerToken field not correct in section RemoteWriteSpec expected 'password', got %s", target.BearerToken)
+					}
+				},
+			},
+		},
+		{
 			name: "authorization authentication configuration",
 			config: `prometheusK8s:
   remoteWrite:

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -736,6 +736,8 @@ type RemoteWriteSpec struct {
 	// However, because you cannot mount secrets in a pod, in practice
 	// you can only reference the token of the service account.
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
+	// Defines the bearer token for the remote write endpoint.
+	BearerToken string `json:"bearerToken,omitempty"`
 	// Specifies the custom HTTP headers to be sent along with each remote write request.
 	// Headers set by Prometheus cannot be overwritten.
 	Headers map[string]string `json:"headers,omitempty"`


### PR DESCRIPTION
Only bearertokenfile exists not bearertoken and I need this to configure my prometheus crd. Could you please merge this?

I couldn't find the link for bugzilla in the https://github.com/openshift/cluster-monitoring-operator/blob/master/CONTRIBUTING.md page