### PR TITLE
Set Thanos version in the Thanos Ruler spec

### DIFF
--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -151,6 +151,7 @@ spec:
     seccompProfile:
       type: RuntimeDefault
   serviceAccountName: thanos-ruler
+  version: 0.32.3
   volumes:
   - configmap:
       items:

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -351,6 +351,7 @@ function(params)
             ],
         },
         ruleNamespaceSelector: cfg.namespaceSelector,
+        version: cfg.version,
         volumes: [
           generateCertInjection.SCOCaBundleVolume('serving-certs-ca-bundle'),
           {


### PR DESCRIPTION
The `.spec.version` field is used by the operator to adapt the statefulset configuration depending on which features are supported or not.

In practice, it shouldn't induce any change in functionality but it's always better to be explicit.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
