### PR TITLE
OCPVE-711: feat: add olm capability annotation

### DIFF
--- a/manifests/0000_90_cluster-monitoring-operator_00-operatorgroup.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_00-operatorgroup.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     olm.providedAPIs: Alertmanager.v1.monitoring.coreos.com,PodMonitor.v1.monitoring.coreos.com,Probe.v1.monitoring.coreos.com,Prometheus.v1.monitoring.coreos.com,PrometheusRule.v1.monitoring.coreos.com,ServiceMonitor.v1.monitoring.coreos.com,ThanosRuler.v1.monitoring.coreos.com,AlertmanagerConfig.v1alpha1.monitoring.coreos.com
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   staticProvidedAPIs: true
   selector:


### PR DESCRIPTION
OLM is an optional operator, we exclude OLM resources with this annotation if the monitoring operator ever becomes a capability, using a <monitoring_label>+OperatorLifecycleManager will work for both

/hold

Wait for https://github.com/openshift/api/pull/1589 to be merged in

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
