### PR TITLE
Add alert to detect multiple operators accesing prometheus crd

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -277,6 +277,14 @@ spec:
       for: 30m
       labels:
         severity: warning
+    - alert: MultipleOperatorsAccesingPrometheusCRD
+      annotations:
+        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} restarted more than 5 times in last 10m
+        summary: Detect multiple operators accessing to the prometheus CRD.
+      expr: sum(max by(namespace, container, pod) (increase(kube_pod_container_status_restarts_total[10m]))) > 5
+      for: 10m
+      labels:
+        severity: warning
   - interval: 30s
     name: kubernetes-recurring.rules
     rules:

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -424,6 +424,18 @@ function(params) {
             severity: 'warning',
           },
         },
+        {
+          expr: 'sum(max by(namespace, container, pod) (increase(kube_pod_container_status_restarts_total[10m]))) > 5',
+          'for': '10m',
+          alert: 'MultipleOperatorsAccesingPrometheusCRD',
+          annotations: {
+            description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} restarted more than 5 times in last 10m',
+            summary: 'Detect multiple operators accessing to the prometheus CRD.',
+          },
+          labels: {
+            severity: 'warning',
+          },
+        },
       ],
     },
     {

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -161,6 +161,12 @@ local patchedRules = [
           severity: 'warning',
         },
       },
+      {
+        alert: 'AlertmanagerMultipleOperatorsAccesingPrometheusCRD',
+        labels: {
+          severity: 'warning',
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
New Alert AlertmanagerMultipleOperatorsAccesingPrometheusCRD

Alert to detect many pod restart dude to multiple operators accessing to the prometheus CRD


* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
