### PR TITLE
WIP: OCPBUGS-18282: Reject reserved labels used as external labels

### DIFF
--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -33,6 +33,8 @@ const (
 	StorageNotConfiguredReason                       = "PrometheusDataPersistenceNotConfigured"
 	UserAlermanagerConfigMisconfiguredMessage        = "Misconfigured Alertmanager:  Alertmanager for user-defined alerting is enabled in the openshift-monitoring/cluster-monitoring-config configmap by setting 'enableUserAlertmanagerConfig: true' field. This conflicts with a dedicated Alertmanager instance enabled in  openshift-user-workload-monitoring/user-workload-monitoring-config. Alertmanager enabled in openshift-user-workload-monitoring takes precedence over the one in openshift-monitoring, so please remove the 'enableUserAlertmanagerConfig' field in openshift-monitoring/cluster-monitoring-config."
 	UserAlermanagerConfigMisconfiguredReason         = "UserAlertmanagerMisconfigured"
+	CannotUseReservedExternalLabelsMessage           = "Reserved Labels cannot be as External Labels. `externalLabels` specified under `prometheusK8s` field in the `openshift-monitoring/cluster-monitoring-config` uses reserved labels `prometheus` or `prometheus_replica` which is not allowed, please remove these from externalLabels"
+	CannotUseReservedExternalLabelsReason            = "ReservedExternalLabelsConfigured"
 )
 
 // Status represents if the state being reported is known to be True, False, or Unknown.

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -48,6 +48,8 @@ const (
 	automaticBodySizeLimit = "automatic"
 )
 
+var DefaultReservedPrometheusExternalLabels = []string{"prometheus", "promtheus_replica"}
+
 type Config struct {
 	Images      *Images `json:"-"`
 	RemoteWrite bool    `json:"-"`
@@ -83,6 +85,29 @@ func (c Config) HasInconsistentAlertmanagerConfigurations() bool {
 	}
 
 	return amConfig.EnableUserAlertManagerConfig && uwmConfig.Enabled
+}
+
+func (c Config) HasPrometheusReservedExternalLabelsConfigured() bool {
+	if c.ClusterMonitoringConfiguration == nil {
+		return false
+	}
+
+	prometheusK8sConfig := c.ClusterMonitoringConfiguration.PrometheusK8sConfig
+	if prometheusK8sConfig == nil {
+		return false
+	}
+
+	if prometheusK8sConfig.ExternalLabels == nil {
+		return false
+	}
+
+	for _, reservedLabel := range DefaultReservedPrometheusExternalLabels {
+		if _, found := prometheusK8sConfig.ExternalLabels[reservedLabel]; found {
+			return true
+		}
+	}
+
+	return false
 }
 
 // AdditionalAlertmanagerConfigsForPrometheusUserWorkload returns the alertmanager configurations for

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -736,6 +736,9 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	} else if config.HasInconsistentAlertmanagerConfigurations() {
 		degradedConditionMessage = client.UserAlermanagerConfigMisconfiguredMessage
 		degradedConditionReason = client.UserAlermanagerConfigMisconfiguredReason
+	} else if config.HasPrometheusReservedExternalLabelsConfigured() {
+		degradedConditionMessage = client.CannotUseReservedExternalLabelsMessage
+		degradedConditionReason = client.CannotUseReservedExternalLabelsReason
 	}
 
 	klog.Info("Updating ClusterOperator status to done.")

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -170,6 +170,34 @@ prometheusK8s:
 				f.AssertOperatorConditionMessage(configv1.OperatorDegraded, "")
 			},
 		},
+		{
+			name: "default config with reserved external labels used",
+			config: `
+prometheusK8s:
+  externalLabels:
+    prometheus: "some-value"
+`,
+			assertion: func(t *testing.T) {
+				f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+				f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
+				f.AssertOperatorConditionReason(configv1.OperatorDegraded, client.CannotUseReservedExternalLabelsReason)
+				f.AssertOperatorConditionMessageContains(configv1.OperatorDegraded, client.CannotUseReservedExternalLabelsMessage)
+			},
+		},
+		{
+			name: "default config with no reserved external labels used",
+			config: `
+prometheusK8s:
+  externalLabels:
+    dc: "us-east-1"
+`,
+			assertion: func(t *testing.T) {
+				f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+				f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
+				f.AssertOperatorConditionReason(configv1.OperatorDegraded, "")
+				f.AssertOperatorConditionMessage(configv1.OperatorDegraded, "")
+			},
+		},
 	} {
 		f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, tc.config))
 


### PR DESCRIPTION
prometheus and prometheus_replica are reserved labels, if a user configures this as a label in externalLabels in cluster-monitoring-configmap warn user about this and make operator status Degraded

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
