### PR TITLE
MON-3270: Add kube-metrics-server to image-references

### DIFF
--- a/hack/generate-versions.sh
+++ b/hack/generate-versions.sh
@@ -28,7 +28,13 @@ if [ "$PULL_BASE_REF" != "$MAIN_BRANCH" ]; then
 fi
 
 version_from_remote() {
-	curl --retry 5 --silent --fail "https://raw.githubusercontent.com/${1}/${MAIN_BRANCH}/VERSION"
+  # since kubernetes-metrics-server repo doesn't have a VERSION file
+  if [ "$1" == "openshift/kubernetes-metrics-server" ]; then
+    curl --retry 5 --silent --fail "https://raw.githubusercontent.com/${1}/${MAIN_BRANCH}/manifests/release/kustomization.yaml" | \
+      gojsontoyaml -yamltojson | jq '.images[0].newTag' | sed 's/"//g'
+  else
+    curl --retry 5 --silent --fail "https://raw.githubusercontent.com/${1}/${MAIN_BRANCH}/VERSION"
+  fi
 }
 
 CONTENT="$(gojsontoyaml -yamltojson <"${VERSION_FILE}")"

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -6,6 +6,7 @@ repos:
   alertmanager: openshift/prometheus-alertmanager
   kubeRbacProxy: openshift/kube-rbac-proxy
   kubeStateMetrics: openshift/kube-state-metrics
+  kubernetesMetricsServer: openshift/kubernetes-metrics-server
   monitoringPlugin: openshift/monitoring-plugin
   nodeExporter: openshift/node_exporter
   promLabelProxy: openshift/prom-label-proxy
@@ -17,6 +18,7 @@ versions:
   alertmanager: 0.26.0
   kubeRbacProxy: 0.14.2
   kubeStateMetrics: 2.9.2
+  kubernetesMetricsServer: 0.6.4
   monitoringPlugin: 1.0.0
   nodeExporter: 1.6.1
   promLabelProxy: 0.7.0

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -70,3 +70,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-monitoring-plugin:latest
+  - name: kube-metrics-server
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-metrics-server:latest


### PR DESCRIPTION
Since ART build is completed inorder to get
included in payload it needs to be referred in
image-references.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
