### PR TITLE
Revert "feat: add olm capability annotation"

### DIFF
--- a/manifests/0000_90_cluster-monitoring-operator_00-operatorgroup.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_00-operatorgroup.yaml
@@ -8,7 +8,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     olm.providedAPIs: Alertmanager.v1.monitoring.coreos.com,PodMonitor.v1.monitoring.coreos.com,Probe.v1.monitoring.coreos.com,Prometheus.v1.monitoring.coreos.com,PrometheusRule.v1.monitoring.coreos.com,ServiceMonitor.v1.monitoring.coreos.com,ThanosRuler.v1.monitoring.coreos.com,AlertmanagerConfig.v1alpha1.monitoring.coreos.com
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   staticProvidedAPIs: true
   selector:


### PR DESCRIPTION
This reverts commit 31b1b1d53f4e538ea63f323a90def9c90fe626e3.

Mistaken timing on my part, will need to re-add change after CVO change is in https://github.com/openshift/cluster-version-operator/pull/971

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
