### PR TITLE
WIP: Detect static pods from metrics

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -38,8 +38,8 @@ spec:
         - |
           --metric-denylist=
           ^kube_secret_labels$,
-          ^kube_.+_annotations$
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]
+        - --metric-annotations-allowlist=pods=[kubernetes.io/config.source]
         - |
           --metric-denylist=
           ^kube_.+_created$,

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -201,9 +201,9 @@ function(params)
                         |||
                           --metric-denylist=
                           ^kube_secret_labels$,
-                          ^kube_.+_annotations$
                         |||,
                         '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]',
+                        '--metric-annotations-allowlist=pods=[kubernetes.io/config.source]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
The kubernetes.io/config.seen annotation on pods is set by kubelet and
can be helpful to identify static pods. For static pods, this annotation
will be equal to file since their configurations are files on disk.
Exposing this information via kube-state-metrics would allow correlating
the annotation metrics with other metric to build alerts specific to
static pods.