### PR TITLE
OCPBUGS-11344: alertmanager: use alertmanager CRD's automountServiceAccountToken option

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -23,6 +23,7 @@ spec:
         namespaces:
         - openshift-monitoring
         topologyKey: kubernetes.io/hostname
+  automountServiceAccountToken: true
   containers:
   - args:
     - -provider=openshift

--- a/assets/alertmanager/service-account.yaml
+++ b/assets/alertmanager/service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   annotations:

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -47,9 +47,10 @@ function(params)
           'serviceaccounts.openshift.io/oauth-redirectreference.alertmanager-main': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"alertmanager-main"}}',
         },
       },
-      // automountServiceAccountToken is set to true as kube-rbac-proxy sidecar
-      // requires connection to kubernetes API
-      automountServiceAccountToken: true,
+      // Alertmanager can mount the token into the pod since
+      // https://github.com/prometheus-operator/prometheus-operator/pull/5474
+      // and v0.66.0
+      automountServiceAccountToken: false,
     },
 
     // Adding the serving certs annotation causes the serving certs controller
@@ -238,6 +239,7 @@ function(params)
             memory: '40Mi',
           },
         },
+        automountServiceAccountToken: true,
         containers: [
           {
             name: 'alertmanager-proxy',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
