### PR TITLE
build: add `-e` to `go list` command to install tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,6 @@ $(JSON_MANIFESTS_DIR):
 
 $(TOOLING): $(BIN_DIR)
 	@echo Installing tools from hack/tools.go
-	@cd hack/tools && go list -mod=mod -tags tools -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %
+	@cd hack/tools && go list -mod=mod -tags tools -e -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %
 	@GOBIN=$(BIN_DIR) go install $(GO_PKG)/hack/docgen
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(BIN_DIR) $(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
we rely on go imports to install our build tooling via hack/tools/go.mod. Some of these imports don't actually import valid modules since `package main` is used in some of them (e.g.
https://github.com/brancz/gojsontoyaml/blob/6ffa820a00533125ad1c3f77d0429e4cac6f7072/main.go#L1). With go1.21 the `list` command will fail on those. Adding `-e` fixes this. I think this flag exists in older go version too, so this should work without being aware of the version.

\cc @simonpasquier 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
