### PR TITLE
[OCPBUGS-20221] Change kube-rbac-proxy-thanos port

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -108,7 +108,7 @@ spec:
     - mountPath: /etc/kube-rbac-proxy
       name: secret-kube-rbac-proxy
   - args:
-    - --secure-listen-address=[$(POD_IP)]:10902
+    - --secure-listen-address=[$(POD_IP)]:10903
     - --upstream=http://127.0.0.1:10902
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key
@@ -125,7 +125,7 @@ spec:
     image: quay.io/brancz/kube-rbac-proxy:v0.14.2
     name: kube-rbac-proxy-thanos
     ports:
-    - containerPort: 10902
+    - containerPort: 10903
       name: thanos-proxy
     resources:
       requests:

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -472,12 +472,12 @@ function(params)
             }],
             ports: [
               {
-                containerPort: 10902,
+                containerPort: 10903,
                 name: 'thanos-proxy',
               },
             ],
             args: [
-              '--secure-listen-address=[$(POD_IP)]:10902',
+              '--secure-listen-address=[$(POD_IP)]:10903',
               '--upstream=http://127.0.0.1:10902',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',


### PR DESCRIPTION
This commit changes kube-rbac-proxy-thanos in order to avoid duplicate
port definition logs messages in prometheus operator.

