### PR TITLE
MON-3286: Remove no longer needed code.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -857,18 +857,6 @@ func (c *Client) DeleteSecret(ctx context.Context, s *v1.Secret) error {
 	return err
 }
 
-// NOTE: this is only used during 4.13->4.14 upgrade, will be removed after.
-// TODO: remove this
-func (c *Client) DeleteSecretByNamespaceAndName(ctx context.Context, namespace, name string) error {
-	err := c.kclient.CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
-	// if the object does not exist then everything is good here
-	if err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrap(err, "deleting Secret object failed")
-	}
-
-	return nil
-}
-
 // validatePrometheusResource is a helper method for ValidatePrometheus.
 // NOTE: this function is refactored out of wait.Poll for testing
 func (c Client) validatePrometheusResource(ctx context.Context, prom types.NamespacedName) (bool, []error) {

--- a/pkg/tasks/controlplane.go
+++ b/pkg/tasks/controlplane.go
@@ -75,21 +75,5 @@ func (t *ControlPlaneTask) Run(ctx context.Context) error {
 		}
 	}
 
-	// NOTE: This is temporary, to clean these resources that used to be managed by CMO, now
-	// they are managed by CEO
-	// TODO: Remove this in 4.15
-	err = t.client.DeleteSecretByNamespaceAndName(ctx, t.client.Namespace(), "kube-etcd-client-certs")
-	if err != nil {
-		return errors.Wrap(err, "cleaning up the Secret failed")
-	}
-	err = t.client.DeleteServiceMonitorByNamespaceAndName(ctx, t.client.Namespace(), "etcd")
-	if err != nil {
-		return errors.Wrap(err, "cleaning up the ServiceMonitor failed")
-	}
-	err = t.client.DeleteServiceMonitorByNamespaceAndName(ctx, t.client.Namespace(), "etcd-minimal")
-	if err != nil {
-		return errors.Wrap(err, "cleaning up the ServiceMonitor failed")
-	}
-
 	return nil
 }


### PR DESCRIPTION
This code was introduced in https://github.com/openshift/cluster-monitoring-operator/pull/2039 to make sure CMO delete some resources it used to deploy for etcd monitoring.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
