### PR TITLE
OCPBUGS-4069: Prometheus Adatper takes metrics from kubelet job only.

### DIFF
--- a/assets/prometheus-adapter/config-map-dedicated-service-monitors.yaml
+++ b/assets/prometheus-adapter/config-map-dedicated-service-monitors.yaml
@@ -7,7 +7,7 @@ data:
         "containerQuery": |
           sum by (<<.GroupBy>>) (
             irate (
-                pa_container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[4m]
+                pa_container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!="",job="kubelet"}[4m]
             )
           )
         "nodeQuery": |
@@ -36,7 +36,7 @@ data:
         "containerLabel": "container"
         "containerQuery": |
           sum by (<<.GroupBy>>) (
-            pa_container_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!=""}
+            pa_container_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!="",job="kubelet"}
           )
         "nodeQuery": |
           sum by (<<.GroupBy>>) (

--- a/assets/prometheus-adapter/config-map.yaml
+++ b/assets/prometheus-adapter/config-map.yaml
@@ -7,7 +7,7 @@ data:
         "containerQuery": |
           sum by (<<.GroupBy>>) (
             irate (
-                container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[4m]
+                container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!="",job="kubelet"}[4m]
             )
           )
         "nodeQuery": |
@@ -36,7 +36,7 @@ data:
         "containerLabel": "container"
         "containerQuery": |
           sum by (<<.GroupBy>>) (
-            container_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!=""}
+            container_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!="",job="kubelet"}
           )
         "nodeQuery": |
           sum by (<<.GroupBy>>) (

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum.config/md5: f4e13b570c6a6bd90981fd20841716e2
+        checksum.config/md5: c7fb4696aad1a53eaad3f90f16b9905b
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: metrics-adapter

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -246,6 +246,7 @@ local inCluster =
         commonLabels+: $.values.common.commonLabels,
         tlsCipherSuites: $.values.common.tlsCipherSuites,
         prometheusAdapterMetricPrefix: $.values.common.prometheusAdapterMetricPrefix,
+        containerQuerySelector: 'job="kubelet"',
       },
       admissionWebhook: {
         name: 'prometheus-operator-admission-webhook',


### PR DESCRIPTION
The same modification in CMO as https://github.com/openshift/cluster-monitoring-operator/pull/1875 but using the new option in upstream kube-prometheus introduced by [this PR](https://github.com/prometheus-operator/kube-prometheus/pull/2003). 