### PR TITLE
OCPBUGS-18326: revert previous fix to avoid activating console capability during update

### DIFF
--- a/jsonnet/components/dashboards.libsonnet
+++ b/jsonnet/components/dashboards.libsonnet
@@ -157,9 +157,6 @@ function(params)
               } + if std.count(odcDashboards, d.metadata.name) > 0 then {
                 'console.openshift.io/odc-dashboard': 'true',
               } else {},
-              annotations+: {
-                'capability.openshift.io/name': 'Console',
-              },
             },
           },
         // Openshift Console cannot show chart with both stacked and unstacked metrics,

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1865,7 +1865,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -4908,7 +4907,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -7659,7 +7657,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -8689,7 +8686,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -10622,7 +10618,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -12614,7 +12609,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -14765,7 +14759,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -16224,7 +16217,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -17280,7 +17272,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -18390,7 +18381,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -19612,7 +19602,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -20825,7 +20814,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
Revert PR#2101
As Trevor commented in https://issues.redhat.com/browse/OCPBUGS-18326 , the capability annotation will activate the required capability implicitly on clusters during an update. We should avoid activating capabilities during update. 