### PR TITLE
[WIP] Add ipv6only=off to monitoring-plugin

### DIFF
--- a/assets/monitoring-plugin/config-map.yaml
+++ b/assets/monitoring-plugin/config-map.yaml
@@ -8,8 +8,7 @@ data:
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              9443 ssl;
-        listen              [::]:9443 ssl;
+        listen              [::]:9443 ipv6only=off ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /usr/share/nginx/html;

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -22,8 +22,7 @@ function(params)
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              %(nginxPort)d ssl;
-        listen              [::]:%(nginxPort)d ssl;
+        listen              [::]:%(nginxPort)d ipv6only=off ssl;
         ssl_certificate     %(tlsPath)s/tls.crt;
         ssl_certificate_key %(tlsPath)s/tls.key;
         root                /usr/share/nginx/html;


### PR DESCRIPTION
This PR sets ipv6only=off to monitoring plugin nginx config so the IPv6 socket
can be used for both IPv6 and IPv4 connections.
