### PR TITLE
fix: force HTTP/1.1 connections

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -78,6 +78,11 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Mitigate CVE-2023-44487 by disabling HTTP2 until the Go standard library
+	// and golang.org/x/net are fully fixed.
+	// Since the web server is only used to expose the metrics endpoint,
+	// downgrading to HTTP/1.1 doesn't bring any performance penalty.
+	serverConfig.SecureServing.DisableHTTP2 = true
 
 	serverConfig.Authorization.Authorizer = union.New(
 		// prefix the authorizer with the permissions for metrics scraping which are well known.


### PR DESCRIPTION
Commit b3b011b0 was not enough to prevent HTTP2 connections as demonstrated in https://github.com/kubernetes/kubernetes/issues/121197.

To prevent any risk with HTTP2, this change disables HTTP2 at the server level. There's no expected performance penalty because the web server is only used for scraping metrics.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
