### PR TITLE
[WIP] MON-3462: remove temporary fix for TRT-589

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -30,8 +30,7 @@ spec:
       expr: |
         sum by (namespace, pod, cluster) (
           max by(namespace, pod, cluster) (
-            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)", job="kube-state-metrics", phase=~"Pending|Unknown"}
-            unless ignoring(phase) (kube_pod_status_unschedulable{job="kube-state-metrics"} == 1)
+            kube_pod_status_phase{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
           )

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -205,25 +205,6 @@ local patchedRules = [
         },
         'for': '30m',
       },
-      // This patches the alert KubePodNotReady to exclude pods with 'Failed' phase.
-      // This should be removed after the resolution of the bug TRT-589:
-      // https://issues.redhat.com/browse/TRT-589
-      {
-        alert: 'KubePodNotReady',
-        expr: |||
-          sum by (namespace, pod, cluster) (
-            max by(namespace, pod, cluster) (
-              kube_pod_status_phase{%(prefixedNamespaceSelector)s, %(kubeStateMetricsSelector)s, phase=~"Pending|Unknown"}
-              unless ignoring(phase) (kube_pod_status_unschedulable{%(kubeStateMetricsSelector)s} == 1)
-            ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
-              1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
-            )
-          ) > 0
-        ||| % {
-          prefixedNamespaceSelector: 'namespace=~"(openshift-.*|kube-.*|default)"',
-          kubeStateMetricsSelector: 'job="kube-state-metrics"',
-        },
-      },
     ],
   },
   {


### PR DESCRIPTION
[TRT-589](https://issues.redhat.com//browse/TRT-589) [1] required to patch the upstream KubePodNotReady alerting rule. Now that the original issue is fixed, we should be able to revert the patch.

[1] https://issues.redhat.com/browse/TRT-589

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
