### PR TITLE
OCPBUGS-21441: Set the new --disable-http2 flag for prometheus-adapter to disable HTTP2

### DIFF
--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -51,6 +51,7 @@ spec:
         - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc:9091
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --disable-http2
         image: directxman12/k8s-prometheus-adapter:v0.10.0
         livenessProbe:
           failureThreshold: 5

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -129,6 +129,7 @@ function(params)
                           '--prometheus-url=' + cfg.prometheusURL,
                           '--secure-port=6443',
                           '--tls-cipher-suites=' + cfg.tlsCipherSuites,
+                          '--disable-http2',
                         ],
                         // OCPBUGS-10895: configure a startup probe to prevent
                         // the container from being killed by kubelet in case


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

/hold
needs https://github.com/openshift/k8s-prometheus-adapter/pull/91
/retitle OCPBUGS-21441: Set the new --disable-http2 flag for prometheus-adapter to disable HTTP2
/cc @simonpasquier

