### PR TITLE
MON-3479: update Prometheus operator assets to v0.69.1

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -530,7 +530,7 @@ spec:
       labels:
         namespace: kube-system
         severity: critical
-  - name: k8s.rules
+  - name: k8s.rules.container_cpu_usage_seconds_total
     rules:
     - expr: |
         sum by (cluster, namespace, pod, container) (
@@ -539,30 +539,40 @@ spec:
           1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
+  - name: k8s.rules.container_memory_working_set_bytes
+    rules:
     - expr: |
         container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_working_set_bytes
+  - name: k8s.rules.container_memory_rss
+    rules:
     - expr: |
         container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_rss
+  - name: k8s.rules.container_memory_cache
+    rules:
     - expr: |
         container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_cache
+  - name: k8s.rules.container_memory_swap
+    rules:
     - expr: |
         container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_swap
+  - name: k8s.rules.container_resource
+    rules:
     - expr: |
         kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}  * on (namespace, pod, cluster)
         group_left() max by (namespace, pod, cluster) (
@@ -631,6 +641,8 @@ spec:
             )
         )
       record: namespace_cpu:kube_pod_container_resource_limits:sum
+  - name: k8s.rules.pod_owner
+    rules:
     - expr: |
         max by (cluster, namespace, workload, pod) (
           label_replace(

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -110,6 +110,8 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private

--- a/assets/node-exporter/security-context-constraints.yaml
+++ b/assets/node-exporter/security-context-constraints.yaml
@@ -17,4 +17,6 @@ runAsUser:
   type: RunAsAny
 seLinuxContext:
   type: RunAsAny
+seccompProfiles:
+- runtime/default
 users: []

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         startupProbe:
           failureThreshold: 18
           httpGet:

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -188,6 +188,8 @@ spec:
     matchLabels:
       openshift.io/cluster-monitoring: "true"
   ruleSelector: {}
+  scrapeConfigNamespaceSelector: null
+  scrapeConfigSelector: null
   secrets:
   - prometheus-k8s-tls
   - prometheus-k8s-proxy

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -223,6 +223,8 @@ spec:
   ruleSelector:
     matchLabels:
       openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
+  scrapeConfigNamespaceSelector: null
+  scrapeConfigSelector: null
   secrets:
   - prometheus-user-workload-tls
   - prometheus-user-workload-thanos-sidecar-tls

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -76,6 +76,15 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/grpc

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -140,6 +140,7 @@ function(params)
       seLinuxContext: {
         type: 'RunAsAny',
       },
+      seccompProfiles: ['runtime/default'],
       users: [],
     },
 

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -278,11 +278,6 @@ function(params)
         overrideHonorLabels: true,
         ignoreNamespaceSelectors: true,
         enforcedNamespaceLabel: 'namespace',
-        ruleSelector: {
-          matchLabels: {
-            'openshift.io/prometheus-rule-evaluation-scope': 'leaf-prometheus',
-          },
-        },
         arbitraryFSAccessThroughSMs+: {
           deny: true,
         },
@@ -327,11 +322,20 @@ function(params)
           $.kubeRbacProxyFederateSecret.metadata.name,
         ],
         configMaps: ['serving-certs-ca-bundle', 'metrics-client-ca'],
+        probeSelector: {},
         probeNamespaceSelector: cfg.namespaceSelector,
+        podMonitorSelector: {},
         podMonitorNamespaceSelector: cfg.namespaceSelector,
         serviceMonitorSelector: {},
         serviceMonitorNamespaceSelector: cfg.namespaceSelector,
+        ruleSelector: {
+          matchLabels: {
+            'openshift.io/prometheus-rule-evaluation-scope': 'leaf-prometheus',
+          },
+        },
         ruleNamespaceSelector: cfg.namespaceSelector,
+        scrapeConfigSelector: null,
+        scrapeConfigNamespaceSelector: null,
         listenLocal: true,
         priorityClassName: 'openshift-user-critical',
         containers: [

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -350,6 +350,8 @@ function(params)
         serviceMonitorNamespaceSelector: cfg.namespaceSelector,
         ruleSelector: {},
         ruleNamespaceSelector: cfg.namespaceSelector,
+        scrapeConfigSelector: null,
+        scrapeConfigNamespaceSelector: null,
         listenLocal: true,
         priorityClassName: 'system-cluster-critical',
         additionalAlertRelabelConfigs: cfg.additionalRelabelConfigs,

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "main"
+      "version": "release-0.69"
     },
     {
       "source": {

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -18,8 +18,8 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "01a0d8ba839120fab607fdc258cb8b0437565507",
-      "sum": "LTbR+JGJ0gW3AdJQRl24VIKyKnPlPFaB+d+iysj4IU0="
+      "version": "c0bb57a3d46dab144bd02ee27192006b2bd4f72c",
+      "sum": "xuUBd2vqF7asyVDe5CE08uPT/RxAdy8O75EjFJoMXXU="
     },
     {
       "source": {
@@ -58,8 +58,8 @@
           "subdir": "gen/grafonnet-v10.0.0"
         }
       },
-      "version": "e85299323fd8808187d30865cc5c7a38a347399a",
-      "sum": "uJCTMGtY/7c5HSLQ7UQD38TOPmuSYrIKLIKmdSF/Htk="
+      "version": "9e217263ac4b922ca2e00bc5cc36ada2311bb5a6",
+      "sum": "gj/20VIGucG2vDGjG7YdHLC4yUUfrpuaneUYaRmymOM="
     },
     {
       "source": {
@@ -68,8 +68,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "4ef571d6a729989dec2f7dd3ba63b664988d0a3f",
-      "sum": "xEFMv4+ObwP5L1Wu0XK5agWci4AJzNApys6iKAQxLlQ="
+      "version": "a7647832fd3eaae70411bc9f697fa7504b04796c",
+      "sum": "aCN8uCrs2PDLR0SzRAuwZ6C5hiKt1KggCUCT7/F8yZ0="
     },
     {
       "source": {
@@ -78,8 +78,8 @@
           "subdir": "doc-util"
         }
       },
-      "version": "fd8de9039b3c06da77d635a3a8289809a5bfb542",
-      "sum": "mFebrE9fhyAKW4zbnidcjVFupziN5LPA/Z7ii94uCzs="
+      "version": "503e5c8fe96d6b55775037713ac10b184709ad93",
+      "sum": "BY4u0kLF3Qf/4IB4HnX9S5kEQIpHb4MUrppp6WLDtlU="
     },
     {
       "source": {
@@ -88,8 +88,8 @@
           "subdir": ""
         }
       },
-      "version": "0256a910ac71f0f842696d7bca0bf01ea77eb654",
-      "sum": "zBOpb1oTNvXdq9RF6yzTHill5r1YTJLBBoqyx4JYtAg="
+      "version": "c1a315a7dbead0335a5e0486acc5583395b22a24",
+      "sum": "UVdL+uuFI8BSQgLfMJEJk2WDKsQXNT3dRHcr2Ti9rLI="
     },
     {
       "source": {
@@ -109,8 +109,8 @@
           "subdir": ""
         }
       },
-      "version": "31169fd115654ca023c03cd7b45b9c96704a87e2",
-      "sum": "KJZ5QCtsPm3NofFURHO315rd4pnKc5+trU6ihuE64P8="
+      "version": "bcf8426b9c5ee85fdf8a6d9c62708f94e0367b21",
+      "sum": "1pCIS5kwa2b5JniHr3WV5wwiau29gM0fNQmqO2mXiCQ="
     },
     {
       "source": {
@@ -119,7 +119,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "b91dd311397047f15aae4f6dacba0708f24cf446",
+      "version": "4e431f6d149abbb547cefdd884274c1e9a6c5c9f",
       "sum": "+dOzAK+fwsFf97uZpjcjTcEJEC1H8hh/j8f5uIQK/5g="
     },
     {
@@ -129,7 +129,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "b91dd311397047f15aae4f6dacba0708f24cf446",
+      "version": "4e431f6d149abbb547cefdd884274c1e9a6c5c9f",
       "sum": "qclI7LwucTjBef3PkGBkKxF0mfZPbHnn4rlNWKGtR4c="
     },
     {
@@ -139,7 +139,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "774cb2ff4b9e21c452650643528c6fa190c7885a",
+      "version": "899188df28b0e495026833c606e16f8fc6b239cf",
       "sum": "9/dHjMKxPKGTAPV1fMAV0RuBck0O+Xyj/FkZjlN7DMs=",
       "name": "openshift-state-metrics"
     },
@@ -150,7 +150,7 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "5923762c315758d64e0a3ebebb15943ebf0c2a80",
+      "version": "8f091e8e7ecd3052566bd9dd20eb6991abf762c5",
       "sum": "C8wxoobehWU7ykPDhCMiCmSWTe/8jGjOJvcS+rxzp2U=",
       "name": "telemeter-client"
     },
@@ -161,8 +161,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "1706065791862d17f8c09a229d47197663eeebf8",
-      "sum": "YiEeMxGeDyf6F0BMvLQgE1/Dlc71tMMycL8ucPUJzyI="
+      "version": "ddff48cd49b7ea6273800e2ebb62a65025608aef",
+      "sum": "AS00RR9bozYYCHHfMsa+VREZdcHGE1AlCzISj7iMeOI="
     },
     {
       "source": {
@@ -171,7 +171,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "dec6461ac4af1d712e75c756d44a7ec5a4085beb",
+      "version": "fa22f77273f034ff49f364c0cdeb33bfed2cc019",
       "sum": "n3flMIzlADeyygb0uipZ4KPp2uNSjdtkrwgHjTC7Ca4=",
       "name": "prometheus-operator-mixin"
     },
@@ -182,8 +182,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "dec6461ac4af1d712e75c756d44a7ec5a4085beb",
-      "sum": "gl4yvv+WLjt+CaTW4/urKAMx8fs9I4K8PgZ4PyOMD58="
+      "version": "941b9e98d4ae5faa952af250e23c31c56cc1190c",
+      "sum": "RlttLdc+7oWRlxrwsazL2LgvudcSsSAHvy0oqKAc+Mw="
     },
     {
       "source": {
@@ -192,7 +192,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "e92d29d8618b2c7c291a86d79ed46a42c0035e8a",
+      "version": "ce6efba023b0397cb522d64e910684e48d12455f",
       "sum": "1d7ZKYArJKacAWXLUz0bRC1uOkozee/PPw97/W5zGhc=",
       "name": "alertmanager"
     },
@@ -203,7 +203,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "7dd2f0dc4f632f7778be134ace0e7c8ecdfe279a",
+      "version": "ed1b8e3d88851806627e4f8262ee26232ca56c2c",
       "sum": "By6n6U10hYDogUsyhsaKZehbhzxBZZobJloiKyKadgM="
     },
     {
@@ -213,8 +213,8 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "b787e5f190428ba23de9b6dcaa18eb963f239a76",
-      "sum": "8OngT76gVXOUROOOeP9yTe6E/dn+2D2J34Dn690QCG0=",
+      "version": "e250f09b5d34d6c936b18f3b7699df23a0555092",
+      "sum": "rNvddVTMNfaguOGzEGoeKjUsfhlXJBUImC+SIFNNCiM=",
       "name": "prometheus"
     },
     {
@@ -235,8 +235,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "ac261330bb819523d2caba81b4e82add166436c7",
-      "sum": "sN9PqW93Kh+jyf5kvRKQgotY3xbRIU/h22TcNO2KTag="
+      "version": "48639958ccd4fa81fbb261ce4f9e790d69c71e2e",
+      "sum": "22UgIfAACAxg2HRyAXFIN8Qi+p8rEcbWoM5XsXu9Mdo="
     },
     {
       "source": {
@@ -245,7 +245,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "ef2d5d63b184a513af1e188b7a625ad8ef3bce5d",
+      "version": "c74a050a190486addc1ea1ca4b522462fc7ec680",
       "sum": "HhSSbGGCNHCMy1ee5jElYDm0yS9Vesa7QB2/SHKdjsY="
     }
   ],

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -310,6 +310,17 @@ local inCluster =
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
         promLabelProxyImage: $.values.common.images.promLabelProxy,
         commonLabels+: $.values.common.commonLabels,
+        securityContext: {
+          runAsNonRoot: true,
+          seccompProfile: { type: 'RuntimeDefault' },
+        },
+        securityContextContainer: {
+          runAsNonRoot: true,
+          seccompProfile: { type: 'RuntimeDefault' },
+          allowPrivilegeEscalation: false,
+          readOnlyRootFilesystem: true,
+          capabilities: { drop: ['ALL'] },
+        },
       },
       telemeterClient: {
         namespace: $.values.common.namespace,

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    operator.prometheus.io/version: 0.69.1
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -663,6 +664,295 @@ spec:
                           to:
                             description: The email address to send notifications to.
                             type: string
+                        type: object
+                      type: array
+                    msteamsConfigs:
+                      description: List of MSTeams configurations. It requires Alertmanager >= 0.26.0.
+                      items:
+                        description: MSTeamsConfig configures notifications via Microsoft Teams. It requires Alertmanager >= 0.26.0.
+                        properties:
+                          httpConfig:
+                            description: HTTP client configuration.
+                            properties:
+                              authorization:
+                                description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                properties:
+                                  credentials:
+                                    description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type:
+                                    description: "Defines the authentication type. The value is case-insensitive. \n \"Basic\" is not a supported value. \n Default: \"Bearer\""
+                                    type: string
+                                type: object
+                              basicAuth:
+                                description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                properties:
+                                  password:
+                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  username:
+                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              bearerTokenSecret:
+                                description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              followRedirects:
+                                description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
+                                type: boolean
+                              oauth2:
+                                description: OAuth2 client credentials used to fetch a token for the targets.
+                                properties:
+                                  clientId:
+                                    description: The secret or configmap containing the OAuth2 client id
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  clientSecret:
+                                    description: The secret containing the OAuth2 client secret
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  endpointParams:
+                                    additionalProperties:
+                                      type: string
+                                    description: Parameters to append to the token URL
+                                    type: object
+                                  scopes:
+                                    description: OAuth2 scopes used for the token request
+                                    items:
+                                      type: string
+                                    type: array
+                                  tokenUrl:
+                                    description: The URL to fetch the token from
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - clientId
+                                - clientSecret
+                                - tokenUrl
+                                type: object
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tlsConfig:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Certificate authority used when verifying server certificates.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  cert:
+                                    description: Client certificate to present when doing client-authentication.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keySecret:
+                                    description: Secret containing the client key file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serverName:
+                                    description: Used to verify the hostname for the targets.
+                                    type: string
+                                type: object
+                            type: object
+                          sendResolved:
+                            description: Whether to notify about resolved alerts.
+                            type: boolean
+                          text:
+                            description: Message body template.
+                            type: string
+                          title:
+                            description: Message title template.
+                            type: string
+                          webhookUrl:
+                            description: MSTeams webhook URL.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        required:
+                        - webhookUrl
                         type: object
                       type: array
                     name:
@@ -4544,6 +4834,296 @@ spec:
                           to:
                             description: The email address to send notifications to.
                             type: string
+                        type: object
+                      type: array
+                    msteamsConfigs:
+                      description: List of MSTeams configurations. It requires Alertmanager >= 0.26.0.
+                      items:
+                        description: MSTeamsConfig configures notifications via Microsoft Teams. It requires Alertmanager >= 0.26.0.
+                        properties:
+                          httpConfig:
+                            description: HTTP client configuration.
+                            properties:
+                              authorization:
+                                description: Authorization header configuration for the client. This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                properties:
+                                  credentials:
+                                    description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type:
+                                    description: "Defines the authentication type. The value is case-insensitive. \n \"Basic\" is not a supported value. \n Default: \"Bearer\""
+                                    type: string
+                                type: object
+                              basicAuth:
+                                description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                properties:
+                                  password:
+                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  username:
+                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              bearerTokenSecret:
+                                description: The secret's key that contains the bearer token to be used by the client for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    minLength: 1
+                                    type: string
+                                  name:
+                                    description: The name of the secret in the object's namespace to select from.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              followRedirects:
+                                description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
+                                type: boolean
+                              oauth2:
+                                description: OAuth2 client credentials used to fetch a token for the targets.
+                                properties:
+                                  clientId:
+                                    description: The secret or configmap containing the OAuth2 client id
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  clientSecret:
+                                    description: The secret containing the OAuth2 client secret
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  endpointParams:
+                                    additionalProperties:
+                                      type: string
+                                    description: Parameters to append to the token URL
+                                    type: object
+                                  scopes:
+                                    description: OAuth2 scopes used for the token request
+                                    items:
+                                      type: string
+                                    type: array
+                                  tokenUrl:
+                                    description: The URL to fetch the token from
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - clientId
+                                - clientSecret
+                                - tokenUrl
+                                type: object
+                              proxyURL:
+                                description: Optional proxy URL.
+                                type: string
+                              tlsConfig:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Certificate authority used when verifying server certificates.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  cert:
+                                    description: Client certificate to present when doing client-authentication.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keySecret:
+                                    description: Secret containing the client key file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serverName:
+                                    description: Used to verify the hostname for the targets.
+                                    type: string
+                                type: object
+                            type: object
+                          sendResolved:
+                            description: Whether to notify about resolved alerts.
+                            type: boolean
+                          text:
+                            description: Message body template.
+                            type: string
+                          title:
+                            description: Message title template.
+                            type: string
+                          webhookUrl:
+                            description: MSTeams webhook URL.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - webhookUrl
                         type: object
                       type: array
                     name:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    operator.prometheus.io/version: 0.69.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
@@ -2798,7 +2799,7 @@ spec:
                 description: If set to true all actions on the underlying managed objects are not goint to be performed, except for delete actions.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures Labels and Annotations which are propagated to the alertmanager pods.
+                description: "PodMetadata configures labels and annotations which are propagated to the Alertmanager pods. \n The following items are reserved and cannot be overridden: * \"alertmanager\" label, set to the name of the Alertmanager instance. * \"app.kubernetes.io/instance\" label, set to the name of the Alertmanager instance. * \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\" label, set to \"alertmanager\". * \"app.kubernetes.io/version\" label, set to the Alertmanager version. * \"kubectl.kubernetes.io/default-container\" annotation, set to \"alertmanager\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    operator.prometheus.io/version: 0.69.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    operator.prometheus.io/version: 0.69.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    operator.prometheus.io/version: 0.69.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
@@ -615,7 +616,7 @@ spec:
                           description: Version of the Alertmanager API that Prometheus uses to send alerts. It can be "v1" or "v2".
                           type: string
                         authorization:
-                          description: "Authorization section for Alertmanager. \n Cannot be set at the same time as `basicAuth`, or `bearerTokenFile`."
+                          description: "Authorization section for Alertmanager. \n Cannot be set at the same time as `basicAuth`, `bearerTokenFile` or `sigv4`."
                           properties:
                             credentials:
                               description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
@@ -638,7 +639,7 @@ spec:
                               type: string
                           type: object
                         basicAuth:
-                          description: "BasicAuth configuration for Alertmanager. \n Cannot be set at the same time as `bearerTokenFile`, or `authorization`."
+                          description: "BasicAuth configuration for Alertmanager. \n Cannot be set at the same time as `bearerTokenFile`, `authorization` or `sigv4`."
                           properties:
                             password:
                               description: The secret in the service monitor namespace that contains the password for authentication.
@@ -674,7 +675,7 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         bearerTokenFile:
-                          description: "File to read bearer token for Alertmanager. \n Cannot be set at the same time as `basicAuth`, or `authorization`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*"
+                          description: "File to read bearer token for Alertmanager. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*"
                           type: string
                         enableHttp2:
                           description: Whether to enable HTTP2.
@@ -697,6 +698,51 @@ spec:
                         scheme:
                           description: Scheme to use when firing alerts.
                           type: string
+                        sigv4:
+                          description: "Sigv4 allows to configures AWS's Signature Verification 4 for the URL. \n It requires Prometheus >= v2.48.0. \n Cannot be set at the same time as `basicAuth`, `bearerTokenFile` or `authorization`."
+                          properties:
+                            accessKey:
+                              description: AccessKey is the AWS API key. If not specified, the environment variable `AWS_ACCESS_KEY_ID` is used.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            profile:
+                              description: Profile is the named AWS profile used to authenticate.
+                              type: string
+                            region:
+                              description: Region is the AWS region. If blank, the region from the default credentials chain used.
+                              type: string
+                            roleArn:
+                              description: RoleArn is the named AWS profile used to authenticate.
+                              type: string
+                            secretKey:
+                              description: SecretKey is the AWS API secret. If not specified, the environment variable `AWS_SECRET_ACCESS_KEY` is used.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         timeout:
                           description: Timeout is a per-target Alertmanager timeout when pushing alerts.
                           pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
@@ -2865,7 +2911,7 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures labels and annotations which are propagated to the Prometheus pods.
+                description: "PodMetadata configures labels and annotations which are propagated to the Prometheus pods. \n The following items are reserved and cannot be overridden: * \"prometheus\" label, set to the name of the Prometheus object. * \"app.kubernetes.io/instance\" label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\" label, set to \"prometheus\". * \"app.kubernetes.io/version\" label, set to the Prometheus version. * \"operator.prometheus.io/name\" label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\" label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\" annotation, set to \"prometheus\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    operator.prometheus.io/version: 0.69.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    operator.prometheus.io/version: 0.69.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    operator.prometheus.io/version: 0.69.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
@@ -2494,7 +2495,7 @@ spec:
                 description: When a ThanosRuler deployment is paused, no actions except for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata contains Labels and Annotations gets propagated to the thanos ruler pods.
+                description: "PodMetadata configures labels and annotations which are propagated to the ThanosRuler pods. \n The following items are reserved and cannot be overridden: * \"app.kubernetes.io/name\" label, set to \"thanos-ruler\". * \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\". * \"app.kubernetes.io/instance\" label, set to the name of the ThanosRuler instance. * \"thanos-ruler\" label, set to the name of the ThanosRuler instance. * \"kubectl.kubernetes.io/default-container\" annotation, set to \"thanos-ruler\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -4576,7 +4576,7 @@ data:
 
                                 ],
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": -1,
+                                "decimals": 3,
                                 "link": false,
                                 "linkTargetBlank": false,
                                 "linkTooltip": "Drill down",
@@ -4586,7 +4586,7 @@ data:
 
                                 ],
                                 "type": "number",
-                                "unit": "short"
+                                "unit": "iops"
                             },
                             {
                                 "alias": "IOPS(Writes)",
@@ -4595,7 +4595,7 @@ data:
 
                                 ],
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": -1,
+                                "decimals": 3,
                                 "link": false,
                                 "linkTargetBlank": false,
                                 "linkTooltip": "Drill down",
@@ -4605,7 +4605,7 @@ data:
 
                                 ],
                                 "type": "number",
-                                "unit": "short"
+                                "unit": "iops"
                             },
                             {
                                 "alias": "IOPS(Reads + Writes)",
@@ -4614,7 +4614,7 @@ data:
 
                                 ],
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": -1,
+                                "decimals": 3,
                                 "link": false,
                                 "linkTargetBlank": false,
                                 "linkTooltip": "Drill down",
@@ -4624,7 +4624,7 @@ data:
 
                                 ],
                                 "type": "number",
-                                "unit": "short"
+                                "unit": "iops"
                             },
                             {
                                 "alias": "Throughput(Read)",
@@ -7299,7 +7299,7 @@ data:
 
                                 ],
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": -1,
+                                "decimals": 3,
                                 "link": false,
                                 "linkTargetBlank": false,
                                 "linkTooltip": "Drill down",
@@ -7309,7 +7309,7 @@ data:
 
                                 ],
                                 "type": "number",
-                                "unit": "short"
+                                "unit": "iops"
                             },
                             {
                                 "alias": "IOPS(Writes)",
@@ -7318,7 +7318,7 @@ data:
 
                                 ],
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": -1,
+                                "decimals": 3,
                                 "link": false,
                                 "linkTargetBlank": false,
                                 "linkTooltip": "Drill down",
@@ -7328,7 +7328,7 @@ data:
 
                                 ],
                                 "type": "number",
-                                "unit": "short"
+                                "unit": "iops"
                             },
                             {
                                 "alias": "IOPS(Reads + Writes)",
@@ -7337,7 +7337,7 @@ data:
 
                                 ],
                                 "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                "decimals": -1,
+                                "decimals": 3,
                                 "link": false,
                                 "linkTargetBlank": false,
                                 "linkTooltip": "Drill down",
@@ -7347,7 +7347,7 @@ data:
 
                                 ],
                                 "type": "number",
-                                "unit": "short"
+                                "unit": "iops"
                             },
                             {
                                 "alias": "Throughput(Read)",


### PR DESCRIPTION
This commit also pins the prometheus-operator jsonnet to the current stable release branch of the operator. The reason is that pinning to the main branch has the drawback of pulling CRD changes which are not yet supported by the downstream operator.

The commit also updates the different jsonnet dependencies to their latest versions.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
