### PR TITLE
MON-3500: Enable sending exemplars over RW in UWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.15
+
+- [#2161](https://github.com/openshift/cluster-monitoring-operator/pull/2161) Add `PrometheusRestrictedConfig.RemoteWrite[].SendExemplars`.
+
 ## 4.14
 
 - [#1937](https://github.com/openshift/cluster-monitoring-operator/pull/1937) Disables btrfs collector

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -525,6 +525,7 @@ The `RemoteWriteSpec` resource defines the settings for remote write storage.
 | proxyUrl | string | Defines an optional proxy URL. |
 | queueConfig | *[monv1.QueueConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#queueconfig) | Allows tuning configuration for remote write queue parameters. |
 | remoteTimeout | string | Defines the timeout value for requests to the remote write endpoint. |
+| sendExemplars | *bool | Enables sending of exemplars over remote write. Note that the experimental \"exemplar-storage\" feature must be enabled using the `spec.enableFeature` option for exemplars to be scraped in the first place. Only supported for UWM configurations. |
 | sigv4 | *monv1.Sigv4 | Defines AWS Signature Version 4 authentication settings. |
 | tlsConfig | *[monv1.SafeTLSConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#safetlsconfig) | Defines TLS authentication settings for the remote write endpoint. |
 | url | string | Defines the URL of the remote write endpoint to which samples will be sent. |

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -525,7 +525,7 @@ The `RemoteWriteSpec` resource defines the settings for remote write storage.
 | proxyUrl | string | Defines an optional proxy URL. |
 | queueConfig | *[monv1.QueueConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#queueconfig) | Allows tuning configuration for remote write queue parameters. |
 | remoteTimeout | string | Defines the timeout value for requests to the remote write endpoint. |
-| sendExemplars | *bool | Enables sending of exemplars over remote write. Note when enabled, Prometheus is configured to store exemplars in memory with a maximum number of 100,000 exemplars. The setting is only effective for user-defined monitoring and has no effect for cluster monitoring. |
+| sendExemplars | *bool | Enables sending exemplars via remote write. When enabled, Prometheus is configured to store a maximum of 100,000 exemplars in memory. Note that this setting only applies to user-defined monitoring. It is not applicable to default in-cluster monitoring. |
 | sigv4 | *monv1.Sigv4 | Defines AWS Signature Version 4 authentication settings. |
 | tlsConfig | *[monv1.SafeTLSConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#safetlsconfig) | Defines TLS authentication settings for the remote write endpoint. |
 | url | string | Defines the URL of the remote write endpoint to which samples will be sent. |

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -525,7 +525,7 @@ The `RemoteWriteSpec` resource defines the settings for remote write storage.
 | proxyUrl | string | Defines an optional proxy URL. |
 | queueConfig | *[monv1.QueueConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#queueconfig) | Allows tuning configuration for remote write queue parameters. |
 | remoteTimeout | string | Defines the timeout value for requests to the remote write endpoint. |
-| sendExemplars | *bool | Enables sending of exemplars over remote write. Note that the experimental \"exemplar-storage\" feature must be enabled using the `spec.enableFeature` option for exemplars to be scraped in the first place. Only supported for UWM configurations. |
+| sendExemplars | *bool | Enables sending of exemplars over remote write. Note when enabled, Prometheus is configured to store exemplars in memory with a maximum number of 100,000 exemplars. The setting is only effective for user-defined monitoring and has no effect for cluster monitoring. |
 | sigv4 | *monv1.Sigv4 | Defines AWS Signature Version 4 authentication settings. |
 | tlsConfig | *[monv1.SafeTLSConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#safetlsconfig) | Defines TLS authentication settings for the remote write endpoint. |
 | url | string | Defines the URL of the remote write endpoint to which samples will be sent. |

--- a/Documentation/openshiftdocs/modules/remotewritespec.adoc
+++ b/Documentation/openshiftdocs/modules/remotewritespec.adoc
@@ -41,7 +41,7 @@ link:prometheusrestrictedconfig.adoc[PrometheusRestrictedConfig]
 
 |remoteTimeout|string|Defines the timeout value for requests to the remote write endpoint.
 
-|sendExemplars|*bool|Enables sending of exemplars over remote write. Note that the experimental \"exemplar-storage\" feature must be enabled using the `spec.enableFeature` option for exemplars to be scraped in the first place. Only supported for UWM configurations.
+|sendExemplars|*bool|Enables sending of exemplars over remote write. Note when enabled, Prometheus is configured to store exemplars in memory with a maximum number of 100,000 exemplars. The setting is only effective for user-defined monitoring and has no effect for cluster monitoring.
 
 |sigv4|*monv1.Sigv4|Defines AWS Signature Version 4 authentication settings.
 

--- a/Documentation/openshiftdocs/modules/remotewritespec.adoc
+++ b/Documentation/openshiftdocs/modules/remotewritespec.adoc
@@ -41,6 +41,8 @@ link:prometheusrestrictedconfig.adoc[PrometheusRestrictedConfig]
 
 |remoteTimeout|string|Defines the timeout value for requests to the remote write endpoint.
 
+|sendExemplars|*bool|Enables sending of exemplars over remote write. Note that the experimental \"exemplar-storage\" feature must be enabled using the `spec.enableFeature` option for exemplars to be scraped in the first place. Only supported for UWM configurations.
+
 |sigv4|*monv1.Sigv4|Defines AWS Signature Version 4 authentication settings.
 
 |tlsConfig|*monv1.SafeTLSConfig|Defines TLS authentication settings for the remote write endpoint.

--- a/Documentation/openshiftdocs/modules/remotewritespec.adoc
+++ b/Documentation/openshiftdocs/modules/remotewritespec.adoc
@@ -41,7 +41,7 @@ link:prometheusrestrictedconfig.adoc[PrometheusRestrictedConfig]
 
 |remoteTimeout|string|Defines the timeout value for requests to the remote write endpoint.
 
-|sendExemplars|*bool|Enables sending of exemplars over remote write. Note when enabled, Prometheus is configured to store exemplars in memory with a maximum number of 100,000 exemplars. The setting is only effective for user-defined monitoring and has no effect for cluster monitoring.
+|sendExemplars|*bool|Enables sending exemplars via remote write. When enabled, Prometheus is configured to store a maximum of 100,000 exemplars in memory. Note that this setting only applies to user-defined monitoring. It is not applicable to default in-cluster monitoring.
 
 |sigv4|*monv1.Sigv4|Defines AWS Signature Version 4 authentication settings.
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -753,10 +753,10 @@ type RemoteWriteSpec struct {
 	QueueConfig *monv1.QueueConfig `json:"queueConfig,omitempty"`
 	// Defines the timeout value for requests to the remote write endpoint.
 	RemoteTimeout string `json:"remoteTimeout,omitempty"`
-	// Enables sending of exemplars over remote write. Note that the experimental
-	// "exemplar-storage" feature must be enabled using the `spec.enableFeature`
-	// option for exemplars to be scraped in the first place. Only supported for
-	// UWM configurations.
+	// Enables sending of exemplars over remote write. Note when enabled, Prometheus is
+	// configured to store exemplars in memory with a maximum number of 100,000 exemplars.
+	// The setting is only effective for user-defined monitoring and has no effect for
+	// cluster monitoring.
 	SendExemplars *bool `json:"sendExemplars,omitempty"`
 	// Defines AWS Signature Version 4 authentication settings.
 	Sigv4 *monv1.Sigv4 `json:"sigv4,omitempty"`

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -753,6 +753,11 @@ type RemoteWriteSpec struct {
 	QueueConfig *monv1.QueueConfig `json:"queueConfig,omitempty"`
 	// Defines the timeout value for requests to the remote write endpoint.
 	RemoteTimeout string `json:"remoteTimeout,omitempty"`
+	// Enables sending of exemplars over remote write. Note that the experimental
+	// "exemplar-storage" feature must be enabled using the `spec.enableFeature`
+	// option for exemplars to be scraped in the first place. Only supported for
+	// UWM configurations.
+	SendExemplars *bool `json:"sendExemplars,omitempty"`
 	// Defines AWS Signature Version 4 authentication settings.
 	Sigv4 *monv1.Sigv4 `json:"sigv4,omitempty"`
 	// Defines TLS authentication settings for the remote write endpoint.

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -753,10 +753,10 @@ type RemoteWriteSpec struct {
 	QueueConfig *monv1.QueueConfig `json:"queueConfig,omitempty"`
 	// Defines the timeout value for requests to the remote write endpoint.
 	RemoteTimeout string `json:"remoteTimeout,omitempty"`
-	// Enables sending of exemplars over remote write. Note when enabled, Prometheus is
-	// configured to store exemplars in memory with a maximum number of 100,000 exemplars.
-	// The setting is only effective for user-defined monitoring and has no effect for
-	// cluster monitoring.
+	// Enables sending exemplars via remote write. When enabled, Prometheus is
+	// configured to store a maximum of 100,000 exemplars in memory.
+	// Note that this setting only applies to user-defined monitoring. It is not applicable
+	// to default in-cluster monitoring.
 	SendExemplars *bool `json:"sendExemplars,omitempty"`
 	// Defines AWS Signature Version 4 authentication settings.
 	Sigv4 *monv1.Sigv4 `json:"sigv4,omitempty"`


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
