### PR TITLE
MON-3505: move aggregated-metrics-reader role to cmo jsonnet

### DIFF
--- a/assets/cluster-monitoring-operator/cluster-role-aggregated-metrics-reader.yaml
+++ b/assets/cluster-monitoring-operator/cluster-role-aggregated-metrics-reader.yaml
@@ -4,9 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: cluster-monitoring-operator
-    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/name: cluster-monitoring-operator
     app.kubernetes.io/part-of: openshift-monitoring
-    app.kubernetes.io/version: 0.11.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -39,14 +39,9 @@ function(params)
       },
     },
 
-    clusterRoleAggregatedMetricsReader+:
-      {
-        metadata+: {
-          labels+: {
-            'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
-          },
-        },
-      },
+    // This role is moved to cluster-monitoring-operator.libsonnet
+    // Hence hiding it in prometheus-adapter.
+    clusterRoleAggregatedMetricsReader:: null,
 
     apiService+:
       {

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -354,11 +354,11 @@ local inCluster =
         rules+: inCluster.alertmanager.clusterRole.rules +
                 inCluster.clusterMonitoringOperator.clusterRoleView.rules +
                 inCluster.clusterMonitoringOperator.userWorkloadConfigEditRole.rules +
+                inCluster.clusterMonitoringOperator.clusterRoleAggregatedMetricsReader.rules +
                 inCluster.kubeStateMetrics.clusterRole.rules +
                 inCluster.nodeExporter.clusterRole.rules +
                 inCluster.openshiftStateMetrics.clusterRole.rules +
                 inCluster.prometheusAdapter.clusterRole.rules +
-                inCluster.prometheusAdapter.clusterRoleAggregatedMetricsReader.rules +
                 inCluster.prometheusAdapter.clusterRoleServerResources.rules +
                 inCluster.prometheus.clusterRole.rules +
                 std.flatMap(function(role) role.rules,

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -214,6 +214,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -407,15 +416,6 @@ rules:
   - namespaces
   - pods
   - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metrics.k8s.io
-  resources:
-  - pods
-  - nodes
   verbs:
   - get
   - list

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -178,24 +178,23 @@ var (
 	PrometheusUserWorkloadConfigMap                           = "prometheus-user-workload/config-map.yaml"
 	PrometheusUserWorkloadFederateRoute                       = "prometheus-user-workload/federate-route.yaml"
 
-	PrometheusAdapterAPIService                         = "prometheus-adapter/api-service.yaml"
-	PrometheusAdapterClusterRole                        = "prometheus-adapter/cluster-role.yaml"
-	PrometheusAdapterClusterRoleBinding                 = "prometheus-adapter/cluster-role-binding.yaml"
-	PrometheusAdapterClusterRoleBindingDelegator        = "prometheus-adapter/cluster-role-binding-delegator.yaml"
-	PrometheusAdapterClusterRoleBindingView             = "prometheus-adapter/cluster-role-binding-view.yaml"
-	PrometheusAdapterClusterRoleServerResources         = "prometheus-adapter/cluster-role-server-resources.yaml"
-	PrometheusAdapterClusterRoleAggregatedMetricsReader = "prometheus-adapter/cluster-role-aggregated-metrics-reader.yaml"
-	PrometheusAdapterConfigMap                          = "prometheus-adapter/config-map.yaml"
-	PrometheusAdapterConfigMapDedicatedSM               = "prometheus-adapter/config-map-dedicated-service-monitors.yaml"
-	PrometheusAdapterConfigMapPrometheus                = "prometheus-adapter/configmap-prometheus.yaml"
-	PrometheusAdapterConfigMapAuditPolicy               = "prometheus-adapter/configmap-audit-profiles.yaml"
-	PrometheusAdapterDeployment                         = "prometheus-adapter/deployment.yaml"
-	PrometheusAdapterPodDisruptionBudget                = "prometheus-adapter/pod-disruption-budget.yaml"
-	PrometheusAdapterRoleBindingAuthReader              = "prometheus-adapter/role-binding-auth-reader.yaml"
-	PrometheusAdapterService                            = "prometheus-adapter/service.yaml"
-	PrometheusAdapterServiceMonitor                     = "prometheus-adapter/service-monitor.yaml"
-	PrometheusAdapterMinimalServiceMonitor              = "prometheus-adapter/minimal-service-monitor.yaml"
-	PrometheusAdapterServiceAccount                     = "prometheus-adapter/service-account.yaml"
+	PrometheusAdapterAPIService                  = "prometheus-adapter/api-service.yaml"
+	PrometheusAdapterClusterRole                 = "prometheus-adapter/cluster-role.yaml"
+	PrometheusAdapterClusterRoleBinding          = "prometheus-adapter/cluster-role-binding.yaml"
+	PrometheusAdapterClusterRoleBindingDelegator = "prometheus-adapter/cluster-role-binding-delegator.yaml"
+	PrometheusAdapterClusterRoleBindingView      = "prometheus-adapter/cluster-role-binding-view.yaml"
+	PrometheusAdapterClusterRoleServerResources  = "prometheus-adapter/cluster-role-server-resources.yaml"
+	PrometheusAdapterConfigMap                   = "prometheus-adapter/config-map.yaml"
+	PrometheusAdapterConfigMapDedicatedSM        = "prometheus-adapter/config-map-dedicated-service-monitors.yaml"
+	PrometheusAdapterConfigMapPrometheus         = "prometheus-adapter/configmap-prometheus.yaml"
+	PrometheusAdapterConfigMapAuditPolicy        = "prometheus-adapter/configmap-audit-profiles.yaml"
+	PrometheusAdapterDeployment                  = "prometheus-adapter/deployment.yaml"
+	PrometheusAdapterPodDisruptionBudget         = "prometheus-adapter/pod-disruption-budget.yaml"
+	PrometheusAdapterRoleBindingAuthReader       = "prometheus-adapter/role-binding-auth-reader.yaml"
+	PrometheusAdapterService                     = "prometheus-adapter/service.yaml"
+	PrometheusAdapterServiceMonitor              = "prometheus-adapter/service-monitor.yaml"
+	PrometheusAdapterMinimalServiceMonitor       = "prometheus-adapter/minimal-service-monitor.yaml"
+	PrometheusAdapterServiceAccount              = "prometheus-adapter/service-account.yaml"
 
 	AdmissionWebhookRuleValidatingWebhook               = "admission-webhook/prometheus-rule-validating-webhook.yaml"
 	AdmissionWebhookAlertmanagerConfigValidatingWebhook = "admission-webhook/alertmanager-config-validating-webhook.yaml"
@@ -223,6 +222,7 @@ var (
 
 	ClusterMonitoringOperatorServiceMonitor                = "cluster-monitoring-operator/service-monitor.yaml"
 	ClusterMonitoringClusterRoleView                       = "cluster-monitoring-operator/cluster-role-view.yaml"
+	ClusterMonitoringClusterRoleAggregatedMetricsReader    = "cluster-monitoring-operator/cluster-role-aggregated-metrics-reader.yaml"
 	ClusterMonitoringAlertmanagerEditRole                  = "cluster-monitoring-operator/monitoring-alertmanager-edit-role.yaml"
 	ClusterMonitoringRulesEditClusterRole                  = "cluster-monitoring-operator/monitoring-rules-edit-cluster-role.yaml"
 	ClusterMonitoringRulesViewClusterRole                  = "cluster-monitoring-operator/monitoring-rules-view-cluster-role.yaml"
@@ -1869,10 +1869,6 @@ func (f *Factory) PrometheusAdapterClusterRoleServerResources() (*rbacv1.Cluster
 	return f.NewClusterRole(f.assets.MustNewAssetReader(PrometheusAdapterClusterRoleServerResources))
 }
 
-func (f *Factory) PrometheusAdapterClusterRoleAggregatedMetricsReader() (*rbacv1.ClusterRole, error) {
-	return f.NewClusterRole(f.assets.MustNewAssetReader(PrometheusAdapterClusterRoleAggregatedMetricsReader))
-}
-
 func (f *Factory) PrometheusAdapterClusterRoleBinding() (*rbacv1.ClusterRoleBinding, error) {
 	return f.NewClusterRoleBinding(f.assets.MustNewAssetReader(PrometheusAdapterClusterRoleBinding))
 }
@@ -2423,6 +2419,10 @@ func (f *Factory) PrometheusUserWorkloadServiceThanosSidecar() (*v1.Service, err
 
 func (f *Factory) ClusterMonitoringClusterRoleView() (*rbacv1.ClusterRole, error) {
 	return f.NewClusterRole(f.assets.MustNewAssetReader(ClusterMonitoringClusterRoleView))
+}
+
+func (f *Factory) ClusterMonitoringClusterRoleAggregatedMetricsReader() (*rbacv1.ClusterRole, error) {
+	return f.NewClusterRole(f.assets.MustNewAssetReader(ClusterMonitoringClusterRoleAggregatedMetricsReader))
 }
 
 func (f *Factory) ClusterMonitoringRulesEditClusterRole() (*rbacv1.ClusterRole, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -406,11 +406,6 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.PrometheusAdapterClusterRoleAggregatedMetricsReader()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	_, err = f.PrometheusAdapterClusterRoleBinding()
 	if err != nil {
 		t.Fatal(err)
@@ -599,6 +594,11 @@ func TestUnconfiguredManifests(t *testing.T) {
 	}
 
 	_, err = f.ClusterMonitoringClusterRoleView()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.ClusterMonitoringClusterRoleAggregatedMetricsReader()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/tasks/clustermonitoringoperator.go
+++ b/pkg/tasks/clustermonitoringoperator.go
@@ -45,11 +45,12 @@ func NewClusterMonitoringOperatorTask(
 
 func (t *ClusterMonitoringOperatorTask) Run(ctx context.Context) error {
 	for name, crf := range map[string]func() (*rbacv1.ClusterRole, error){
-		"cluster-monitoring-view": t.factory.ClusterMonitoringClusterRoleView,
-		"monitoring-rules-edit":   t.factory.ClusterMonitoringRulesEditClusterRole,
-		"monitoring-rules-view":   t.factory.ClusterMonitoringRulesViewClusterRole,
-		"monitoring-edit":         t.factory.ClusterMonitoringEditClusterRole,
-		"alert-routing-edit":      t.factory.ClusterMonitoringAlertingEditClusterRole,
+		"cluster-monitoring-view":          t.factory.ClusterMonitoringClusterRoleView,
+		"system:aggregated-metrics-reader": t.factory.ClusterMonitoringClusterRoleAggregatedMetricsReader,
+		"monitoring-rules-edit":            t.factory.ClusterMonitoringRulesEditClusterRole,
+		"monitoring-rules-view":            t.factory.ClusterMonitoringRulesViewClusterRole,
+		"monitoring-edit":                  t.factory.ClusterMonitoringEditClusterRole,
+		"alert-routing-edit":               t.factory.ClusterMonitoringAlertingEditClusterRole,
 	} {
 		cr, err := crf()
 		if err != nil {

--- a/pkg/tasks/prometheusadapter.go
+++ b/pkg/tasks/prometheusadapter.go
@@ -52,17 +52,6 @@ func (t *PrometheusAdapterTask) Run(ctx context.Context) error {
 		}
 	}
 	{
-		cr, err := t.factory.PrometheusAdapterClusterRoleAggregatedMetricsReader()
-		if err != nil {
-			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRole aggregating resource metrics read permissions failed")
-		}
-
-		err = t.client.CreateOrUpdateClusterRole(ctx, cr)
-		if err != nil {
-			return errors.Wrap(err, "reconciling PrometheusAdapter ClusterRole aggregating resource metrics read permissions failed")
-		}
-	}
-	{
 		crb, err := t.factory.PrometheusAdapterClusterRoleBinding()
 		if err != nil {
 			return errors.Wrap(err, "initializing PrometheusAdapter ClusterRoleBinding failed")


### PR DESCRIPTION
This change came as part of reviewing #2022
To avoid duplicated code in metrics-server
and prometheus-adapter moving this role
to cluster-monitoring-operator.jsonnet

cc: @simonpasquier 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
