### PR TITLE
OCPBUGS-23495: Change UWM Prometheus' kube-rbac-proxy-thanos port num…

### DIFF
--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -105,7 +105,7 @@ spec:
     - mountPath: /etc/kube-rbac-proxy
       name: secret-kube-rbac-proxy-metrics
   - args:
-    - --secure-listen-address=[$(POD_IP)]:10902
+    - --secure-listen-address=[$(POD_IP)]:10903
     - --upstream=http://127.0.0.1:10902
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key
@@ -121,7 +121,7 @@ spec:
     image: quay.io/brancz/kube-rbac-proxy:v0.15.0
     name: kube-rbac-proxy-thanos
     ports:
-    - containerPort: 10902
+    - containerPort: 10903
       name: thanos-proxy
     resources:
       requests:

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -450,12 +450,12 @@ function(params)
             }],
             ports: [
               {
-                containerPort: 10902,
+                containerPort: 10903,
                 name: 'thanos-proxy',
               },
             ],
             args: [
-              '--secure-listen-address=[$(POD_IP)]:10902',
+              '--secure-listen-address=[$(POD_IP)]:10903',
               '--upstream=http://127.0.0.1:10902',
               '--tls-cert-file=/etc/tls/private/tls.crt',
               '--tls-private-key-file=/etc/tls/private/tls.key',


### PR DESCRIPTION
…ber to avoid duplicate

The port name stays the same so this is not breaking.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
