### PR TITLE
OCPBUGS-21610: Change config to allow ipv6/4

### DIFF
--- a/assets/monitoring-plugin/config-map.yaml
+++ b/assets/monitoring-plugin/config-map.yaml
@@ -8,8 +8,7 @@ data:
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              9443 ssl;
-        listen              [::]:9443 ssl;
+        listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /usr/share/nginx/html;

--- a/assets/monitoring-plugin/deployment.yaml
+++ b/assets/monitoring-plugin/deployment.yaml
@@ -44,7 +44,23 @@ spec:
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
-      - image: quay.io/openshift/origin-monitoring-plugin:1.0.0
+      - command:
+        - /bin/sh
+        - -c
+        - |
+          if echo "$POD_IP" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+            LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="9943"
+          else
+            LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:9443"
+          fi
+          sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
+          exec nginx -c /tmp/nginx.conf -g 'daemon off;'
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/openshift/origin-monitoring-plugin:1.0.0
         imagePullPolicy: IfNotPresent
         name: monitoring-plugin
         ports:


### PR DESCRIPTION
This commit uses the Kube Downward API to get the plugin's pod
status.podIP and bash to set it and run nginx accordingly. This is also
set in the jsonnet so it gets generated, even though it's some kind of
double templating.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
