### PR TITLE
MON-3511: hack/local-cmo.sh: pass desired version in cmo run command

### DIFF
--- a/hack/local-cmo.sh
+++ b/hack/local-cmo.sh
@@ -201,6 +201,9 @@ main() {
 	local operator_config=manifests/0000_50_cluster-monitoring-operator_04-config.yaml
 	local telemetry_conf=/tmp/telemetry-config.yaml
 
+	local desired_version
+	desired_version=$(kubectl get clusterversion version -o jsonpath='{ .status.desired.version }')
+
 	gojsontoyaml -yamltojson <$operator_config |
 		jq -r '.data["metrics.yaml"]' >$telemetry_conf
 
@@ -218,6 +221,7 @@ main() {
 
 	run go run ./cmd/operator/... "${images[@]}" \
 		-assets assets/ \
+		-release-version="$desired_version" \
 		-telemetry-config $telemetry_conf \
 		-kubeconfig="$kubeconfig" \
 		-namespace=openshift-monitoring \


### PR DESCRIPTION
After FeatureGate is introduced in #2151, local run doesn't correctly since it cannot get the desired version. This commit pass release-version in cmo run

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
