### PR TITLE
Update cluster:kube_persistentvolume_plugin_type_counts:sum

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -210,7 +210,7 @@ spec:
       record: node_role_os_version_machine:cpu_capacity_sockets:sum
     - expr: max(alertmanager_integrations{namespace="openshift-monitoring"})
       record: cluster:alertmanager_integrations:max
-    - expr: sum by(plugin_name, volume_mode)(pv_collector_total_pv_count)
+    - expr: sum by(plugin_name, volume_mode)(pv_collector_total_pv_count{volume_plugin!~".*-e2e-.*"})
       record: cluster:kube_persistentvolume_plugin_type_counts:sum
     - expr: |
         sum(

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -323,7 +323,7 @@ function(params) {
           record: 'cluster:alertmanager_integrations:max',
         },
         {
-          expr: 'sum by(plugin_name, volume_mode)(pv_collector_total_pv_count)',
+          expr: 'sum by(plugin_name, volume_mode)(pv_collector_total_pv_count{volume_plugin!~".*-e2e-.*"})',
           record: 'cluster:kube_persistentvolume_plugin_type_counts:sum',
         },
         {


### PR DESCRIPTION
This commit excludes plugin_name label values containing "e2e" which come from the end-to-end testing of the CSI drivers.

This is similar to what has been done in
https://github.com/openshift/cluster-monitoring-operator/pull/2155.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
