### PR TITLE
OCPBUGS-21610: revert #2166

### DIFF
--- a/assets/monitoring-plugin/config-map.yaml
+++ b/assets/monitoring-plugin/config-map.yaml
@@ -8,7 +8,8 @@ data:
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
+        listen              9443 ssl;
+        listen              [::]:9443 ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /usr/share/nginx/html;

--- a/assets/monitoring-plugin/deployment.yaml
+++ b/assets/monitoring-plugin/deployment.yaml
@@ -44,23 +44,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /bin/sh
-        - -c
-        - |
-          if echo "$POD_IP" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
-            LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="9943"
-          else
-            LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:9443"
-          fi
-          sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
-          exec nginx -c /tmp/nginx.conf -g 'daemon off;'
-        env:
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay.io/openshift/origin-monitoring-plugin:1.0.0
+      - image: quay.io/openshift/origin-monitoring-plugin:1.0.0
         imagePullPolicy: IfNotPresent
         name: monitoring-plugin
         ports:

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -22,7 +22,8 @@ function(params)
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
+        listen              %(nginxPort)d ssl;
+        listen              [::]:%(nginxPort)d ssl;
         ssl_certificate     %(tlsPath)s/tls.crt;
         ssl_certificate_key %(tlsPath)s/tls.key;
         root                /usr/share/nginx/html;
@@ -211,29 +212,8 @@ function(params)
                   $.volumeMount(tlsVolumeName, tlsMountPath),
                   $.volumeMount(nginxCMVolName, nginxConfMountPath, 'nginx.conf'),
                 ],
-                env: [
-                  {
-                    name: 'POD_IP',
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: 'status.podIP',
-                      },
-                    },
-                  },
-                ],
-                command: [
-                  '/bin/sh',
-                  '-c',
-                  |||
-                    if echo "$POD_IP" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
-                      LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="9943"
-                    else
-                      LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:9443"
-                    fi
-                    sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
-                    exec nginx -c /tmp/nginx.conf -g 'daemon off;'
-                  |||,
-                ],
+
+
               },  // monitoring-plugin container
             ],  // containers
 


### PR DESCRIPTION
This reverts commit 0ee89229f1e2488b5f494ed821cc4ac597bfa9fa.
as it's creating issues with the monitoring UI.

 ------------------------ >8 ------------------------
> Do not modify or remove the line above.
> Everything below it will be ignored.
## Revert "OCPBUGS-21610: Change config to allow ipv6/4"

This reverts commit 0ee89229f1e2488b5f494ed821cc4ac597bfa9fa.
as it's creating issues with the monitoring UI.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>