### PR TITLE
OCPBUGS-21610: Detect ipv4/ipv6 socket in pod ip for nginx conf

### DIFF
--- a/assets/monitoring-plugin/config-map.yaml
+++ b/assets/monitoring-plugin/config-map.yaml
@@ -8,8 +8,7 @@ data:
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              9443 ssl;
-        listen              [::]:9443 ssl;
+        listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /usr/share/nginx/html;

--- a/assets/monitoring-plugin/deployment.yaml
+++ b/assets/monitoring-plugin/deployment.yaml
@@ -44,7 +44,23 @@ spec:
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
-      - image: quay.io/openshift/origin-monitoring-plugin:1.0.0
+      - command:
+        - /bin/sh
+        - -c
+        - |
+          if echo "$POD_IP" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+            LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="9443"
+          else
+            LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:9443"
+          fi
+          sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
+          exec nginx -c /tmp/nginx.conf -g 'daemon off;'
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/openshift/origin-monitoring-plugin:1.0.0
         imagePullPolicy: IfNotPresent
         name: monitoring-plugin
         ports:

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -22,8 +22,7 @@ function(params)
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              %(nginxPort)d ssl;
-        listen              [::]:%(nginxPort)d ssl;
+        listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
         ssl_certificate     %(tlsPath)s/tls.crt;
         ssl_certificate_key %(tlsPath)s/tls.key;
         root                /usr/share/nginx/html;
@@ -212,8 +211,29 @@ function(params)
                   $.volumeMount(tlsVolumeName, tlsMountPath),
                   $.volumeMount(nginxCMVolName, nginxConfMountPath, 'nginx.conf'),
                 ],
-
-
+                env: [
+                  {
+                    name: 'POD_IP',
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: 'status.podIP',
+                      },
+                    },
+                  },
+                ],
+                command: [
+                  '/bin/sh',
+                  '-c',
+                  |||
+                    if echo "$POD_IP" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+                      LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="9443"
+                    else
+                      LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:9443"
+                    fi
+                    sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
+                    exec nginx -c /tmp/nginx.conf -g 'daemon off;'
+                  |||,
+                ],
               },  // monitoring-plugin container
             ],  // containers
 


### PR DESCRIPTION
This PR fixes a typo in monitoring plugin config rendering and
brings back the rendering to ngingx.conf file to detect ipv4/ipv6
socket.


* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

