### PR TITLE
OCPBUGS-24323: update prometheus-operator jsonnet to v0.70.0

### DIFF
--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -50,7 +50,7 @@ spec:
         (
           rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
         /
-          rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
         )
         > 0.01
       for: 5m
@@ -65,7 +65,7 @@ spec:
         min by (namespace,service, integration) (
           rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
         /
-          rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
         )
         > 0.01
       for: 5m

--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -274,6 +274,15 @@ spec:
       for: 15m
       labels:
         severity: warning
+    - alert: NodeBondingDegraded
+      annotations:
+        description: Bonding interface {{ $labels.master }} on {{ $labels.instance }} is in degraded state due to one or more slave failures.
+        summary: Bonding interface is degraded
+      expr: |
+        (node_bonding_slaves - node_bonding_active) != 0
+      for: 5m
+      labels:
+        severity: warning
   - name: node-exporter.rules
     rules:
     - expr: |

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
         - --web.listen-address=127.0.0.1:8080
+        env:
+        - name: GOGC
+          value: "30"
         image: quay.io/prometheus-operator/prometheus-operator:v0.69.1
         name: prometheus-operator
         ports: []

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
         - --web.listen-address=127.0.0.1:8080
+        env:
+        - name: GOGC
+          value: "30"
         image: quay.io/prometheus-operator/prometheus-operator:v0.69.1
         name: prometheus-operator
         ports: []

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "release-0.69"
+      "version": "release-0.70"
     },
     {
       "source": {

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "c0bb57a3d46dab144bd02ee27192006b2bd4f72c",
+      "version": "93ab2ef7b2b7221799b27c6f521348da744282fd",
       "sum": "xuUBd2vqF7asyVDe5CE08uPT/RxAdy8O75EjFJoMXXU="
     },
     {
@@ -58,7 +58,7 @@
           "subdir": "gen/grafonnet-v10.0.0"
         }
       },
-      "version": "9e217263ac4b922ca2e00bc5cc36ada2311bb5a6",
+      "version": "bb2afaffbcefeae1035cd691ab06a486e0022002",
       "sum": "gj/20VIGucG2vDGjG7YdHLC4yUUfrpuaneUYaRmymOM="
     },
     {
@@ -68,8 +68,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "a7647832fd3eaae70411bc9f697fa7504b04796c",
-      "sum": "aCN8uCrs2PDLR0SzRAuwZ6C5hiKt1KggCUCT7/F8yZ0="
+      "version": "931f6b1139bb3694b06f2261279ba3dc01aca5b8",
+      "sum": "VmOxvg9FuY9UYr3lN6ZJe2HhuIErJoWimPybQr3S3yQ="
     },
     {
       "source": {
@@ -109,8 +109,8 @@
           "subdir": ""
         }
       },
-      "version": "bcf8426b9c5ee85fdf8a6d9c62708f94e0367b21",
-      "sum": "1pCIS5kwa2b5JniHr3WV5wwiau29gM0fNQmqO2mXiCQ="
+      "version": "2dbe4f9625a811b8b89f0495e74509c74779da82",
+      "sum": "Fe7bN9E6qeKNUdENjQvYttgf4S1DDqXRVB80wdmQgHQ="
     },
     {
       "source": {
@@ -119,7 +119,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "4e431f6d149abbb547cefdd884274c1e9a6c5c9f",
+      "version": "98b38ba9bbfdff27b359c58adecab30cc1311a78",
       "sum": "+dOzAK+fwsFf97uZpjcjTcEJEC1H8hh/j8f5uIQK/5g="
     },
     {
@@ -129,7 +129,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "4e431f6d149abbb547cefdd884274c1e9a6c5c9f",
+      "version": "98b38ba9bbfdff27b359c58adecab30cc1311a78",
       "sum": "qclI7LwucTjBef3PkGBkKxF0mfZPbHnn4rlNWKGtR4c="
     },
     {
@@ -139,7 +139,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "899188df28b0e495026833c606e16f8fc6b239cf",
+      "version": "9b0d8ded185072100c9c2ec67ce3e21cbe205cca",
       "sum": "9/dHjMKxPKGTAPV1fMAV0RuBck0O+Xyj/FkZjlN7DMs=",
       "name": "openshift-state-metrics"
     },
@@ -150,8 +150,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "8f091e8e7ecd3052566bd9dd20eb6991abf762c5",
-      "sum": "C8wxoobehWU7ykPDhCMiCmSWTe/8jGjOJvcS+rxzp2U=",
+      "version": "e1f625aa31e46a84fb5d9f97c8224b9059e27d8a",
+      "sum": "fe88JuYCGr8pLQPuI2GxdDbrb+5U6ZwyNMQ+0fF8lgE=",
       "name": "telemeter-client"
     },
     {
@@ -161,8 +161,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "ddff48cd49b7ea6273800e2ebb62a65025608aef",
-      "sum": "AS00RR9bozYYCHHfMsa+VREZdcHGE1AlCzISj7iMeOI="
+      "version": "035b09f42441d4630b3a3de4e4a490d19b1ba5e4",
+      "sum": "bp+cUUcoQjREBPigCP2S1xIvrh7HDQeYqCcrHCuDnUQ="
     },
     {
       "source": {
@@ -171,7 +171,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "fa22f77273f034ff49f364c0cdeb33bfed2cc019",
+      "version": "88e86c5caf84dc85338c904e13b0656bf1b56a67",
       "sum": "n3flMIzlADeyygb0uipZ4KPp2uNSjdtkrwgHjTC7Ca4=",
       "name": "prometheus-operator-mixin"
     },
@@ -182,8 +182,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "941b9e98d4ae5faa952af250e23c31c56cc1190c",
-      "sum": "RlttLdc+7oWRlxrwsazL2LgvudcSsSAHvy0oqKAc+Mw="
+      "version": "88e86c5caf84dc85338c904e13b0656bf1b56a67",
+      "sum": "3tRcbCxuH5piaixkvwe4UdVVWlxkxKz8eBgbgYqvbRk="
     },
     {
       "source": {
@@ -192,8 +192,8 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "ce6efba023b0397cb522d64e910684e48d12455f",
-      "sum": "1d7ZKYArJKacAWXLUz0bRC1uOkozee/PPw97/W5zGhc=",
+      "version": "b82df1dc9b057520d6f558db5f19f8fc4d0659a4",
+      "sum": "IpF46ZXsm+0wJJAPtAre8+yxTNZA57mBqGpBP/r7/kw=",
       "name": "alertmanager"
     },
     {
@@ -203,8 +203,8 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "ed1b8e3d88851806627e4f8262ee26232ca56c2c",
-      "sum": "By6n6U10hYDogUsyhsaKZehbhzxBZZobJloiKyKadgM="
+      "version": "332232c22cd6934d7941a905f271407ffa07101f",
+      "sum": "QZwFBpulndqo799gkR5rP2/WdcQKQkNnaBwhaOI8Jeg="
     },
     {
       "source": {
@@ -213,7 +213,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "e250f09b5d34d6c936b18f3b7699df23a0555092",
+      "version": "e4ec263bcc11493953c75d1b2e7bc78fd0463e05",
       "sum": "rNvddVTMNfaguOGzEGoeKjUsfhlXJBUImC+SIFNNCiM=",
       "name": "prometheus"
     },
@@ -245,7 +245,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "c74a050a190486addc1ea1ca4b522462fc7ec680",
+      "version": "2de1266eb100974a808de70c0eedfa5c5af975b7",
       "sum": "HhSSbGGCNHCMy1ee5jElYDm0yS9Vesa7QB2/SHKdjsY="
     }
   ],

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -2,13 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.69.1
+    operator.prometheus.io/version: 0.70.0
     service.beta.openshift.io/inject-cabundle: "true"
-  creationTimestamp: null
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -215,6 +214,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           httpConfig:
                             description: HTTP client configuration.
                             properties:
@@ -245,7 +245,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -261,7 +261,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -292,6 +292,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -299,7 +300,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -335,7 +336,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -353,15 +354,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -507,6 +508,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           authSecret:
                             description: The secret's key that contains the CRAM-MD5 secret. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                             properties:
@@ -522,6 +524,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           authUsername:
                             description: The username to use for authentication.
                             type: string
@@ -701,7 +704,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -717,7 +720,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -748,6 +751,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -755,7 +759,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -791,7 +795,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -809,15 +813,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -951,6 +955,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                         required:
                         - webhookUrl
                         type: object
@@ -982,6 +987,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           apiURL:
                             description: The URL to send OpsGenie API requests to.
                             type: string
@@ -1038,7 +1044,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1054,7 +1060,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1085,6 +1091,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -1092,7 +1099,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -1128,7 +1135,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1146,15 +1153,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -1385,7 +1392,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1401,7 +1408,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1432,6 +1439,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -1439,7 +1447,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -1475,7 +1483,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1493,15 +1501,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -1655,6 +1663,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           sendResolved:
                             description: Whether or not to notify about resolved alerts.
                             type: boolean
@@ -1673,6 +1682,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           severity:
                             description: Severity of the incident.
                             type: string
@@ -1686,6 +1696,9 @@ spec:
                       items:
                         description: PushoverConfig configures notifications via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                         properties:
+                          device:
+                            description: The name of a device to send the notification to
+                            type: string
                           expire:
                             description: How long your notification will continue to be retried for, unless the user acknowledges the notification.
                             pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
@@ -1723,7 +1736,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1739,7 +1752,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1770,6 +1783,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -1777,7 +1791,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -1813,7 +1827,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -1831,15 +1845,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -1983,6 +1997,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           tokenFile:
                             description: The token file that contains the registered application's API token, see https://pushover.net/apps. Either `token` or `tokenFile` is required. It requires Alertmanager >= v0.26.0.
                             type: string
@@ -2007,6 +2022,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           userKeyFile:
                             description: The user key file that contains the recipient user's user key. Either `userKey` or `userKeyFile` is required. It requires Alertmanager >= v0.26.0.
                             type: string
@@ -2071,6 +2087,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           callbackId:
                             type: string
                           channel:
@@ -2130,7 +2147,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2146,7 +2163,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2177,6 +2194,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -2184,7 +2202,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -2220,7 +2238,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2238,15 +2256,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -2430,7 +2448,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2446,7 +2464,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2477,6 +2495,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -2484,7 +2503,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -2520,7 +2539,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2538,15 +2557,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -2744,6 +2763,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           botTokenFile:
                             description: "File to read the Telegram bot token from. It is mutually exclusive with `botToken`. Either `botToken` or `botTokenFile` is required. \n It requires Alertmanager >= v0.26.0."
                             type: string
@@ -2784,7 +2804,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2800,7 +2820,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2831,6 +2851,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -2838,7 +2859,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -2874,7 +2895,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -2892,15 +2913,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -3045,6 +3066,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           apiUrl:
                             description: The VictorOps API URL.
                             type: string
@@ -3098,7 +3120,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3114,7 +3136,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3145,6 +3167,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -3152,7 +3175,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -3188,7 +3211,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3206,15 +3229,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -3380,7 +3403,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3396,7 +3419,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3427,6 +3450,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -3434,7 +3458,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -3470,7 +3494,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3488,15 +3512,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -3655,7 +3679,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3671,7 +3695,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3702,6 +3726,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -3709,7 +3734,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -3745,7 +3770,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3763,15 +3788,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -3907,6 +3932,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       type: array
                     wechatConfigs:
@@ -3931,6 +3957,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           apiURL:
                             description: The WeChat API URL.
                             type: string
@@ -3967,7 +3994,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -3983,7 +4010,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -4014,6 +4041,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
                                 type: boolean
@@ -4021,7 +4049,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -4057,7 +4085,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -4075,15 +4103,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -4417,7 +4445,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -4433,7 +4461,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -4471,7 +4499,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -4507,7 +4535,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -4525,15 +4553,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -4871,7 +4899,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -4887,7 +4915,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -4925,7 +4953,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -4961,7 +4989,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -4979,15 +5007,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -5209,7 +5237,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5225,7 +5253,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5263,7 +5291,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -5299,7 +5327,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5317,15 +5345,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -5553,7 +5581,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5569,7 +5597,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5607,7 +5635,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -5643,7 +5671,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5661,15 +5689,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -5854,6 +5882,9 @@ spec:
                       items:
                         description: PushoverConfig configures notifications via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                         properties:
+                          device:
+                            description: The name of a device to send the notification to
+                            type: string
                           expire:
                             description: How long your notification will continue to be retried for, unless the user acknowledges the notification.
                             pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
@@ -5891,7 +5922,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5907,7 +5938,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5945,7 +5976,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -5981,7 +6012,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -5999,15 +6030,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -6298,7 +6329,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -6314,7 +6345,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -6352,7 +6383,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -6388,7 +6419,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -6406,15 +6437,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -6598,7 +6629,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -6614,7 +6645,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -6652,7 +6683,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -6688,7 +6719,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -6706,15 +6737,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -6952,7 +6983,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -6968,7 +6999,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7006,7 +7037,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -7042,7 +7073,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7060,15 +7091,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -7266,7 +7297,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7282,7 +7313,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7320,7 +7351,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -7356,7 +7387,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7374,15 +7405,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -7548,7 +7579,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7564,7 +7595,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7602,7 +7633,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -7638,7 +7669,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7656,15 +7687,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -7823,7 +7854,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7839,7 +7870,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7877,7 +7908,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -7913,7 +7944,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -7931,15 +7962,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -8135,7 +8166,7 @@ spec:
                                 description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -8151,7 +8182,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -8189,7 +8220,7 @@ spec:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing the OAuth2 client id
+                                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to use for the targets.
@@ -8225,7 +8256,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2 client secret
+                                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -8243,15 +8274,15 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token URL
+                                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token request
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -2,12 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.69.1
-  creationTimestamp: null
+    operator.prometheus.io/version: 0.70.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -654,7 +653,7 @@ spec:
                             description: BasicAuth for the client. This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
                             properties:
                               password:
-                                description: The secret in the service monitor namespace that contains the password for authentication.
+                                description: '`password` specifies a key of a Secret containing the password for authentication.'
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must be a valid secret key.
@@ -670,7 +669,7 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               username:
-                                description: The secret in the service monitor namespace that contains the username for authentication.
+                                description: '`username` specifies a key of a Secret containing the username for authentication.'
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must be a valid secret key.
@@ -709,7 +708,7 @@ spec:
                             description: OAuth2 client credentials used to fetch a token for the targets.
                             properties:
                               clientId:
-                                description: The secret or configmap containing the OAuth2 client id
+                                description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                                 properties:
                                   configMap:
                                     description: ConfigMap containing data to use for the targets.
@@ -745,7 +744,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               clientSecret:
-                                description: The secret containing the OAuth2 client secret
+                                description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must be a valid secret key.
@@ -763,15 +762,15 @@ spec:
                               endpointParams:
                                 additionalProperties:
                                   type: string
-                                description: Parameters to append to the token URL
+                                description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                                 type: object
                               scopes:
-                                description: OAuth2 scopes used for the token request
+                                description: '`scopes` defines the OAuth2 scopes used for the token request.'
                                 items:
                                   type: string
                                 type: array
                               tokenUrl:
-                                description: The URL to fetch the token from
+                                description: '`tokenURL` configures the URL to fetch the token from.'
                                 minLength: 1
                                 type: string
                             required:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -2,12 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.69.1
-  creationTimestamp: null
+    operator.prometheus.io/version: 0.70.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -42,33 +41,33 @@ spec:
             description: Specification of desired Pod selection for target discovery by Prometheus.
             properties:
               attachMetadata:
-                description: Attaches node metadata to discovered targets. Requires Prometheus v2.35.0 and above.
+                description: "`attachMetadata` defines additional metadata which is added to the discovered targets. \n It requires Prometheus >= v2.37.0."
                 properties:
                   node:
-                    description: When set to true, Prometheus must have permissions to get Nodes.
+                    description: When set to true, Prometheus must have the `get` permission on the `Nodes` objects.
                     type: boolean
                 type: object
               jobLabel:
-                description: The label to use to retrieve the job name from.
+                description: "The label to use to retrieve the job name from. `jobLabel` selects the label from the associated Kubernetes `Pod` object which will be used as the `job` label for all metrics. \n For example if `jobLabel` is set to `foo` and the Kubernetes `Pod` object is labeled with `foo: bar`, then Prometheus adds the `job=\"bar\"` label to all ingested metrics. \n If the value of this field is empty, the `job` label of the metrics defaults to the namespace and name of the PodMonitor object (e.g. `<namespace>/<name>`)."
                 type: string
               keepDroppedTargets:
                 description: "Per-scrape limit on the number of targets dropped by relabeling that will be kept in memory. 0 means no limit. \n It requires Prometheus >= v2.47.0."
                 format: int64
                 type: integer
               labelLimit:
-                description: Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: "Per-scrape limit on number of labels that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               labelNameLengthLimit:
-                description: Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: "Per-scrape limit on length of labels name that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               labelValueLengthLimit:
-                description: Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: "Per-scrape limit on length of labels value that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               namespaceSelector:
-                description: Selector to select which namespaces the Endpoints objects are discovered from.
+                description: Selector to select which namespaces the Kubernetes `Pods` objects are discovered from.
                 properties:
                   any:
                     description: Boolean describing whether all namespaces are selected in contrast to a list restricting them.
@@ -80,12 +79,12 @@ spec:
                     type: array
                 type: object
               podMetricsEndpoints:
-                description: A list of endpoints allowed as part of this PodMonitor.
+                description: List of endpoints part of this PodMonitor.
                 items:
-                  description: PodMetricsEndpoint defines a scrapeable endpoint of a Kubernetes Pod serving Prometheus metrics.
+                  description: PodMetricsEndpoint defines an endpoint serving Prometheus metrics to be scraped by Prometheus.
                   properties:
                     authorization:
-                      description: Authorization section for this endpoint
+                      description: "`authorization` configures the Authorization header credentials to use when scraping the target. \n Cannot be set at the same time as `basicAuth`, or `oauth2`."
                       properties:
                         credentials:
                           description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
@@ -108,10 +107,10 @@ spec:
                           type: string
                       type: object
                     basicAuth:
-                      description: 'BasicAuth allow an endpoint to authenticate over basic authentication. More info: https://prometheus.io/docs/operating/configuration/#endpoint'
+                      description: "`basicAuth` configures the Basic Authentication credentials to use when scraping the target. \n Cannot be set at the same time as `authorization`, or `oauth2`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -127,7 +126,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -144,7 +143,7 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenSecret:
-                      description: Secret to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the pod monitor and accessible by the Prometheus Operator.
+                      description: "`bearerTokenSecret` specifies a key of a Secret containing the bearer token for scraping targets. The secret needs to be in the same namespace as the PodMonitor object and readable by the Prometheus Operator. \n Deprecated: use `authorization` instead."
                       properties:
                         key:
                           description: The key of the secret to select from.  Must be a valid secret key.
@@ -160,26 +159,26 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: Whether to enable HTTP2.
+                      description: '`enableHttp2` can be used to disable HTTP2 when scraping the target.'
                       type: boolean
                     filterRunning:
-                      description: 'Drop pods that are not running. (Failed, Succeeded). Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                      description: "When true, the pods which are not running (e.g. either in Failed or Succeeded state) are dropped during the target discovery. \n If unset, the filtering is enabled. \n More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase"
                       type: boolean
                     followRedirects:
-                      description: FollowRedirects configures whether scrape requests follow HTTP 3xx redirects.
+                      description: '`followRedirects` defines whether the scrape requests should follow HTTP 3xx redirects.'
                       type: boolean
                     honorLabels:
-                      description: HonorLabels chooses the metric's labels on collisions with target labels.
+                      description: When true, `honorLabels` preserves the metric's labels when they collide with the target's labels.
                       type: boolean
                     honorTimestamps:
-                      description: HonorTimestamps controls whether Prometheus respects the timestamps present in scraped data.
+                      description: '`honorTimestamps` controls whether Prometheus preserves the timestamps when exposed by the target.'
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped If not specified Prometheus' global scrape interval is used.
+                      description: "Interval at which Prometheus scrapes the metrics from the target. \n If empty, Prometheus uses the global scrape interval."
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
-                      description: MetricRelabelConfigs to apply to samples before ingestion.
+                      description: '`metricRelabelings` configures the relabeling rules to apply to the samples before ingestion.'
                       items:
                         description: "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                         properties:
@@ -236,10 +235,10 @@ spec:
                         type: object
                       type: array
                     oauth2:
-                      description: OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.
+                      description: "`oauth2` configures the OAuth2 settings to use when scraping the target. \n It requires Prometheus >= 2.27.0. \n Cannot be set at the same time as `authorization`, or `basicAuth`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2 client id
+                          description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the targets.
@@ -275,7 +274,7 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -293,15 +292,15 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the token from.'
                           minLength: 1
                           type: string
                       required:
@@ -314,19 +313,19 @@ spec:
                         items:
                           type: string
                         type: array
-                      description: Optional HTTP URL parameters
+                      description: '`params` define optional HTTP URL parameters.'
                       type: object
                     path:
-                      description: HTTP path to scrape for metrics. If empty, Prometheus uses the default value (e.g. `/metrics`).
+                      description: "HTTP path from which to scrape for metrics. \n If empty, Prometheus uses the default value (e.g. `/metrics`)."
                       type: string
                     port:
-                      description: Name of the pod port this endpoint refers to. Mutually exclusive with targetPort.
+                      description: "Name of the Pod port which this endpoint refers to. \n It takes precedence over `targetPort`."
                       type: string
                     proxyUrl:
-                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.
+                      description: '`proxyURL` configures the HTTP Proxy URL (e.g. "http://proxyserver:2195") to go through when scraping the target.'
                       type: string
                     relabelings:
-                      description: 'RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job''s name is available via the `__tmp_prometheus_job_name` label. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                      description: "`relabelings` configures the relabeling rules to apply the target's metadata labels. \n The Operator automatically adds relabelings for a few standard Kubernetes fields. \n The original scrape job's name is available via the `__tmp_prometheus_job_name` label. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                       items:
                         description: "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                         properties:
@@ -383,23 +382,23 @@ spec:
                         type: object
                       type: array
                     scheme:
-                      description: HTTP scheme to use for scraping. `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling. If empty, Prometheus uses the default value `http`.
+                      description: "HTTP scheme to use for scraping. \n `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling. \n If empty, Prometheus uses the default value `http`."
                       enum:
                       - http
                       - https
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended If not specified, the Prometheus global scrape interval is used.
+                      description: "Timeout after which Prometheus considers the scrape to be failed. \n If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used."
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: 'Deprecated: Use ''port'' instead.'
+                      description: "Name or number of the target port of the `Pod` object behind the Service, the port must be specified with container port property. \n Deprecated: use 'port' instead."
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the endpoint.
+                      description: TLS configuration to use when scraping the target.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server certificates.
@@ -496,19 +495,22 @@ spec:
                           description: Used to verify the hostname for the targets.
                           type: string
                       type: object
+                    trackTimestampsStaleness:
+                      description: "`trackTimestampsStaleness` defines whether Prometheus tracks staleness of the metrics that have an explicit timestamp present in scraped data. Has no effect if `honorTimestamps` is false. \n It requires Prometheus >= v2.48.0."
+                      type: boolean
                   type: object
                 type: array
               podTargetLabels:
-                description: PodTargetLabels transfers labels on the Kubernetes Pod onto the target.
+                description: '`podTargetLabels` defines the labels which are transferred from the associated Kubernetes `Pod` object onto the ingested metrics.'
                 items:
                   type: string
                 type: array
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+                description: '`sampleLimit` defines a per-scrape limit on the number of scraped samples that will be accepted.'
                 format: int64
                 type: integer
               selector:
-                description: Selector to select Pod objects.
+                description: Label selector to select the Kubernetes `Pod` objects.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -539,11 +541,10 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped targets that will be accepted.
+                description: '`targetLimit` defines a limit on the number of scraped targets that will be accepted.'
                 format: int64
                 type: integer
             required:
-            - podMetricsEndpoints
             - selector
             type: object
         required:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -2,12 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.69.1
-  creationTimestamp: null
+    operator.prometheus.io/version: 0.70.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -68,7 +67,7 @@ spec:
                 description: 'BasicAuth allow an endpoint to authenticate over basic authentication. More info: https://prometheus.io/docs/operating/configuration/#endpoint'
                 properties:
                   password:
-                    description: The secret in the service monitor namespace that contains the password for authentication.
+                    description: '`password` specifies a key of a Secret containing the password for authentication.'
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -84,7 +83,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   username:
-                    description: The secret in the service monitor namespace that contains the username for authentication.
+                    description: '`username` specifies a key of a Secret containing the username for authentication.'
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -203,7 +202,7 @@ spec:
                 description: OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.
                 properties:
                   clientId:
-                    description: The secret or configmap containing the OAuth2 client id
+                    description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                     properties:
                       configMap:
                         description: ConfigMap containing data to use for the targets.
@@ -239,7 +238,7 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   clientSecret:
-                    description: The secret containing the OAuth2 client secret
+                    description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be a valid secret key.
@@ -257,15 +256,15 @@ spec:
                   endpointParams:
                     additionalProperties:
                       type: string
-                    description: Parameters to append to the token URL
+                    description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                     type: object
                   scopes:
-                    description: OAuth2 scopes used for the token request
+                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
                     items:
                       type: string
                     type: array
                   tokenUrl:
-                    description: The URL to fetch the token from
+                    description: '`tokenURL` configures the URL to fetch the token from.'
                     minLength: 1
                     type: string
                 required:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -2,12 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.69.1
-  creationTimestamp: null
+    operator.prometheus.io/version: 0.70.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -642,7 +641,7 @@ spec:
                           description: "BasicAuth configuration for Alertmanager. \n Cannot be set at the same time as `bearerTokenFile`, `authorization` or `sigv4`."
                           properties:
                             password:
-                              description: The secret in the service monitor namespace that contains the password for authentication.
+                              description: '`password` specifies a key of a Secret containing the password for authentication.'
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -658,7 +657,7 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             username:
-                              description: The secret in the service monitor namespace that contains the username for authentication.
+                              description: '`username` specifies a key of a Secret containing the username for authentication.'
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -899,7 +898,7 @@ spec:
                     description: "BasicAuth configuration for the API server. \n Cannot be set at the same time as `authorization`, `bearerToken`, or `bearerTokenFile`."
                     properties:
                       password:
-                        description: The secret in the service monitor namespace that contains the password for authentication.
+                        description: '`password` specifies a key of a Secret containing the password for authentication.'
                         properties:
                           key:
                             description: The key of the secret to select from.  Must be a valid secret key.
@@ -915,7 +914,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       username:
-                        description: The secret in the service monitor namespace that contains the username for authentication.
+                        description: '`username` specifies a key of a Secret containing the username for authentication.'
                         properties:
                           key:
                             description: The key of the secret to select from.  Must be a valid secret key.
@@ -2910,6 +2909,16 @@ spec:
               paused:
                 description: When a Prometheus deployment is paused, no actions except for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet. The default behavior is all PVCs are retained. This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted. The default policy of `Retain` causes PVCs to not be affected by StatefulSet deletion. The `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down. The default policy of `Retain` causes PVCs to not be affected by a scaledown. The `Delete` policy causes the associated PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: "PodMetadata configures labels and annotations which are propagated to the Prometheus pods. \n The following items are reserved and cannot be overridden: * \"prometheus\" label, set to the name of the Prometheus object. * \"app.kubernetes.io/instance\" label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\" label, set to \"prometheus\". * \"app.kubernetes.io/version\" label, set to the Prometheus version. * \"operator.prometheus.io/name\" label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\" label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\" annotation, set to \"prometheus\"."
                 properties:
@@ -3105,6 +3114,12 @@ spec:
               queryLogFile:
                 description: "queryLogFile specifies where the file to which PromQL queries are logged. \n If the filename has an empty path, e.g. 'query.log', The Prometheus Pods will mount the file into an emptyDir volume at `/var/log/prometheus`. If a full path is provided, e.g. '/var/log/prometheus/query.log', you must mount a volume in the specified directory and it must be writable. This is because the prometheus container runs with a read-only root filesystem for security reasons. Alternatively, the location can be set to a standard I/O stream, e.g. `/dev/stdout`, to log query information to the default Prometheus log stream."
                 type: string
+              reloadStrategy:
+                description: Defines the strategy used to reload the Prometheus configuration. If not specified, the configuration is reloaded using the /-/reload HTTP endpoint.
+                enum:
+                - HTTP
+                - ProcessSignal
+                type: string
               remoteRead:
                 description: Defines the list of remote read configurations.
                 items:
@@ -3140,7 +3155,7 @@ spec:
                       description: "BasicAuth configuration for the URL. \n Cannot be set at the same time as `authorization`, or `oauth2`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -3156,7 +3171,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -3196,7 +3211,7 @@ spec:
                       description: "OAuth2 configuration for the URL. \n It requires Prometheus >= v2.27.0. \n Cannot be set at the same time as `authorization`, or `basicAuth`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2 client id
+                          description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the targets.
@@ -3232,7 +3247,7 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -3250,15 +3265,15 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the token from.'
                           minLength: 1
                           type: string
                       required:
@@ -3437,7 +3452,7 @@ spec:
                           - AzurePublic
                           type: string
                         managedIdentity:
-                          description: ManagedIdentity defines the Azure User-assigned Managed identity.
+                          description: ManagedIdentity defines the Azure User-assigned Managed identity. Cannot be set at the same time as `oauth`.
                           properties:
                             clientId:
                               description: The client id
@@ -3445,14 +3460,45 @@ spec:
                           required:
                           - clientId
                           type: object
-                      required:
-                      - managedIdentity
+                        oauth:
+                          description: "OAuth defines the oauth config that is being used to authenticate. Cannot be set at the same time as `managedIdentity`. \n It requires Prometheus >= v2.48.0."
+                          properties:
+                            clientId:
+                              description: '`clientID` is the clientId of the Azure Active Directory application that is being used to authenticate.'
+                              minLength: 1
+                              type: string
+                            clientSecret:
+                              description: '`clientSecret` specifies a key of a Secret containing the client secret of the Azure Active Directory application that is being used to authenticate.'
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            tenantId:
+                              description: '`tenantID` is the tenant ID of the Azure Active Directory application that is being used to authenticate.'
+                              minLength: 1
+                              pattern: ^[0-9a-zA-Z-.]+$
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecret
+                          - tenantId
+                          type: object
                       type: object
                     basicAuth:
                       description: "BasicAuth configuration for the URL. \n Cannot be set at the same time as `sigv4`, `authorization`, `oauth2`, or `azureAd`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -3468,7 +3514,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -3513,7 +3559,7 @@ spec:
                       description: "OAuth2 configuration for the URL. \n It requires Prometheus >= v2.27.0. \n Cannot be set at the same time as `sigv4`, `authorization`, `basicAuth`, or `azureAd`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2 client id
+                          description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the targets.
@@ -3549,7 +3595,7 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -3567,15 +3613,15 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the token from.'
                           minLength: 1
                           type: string
                       required:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -2,12 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.69.1
-  creationTimestamp: null
+    operator.prometheus.io/version: 0.70.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -2,12 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.69.1
-  creationTimestamp: null
+    operator.prometheus.io/version: 0.70.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -42,19 +41,19 @@ spec:
             description: Specification of desired Service selection for target discovery by Prometheus.
             properties:
               attachMetadata:
-                description: Attaches node metadata to discovered targets. Requires Prometheus v2.37.0 and above.
+                description: "`attachMetadata` defines additional metadata which is added to the discovered targets. \n It requires Prometheus >= v2.37.0."
                 properties:
                   node:
-                    description: When set to true, Prometheus must have permissions to get Nodes.
+                    description: When set to true, Prometheus must have the `get` permission on the `Nodes` objects.
                     type: boolean
                 type: object
               endpoints:
-                description: A list of endpoints allowed as part of this ServiceMonitor.
+                description: List of endpoints part of this ServiceMonitor.
                 items:
-                  description: Endpoint defines a scrapeable endpoint serving Prometheus metrics.
+                  description: Endpoint defines an endpoint serving Prometheus metrics to be scraped by Prometheus.
                   properties:
                     authorization:
-                      description: Authorization section for this endpoint
+                      description: "`authorization` configures the Authorization header credentials to use when scraping the target. \n Cannot be set at the same time as `basicAuth`, or `oauth2`."
                       properties:
                         credentials:
                           description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
@@ -77,10 +76,10 @@ spec:
                           type: string
                       type: object
                     basicAuth:
-                      description: 'BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                      description: "`basicAuth` configures the Basic Authentication credentials to use when scraping the target. \n Cannot be set at the same time as `authorization`, or `oauth2`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -96,7 +95,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -113,10 +112,10 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenFile:
-                      description: File to read bearer token for scraping targets.
+                      description: "File to read bearer token for scraping the target. \n Deprecated: use `authorization` instead."
                       type: string
                     bearerTokenSecret:
-                      description: Secret to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the service monitor and accessible by the Prometheus Operator.
+                      description: "`bearerTokenSecret` specifies a key of a Secret containing the bearer token for scraping targets. The secret needs to be in the same namespace as the ServiceMonitor object and readable by the Prometheus Operator. \n Deprecated: use `authorization` instead."
                       properties:
                         key:
                           description: The key of the secret to select from.  Must be a valid secret key.
@@ -132,26 +131,26 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: Whether to enable HTTP2.
+                      description: '`enableHttp2` can be used to disable HTTP2 when scraping the target.'
                       type: boolean
                     filterRunning:
-                      description: 'Drop pods that are not running. (Failed, Succeeded). Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                      description: "When true, the pods which are not running (e.g. either in Failed or Succeeded state) are dropped during the target discovery. \n If unset, the filtering is enabled. \n More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase"
                       type: boolean
                     followRedirects:
-                      description: FollowRedirects configures whether scrape requests follow HTTP 3xx redirects.
+                      description: '`followRedirects` defines whether the scrape requests should follow HTTP 3xx redirects.'
                       type: boolean
                     honorLabels:
-                      description: HonorLabels chooses the metric's labels on collisions with target labels.
+                      description: When true, `honorLabels` preserves the metric's labels when they collide with the target's labels.
                       type: boolean
                     honorTimestamps:
-                      description: HonorTimestamps controls whether Prometheus respects the timestamps present in scraped data.
+                      description: '`honorTimestamps` controls whether Prometheus preserves the timestamps when exposed by the target.'
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped If not specified Prometheus' global scrape interval is used.
+                      description: "Interval at which Prometheus scrapes the metrics from the target. \n If empty, Prometheus uses the global scrape interval."
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
-                      description: MetricRelabelConfigs to apply to samples before ingestion.
+                      description: '`metricRelabelings` configures the relabeling rules to apply to the samples before ingestion.'
                       items:
                         description: "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                         properties:
@@ -208,10 +207,10 @@ spec:
                         type: object
                       type: array
                     oauth2:
-                      description: OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.
+                      description: "`oauth2` configures the OAuth2 settings to use when scraping the target. \n It requires Prometheus >= 2.27.0. \n Cannot be set at the same time as `authorization`, or `basicAuth`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2 client id
+                          description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the targets.
@@ -247,7 +246,7 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must be a valid secret key.
@@ -265,15 +264,15 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the token from.'
                           minLength: 1
                           type: string
                       required:
@@ -286,19 +285,19 @@ spec:
                         items:
                           type: string
                         type: array
-                      description: Optional HTTP URL parameters
+                      description: params define optional HTTP URL parameters.
                       type: object
                     path:
-                      description: HTTP path to scrape for metrics. If empty, Prometheus uses the default value (e.g. `/metrics`).
+                      description: "HTTP path from which to scrape for metrics. \n If empty, Prometheus uses the default value (e.g. `/metrics`)."
                       type: string
                     port:
-                      description: Name of the service port this endpoint refers to. Mutually exclusive with targetPort.
+                      description: "Name of the Service port which this endpoint refers to. \n It takes precedence over `targetPort`."
                       type: string
                     proxyUrl:
-                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.
+                      description: '`proxyURL` configures the HTTP Proxy URL (e.g. "http://proxyserver:2195") to go through when scraping the target.'
                       type: string
                     relabelings:
-                      description: 'RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job''s name is available via the `__tmp_prometheus_job_name` label. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                      description: "`relabelings` configures the relabeling rules to apply the target's metadata labels. \n The Operator automatically adds relabelings for a few standard Kubernetes fields. \n The original scrape job's name is available via the `__tmp_prometheus_job_name` label. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                       items:
                         description: "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                         properties:
@@ -355,23 +354,23 @@ spec:
                         type: object
                       type: array
                     scheme:
-                      description: HTTP scheme to use for scraping. `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling. If empty, Prometheus uses the default value `http`.
+                      description: "HTTP scheme to use for scraping. \n `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling. \n If empty, Prometheus uses the default value `http`."
                       enum:
                       - http
                       - https
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended If not specified, the Prometheus global scrape timeout is used unless it is less than `Interval` in which the latter is used.
+                      description: "Timeout after which Prometheus considers the scrape to be failed. \n If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used."
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the target port of the Pod behind the Service, the port must be specified with container port property. Mutually exclusive with port.
+                      description: "Name or number of the target port of the `Pod` object behind the Service, the port must be specified with container port property. \n Deprecated: use `port` instead."
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the endpoint
+                      description: TLS configuration to use when scraping the target.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server certificates.
@@ -477,29 +476,32 @@ spec:
                           description: Used to verify the hostname for the targets.
                           type: string
                       type: object
+                    trackTimestampsStaleness:
+                      description: "`trackTimestampsStaleness` defines whether Prometheus tracks staleness of the metrics that have an explicit timestamp present in scraped data. Has no effect if `honorTimestamps` is false. \n It requires Prometheus >= v2.48.0."
+                      type: boolean
                   type: object
                 type: array
               jobLabel:
-                description: "JobLabel selects the label from the associated Kubernetes service which will be used as the `job` label for all metrics. \n For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo: bar`, then the `job=\"bar\"` label is added to all metrics. \n If the value of this field is empty or if the label doesn't exist for the given Service, the `job` label of the metrics defaults to the name of the Kubernetes Service."
+                description: "`jobLabel` selects the label from the associated Kubernetes `Service` object which will be used as the `job` label for all metrics. \n For example if `jobLabel` is set to `foo` and the Kubernetes `Service` object is labeled with `foo: bar`, then Prometheus adds the `job=\"bar\"` label to all ingested metrics. \n If the value of this field is empty or if the label doesn't exist for the given Service, the `job` label of the metrics defaults to the name of the associated Kubernetes `Service`."
                 type: string
               keepDroppedTargets:
                 description: "Per-scrape limit on the number of targets dropped by relabeling that will be kept in memory. 0 means no limit. \n It requires Prometheus >= v2.47.0."
                 format: int64
                 type: integer
               labelLimit:
-                description: Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: "Per-scrape limit on number of labels that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               labelNameLengthLimit:
-                description: Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: "Per-scrape limit on length of labels name that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               labelValueLengthLimit:
-                description: Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: "Per-scrape limit on length of labels value that will be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               namespaceSelector:
-                description: Selector to select which namespaces the Kubernetes Endpoints objects are discovered from.
+                description: Selector to select which namespaces the Kubernetes `Endpoints` objects are discovered from.
                 properties:
                   any:
                     description: Boolean describing whether all namespaces are selected in contrast to a list restricting them.
@@ -511,16 +513,16 @@ spec:
                     type: array
                 type: object
               podTargetLabels:
-                description: PodTargetLabels transfers labels on the Kubernetes `Pod` onto the created metrics.
+                description: '`podTargetLabels` defines the labels which are transferred from the associated Kubernetes `Pod` object onto the ingested metrics.'
                 items:
                   type: string
                 type: array
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+                description: '`sampleLimit` defines a per-scrape limit on the number of scraped samples that will be accepted.'
                 format: int64
                 type: integer
               selector:
-                description: Selector to select Endpoints objects.
+                description: Label selector to select the Kubernetes `Endpoints` objects.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -551,16 +553,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               targetLabels:
-                description: TargetLabels transfers labels from the Kubernetes `Service` onto the created metrics.
+                description: '`targetLabels` defines the labels which are transferred from the associated Kubernetes `Service` object onto the ingested metrics.'
                 items:
                   type: string
                 type: array
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped targets that will be accepted.
+                description: '`targetLimit` defines a limit on the number of scraped targets that will be accepted.'
                 format: int64
                 type: integer
             required:
-            - endpoints
             - selector
             type: object
         required:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -2,12 +2,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.69.1
-  creationTimestamp: null
+    operator.prometheus.io/version: 0.70.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1941,7 +1941,6 @@ data:
                                 "expr": "cluster:node_cpu:ratio_rate5m{cluster=\"$cluster\"}",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -2028,7 +2027,6 @@ data:
                                 "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -2115,7 +2113,6 @@ data:
                                 "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -2202,7 +2199,6 @@ data:
                                 "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{job=\"node-exporter\",cluster=\"$cluster\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -2289,7 +2285,6 @@ data:
                                 "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -2376,7 +2371,6 @@ data:
                                 "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -2473,7 +2467,6 @@ data:
                             {
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -2749,7 +2742,6 @@ data:
                                 "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -2757,7 +2749,6 @@ data:
                                 "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -2765,7 +2756,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -2773,7 +2763,6 @@ data:
                                 "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -2781,7 +2770,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -2789,7 +2777,6 @@ data:
                                 "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             },
@@ -2797,7 +2784,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "G"
                             }
@@ -2898,7 +2884,6 @@ data:
                             {
                                 "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -3174,7 +3159,6 @@ data:
                                 "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -3182,7 +3166,6 @@ data:
                                 "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -3190,7 +3173,6 @@ data:
                                 "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -3198,7 +3180,6 @@ data:
                                 "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -3206,7 +3187,6 @@ data:
                                 "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -3214,7 +3194,6 @@ data:
                                 "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             },
@@ -3222,7 +3201,6 @@ data:
                                 "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "G"
                             }
@@ -3480,7 +3458,6 @@ data:
                                 "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -3488,7 +3465,6 @@ data:
                                 "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -3496,7 +3472,6 @@ data:
                                 "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -3504,7 +3479,6 @@ data:
                                 "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -3512,7 +3486,6 @@ data:
                                 "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -3520,7 +3493,6 @@ data:
                                 "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             }
@@ -3621,7 +3593,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -3709,7 +3680,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -3809,7 +3779,6 @@ data:
                             {
                                 "expr": "avg(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -3897,7 +3866,6 @@ data:
                             {
                                 "expr": "avg(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -3997,7 +3965,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -4085,7 +4052,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -4185,7 +4151,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -4273,7 +4238,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -4374,7 +4338,6 @@ data:
                             {
                                 "expr": "ceil(sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval])))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -4462,7 +4425,6 @@ data:
                             {
                                 "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{namespace}}",
                                 "legendLink": null
                             }
@@ -4723,7 +4685,6 @@ data:
                                 "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -4731,7 +4692,6 @@ data:
                                 "expr": "sum by(namespace) (rate(container_fs_writes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -4739,7 +4699,6 @@ data:
                                 "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -4747,7 +4706,6 @@ data:
                                 "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -4755,7 +4713,6 @@ data:
                                 "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -4763,7 +4720,6 @@ data:
                                 "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             }
@@ -4983,7 +4939,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -5070,7 +5025,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -5157,7 +5111,6 @@ data:
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -5244,7 +5197,6 @@ data:
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
                                 "format": "time_series",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "refId": "A"
                             }
                         ],
@@ -5362,21 +5314,18 @@ data:
                             {
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "quota - requests",
                                 "legendLink": null
                             },
                             {
                                 "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "quota - limits",
                                 "legendLink": null
                             }
@@ -5614,7 +5563,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -5622,7 +5570,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -5630,7 +5577,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -5638,7 +5584,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -5646,7 +5591,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             }
@@ -5768,21 +5712,18 @@ data:
                             {
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "quota - requests",
                                 "legendLink": null
                             },
                             {
                                 "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "quota - limits",
                                 "legendLink": null
                             }
@@ -6077,7 +6018,6 @@ data:
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -6085,7 +6025,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -6093,7 +6032,6 @@ data:
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -6101,7 +6039,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -6109,7 +6046,6 @@ data:
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -6117,7 +6053,6 @@ data:
                                 "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             },
@@ -6125,7 +6060,6 @@ data:
                                 "expr": "sum(container_memory_cache{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "G"
                             },
@@ -6133,7 +6067,6 @@ data:
                                 "expr": "sum(container_memory_swap{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "H"
                             }
@@ -6391,7 +6324,6 @@ data:
                                 "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -6399,7 +6331,6 @@ data:
                                 "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -6407,7 +6338,6 @@ data:
                                 "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -6415,7 +6345,6 @@ data:
                                 "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -6423,7 +6352,6 @@ data:
                                 "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -6431,7 +6359,6 @@ data:
                                 "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             }
@@ -6532,7 +6459,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -6620,7 +6546,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -6720,7 +6645,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -6808,7 +6732,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -6908,7 +6831,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -6996,7 +6918,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -7097,7 +7018,6 @@ data:
                             {
                                 "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -7185,7 +7105,6 @@ data:
                             {
                                 "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -7446,7 +7365,6 @@ data:
                                 "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -7454,7 +7372,6 @@ data:
                                 "expr": "sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -7462,7 +7379,6 @@ data:
                                 "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -7470,7 +7386,6 @@ data:
                                 "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -7478,7 +7393,6 @@ data:
                                 "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -7486,7 +7400,6 @@ data:
                                 "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             }
@@ -7742,14 +7655,12 @@ data:
                             {
                                 "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "max capacity",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -7987,7 +7898,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -7995,7 +7905,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -8003,7 +7912,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -8011,7 +7919,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -8019,7 +7926,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             }
@@ -8130,14 +8036,12 @@ data:
                             {
                                 "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "max capacity",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -8432,7 +8336,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -8440,7 +8343,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -8448,7 +8350,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -8456,7 +8357,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -8464,7 +8364,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -8472,7 +8371,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             },
@@ -8480,7 +8378,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "G"
                             },
@@ -8488,7 +8385,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "H"
                             }
@@ -8777,21 +8673,18 @@ data:
                             {
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}) by (container)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{container}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "requests",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "limits",
                                 "legendLink": null
                             }
@@ -8891,7 +8784,6 @@ data:
                             {
                                 "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container) /sum(increase(container_cpu_cfs_periods_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{container}}",
                                 "legendLink": null
                             }
@@ -9136,7 +9028,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -9144,7 +9035,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -9152,7 +9042,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -9160,7 +9049,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -9168,7 +9056,6 @@ data:
                                 "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             }
@@ -9288,21 +9175,18 @@ data:
                             {
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{container}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "requests",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "limits",
                                 "legendLink": null
                             }
@@ -9597,7 +9481,6 @@ data:
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -9605,7 +9488,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -9613,7 +9495,6 @@ data:
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -9621,7 +9502,6 @@ data:
                                 "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -9629,7 +9509,6 @@ data:
                                 "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -9637,7 +9516,6 @@ data:
                                 "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             },
@@ -9645,7 +9523,6 @@ data:
                                 "expr": "sum(container_memory_cache{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "G"
                             },
@@ -9653,7 +9530,6 @@ data:
                                 "expr": "sum(container_memory_swap{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "H"
                             }
@@ -9754,7 +9630,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -9842,7 +9717,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -9942,7 +9816,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -10030,7 +9903,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -10130,7 +10002,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -10218,7 +10089,6 @@ data:
                             {
                                 "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -10319,14 +10189,12 @@ data:
                             {
                                 "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "Reads",
                                 "legendLink": null
                             },
                             {
                                 "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "Writes",
                                 "legendLink": null
                             }
@@ -10414,14 +10282,12 @@ data:
                             {
                                 "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "Reads",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "Writes",
                                 "legendLink": null
                             }
@@ -10693,7 +10559,6 @@ data:
                             {
                                 "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -10931,7 +10796,6 @@ data:
                                 "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -10939,7 +10803,6 @@ data:
                                 "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -10947,7 +10810,6 @@ data:
                                 "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -10955,7 +10817,6 @@ data:
                                 "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -10963,7 +10824,6 @@ data:
                                 "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             }
@@ -11064,7 +10924,6 @@ data:
                             {
                                 "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -11302,7 +11161,6 @@ data:
                                 "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -11310,7 +11168,6 @@ data:
                                 "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -11318,7 +11175,6 @@ data:
                                 "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -11326,7 +11182,6 @@ data:
                                 "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -11334,7 +11189,6 @@ data:
                                 "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             }
@@ -11592,7 +11446,6 @@ data:
                                 "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -11600,7 +11453,6 @@ data:
                                 "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -11608,7 +11460,6 @@ data:
                                 "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -11616,7 +11467,6 @@ data:
                                 "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -11624,7 +11474,6 @@ data:
                                 "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -11632,7 +11481,6 @@ data:
                                 "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             }
@@ -11733,7 +11581,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -11821,7 +11668,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -11921,7 +11767,6 @@ data:
                             {
                                 "expr": "(avg(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -12009,7 +11854,6 @@ data:
                             {
                                 "expr": "(avg(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -12109,7 +11953,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -12197,7 +12040,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -12297,7 +12139,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -12385,7 +12226,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{pod}}",
                                 "legendLink": null
                             }
@@ -12705,21 +12545,18 @@ data:
                             {
                                 "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}} - {{workload_type}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "quota - requests",
                                 "legendLink": null
                             },
                             {
                                 "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "quota - limits",
                                 "legendLink": null
                             }
@@ -12995,7 +12832,6 @@ data:
                                 "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload, workload_type)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -13003,7 +12839,6 @@ data:
                                 "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -13011,7 +12846,6 @@ data:
                                 "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -13019,7 +12853,6 @@ data:
                                 "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -13027,7 +12860,6 @@ data:
                                 "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -13035,7 +12867,6 @@ data:
                                 "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             }
@@ -13157,21 +12988,18 @@ data:
                             {
                                 "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}} - {{workload_type}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "quota - requests",
                                 "legendLink": null
                             },
                             {
                                 "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "quota - limits",
                                 "legendLink": null
                             }
@@ -13447,7 +13275,6 @@ data:
                                 "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload, workload_type)",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -13455,7 +13282,6 @@ data:
                                 "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -13463,7 +13289,6 @@ data:
                                 "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -13471,7 +13296,6 @@ data:
                                 "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -13479,7 +13303,6 @@ data:
                                 "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -13487,7 +13310,6 @@ data:
                                 "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             }
@@ -13764,7 +13586,6 @@ data:
                                 "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -13772,7 +13593,6 @@ data:
                                 "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             },
@@ -13780,7 +13600,6 @@ data:
                                 "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "C"
                             },
@@ -13788,7 +13607,6 @@ data:
                                 "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "D"
                             },
@@ -13796,7 +13614,6 @@ data:
                                 "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "E"
                             },
@@ -13804,7 +13621,6 @@ data:
                                 "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "F"
                             }
@@ -13905,7 +13721,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}}",
                                 "legendLink": null
                             }
@@ -13993,7 +13808,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}}",
                                 "legendLink": null
                             }
@@ -14093,7 +13907,6 @@ data:
                             {
                                 "expr": "(avg(irate(container_network_receive_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}}",
                                 "legendLink": null
                             }
@@ -14181,7 +13994,6 @@ data:
                             {
                                 "expr": "(avg(irate(container_network_transmit_bytes_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}}",
                                 "legendLink": null
                             }
@@ -14281,7 +14093,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}}",
                                 "legendLink": null
                             }
@@ -14369,7 +14180,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}}",
                                 "legendLink": null
                             }
@@ -14469,7 +14279,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}}",
                                 "legendLink": null
                             }
@@ -14557,7 +14366,6 @@ data:
                             {
                                 "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{workload}}",
                                 "legendLink": null
                             }
@@ -19792,7 +19600,6 @@ data:
                                 "expr": "count by (job, instance, version) (prometheus_build_info{job=~\"$job\", instance=~\"$instance\"})",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
@@ -19800,7 +19607,6 @@ data:
                                 "expr": "max by (job, instance) (time() - process_start_time_seconds{job=~\"$job\", instance=~\"$instance\"})",
                                 "format": "table",
                                 "instant": true,
-                                "intervalFactor": 2,
                                 "legendFormat": "",
                                 "refId": "B"
                             }
@@ -19898,7 +19704,6 @@ data:
                             {
                                 "expr": "sum(rate(prometheus_target_sync_length_seconds_sum{job=~\"$job\",instance=~\"$instance\"}[5m])) by (scrape_job) * 1e3",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{scrape_job}}",
                                 "legendLink": null
                             }
@@ -19983,7 +19788,6 @@ data:
                             {
                                 "expr": "sum(prometheus_sd_discovered_targets{job=~\"$job\",instance=~\"$instance\"})",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "Targets",
                                 "legendLink": null
                             }
@@ -20080,7 +19884,6 @@ data:
                             {
                                 "expr": "rate(prometheus_target_interval_length_seconds_sum{job=~\"$job\",instance=~\"$instance\"}[5m]) / rate(prometheus_target_interval_length_seconds_count{job=~\"$job\",instance=~\"$instance\"}[5m]) * 1e3",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{interval}} configured",
                                 "legendLink": null
                             }
@@ -20165,35 +19968,30 @@ data:
                             {
                                 "expr": "sum by (job) (rate(prometheus_target_scrapes_exceeded_body_size_limit_total[1m]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "exceeded body size limit: {{job}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum by (job) (rate(prometheus_target_scrapes_exceeded_sample_limit_total[1m]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "exceeded sample limit: {{job}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total[1m]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "duplicate timestamp: {{job}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_out_of_bounds_total[1m]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "out of bounds: {{job}}",
                                 "legendLink": null
                             },
                             {
                                 "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_out_of_order_total[1m]))",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "out of order: {{job}}",
                                 "legendLink": null
                             }
@@ -20278,7 +20076,6 @@ data:
                             {
                                 "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=~\"$job\",instance=~\"$instance\"}[5m])",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{job}} {{instance}}",
                                 "legendLink": null
                             }
@@ -20375,7 +20172,6 @@ data:
                             {
                                 "expr": "prometheus_tsdb_head_series{job=~\"$job\",instance=~\"$instance\"}",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{job}} {{instance}} head series",
                                 "legendLink": null
                             }
@@ -20460,7 +20256,6 @@ data:
                             {
                                 "expr": "prometheus_tsdb_head_chunks{job=~\"$job\",instance=~\"$instance\"}",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{job}} {{instance}} head chunks",
                                 "legendLink": null
                             }
@@ -20557,7 +20352,6 @@ data:
                             {
                                 "expr": "rate(prometheus_engine_query_duration_seconds_count{job=~\"$job\",instance=~\"$instance\",slice=\"inner_eval\"}[5m])",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{job}} {{instance}}",
                                 "legendLink": null
                             }
@@ -20642,7 +20436,6 @@ data:
                             {
                                 "expr": "max by (slice) (prometheus_engine_query_duration_seconds{quantile=\"0.9\",job=~\"$job\",instance=~\"$instance\"}) * 1e3",
                                 "format": "time_series",
-                                "intervalFactor": 2,
                                 "legendFormat": "{{slice}}",
                                 "legendLink": null
                             }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
