### PR TITLE
OCPBUGS-24340: patch securityContext for Thanos querier

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -81,7 +81,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -340,6 +340,17 @@ function(params)
             },
             containers: [
               super.containers[0] {
+                // The upstream kube-thanos jsonnet provides a hardened
+                // security context which sets "readOnlyRootFilesystem: true"
+                // for the thanos-querier container but a gathering script
+                // running running as a post-step in the CI jobs needs to write
+                // files to /tmp. As a temporary workaround, we patch the
+                // security context here.
+                // See https://issues.redhat.com/browse/OCPBUGS-24340.
+                securityContext+: {
+                  readOnlyRootFilesystem: false,
+                },
+
                 livenessProbe:: {},
                 readinessProbe:: {},
                 args: std.map(


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
