### PR TITLE
MON-3551: fix: simplify jq script avoids error with jq1.7

### DIFF
--- a/hack/local-cmo.sh
+++ b/hack/local-cmo.sh
@@ -80,7 +80,7 @@ disable_managed_cmo() {
 			    {
 			      "spec": {
 			        "overrides": [
-			          [ .spec | .? | .overrides[] | .? | select(.name != "cluster-monitoring-operator")] +
+			          [ .spec? | .overrides[]? | select(.name != "cluster-monitoring-operator")] +
 			          [{
 			            "group": "apps",
 			            "kind": "Deployment",


### PR DESCRIPTION
According to the documentation both the existing version and this change should be legal syntax. With this change I can run a local CMO with jq 1.7.
I think regardless fewer pipes make this more readable.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
