### PR TITLE
MON-3544: Adjust NodeClock* alerting rules to work with PTP operator

### DIFF
--- a/assets/node-exporter/prometheus-rule.yaml
+++ b/assets/node-exporter/prometheus-rule.yaml
@@ -173,7 +173,8 @@ spec:
       annotations:
         description: Clock at {{ $labels.instance }} is out of sync by more than 0.05s. Ensure NTP is configured correctly on this host.
         summary: Clock skew detected.
-      expr: |
+      expr: |-
+        (
         (
           node_timex_offset_seconds{job="node-exporter"} > 0.05
         and
@@ -185,6 +186,7 @@ spec:
         and
           deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) <= 0
         )
+        ) and on() absent(up{job="ptp-monitor-service"})
       for: 10m
       labels:
         severity: warning
@@ -193,10 +195,12 @@ spec:
         description: Clock at {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeClockNotSynchronising.md
         summary: Clock not synchronising.
-      expr: |
+      expr: |-
+        (
         min_over_time(node_timex_sync_status{job="node-exporter"}[5m]) == 0
         and
         node_timex_maxerror_seconds{job="node-exporter"} >= 16
+        ) and on() absent(up{job="ptp-monitor-service"})
       for: 10m
       labels:
         severity: critical

--- a/test/rules/NodeClockNotSynchronising.yaml
+++ b/test/rules/NodeClockNotSynchronising.yaml
@@ -1,0 +1,80 @@
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # When the PTP operator isn't installed, NodeClockNotSynchronising should
+  # become active when the conditions are met.
+  - interval: 1m
+    input_series:
+      # node with a zero sync status and maxerrors above threshold.
+      - series: 'node_timex_sync_status{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-0",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-0",service="node-exporter"}'
+        values: 0x20 0
+      - series: 'node_timex_maxerror_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-0",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-0",service="node-exporter"}'
+        values: 16x20 0
+      # node with a zero sync status but acceptable maxerrors.
+      - series: 'node_timex_sync_status{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-1",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-1",service="node-exporter"}'
+        values: 0x20
+      - series: 'node_timex_maxerror_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-1",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-1",service="node-exporter"}'
+        values: 15x20
+      # node with a non-zero sync status and increasing maxerrors.
+      - series: 'node_timex_sync_status{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-2",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-2",service="node-exporter"}'
+        values: 1x20
+      - series: 'node_timex_maxerror_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-2",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-2",service="node-exporter"}'
+        values: 0+1x20
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NodeClockNotSynchronising
+        exp_alerts:
+      - eval_time: 10m
+        alertname: NodeClockNotSynchronising
+        exp_alerts:
+        - exp_labels:
+            severity: critical
+            namespace: openshift-monitoring
+            container: kube-rbac-proxy
+            endpoint: https
+            instance: ocp-master-0
+            job: node-exporter
+            pod: node-exporter-master-0
+            service: node-exporter
+          exp_annotations:
+            description: "Clock at ocp-master-0 is not synchronising. Ensure NTP is configured on this host."
+            runbook_url: "https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeClockNotSynchronising.md"
+            summary: "Clock not synchronising."
+      - eval_time: 21m
+        alertname: NodeClockNotSynchronising
+        exp_alerts:
+
+  # When the PTP operator is installed, NodeClockNotSynchronising should
+  # never become active, even when the conditions are met.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="ptp-monitor-service"}'
+        values: 1x40
+      # node with a zero sync status and maxerrors above threshold.
+      - series: 'node_timex_sync_status{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-0",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-0",service="node-exporter"}'
+        values: 0x20 0
+      - series: 'node_timex_maxerror_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-0",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-0",service="node-exporter"}'
+        values: 16x20 0
+      # node with a zero sync status but acceptable maxerrors.
+      - series: 'node_timex_sync_status{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-1",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-1",service="node-exporter"}'
+        values: 0x20
+      - series: 'node_timex_maxerror_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-1",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-1",service="node-exporter"}'
+        values: 15x20
+      # node with a non-zero sync status and increasing maxerrors.
+      - series: 'node_timex_sync_status{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-2",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-2",service="node-exporter"}'
+        values: 1x20
+      - series: 'node_timex_maxerror_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-2",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-2",service="node-exporter"}'
+        values: 0+1x20
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NodeClockNotSynchronising
+        exp_alerts:
+      - eval_time: 10m
+        alertname: NodeClockNotSynchronising
+        exp_alerts:
+      - eval_time: 21m
+        alertname: NodeClockNotSynchronising
+        exp_alerts:

--- a/test/rules/NodeClockSkewDetected.yaml
+++ b/test/rules/NodeClockSkewDetected.yaml
@@ -1,0 +1,109 @@
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # When the PTP operator isn't installed, NodeClockSkewDetected should
+  # become active when the conditions are met.
+  - interval: 1m
+    input_series:
+      # node with a positive clock drift.
+      - series: 'node_timex_offset_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-0",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-0",service="node-exporter"}'
+        values: 0+0.001x9 0.051+0.001x19 0x10
+      # node with a negative clock drift.
+      - series: 'node_timex_offset_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-1",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-1",service="node-exporter"}'
+        values: 0-0.001x9 -0.051-0.001x19 0x10
+      # node with an acceptable clock offset and no drift.
+      - series: 'node_timex_offset_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-2",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-2",service="node-exporter"}'
+        values: 0.001x40
+      # node with an excessive clock offset and no drift.
+      - series: 'node_timex_offset_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-3",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-3",service="node-exporter"}'
+        values: 0.06x30 0x10
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: NodeClockSkewDetected
+        exp_alerts:
+        - exp_labels:
+            severity: warning
+            namespace: openshift-monitoring
+            container: kube-rbac-proxy
+            endpoint: https
+            instance: ocp-master-3
+            job: node-exporter
+            pod: node-exporter-master-3
+            service: node-exporter
+          exp_annotations:
+            description: "Clock at ocp-master-3 is out of sync by more than 0.05s. Ensure NTP is configured correctly on this host."
+            summary: "Clock skew detected."
+      - eval_time: 21m
+        alertname: NodeClockSkewDetected
+        exp_alerts:
+        - exp_labels:
+            severity: warning
+            namespace: openshift-monitoring
+            container: kube-rbac-proxy
+            endpoint: https
+            instance: ocp-master-0
+            job: node-exporter
+            pod: node-exporter-master-0
+            service: node-exporter
+          exp_annotations:
+            description: "Clock at ocp-master-0 is out of sync by more than 0.05s. Ensure NTP is configured correctly on this host."
+            summary: "Clock skew detected."
+        - exp_labels:
+            severity: warning
+            namespace: openshift-monitoring
+            container: kube-rbac-proxy
+            endpoint: https
+            instance: ocp-master-1
+            job: node-exporter
+            pod: node-exporter-master-1
+            service: node-exporter
+          exp_annotations:
+            description: "Clock at ocp-master-1 is out of sync by more than 0.05s. Ensure NTP is configured correctly on this host."
+            summary: "Clock skew detected."
+        - exp_labels:
+            severity: warning
+            namespace: openshift-monitoring
+            container: kube-rbac-proxy
+            endpoint: https
+            instance: ocp-master-3
+            job: node-exporter
+            pod: node-exporter-master-3
+            service: node-exporter
+          exp_annotations:
+            description: "Clock at ocp-master-3 is out of sync by more than 0.05s. Ensure NTP is configured correctly on this host."
+            summary: "Clock skew detected."
+      - eval_time: 31m
+        alertname: NodeClockSkewDetected
+        exp_alerts:
+
+  # When the PTP operator is installed, NodeClockSkewDetected should
+  # never become active, even when the conditions are met.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="ptp-monitor-service"}'
+        values: 1x40
+      # node with a positive clock drift.
+      - series: 'node_timex_offset_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-0",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-0",service="node-exporter"}'
+        values: 0+0.001x9 0.051+0.001x19 0x10
+      # node with a negative clock drift.
+      - series: 'node_timex_offset_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-1",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-1",service="node-exporter"}'
+        values: 0-0.001x9 -0.051-0.001x19 0x10
+      # node with an acceptable clock offset and no drift.
+      - series: 'node_timex_offset_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-2",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-2",service="node-exporter"}'
+        values: 0.001x40
+      # node with an excessive clock offset and no drift.
+      - series: 'node_timex_offset_seconds{container="kube-rbac-proxy",endpoint="https",instance="ocp-master-3",job="node-exporter",namespace="openshift-monitoring",pod="node-exporter-master-3",service="node-exporter"}'
+        values: 0.06x30 0x10
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: NodeClockSkewDetected
+        exp_alerts:
+      - eval_time: 21m
+        alertname: NodeClockSkewDetected
+        exp_alerts:
+      - eval_time: 31m
+        alertname: NodeClockSkewDetected
+        exp_alerts:

--- a/test/rules/TargetDown.yaml
+++ b/test/rules/TargetDown.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - ocpbugs-1453.yaml
+  - rules.yaml
 
 evaluation_interval: 1m
 


### PR DESCRIPTION
This commit adapts the upstream NodeClockNotSynchronising and NodeClockSkewDetected rules to be always inactive when the PTP operator is installed. The PTP operator ships a more robust rule to detect unsynchronised clocks and the default rules are redundant in this case.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
