### PR TITLE
OCPBUGS-25378: No definition of InfoInhibitor is required in alertmanager.yaml

### DIFF
--- a/assets/alertmanager/secret.yaml
+++ b/assets/alertmanager/secret.yaml
@@ -29,17 +29,10 @@ stringData:
       - "severity = warning"
       "target_matchers":
       - "severity = info"
-    - "equal":
-      - "namespace"
-      "source_matchers":
-      - "alertname = InfoInhibitor"
-      "target_matchers":
-      - "severity = info"
     "receivers":
     - "name": "Default"
     - "name": "Watchdog"
     - "name": "Critical"
-    - "name": "null"
     "route":
       "group_by":
       - "namespace"
@@ -51,9 +44,6 @@ stringData:
       - "matchers":
         - "alertname = Watchdog"
         "receiver": "Watchdog"
-      - "matchers":
-        - "alertname = InfoInhibitor"
-        "receiver": "null"
       - "matchers":
         - "severity = critical"
         "receiver": "Critical"


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

The cluster-monitoring-operator does not have a definition for InfoInhibitor. To avoid confusion for the customer, it is safe to remove this from the alertmanager.yaml.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
