### PR TITLE
WIP: Test Metrics API Availability

### DIFF
--- a/pkg/tasks/prometheusadapter.go
+++ b/pkg/tasks/prometheusadapter.go
@@ -219,18 +219,19 @@ func (t *PrometheusAdapterTask) create(ctx context.Context) error {
 			}
 		}
 	}
-	{
-		api, err := t.factory.PrometheusAdapterAPIService()
-		if err != nil {
-			return errors.Wrap(err, "initializing PrometheusAdapter APIService failed")
-		}
+	/*
+		{
+			api, err := t.factory.PrometheusAdapterAPIService()
+			if err != nil {
+				return errors.Wrap(err, "initializing PrometheusAdapter APIService failed")
+			}
 
-		err = t.client.CreateOrUpdateAPIService(ctx, api)
-		if err != nil {
-			return errors.Wrap(err, "reconciling PrometheusAdapter APIService failed")
+			err = t.client.CreateOrUpdateAPIService(ctx, api)
+			if err != nil {
+				return errors.Wrap(err, "reconciling PrometheusAdapter APIService failed")
+			}
 		}
-	}
-
+	*/
 	{
 		// TODO: Remove this in 4.16
 		err := t.client.DeleteConfigMapByNamespaceAndName(ctx, t.client.Namespace(), "adapter-config-dedicated-sm")


### PR DESCRIPTION
/hold
This PR is not meant to be merged I created this to verify how e2e/origin test report failures on metrics api unavailability
cc: @simonpasquier 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
