### PR TITLE
OCPBUGS-25849: make PrometheusAdapter and MetricsServer tasks less conflict prone

### DIFF
--- a/assets/metrics-server/api-service.yaml
+++ b/assets/metrics-server/api-service.yaml
@@ -16,5 +16,6 @@ spec:
   service:
     name: metrics-server
     namespace: openshift-monitoring
+    port: 443
   version: v1beta1
   versionPriority: 100

--- a/assets/prometheus-adapter/api-service.yaml
+++ b/assets/prometheus-adapter/api-service.yaml
@@ -17,5 +17,6 @@ spec:
   service:
     name: prometheus-adapter
     namespace: openshift-monitoring
+    port: 443
   version: v1beta1
   versionPriority: 100

--- a/jsonnet/components/metrics-server.libsonnet
+++ b/jsonnet/components/metrics-server.libsonnet
@@ -321,6 +321,7 @@ function(params) {
       service: {
         name: $.service.metadata.name,
         namespace: cfg.namespace,
+        port: 443,
       },
       group: 'metrics.k8s.io',
       version: 'v1beta1',

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -34,6 +34,9 @@ function(params)
         },
         spec+: {
           insecureSkipTLSVerify: false,
+          service+: {
+            port: 443,
+          },
         },
       },
 


### PR DESCRIPTION
…dateAPIService to avoid code duplication.

The function also avoids running update queries when nothing needs to change from CMO's side which reduces the probability of conflicts with other controllers and consumes resources for nothing.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
