### PR TITLE
OCPBUGS-25676: fix(tasks): adjust 'trusted CA bundle ConfigMap' related logs for alertmanagers.

### DIFF
--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -189,7 +189,7 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		}
 		trustedCA, err = cbs.syncTrustedCABundle(ctx, trustedCA)
 		if err != nil {
-			return errors.Wrap(err, "syncing Thanos Querier trusted CA bundle ConfigMap failed")
+			return errors.Wrap(err, "syncing Alertmanager trusted CA bundle ConfigMap failed")
 		}
 
 		a, err := t.factory.AlertmanagerMain(trustedCA)

--- a/pkg/tasks/alertmanager_user_workload.go
+++ b/pkg/tasks/alertmanager_user_workload.go
@@ -168,7 +168,7 @@ func (t *AlertmanagerUserWorkloadTask) create(ctx context.Context) error {
 		}
 		trustedCA, err = cbs.syncTrustedCABundle(ctx, trustedCA)
 		if err != nil {
-			return errors.Wrap(err, "syncing Thanos Querier trusted CA bundle ConfigMap failed")
+			return errors.Wrap(err, "syncing Alertmanager User Workload trusted CA bundle ConfigMap failed")
 		}
 
 		a, err := t.factory.AlertmanagerUserWorkload(trustedCA)


### PR DESCRIPTION
…rtmanagers

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
