### PR TITLE
OCPBUGS-25378: drop InfoInhibitor from default Alertmanager config

### DIFF
--- a/assets/alertmanager/secret.yaml
+++ b/assets/alertmanager/secret.yaml
@@ -12,8 +12,6 @@ metadata:
   namespace: openshift-monitoring
 stringData:
   alertmanager.yaml: |-
-    "global":
-      "resolve_timeout": "5m"
     "inhibit_rules":
     - "equal":
       - "namespace"
@@ -29,17 +27,10 @@ stringData:
       - "severity = warning"
       "target_matchers":
       - "severity = info"
-    - "equal":
-      - "namespace"
-      "source_matchers":
-      - "alertname = InfoInhibitor"
-      "target_matchers":
-      - "severity = info"
     "receivers":
     - "name": "Default"
     - "name": "Watchdog"
     - "name": "Critical"
-    - "name": "null"
     "route":
       "group_by":
       - "namespace"
@@ -51,9 +42,6 @@ stringData:
       - "matchers":
         - "alertname = Watchdog"
         "receiver": "Watchdog"
-      - "matchers":
-        - "alertname = InfoInhibitor"
-        "receiver": "null"
       - "matchers":
         - "severity = critical"
         "receiver": "Critical"

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -123,6 +123,33 @@ local inCluster =
         },
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
         promLabelProxyImage: $.values.common.images.promLabelProxy,
+        config: {
+          inhibit_rules: [{
+            source_matchers: ['severity = critical'],
+            target_matchers: ['severity =~ warning|info'],
+            equal: ['namespace', 'alertname'],
+          }, {
+            source_matchers: ['severity = warning'],
+            target_matchers: ['severity = info'],
+            equal: ['namespace', 'alertname'],
+          }],
+          route: {
+            group_by: ['namespace'],
+            group_wait: '30s',
+            group_interval: '5m',
+            repeat_interval: '12h',
+            receiver: 'Default',
+            routes: [
+              { receiver: 'Watchdog', matchers: ['alertname = Watchdog'] },
+              { receiver: 'Critical', matchers: ['severity = critical'] },
+            ],
+          },
+          receivers: [
+            { name: 'Default' },
+            { name: 'Watchdog' },
+            { name: 'Critical' },
+          ],
+        },
       },
       dashboards: {
         namespace: $.values.common.namespace,


### PR DESCRIPTION
OCP doesn't include the InfoInhibitor alerting rule out of the box. To avoid confusion, it is desired to remove the alert from the default Alertmanager configuration.

Note that the change will only apply to newly created clusters because the Cluster Monitoring Operator only handles the creation of the Alertmanager configuration secret and it never updates when the secret already exists.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
