### PR TITLE
MON-3717: pkg/client.go: make some CreateOrUpdateXXX functions use library-go’s resourceapply utils.

### DIFF
--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -49,7 +49,10 @@ It is easier to follow the following workflow
 #### Finally:
 1. Port the changes back to `jsonnet` or vendored `jsonnet`
 
-
+#### NOTE:
+For some resources (see corresponding `CreateOrUpdateXXX`), removing a label/annotation needs to be done across two OCP releases:
+- In the first release, you should add the suffix `"-"` to the relevant annotation/label. [CMO will then delete that annotation/label on the Kubernetes API.](https://github.com/openshift/library-go/blob/126b47137408f93a2fc9f2e8cbeedda61f9ebbfb/pkg/operator/resource/resourcemerge/object_merger.go#L141-L169)
+- In the second release, you can remove that annotation/label from the resource manifest under `assets/`.
 
 ## Updating individual vendored jsonnet code
 

--- a/pkg/manifests/tls.go
+++ b/pkg/manifests/tls.go
@@ -144,9 +144,13 @@ func RotateGRPCSecret(s *v1.Secret) error {
 		}
 	}
 
+	// This is not documented and only used in tests.
 	if _, ok := s.Annotations["monitoring.openshift.io/grpc-tls-forced-rotate"]; ok {
 		rotate = true
+		// Remove the annotation from the manifest and request its removal on the API.
+		// Ideally, this should be handled by the function's caller. However, for simplicity, the function itself manages this task.
 		delete(s.Annotations, "monitoring.openshift.io/grpc-tls-forced-rotate")
+		s.Annotations["monitoring.openshift.io/grpc-tls-forced-rotate-"] = ""
 	}
 
 	if !rotate {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
 	monClient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
 	monBetaClient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1beta1"
@@ -117,7 +118,8 @@ func New(kubeConfigPath string) (*Framework, CleanUpFunc, error) {
 		return nil, nil, fmt.Errorf("creating monitoring beta client failed: %w", err)
 	}
 
-	operatorClient, err := client.NewForConfig(config, "", namespaceName, userWorkloadNamespaceName)
+	// The event recorder will be used by some CreateOrUpdateXXX utils for creation/update events.
+	operatorClient, err := client.NewForConfig(config, "", namespaceName, userWorkloadNamespaceName, client.EventRecorder(events.NewInMemoryRecorder("cluster-monitoring-operator")))
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating operator client failed: %w", err)
 	}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

See https://docs.google.com/document/d/1fm2SZs8HroexPQnqI0Ua85Y31-lars8gCsdwSJC3ngo/edit?usp=sharing for benchmarks results.