### PR TITLE
MON-1047: fix: add terminationMessagePolicy: FallbackToLogsOnError to all conta…

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -60,6 +60,7 @@ spec:
             cpu: 2m
             memory: 80Mi
         securityContext: {}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp
           name: volume-directive-shadow

--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -80,6 +80,7 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: secret-metrics-server-tls

--- a/assets/monitoring-plugin/deployment.yaml
+++ b/assets/monitoring-plugin/deployment.yaml
@@ -75,6 +75,7 @@ spec:
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/cert
           name: monitoring-plugin-cert

--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -43,6 +43,7 @@ spec:
           requests:
             cpu: 1m
             memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: openshift-state-metrics-tls
@@ -71,6 +72,7 @@ spec:
           requests:
             cpu: 1m
             memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: openshift-state-metrics-tls
@@ -92,6 +94,7 @@ spec:
           requests:
             cpu: 1m
             memory: 32Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -153,10 +153,12 @@ spec:
       requests:
         cpu: 1m
         memory: 25Mi
+    terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /etc/tls/grpc
       name: secret-grpc-tls
   - name: prometheus
+    terminationMessagePolicy: FallbackToLogsOnError
   enableFeatures: []
   externalLabels: {}
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -159,10 +159,12 @@ spec:
       capabilities:
         drop:
         - ALL
+    terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /etc/tls/grpc
       name: secret-grpc-tls
   - name: prometheus
+    terminationMessagePolicy: FallbackToLogsOnError
   enableFeatures: []
   enforcedNamespaceLabel: namespace
   externalLabels: {}

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -62,6 +62,7 @@ spec:
           requests:
             cpu: 1m
             memory: 40Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/serving-certs-ca-bundle
           name: serving-certs-ca-bundle
@@ -81,6 +82,7 @@ spec:
           requests:
             cpu: 1m
             memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/serving-certs-ca-bundle
           name: serving-certs-ca-bundle
@@ -102,6 +104,7 @@ spec:
           requests:
             cpu: 1m
             memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: telemeter-client-tls

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -54,7 +54,6 @@ function(params)
                         },
                       },
                       securityContext: {},
-                      terminationMessagePolicy: 'FallbackToLogsOnError',
                     }
                   else
                     c,

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -235,7 +235,6 @@ function(params)
               '--config-file=/etc/kube-rbac-proxy/config.yaml',
               '--logtostderr=true',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',
@@ -278,7 +277,6 @@ function(params)
               '--tls-private-key-file=/etc/tls/private/tls.key',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/kube-rbac-proxy',
@@ -324,7 +322,6 @@ function(params)
               '--logtostderr=true',
               '--allow-paths=/metrics',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/kube-rbac-proxy',
@@ -364,7 +361,6 @@ function(params)
                 memory: '20Mi',
               },
             },
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             securityContext: {
               allowPrivilegeEscalation: false,
               capabilities: {

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -280,7 +280,6 @@ function(params)
               '-openshift-ca=/etc/pki/tls/cert.pem',
               '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             resources: {
               requests: {
                 cpu: '1m',
@@ -321,7 +320,6 @@ function(params)
               '--tls-private-key-file=/etc/tls/private/tls.key',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/kube-rbac-proxy',
@@ -361,7 +359,6 @@ function(params)
               '--logtostderr=true',
               '--allow-paths=/metrics',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/kube-rbac-proxy',
@@ -395,7 +392,6 @@ function(params)
                 memory: '20Mi',
               },
             },
-            terminationMessagePolicy: 'FallbackToLogsOnError',
           },
         ],
         volumes+: [

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -169,7 +169,6 @@ function(params)
                         '--client-ca-file=/etc/tls/client/client-ca.crt',
                         '--config-file=/etc/kube-rbac-policy/config.yaml',
                       ],
-                      terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts: [
                         {
                           mountPath: '/etc/tls/private',

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -186,7 +186,6 @@ function(params)
                   privileged: true,
                   runAsUser: 0,
                 },
-                terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts+: [
                   {
                     mountPath: textfileDir,
@@ -213,7 +212,6 @@ function(params)
                         '--client-ca-file=/etc/tls/client/client-ca.crt',
                         '--config-file=/etc/kube-rbac-policy/config.yaml',
                       ],
-                      terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts: [
                         {
                           mountPath: '/etc/tls/private',
@@ -266,7 +264,6 @@ function(params)
                           exec /bin/node_exporter "$0" "$@"
                         |||,
                       ],
-                      terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts+: [{
                         mountPath: textfileDir,
                         name: textfileVolumeName,

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -109,7 +109,6 @@ function(params)
                           '--tls-cipher-suites=' + cfg.tlsCipherSuites,
                           '--disable-http2',
                         ],
-                        terminationMessagePolicy: 'FallbackToLogsOnError',
                         volumeMounts: [
                           {
                             mountPath: '/tmp',

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -104,7 +104,6 @@ function(params)
                           cpu: '1m',
                         },
                       },
-                      terminationMessagePolicy: 'FallbackToLogsOnError',
                     }
                   else if c.name == 'kube-rbac-proxy' then
                     c {
@@ -114,7 +113,6 @@ function(params)
                         '--config-file=/etc/kube-rbac-policy/config.yaml',
                         '--client-ca-file=/etc/tls/client/client-ca.crt',
                       ],
-                      terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts: [
                         {
                           mountPath: '/etc/tls/private',

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -82,7 +82,6 @@ function(params)
                           cpu: '5m',
                         },
                       },
-                      terminationMessagePolicy: 'FallbackToLogsOnError',
                     }
                   else if c.name == 'kube-rbac-proxy' then
                     // TODO(simonpasquier): remove kube-rbac-proxy and
@@ -99,7 +98,6 @@ function(params)
                         '--client-ca-file=/etc/tls/client/client-ca.crt',
                         '--config-file=/etc/kube-rbac-policy/config.yaml',
                       ],
-                      terminationMessagePolicy: 'FallbackToLogsOnError',
                       volumeMounts: [
                         {
                           mountPath: '/etc/tls/private',

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -364,7 +364,6 @@ function(params)
               '--client-ca-file=/etc/tls/client/client-ca.crt',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',
@@ -412,7 +411,6 @@ function(params)
               '--client-ca-file=/etc/tls/client/client-ca.crt',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',
@@ -468,7 +466,6 @@ function(params)
               '--allow-paths=/metrics',
               '--config-file=/etc/kube-rbac-proxy/config.yaml',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -428,7 +428,6 @@ function(params)
               '-openshift-ca=/etc/pki/tls/cert.pem',
               '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',
@@ -465,7 +464,6 @@ function(params)
               '--client-ca-file=/etc/tls/client/client-ca.crt',
               '--tls-cipher-suites=' + cfg.tlsCipherSuites,
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',
@@ -516,7 +514,6 @@ function(params)
               '--allow-paths=/metrics',
               '--logtostderr=true',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -428,7 +428,6 @@ function(params)
                     '/-/ready',
                   ]),
                 ],
-                terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [
                   {
                     mountPath: '/etc/tls/private',
@@ -496,7 +495,6 @@ function(params)
                     '/api/v1/series',
                   ]),
                 ],
-                terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [
                   {
                     mountPath: '/etc/tls/private',
@@ -536,7 +534,6 @@ function(params)
                     drop: ['ALL'],
                   },
                 },
-                terminationMessagePolicy: 'FallbackToLogsOnError',
               },
               {
                 name: 'kube-rbac-proxy-rules',
@@ -565,7 +562,6 @@ function(params)
                     '/api/v1/alerts',
                   ]),
                 ],
-                terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [
                   {
                     mountPath: '/etc/tls/private',
@@ -610,7 +606,6 @@ function(params)
                   '--client-ca-file=/etc/tls/client/client-ca.crt',
                   '--allow-paths=/metrics',
                 ],
-                terminationMessagePolicy: 'FallbackToLogsOnError',
                 volumeMounts: [
                   {
                     mountPath: '/etc/tls/private',

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -403,7 +403,6 @@ function(params)
             // Note: this is performing strategic-merge-patch for thanos-ruler container.
             // Remainder of the container configuration is managed by prometheus-operator based on $.thanosRuler.spec
             name: tr.config.name,
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',
@@ -453,7 +452,6 @@ function(params)
               '-openshift-ca=/etc/pki/tls/cert.pem',
               '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             resources: {
               requests: {
                 cpu: '1m',
@@ -503,7 +501,6 @@ function(params)
               '--client-ca-file=/etc/tls/client/client-ca.crt',
               '--allow-paths=/metrics',
             ],
-            terminationMessagePolicy: 'FallbackToLogsOnError',
             volumeMounts: [
               {
                 mountPath: '/etc/tls/private',

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -4,6 +4,7 @@ local addLabels = (import './utils/add-labels.libsonnet').addLabels;
 local sanitizeAlertRules = (import './utils/sanitize-rules.libsonnet').sanitizeAlertRules;
 local removeNetworkPolicy = (import './utils/remove-network-policy.libsonnet').removeNetworkPolicy;
 local configureAuthenticationForMonitors = (import './utils/configure-authentication-for-monitors.libsonnet').configureAuthenticationForMonitors;
+local setTerminationMessagePolicy = (import './utils/set-terminationMessagePolicy.libsonnet').setTerminationMessagePolicy;
 
 local alertmanager = import './components/alertmanager.libsonnet';
 local alertmanagerUserWorkload = import './components/alertmanager-user-workload.libsonnet';
@@ -473,37 +474,39 @@ local userWorkload =
   {};  // Including empty object to simplify adding and removing imports during development
 
 // Manifestation
-addLabels(
-  commonConfig.commonLabels,
-  addAnnotations(
-    sanitizeAlertRules(
-      removeLimits(
-        removeNetworkPolicy(
-          // Enforce mTLS authentication + disable usage of bearer token for all service/pod monitors.
-          // See https://issues.redhat.com/browse/OCPBUGS-4184 for details.
-          configureAuthenticationForMonitors(
-            { ['alertmanager/' + name]: inCluster.alertmanager[name] for name in std.objectFields(inCluster.alertmanager) } +
-            { ['alertmanager-user-workload/' + name]: userWorkload.alertmanager[name] for name in std.objectFields(userWorkload.alertmanager) } +
-            { ['cluster-monitoring-operator/' + name]: inCluster.clusterMonitoringOperator[name] for name in std.objectFields(inCluster.clusterMonitoringOperator) } +
-            { ['dashboards/' + name]: inCluster.dashboards[name] for name in std.objectFields(inCluster.dashboards) } +
-            { ['kube-state-metrics/' + name]: inCluster.kubeStateMetrics[name] for name in std.objectFields(inCluster.kubeStateMetrics) } +
-            { ['node-exporter/' + name]: inCluster.nodeExporter[name] for name in std.objectFields(inCluster.nodeExporter) } +
-            { ['openshift-state-metrics/' + name]: inCluster.openshiftStateMetrics[name] for name in std.objectFields(inCluster.openshiftStateMetrics) } +
-            { ['prometheus-k8s/' + name]: inCluster.prometheus[name] for name in std.objectFields(inCluster.prometheus) } +
-            { ['admission-webhook/' + name]: inCluster.admissionWebhook[name] for name in std.objectFields(inCluster.admissionWebhook) } +
-            { ['prometheus-operator/' + name]: inCluster.prometheusOperator[name] for name in std.objectFields(inCluster.prometheusOperator) } +
-            { ['prometheus-operator-user-workload/' + name]: userWorkload.prometheusOperator[name] for name in std.objectFields(userWorkload.prometheusOperator) } +
-            { ['prometheus-user-workload/' + name]: userWorkload.prometheus[name] for name in std.objectFields(userWorkload.prometheus) } +
-            { ['prometheus-adapter/' + name]: inCluster.prometheusAdapter[name] for name in std.objectFields(inCluster.prometheusAdapter) } +
-            { ['metrics-server/' + name]: inCluster.metricsServer[name] for name in std.objectFields(inCluster.metricsServer) } +
-            // needs to be removed once remote-write is allowed for sending telemetry
-            { ['telemeter-client/' + name]: inCluster.telemeterClient[name] for name in std.objectFields(inCluster.telemeterClient) } +
-            { ['monitoring-plugin/' + name]: inCluster.monitoringPlugin[name] for name in std.objectFields(inCluster.monitoringPlugin) } +
-            { ['thanos-querier/' + name]: inCluster.thanosQuerier[name] for name in std.objectFields(inCluster.thanosQuerier) } +
-            { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
-            { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
-            { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } +
-            {}
+setTerminationMessagePolicy(
+  addLabels(
+    commonConfig.commonLabels,
+    addAnnotations(
+      sanitizeAlertRules(
+        removeLimits(
+          removeNetworkPolicy(
+            // Enforce mTLS authentication + disable usage of bearer token for all service/pod monitors.
+            // See https://issues.redhat.com/browse/OCPBUGS-4184 for details.
+            configureAuthenticationForMonitors(
+              { ['alertmanager/' + name]: inCluster.alertmanager[name] for name in std.objectFields(inCluster.alertmanager) } +
+              { ['alertmanager-user-workload/' + name]: userWorkload.alertmanager[name] for name in std.objectFields(userWorkload.alertmanager) } +
+              { ['cluster-monitoring-operator/' + name]: inCluster.clusterMonitoringOperator[name] for name in std.objectFields(inCluster.clusterMonitoringOperator) } +
+              { ['dashboards/' + name]: inCluster.dashboards[name] for name in std.objectFields(inCluster.dashboards) } +
+              { ['kube-state-metrics/' + name]: inCluster.kubeStateMetrics[name] for name in std.objectFields(inCluster.kubeStateMetrics) } +
+              { ['node-exporter/' + name]: inCluster.nodeExporter[name] for name in std.objectFields(inCluster.nodeExporter) } +
+              { ['openshift-state-metrics/' + name]: inCluster.openshiftStateMetrics[name] for name in std.objectFields(inCluster.openshiftStateMetrics) } +
+              { ['prometheus-k8s/' + name]: inCluster.prometheus[name] for name in std.objectFields(inCluster.prometheus) } +
+              { ['admission-webhook/' + name]: inCluster.admissionWebhook[name] for name in std.objectFields(inCluster.admissionWebhook) } +
+              { ['prometheus-operator/' + name]: inCluster.prometheusOperator[name] for name in std.objectFields(inCluster.prometheusOperator) } +
+              { ['prometheus-operator-user-workload/' + name]: userWorkload.prometheusOperator[name] for name in std.objectFields(userWorkload.prometheusOperator) } +
+              { ['prometheus-user-workload/' + name]: userWorkload.prometheus[name] for name in std.objectFields(userWorkload.prometheus) } +
+              { ['prometheus-adapter/' + name]: inCluster.prometheusAdapter[name] for name in std.objectFields(inCluster.prometheusAdapter) } +
+              { ['metrics-server/' + name]: inCluster.metricsServer[name] for name in std.objectFields(inCluster.metricsServer) } +
+              // needs to be removed once remote-write is allowed for sending telemetry
+              { ['telemeter-client/' + name]: inCluster.telemeterClient[name] for name in std.objectFields(inCluster.telemeterClient) } +
+              { ['monitoring-plugin/' + name]: inCluster.monitoringPlugin[name] for name in std.objectFields(inCluster.monitoringPlugin) } +
+              { ['thanos-querier/' + name]: inCluster.thanosQuerier[name] for name in std.objectFields(inCluster.thanosQuerier) } +
+              { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
+              { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
+              { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } +
+              {}
+            )
           )
         )
       )

--- a/jsonnet/utils/set-terminationMessagePolicy.libsonnet
+++ b/jsonnet/utils/set-terminationMessagePolicy.libsonnet
@@ -1,0 +1,28 @@
+{
+  setTerminationMessagePolicy(o): o {
+    local addTerminationMessagePolicy(o) = o {
+      [if std.setMember(o.kind, ['DaemonSet', 'Deployment', 'ReplicaSet']) then 'spec']+: {
+        template+: {
+          spec+: {
+            containers: [
+              c {
+                terminationMessagePolicy: 'FallbackToLogsOnError',
+              }
+              for c in super.containers
+            ],
+          },
+        },
+      },
+      [if std.setMember(o.kind, ['Prometheus', 'Alertmanager', 'ThanosRuler']) then 'spec']+: {
+        containers: [
+          c {
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+          }
+          for c in super.containers
+        ],
+      },
+    },
+    [k]: addTerminationMessagePolicy(o[k])
+    for k in std.objectFields(o)
+  },
+}

--- a/jsonnet/utils/set-terminationMessagePolicy.libsonnet
+++ b/jsonnet/utils/set-terminationMessagePolicy.libsonnet
@@ -8,17 +8,29 @@
               c {
                 terminationMessagePolicy: 'FallbackToLogsOnError',
               }
-              for c in super.containers
+              for c in o.spec.template.spec.containers
+            ],
+            [if 'initContainers' in o.spec.template.spec then 'initContainers']: [
+              c {
+                terminationMessagePolicy: 'FallbackToLogsOnError',
+              }
+              for c in o.spec.template.spec.initContainers
             ],
           },
         },
       },
-      [if std.setMember(o.kind, ['Prometheus', 'Alertmanager', 'ThanosRuler']) then 'spec']+: {
+      [if std.setMember(o.kind, ['Alertmanager', 'Prometheus', 'ThanosRuler']) then 'spec']+: {
         containers: [
           c {
             terminationMessagePolicy: 'FallbackToLogsOnError',
           }
-          for c in super.containers
+          for c in o.spec.containers
+        ],
+        [if 'initContainers' in o.spec then 'initContainers']: [
+          c {
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+          }
+          for c in o.spec.initContainers
         ],
       },
     },


### PR DESCRIPTION
…iners

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
