### PR TITLE
OCPNODE-2022: jsonnet: update crio port to TLS port 9637

### DIFF
--- a/assets/control-plane/minimal-service-monitor-kubelet.yaml
+++ b/assets/control-plane/minimal-service-monitor-kubelet.yaml
@@ -80,7 +80,8 @@ spec:
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-  - interval: 30s
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
     metricRelabelings:
     - action: keep
       regex: (apiserver_audit_event_total|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_usage_bytes|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|container_spec_cpu_shares|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_containers_per_pod_count_sum|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_bucket|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|machine_cpu_cores|machine_memory_bytes|process_start_time_seconds|rest_client_requests_total|storage_operation_duration_seconds_count)
@@ -90,7 +91,7 @@ spec:
     relabelings:
     - action: replace
       regex: (.+)(?::\d+)
-      replacement: $1:9537
+      replacement: $1:9637
       sourceLabels:
       - __address__
       targetLabel: __address__
@@ -102,6 +103,13 @@ spec:
     - action: replace
       replacement: crio
       targetLabel: job
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      insecureSkipVerify: false
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+      serverName: machine-config-daemon.openshift-machine-config-operator.svc
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -129,12 +129,13 @@ spec:
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-  - interval: 30s
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
     port: https-metrics
     relabelings:
     - action: replace
       regex: (.+)(?::\d+)
-      replacement: $1:9537
+      replacement: $1:9637
       sourceLabels:
       - __address__
       targetLabel: __address__
@@ -146,6 +147,13 @@ spec:
     - action: replace
       replacement: crio
       targetLabel: job
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      insecureSkipVerify: false
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+      serverName: machine-config-daemon.openshift-machine-config-operator.svc
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -87,13 +87,18 @@ function(params)
           [{
             interval: '30s',
             port: 'https-metrics',
+            scheme: 'https',
+            tlsConfig+: {
+              serverName: 'machine-config-daemon.openshift-machine-config-operator.svc',
+              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+            },
             relabelings: [
               {
                 sourceLabels: ['__address__'],
                 action: 'replace',
                 targetLabel: '__address__',
                 regex: '(.+)(?::\\d+)',
-                replacement: '$1:9537',
+                replacement: '$1:9637',
               },
               {
                 sourceLabels: ['endpoint'],

--- a/jsonnet/utils/configure-authentication-for-monitors.libsonnet
+++ b/jsonnet/utils/configure-authentication-for-monitors.libsonnet
@@ -5,7 +5,9 @@
         [if o.kind == 'ServiceMonitor' then 'endpoints' else 'podMetricsEndpoints']: [
           if std.objectHas(e, 'scheme') && e.scheme == 'https' then
             e {
-              bearerTokenFile: '',
+              bearerTokenFile: if (std.objectHas(e, 'relabelings') && std.isArray(e.relabelings) && std.filter(function(p) if std.objectHas(p, 'replacement') then std.length(std.findSubstr('9637', p.replacement)) > 0 else false, e.relabelings) != []) then '/var/run/secrets/kubernetes.io/serviceaccount/token' else '',
+            } +
+            {
               tlsConfig+: {
                             certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
                             keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
