### PR TITLE
OCPBUGS-26983: rollout monitoring plugin on TLS rotation

### DIFF
--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -29,6 +29,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -4716,4 +4717,19 @@ func volumeMountsConfigured(volumeMounts []v1.VolumeMount, volumeName string) bo
 		}
 	}
 	return false
+}
+
+func TestHashSecretData(t *testing.T) {
+	s := v1.Secret{
+		Data: map[string][]byte{
+			"key1": []byte("value1"),
+			"key2": []byte("value2"),
+			"key3": []byte("value3"),
+		},
+	}
+
+	h := hashSecretData(&s)
+	for i := 0; i < 100; i++ {
+		require.Equal(t, h, hashSecretData(&s), "hashing not stable")
+	}
 }


### PR DESCRIPTION
This commit ensures that the monitoring plugin's pods get redeployed when the TLS serving certificate is rotated.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
