### PR TITLE
MON-2853: add runbook link to TargetDown alert

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -17,6 +17,7 @@ spec:
     - alert: TargetDown
       annotations:
         description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support.'
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/TargetDown.md
         summary: Some targets were not reachable from the monitoring server for an extended period of time.
       expr: |
         100 * ((

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -491,6 +491,7 @@ local includeRunbooks = {
   NodeClockNotSynchronising: openShiftRunbookCMO('NodeClockNotSynchronising.md'),
   PrometheusRuleFailures: openShiftRunbookCMO('PrometheusRuleFailures.md'),
   PrometheusTargetSyncFailure: openShiftRunbookCMO('PrometheusTargetSyncFailure.md'),
+  TargetDown: openShiftRunbookCMO('TargetDown.md'),
   ThanosRuleQueueIsDroppingAlerts: openShiftRunbookCMO('ThanosRuleQueueIsDroppingAlerts.md'),
   ThanosRuleRuleEvaluationLatencyHigh: openShiftRunbookCMO('ThanosRuleRuleEvaluationLatencyHigh.md'),
 };

--- a/test/rules/TargetDown.yaml
+++ b/test/rules/TargetDown.yaml
@@ -34,6 +34,7 @@ tests:
             service: service
           exp_annotations:
             description: "50% of the /service targets in ns namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support."
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/TargetDown.md
             summary: "Some targets were not reachable from the monitoring server for an extended period of time."
       - eval_time: 32m
         alertname: TargetDown
@@ -77,6 +78,7 @@ tests:
             service: service
           exp_annotations:
             description: "50% of the /service targets in ns namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support."
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/TargetDown.md
             summary: "Some targets were not reachable from the monitoring server for an extended period of time."
       - eval_time: 32m
         alertname: TargetDown
@@ -140,6 +142,7 @@ tests:
             service: service
           exp_annotations:
             description: "50% of the /service targets in ns namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support."
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/TargetDown.md
             summary: "Some targets were not reachable from the monitoring server for an extended period of time."
       - eval_time: 32m
         alertname: TargetDown
@@ -170,6 +173,7 @@ tests:
             service: service
           exp_annotations:
             description: "50% of the /service targets in ns namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support."
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/TargetDown.md
             summary: "Some targets were not reachable from the monitoring server for an extended period of time."
       - eval_time: 32m
         alertname: TargetDown


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
