### PR TITLE
OCPBUGS-27289: followup of https://github.com/openshift/cluster-monitoring-operator/pull/2242

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2926,7 +2926,7 @@ func (f *Factory) MonitoringPluginDeployment(tlsSecret *v1.Secret) (*appsv1.Depl
 	// Hash the TLS secret and propagate it as an annotation to the
 	// deployment's pods to trigger a new rollout when the TLS certificate/key
 	// are rotated.
-	d.Spec.Template.Annotations["monitoring.openshift.io/hash"] = hashByteMap(tlsSecret.Data)
+	d.Spec.Template.Annotations["monitoring.openshift.io/cert-hash"] = hashByteMap(tlsSecret.Data)
 
 	cfg := f.config.ClusterMonitoringConfiguration.MonitoringPluginConfig
 	if cfg == nil {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2759,8 +2759,8 @@ metricsServer:
 			Namespace: "openshift-monitoring",
 		},
 		Data: map[string][]byte{
-			"tls.crt": []byte("foo"),
-			"tls.key": []byte("bar"),
+			"tls.crt": []byte("bar"),
+			"tls.key": []byte("foo"),
 		},
 	}
 	d, err := f.MetricsServerDeployment(kubeletCABundle, servingCASecret, metricsClientSecret)
@@ -2806,6 +2806,11 @@ metricsServer:
 			}
 		})
 	}
+
+	podAnnotations := d.Spec.Template.Annotations
+	require.Equal(t, "eplue2a9srfkb", podAnnotations["monitoring.openshift.io/kubelet-serving-ca-bundle-hash"])
+	require.Equal(t, "arprfan3mk728", podAnnotations["monitoring.openshift.io/metrics-client-cert-hash"])
+	require.Equal(t, "383c7cmidrae2", podAnnotations["monitoring.openshift.io/serving-ca-secret-hash"])
 }
 
 func TestAlertmanagerMainStartupProbe(t *testing.T) {

--- a/pkg/tasks/metricsserver.go
+++ b/pkg/tasks/metricsserver.go
@@ -111,12 +111,9 @@ func (t *MetricsServerTask) create(ctx context.Context) error {
 			return fmt.Errorf("initializing kubelet serving CA Bundle ConfigMap failed: %w", err)
 		}
 
-		kscm, err := t.client.WaitForConfigMapByNsName(
+		cacm, err = t.client.WaitForConfigMap(
 			ctx,
-			types.NamespacedName{
-				Namespace: s.Namespace,
-				Name:      cacm.Name,
-			},
+			cacm,
 		)
 		if err != nil {
 			return err
@@ -133,23 +130,20 @@ func (t *MetricsServerTask) create(ctx context.Context) error {
 			return err
 		}
 
-		metricsClientSecret, err := t.factory.MetricsClientCerts()
+		mcs, err := t.factory.MetricsClientCerts()
 		if err != nil {
 			return fmt.Errorf("initializing metrics-client-cert failed: %w", err)
 		}
 
-		mcs, err := t.client.WaitForSecretByNsName(
+		mcs, err = t.client.WaitForSecret(
 			ctx,
-			types.NamespacedName{
-				Namespace: s.Namespace,
-				Name:      metricsClientSecret.Name,
-			},
+			mcs,
 		)
 		if err != nil {
 			return err
 		}
 
-		dep, err := t.factory.MetricsServerDeployment(kscm, scas, mcs)
+		dep, err := t.factory.MetricsServerDeployment(cacm, scas, mcs)
 		if err != nil {
 			return fmt.Errorf("initializing MetricsServer Deployment failed: %w", err)
 		}


### PR DESCRIPTION
chore: adjust monitoring plugin cert hash annotation name to avoid confusion.

chore: adjust code for metrics server certs rotation and add test

followup of https://github.com/openshift/cluster-monitoring-operator/pull/2242

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
