### PR TITLE
MON-3699: chore: merge OmitFromDoc with HideFromDoc introduced in https://github.com/https://github.com/openshift/cluster-monitoring-operator/pull/2210 to hide fields from the doc

### DIFF
--- a/hack/docgen/format/asciidocs/api.go
+++ b/hack/docgen/format/asciidocs/api.go
@@ -133,9 +133,6 @@ func PrintAPIDocs(args []string) {
 			moduleContent += "|===\n"
 			moduleContent += "| Property | Type | Description \n"
 			for _, f := range t.Fields {
-				if strings.HasPrefix(fmt.Sprint(f.Description()), "OmitFromDoc") {
-					continue
-				}
 				moduleContent += fmt.Sprint("|", f.Name(), "|", f.TypeLink(typeSetUnion), "|", f.Description(), "\n\n")
 			}
 			moduleContent += "|===\n"

--- a/hack/docgen/format/markdown/api.go
+++ b/hack/docgen/format/markdown/api.go
@@ -104,9 +104,6 @@ func PrintAPIDocs(args []string) {
 			fmt.Println("| Property | Type | Description |")
 			fmt.Println("| -------- | ---- | ----------- |")
 			for _, f := range t.Fields {
-				if strings.HasPrefix(fmt.Sprint(f.Description()), "OmitFromDoc") {
-					continue
-				}
 				fmt.Println("|", f.Name(), "|", f.TypeLink(typeSetUnion), "|", f.Description(), "|")
 			}
 			fmt.Println("")

--- a/hack/docgen/model/parser.go
+++ b/hack/docgen/model/parser.go
@@ -32,7 +32,7 @@ func Load(path string) (TypeSet, error) {
 
 	for _, t := range types.Types {
 		structType, ok := t.Decl.Specs[0].(*ast.TypeSpec).Type.(*ast.StructType)
-		if !ok || hideFromDoc(t.Doc) {
+		if !ok || omitFromDoc(t.Doc) {
 			continue
 		}
 
@@ -49,7 +49,7 @@ func Load(path string) (TypeSet, error) {
 	for _, currentStruct := range structs {
 		for _, field := range currentStruct.rawFields {
 			field := Field(*field)
-			if hideFromDoc(field.Doc.Text()) {
+			if omitFromDoc(field.Doc.Text()) {
 				continue
 			}
 			if field.IsInlined() {
@@ -83,9 +83,9 @@ func Load(path string) (TypeSet, error) {
 	return structs, nil
 }
 
-// hideFromDoc helps filetring out elements that are not intended to be shown in docs.
-func hideFromDoc(doc string) bool {
-	return strings.HasPrefix(doc, "HideFromDoc: ")
+// omitFromDoc helps filetring out elements that are not intended to be shown in docs.
+func omitFromDoc(doc string) bool {
+	return strings.HasPrefix(doc, "OmitFromDoc")
 }
 
 func mergeFields(to *StructType, from *StructType, structs TypeSet) {

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -117,7 +117,7 @@ type K8sPrometheusAdapter struct {
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Defines a pod's topology spread constraints.
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
-	// HideFromDoc: Defines dedicated service monitors.
+	// OmitFromDoc: Defines dedicated service monitors.
 	DedicatedServiceMonitors *DedicatedServiceMonitors `json:"dedicatedServiceMonitors,omitempty"`
 }
 
@@ -134,7 +134,7 @@ type MetricsServerConfig struct {
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
-// HideFromDoc: This is deprecated and will be removed in a future version, setting it has no effect.
+// OmitFromDoc: This is deprecated and will be removed in a future version, setting it has no effect.
 type DedicatedServiceMonitors struct {
 	Enabled bool `json:"enabled,omitempty"`
 }


### PR DESCRIPTION
…b.com/openshift/cluster-monitoring-operator/pull/2210 to hide fields from the doc

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
