### PR TITLE
OCPBUGS-28246: fix: set externalURL in UWM Prometheus

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1736,6 +1736,13 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 
 	p.Spec.Image = &f.config.Images.Prometheus
 
+	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
+		p.Spec.ExternalURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if f.config.UserWorkloadConfiguration.Prometheus.Resources != nil {
 		p.Spec.Resources = *f.config.UserWorkloadConfiguration.Prometheus.Resources
 	}


### PR DESCRIPTION
This sets the correct source URL in UWM alert notifications.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
