### PR TITLE
MON-3697: use `maximumStartupDurationSeconds` instead of container patch

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -164,6 +164,7 @@ spec:
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091
   image: quay.io/prometheus/prometheus:v2.49.1
   listenLocal: true
+  maximumStartupDurationSeconds: 3600
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -382,6 +382,10 @@ function(params)
             value: '15ms',
           },
         ],
+        // Increase the startup probe timeout to 1h from 15m to avoid restart
+        // failures when the WAL replay takes a long time.
+        // See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
+        maximumStartupDurationSeconds: 3600,
         containers: [
           {
             name: 'prometheus-proxy',

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1483,16 +1483,6 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 
 	for i, container := range p.Spec.Containers {
 		switch container.Name {
-		case "prometheus":
-			// Increase the startup probe timeout to 1h from 15m to avoid restart failures when the WAL replay
-			// takes a long time. See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
-			// TODO (JoaoBraveCoding): Once prometheus-operator adds CRD support to configure startupProbe directly
-			// we should use that instead of using strategic merge patch
-			// See https://github.com/prometheus-operator/prometheus-operator/issues/4730
-			p.Spec.Containers[i].StartupProbe = &v1.Probe{
-				PeriodSeconds:    15,
-				FailureThreshold: 240,
-			}
 		case "prometheus-proxy":
 			p.Spec.Containers[i].Image = f.config.Images.OauthProxy
 


### PR DESCRIPTION
The latest version of the Prometheus CRD allows to customize the overall startup probe duration. This commit makes use of it instead of patching the Prometheus container definition at runtime.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
