### PR TITLE
fix: update generate_versions.go

### DIFF
--- a/hack/go/generate_versions.go
+++ b/hack/go/generate_versions.go
@@ -17,11 +17,11 @@ import (
 )
 
 const (
-	mainBranch        = "master"
-	metricsServerRepo = "openshift/kubernetes-metrics-server"
-	versionFile       = "../../jsonnet/versions.yaml"
+	mainBranch          = "master"
+	metricsServerRepo   = "openshift/kubernetes-metrics-server"
+	versionFile         = "../../jsonnet/versions.yaml"
 	versionNotFound     = "N/A"
-	OCPVersionHeader   = " OCP Version"
+	OCPVersionHeader    = " OCP Version"
 	depsVersionsFile    = "../../Documentation/deps-versions.md"
 	versionFileComments = `---
 # This file is meant to be managed by hack/go/generate_versions.go script
@@ -146,7 +146,7 @@ func updateDepsVersionsFile(fileP string, components Components) error {
 		}
 		rows = append(rows, row)
 		err = releaseVersion.IncrementMinor()
-		if err != nil{
+		if err != nil {
 			return err
 		}
 	}
@@ -181,7 +181,7 @@ func getVersion(repo, ref string) (string, error) {
 	baseURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s", repo, ref)
 	link := fmt.Sprintf("%s/VERSION", baseURL)
 	if repo == metricsServerRepo {
-		link = fmt.Sprintf("%s/manifests/release/kustomization.yaml", baseURL)
+		link = fmt.Sprintf("%s/manifests/components/release/kustomization.yaml", baseURL)
 	}
 	raw, err := fetchVersion(link)
 	if err != nil {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

Follow-up of https://github.com/rhobs/syncbot/pull/72

* [ ] I added CHANGELOG entry for this change.
* [ x] No user facing changes, so no entry in CHANGELOG was needed.
