### PR TITLE
OCPBUGS-18326: add Console cap annotation to dashboards

### DIFF
--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1865,12 +1865,24 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
+  name: dashboard-cluster-total
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-cluster-total
   namespace: openshift-config-managed
 ---
@@ -4863,12 +4875,24 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
+  name: dashboard-k8s-resources-cluster
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-k8s-resources-cluster
   namespace: openshift-config-managed
 ---
@@ -7570,6 +7594,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -7577,6 +7602,17 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
+  name: dashboard-k8s-resources-namespace
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-k8s-resources-namespace
   namespace: openshift-config-managed
 ---
@@ -8582,12 +8618,24 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
+  name: dashboard-k8s-resources-node
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-k8s-resources-node
   namespace: openshift-config-managed
 ---
@@ -10484,6 +10532,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -10491,6 +10540,17 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
+  name: dashboard-k8s-resources-pod
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-k8s-resources-pod
   namespace: openshift-config-managed
 ---
@@ -12449,6 +12509,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -12456,6 +12517,17 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
+  name: dashboard-k8s-resources-workload
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-k8s-resources-workload
   namespace: openshift-config-managed
 ---
@@ -14567,6 +14639,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -14574,6 +14647,17 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
+  name: dashboard-k8s-resources-workloads-namespace
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-k8s-resources-workloads-namespace
   namespace: openshift-config-managed
 ---
@@ -16025,12 +16109,24 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
+  name: dashboard-namespace-by-pod
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-namespace-by-pod
   namespace: openshift-config-managed
 ---
@@ -17080,12 +17176,24 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
+  name: dashboard-node-cluster-rsrc-use
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-node-cluster-rsrc-use
   namespace: openshift-config-managed
 ---
@@ -18189,12 +18297,24 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
+  name: dashboard-node-rsrc-use
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-node-rsrc-use
   namespace: openshift-config-managed
 ---
@@ -19410,12 +19530,24 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
+  name: dashboard-pod-total
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-pod-total
   namespace: openshift-config-managed
 ---
@@ -20654,11 +20786,23 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
+  name: dashboard-prometheus
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
   name: grafana-dashboard-prometheus
   namespace: openshift-config-managed


### PR DESCRIPTION
This commit adds the "capability.openshift.io/name: Console" annotation to the dashboard configmaps.

It also renames the existing configmaps from "grafana-xxx" to "xxx" because otherwise CVO would enable the Console capability on all clusters, even those where the capability was initially disabled [1]. The CVO team has a feature request [2] to improve the situation but for now, we have no other option than creating the configmaps with a different name and deleting the old configmaps (anyway the "grafana-" prefix is misleading since OCP doesn't ship any Grafana instance by default).

[1] https://github.com/openshift/enhancements/blob/master/enhancements/installer/component-selection.md#how-to-implement-a-new-capability
[2] https://issues.redhat.com/browse/OTA-1039

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
