### PR TITLE
OCPNODE-2100: jsonnet: update crio port to TLS port 9637

### DIFF
--- a/assets/control-plane/minimal-service-monitor-kubelet.yaml
+++ b/assets/control-plane/minimal-service-monitor-kubelet.yaml
@@ -80,7 +80,8 @@ spec:
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-  - interval: 30s
+  - bearerTokenFile: ""
+    interval: 30s
     metricRelabelings:
     - action: keep
       regex: (apiserver_audit_event_total|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_usage_bytes|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|container_spec_cpu_shares|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_containers_per_pod_count_sum|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_bucket|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|machine_cpu_cores|machine_memory_bytes|process_start_time_seconds|rest_client_requests_total|storage_operation_duration_seconds_count)
@@ -90,7 +91,7 @@ spec:
     relabelings:
     - action: replace
       regex: (.+)(?::\d+)
-      replacement: $1:9537
+      replacement: $1:9637
       sourceLabels:
       - __address__
       targetLabel: __address__
@@ -102,6 +103,12 @@ spec:
     - action: replace
       replacement: crio
       targetLabel: job
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      insecureSkipVerify: false
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -129,12 +129,13 @@ spec:
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-  - interval: 30s
+  - bearerTokenFile: ""
+    interval: 30s
     port: https-metrics
     relabelings:
     - action: replace
       regex: (.+)(?::\d+)
-      replacement: $1:9537
+      replacement: $1:9637
       sourceLabels:
       - __address__
       targetLabel: __address__
@@ -146,6 +147,12 @@ spec:
     - action: replace
       replacement: crio
       targetLabel: job
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      insecureSkipVerify: false
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -87,13 +87,17 @@ function(params)
           [{
             interval: '30s',
             port: 'https-metrics',
+            scheme: 'https',
+            tlsConfig+: {
+              caFile: '/etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt',
+            },
             relabelings: [
               {
                 sourceLabels: ['__address__'],
                 action: 'replace',
                 targetLabel: '__address__',
                 regex: '(.+)(?::\\d+)',
-                replacement: '$1:9537',
+                replacement: '$1:9637',
               },
               {
                 sourceLabels: ['endpoint'],


### PR DESCRIPTION
This PR switches monitoring over to use the secure 9637 metrics port for crio (backed by kube-rbac-proxy). It also changes the authentication to use the client certificate auth, since static pods cannot mount secrets.