### PR TITLE
MON-3706: chore: poll immediately in the e2e tests

### DIFF
--- a/test/e2e/alertmanager_user_workload_test.go
+++ b/test/e2e/alertmanager_user_workload_test.go
@@ -36,6 +36,7 @@ func TestUserWorkloadAlertmanager(t *testing.T) {
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
 	f.AssertStatefulSetExistsAndRollout("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
+	f.AssertServiceExists("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
 
 	for _, scenario := range []struct {
 		name string

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -445,9 +445,16 @@ func (f *Framework) AssertOperatorConditionMessageContains(conditionType configv
 
 func (f *Framework) AssertValueInConfigMapEquals(name, namespace, key, compareWith string) func(t *testing.T) {
 	return func(t *testing.T) {
-		cm := f.MustGetConfigMap(t, name, namespace)
-		if cm.Data[key] != compareWith {
-			t.Fatalf("wanted value %s for key %s but got %s", compareWith, key, cm.Data[key])
+		err := Poll(time.Second, time.Minute, func() error {
+			cm := f.MustGetConfigMap(t, name, namespace)
+			if cm.Data[key] != compareWith {
+				return fmt.Errorf("wanted value %s for key %s but got %s", compareWith, key, cm.Data[key])
+			}
+
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -626,7 +626,7 @@ func (f *Framework) ForwardPort(t *testing.T, ns, svc string, port int) (string,
 func Poll(interval, timeout time.Duration, f func() error) error {
 	var lastErr error
 
-	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(context.Context) (bool, error) {
 		lastErr = f()
 		if lastErr != nil {
 			return false, nil

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -549,6 +549,7 @@ func assertTenancyForMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check that the service account can request the tenancy-aware /api/v1/query API endpoint using HTTP GET.
 	for _, tc := range []struct {
 		name      string
 		query     string
@@ -665,7 +666,7 @@ func assertTenancyForMetrics(t *testing.T) {
 		})
 	}
 
-	// Check that the account doesn't have to access the rules and alerts endpoint.
+	// Check that the account doesn't have to access the rules and alerts endpoints.
 	for _, path := range []string{"/api/v1/rules", "/api/v1/alerts"} {
 		err = framework.Poll(5*time.Second, time.Minute, func() error {
 			// The tenancy port (9092) is only exposed in-cluster so we need to use
@@ -800,25 +801,33 @@ func assertTenancyForMetrics(t *testing.T) {
 				},
 			)
 
-			resp, err := client.Do(tc.method, "/api/v1/query?namespace="+userWorkloadTestNs+"&query=up", nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer resp.Body.Close()
-			// Body: {"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up",...},"value":[1695582946.784,"1"]}]}}
-			respBodyBytes, err := io.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
+			// It might take some time for kube-rbac-proxy to catch up the updated permission.
+			err = framework.Poll(time.Second, time.Minute, func() error {
+				resp, err := client.Do(tc.method, "/api/v1/query?namespace="+userWorkloadTestNs+"&query=up", nil)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				// Body: {"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up",...},"value":[1695582946.784,"1"]}]}}
+				respBodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
 
-			if tc.expectNotOKOnQuery {
-				if resp.StatusCode == http.StatusOK {
-					t.Fatal("expected request to be rejected, but succeeded")
+				if tc.expectNotOKOnQuery {
+					if resp.StatusCode == http.StatusOK {
+						return fmt.Errorf("expected request to be rejected, but succeeded")
+					}
+				} else {
+					if resp.StatusCode != http.StatusOK {
+						return fmt.Errorf("expected request to be accepted, but got status code %d (%s)", resp.StatusCode, respBodyBytes)
+					}
 				}
-			} else {
-				if resp.StatusCode != http.StatusOK {
-					t.Fatalf("expected request to be accepted, but got status code %d (%s)", resp.StatusCode, respBodyBytes)
-				}
+
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
 			}
 		})
 	}


### PR DESCRIPTION
It should speed up the test run if we check the condition immediately instead of waiting for 5 seconds.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
