### PR TITLE
[ART-8431] Apply hypershift cluster-profile for ibm-cloud-managed

### DIFF
--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertingrules-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertingrules-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1406
     description: OpenShift Monitoring alerting rules
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     operator.prometheus.io/version: 0.71.2

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     operator.prometheus.io/version: 0.71.2

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertrelabelconfigs-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertrelabelconfigs-custom-resource-definition.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1406
     description: OpenShift Monitoring alert relabel configurations
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     operator.prometheus.io/version: 0.71.2

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     operator.prometheus.io/version: 0.71.2

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     operator.prometheus.io/version: 0.71.2

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     operator.prometheus.io/version: 0.71.2

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     operator.prometheus.io/version: 0.71.2

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     operator.prometheus.io/version: 0.71.2

--- a/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_01-namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
     include.release.openshift.io/single-node-developer: "true"
@@ -22,6 +23,7 @@ metadata:
   name: openshift-user-workload-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_50_cluster-monitoring-operator_02-alert-customization-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-alert-customization-role.yaml
@@ -3,6 +3,7 @@ kind: Role
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_50_cluster-monitoring-operator_02-namespaced-cluster-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-namespaced-cluster-role.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_50_cluster-monitoring-operator_03-role-binding.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_03-role-binding.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 ---
@@ -15,6 +16,7 @@ metadata:
   name: cluster-monitoring-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:
@@ -33,6 +35,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:
@@ -51,6 +54,7 @@ metadata:
   namespace: openshift-user-workload-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:
@@ -69,6 +73,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:

--- a/manifests/0000_50_cluster-monitoring-operator_03-service.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_03-service.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: cluster-monitoring-operator-tls
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/description: Expose the `/metrics` endpoint on port 8443. This port is for internal use, and no other usage is guaranteed.

--- a/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
@@ -1058,5 +1058,6 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
   labels:
     app: cluster-monitoring-operator
     app.kubernetes.io/managed-by: cluster-version-operator

--- a/manifests/0000_50_cluster-monitoring-operator_06-clusteroperator.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_06-clusteroperator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec: {}

--- a/manifests/0000_90_cluster-monitoring-operator_00-operatorgroup.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_00-operatorgroup.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     olm.providedAPIs: Alertmanager.v1.monitoring.coreos.com,PodMonitor.v1.monitoring.coreos.com,Probe.v1.monitoring.coreos.com,Prometheus.v1.monitoring.coreos.com,PrometheusRule.v1.monitoring.coreos.com,ServiceMonitor.v1.monitoring.coreos.com,ThanosRuler.v1.monitoring.coreos.com,AlertmanagerConfig.v1alpha1.monitoring.coreos.com
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1867,6 +1867,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -1880,6 +1881,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -4877,6 +4879,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -4890,6 +4893,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -7596,6 +7600,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -7610,6 +7615,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -8620,6 +8626,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -8633,6 +8640,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -10534,6 +10542,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -10548,6 +10557,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -12511,6 +12521,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -12525,6 +12536,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -14641,6 +14653,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -14655,6 +14668,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -16111,6 +16125,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -16124,6 +16139,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -17178,6 +17194,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -17191,6 +17208,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -18299,6 +18317,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -18312,6 +18331,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -19532,6 +19552,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -19545,6 +19566,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"
@@ -20788,6 +20810,7 @@ metadata:
   annotations:
     capability.openshift.io/name: Console
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -20801,6 +20824,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/delete: "true"


### PR DESCRIPTION
Since HyperShift / Hosted Control Plane have adopted `include.release.openshift.io/ibm-cloud-managed`, to tailor the resources of clusters running in the ROKS IBM environment, the `include.release.openshift.io/hypershift` addition will allow Hypershift to express different profile choices than ROKS