### PR TITLE
OCPBUGS-28246: fix Thanos ruler alert generator url

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3249,7 +3249,6 @@ func (f *Factory) ThanosRulerRBACProxyMetricsSecret() (*v1.Secret, error) {
 }
 
 func (f *Factory) ThanosRulerCustomResource(
-	queryURL string,
 	trustedCA *v1.ConfigMap,
 	grpcTLS *v1.Secret,
 	alertmanagerConfig *v1.Secret,
@@ -3340,8 +3339,11 @@ func (f *Factory) ThanosRulerCustomResource(
 	f.mountThanosRulerAlertmanagerSecrets(t)
 	f.injectThanosRulerAlertmanagerDigest(t, alertmanagerConfig)
 
-	if queryURL != "" {
-		t.Spec.AlertQueryURL = queryURL
+	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
+		t.Spec.AlertQueryURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	t.Namespace = f.namespaceUserWorkload

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -479,12 +479,11 @@ func (f *Factory) AlertmanagerUserWorkload(trustedCABundleCM *v1.ConfigMap) (*mo
 
 	// TODO(simonpasquier): link to the alerting page of the dev console. It
 	// depends on https://issues.redhat.com/browse/MON-2289.
-	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
-		a.Spec.ExternalURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
-		if err != nil {
-			return nil, err
-		}
+	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "monitoring")
+	if err != nil {
+		return nil, err
 	}
+	a.Spec.ExternalURL = alertGeneratorURL
 
 	alertmanagerConfig := f.config.UserWorkloadConfiguration.Alertmanager
 
@@ -610,12 +609,11 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 
 	a.Spec.Image = &f.config.Images.Alertmanager
 
-	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
-		a.Spec.ExternalURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
-		if err != nil {
-			return nil, err
-		}
+	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "monitoring")
+	if err != nil {
+		return nil, err
 	}
+	a.Spec.ExternalURL = alertGeneratorURL
 
 	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.LogLevel != "" {
 		a.Spec.LogLevel = f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.LogLevel
@@ -1342,12 +1340,11 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 
 	p.Spec.Image = &f.config.Images.Prometheus
 
-	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
-		p.Spec.ExternalURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
-		if err != nil {
-			return nil, err
-		}
+	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "monitoring")
+	if err != nil {
+		return nil, err
 	}
+	p.Spec.ExternalURL = alertGeneratorURL
 
 	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Resources != nil {
 		p.Spec.Resources = *f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.Resources
@@ -1672,12 +1669,11 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 
 	p.Spec.Image = &f.config.Images.Prometheus
 
-	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
-		p.Spec.ExternalURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
-		if err != nil {
-			return nil, err
-		}
+	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "monitoring")
+	if err != nil {
+		return nil, err
 	}
+	p.Spec.ExternalURL = alertGeneratorURL
 
 	if f.config.UserWorkloadConfiguration.Prometheus.Resources != nil {
 		p.Spec.Resources = *f.config.UserWorkloadConfiguration.Prometheus.Resources
@@ -3339,12 +3335,11 @@ func (f *Factory) ThanosRulerCustomResource(
 	f.mountThanosRulerAlertmanagerSecrets(t)
 	f.injectThanosRulerAlertmanagerDigest(t, alertmanagerConfig)
 
-	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
-		t.Spec.AlertQueryURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
-		if err != nil {
-			return nil, err
-		}
+	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "monitoring")
+	if err != nil {
+		return nil, err
 	}
+	t.Spec.AlertQueryURL = alertGeneratorURL
 
 	t.Namespace = f.namespaceUserWorkload
 
@@ -3488,6 +3483,13 @@ func (f *Factory) HashSecret(secret *v1.Secret, data ...string) (*v1.Secret, err
 		},
 		Data: m,
 	}, nil
+}
+
+func makeConsoleURL(c *configv1.Console, path string) (string, error) {
+	if c != nil && c.Status.ConsoleURL != "" {
+		return url.JoinPath(c.Status.ConsoleURL, path)
+	}
+	return "", nil
 }
 
 func serviceMonitors(appendMinimal bool, fullServiceMonitor, minimalServiceMonitor func() (*monv1.ServiceMonitor, error)) ([]*monv1.ServiceMonitor, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3064,7 +3064,7 @@ func TestAlertManagerUserWorkloadConfiguration(t *testing.T) {
 
 	c.UserWorkloadConfiguration = uwc
 
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{Status: configv1.ConsoleStatus{ConsoleURL: "https://console-openshift-console.apps.foo.devcluster.openshift.com"}})
 	a, err := f.AlertmanagerUserWorkload(
 		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 	)
@@ -3091,6 +3091,11 @@ func TestAlertManagerUserWorkloadConfiguration(t *testing.T) {
 
 	if a.Spec.TopologySpreadConstraints[0].WhenUnsatisfiable != "DoNotSchedule" {
 		t.Fatal("Alertmanager UWM spread contraints WhenUnsatisfiable not configured correctly")
+	}
+
+	expectedExternalURL := "https://console-openshift-console.apps.foo.devcluster.openshift.com/monitoring"
+	if a.Spec.ExternalURL != expectedExternalURL {
+		t.Fatalf("Alertmanager external URL is not configured correctly, expected %s, but got %s", expectedExternalURL, a.Spec.ExternalURL)
 	}
 }
 
@@ -4078,9 +4083,8 @@ func TestThanosRulerConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{Status: configv1.ConsoleStatus{ConsoleURL: "https://console-openshift-console.apps.foo.devcluster.openshift.com"}})
 	tr, err := f.ThanosRulerCustomResource(
-		"",
 		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 		nil,
@@ -4111,6 +4115,11 @@ func TestThanosRulerConfiguration(t *testing.T) {
 	if !reflect.DeepEqual(tr.Spec.Resources, *f.config.UserWorkloadConfiguration.ThanosRuler.Resources) {
 		t.Fatal("Thanos ruler resources not configured correctly")
 	}
+
+	expectedExternalURL := "https://console-openshift-console.apps.foo.devcluster.openshift.com/monitoring"
+	if tr.Spec.AlertQueryURL != expectedExternalURL {
+		t.Fatalf("Thanos Ruler alertquery URL is not configured correctly, expected %s, but got %s", expectedExternalURL, tr.Spec.AlertQueryURL)
+	}
 }
 
 func TestThanosRulerRetentionConfig(t *testing.T) {
@@ -4120,7 +4129,6 @@ func TestThanosRulerRetentionConfig(t *testing.T) {
 	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 	tr, err := f.ThanosRulerCustomResource(
-		"",
 		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 		nil,
@@ -4215,7 +4223,6 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 			name: "Thanos ruler",
 			getSpec: func(f *Factory) (spec, error) {
 				t, err := f.ThanosRulerCustomResource(
-					"",
 					&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 					&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 					nil,

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -17,7 +17,6 @@ package tasks
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
@@ -230,22 +229,6 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 			return fmt.Errorf("error deleting expired UserWorkload Thanos Ruler GRPC TLS secret: %w", err)
 		}
 
-		hasRoutes, err := t.client.HasRouteCapability(ctx)
-		if err != nil {
-			return fmt.Errorf("checking for Route capability failed: %w", err)
-		}
-		var queryURL *url.URL
-		if hasRoutes {
-			querierRoute, err := t.factory.ThanosQuerierRoute()
-			if err != nil {
-				return fmt.Errorf("initializing Thanos Querier Route failed: %w", err)
-			}
-			queryURL, err = t.client.GetRouteURL(ctx, querierRoute)
-			if err != nil {
-				return fmt.Errorf("error getting Thanos Querier Route url: %w", err)
-			}
-		}
-
 		pdb, err := t.factory.ThanosRulerPodDisruptionBudget()
 		if err != nil {
 			return fmt.Errorf("initializing Thanos Ruler PodDisruptionBudget object failed: %w", err)
@@ -258,7 +241,7 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 			}
 		}
 
-		tr, err := t.factory.ThanosRulerCustomResource(queryURL.String(), trustedCA, grpcSecret, acs)
+		tr, err := t.factory.ThanosRulerCustomResource(trustedCA, grpcSecret, acs)
 		if err != nil {
 			return fmt.Errorf("initializing ThanosRuler object failed: %w", err)
 		}
@@ -448,7 +431,7 @@ func (t *ThanosRulerUserWorkloadTask) destroy(ctx context.Context) error {
 		}
 	}
 
-	tr, err := t.factory.ThanosRulerCustomResource("", trustedCA, grpcSecret, acs)
+	tr, err := t.factory.ThanosRulerCustomResource(trustedCA, grpcSecret, acs)
 	if err != nil {
 		return fmt.Errorf("initializing ThanosRuler object failed: %w", err)
 	}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
