### PR TITLE
OCPBUGS-30257: Making sure proxy settings are correctly forwarded in the generated remote write configs

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1428,7 +1428,9 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 		p.Spec.RemoteWrite = addRemoteWriteConfigs(clusterID, p.Spec.RemoteWrite, f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.RemoteWrite...)
 	}
 
-	for _, rw := range p.Spec.RemoteWrite {
+	for k := range p.Spec.RemoteWrite {
+		rw := &p.Spec.RemoteWrite[k]
+
 		if f.proxy.HTTPProxy() != "" {
 			rw.ProxyURL = f.proxy.HTTPProxy()
 		}


### PR DESCRIPTION
Fix some golang mistake in which the `remoteWrite` config objects were copied instead of being passed by reference.
**This may impact the customers as the remote write calls may now be proxied:**
- We may want to fix this issue first: https://github.com/prometheus-operator/prometheus-operator/issues/6301
- Also it would be nice to have the Prometheus Operator and CMO forward the `noProxy` option on top of the `proxyUrl`; indeed Prometheus is supporting that option: https://github.com/prometheus/prometheus/blob/main/docs/configuration/configuration.md#oauth2

c.c. @simonpasquier 

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.