### PR TITLE
MON-3706: Revert "chore: poll immediately in the e2e tests"

### DIFF
--- a/test/e2e/alertmanager_user_workload_test.go
+++ b/test/e2e/alertmanager_user_workload_test.go
@@ -36,7 +36,6 @@ func TestUserWorkloadAlertmanager(t *testing.T) {
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
 	f.AssertStatefulSetExistsAndRollout("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
-	f.AssertServiceExists("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
 
 	for _, scenario := range []struct {
 		name string

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -445,16 +445,9 @@ func (f *Framework) AssertOperatorConditionMessageContains(conditionType configv
 
 func (f *Framework) AssertValueInConfigMapEquals(name, namespace, key, compareWith string) func(t *testing.T) {
 	return func(t *testing.T) {
-		err := Poll(time.Second, time.Minute, func() error {
-			cm := f.MustGetConfigMap(t, name, namespace)
-			if cm.Data[key] != compareWith {
-				return fmt.Errorf("wanted value %s for key %s but got %s", compareWith, key, cm.Data[key])
-			}
-
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
+		cm := f.MustGetConfigMap(t, name, namespace)
+		if cm.Data[key] != compareWith {
+			t.Fatalf("wanted value %s for key %s but got %s", compareWith, key, cm.Data[key])
 		}
 	}
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -628,7 +628,7 @@ func (f *Framework) ForwardPort(t *testing.T, ns, svc string, port int) (string,
 func Poll(interval, timeout time.Duration, f func() error) error {
 	var lastErr error
 
-	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context.Context) (bool, error) {
 		lastErr = f()
 		if lastErr != nil {
 			return false, nil


### PR DESCRIPTION
This reverts commit 5038186e1c1bf9c86054444310484cc351357f36.

It seems to make the e2e tests very flaky.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
