### PR TITLE
OCPBUGS-30294: Add aggregate-to-view to cluster-monitoring-view

### DIFF
--- a/assets/cluster-monitoring-operator/cluster-role-view.yaml
+++ b/assets/cluster-monitoring-operator/cluster-role-view.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/part-of: openshift-monitoring
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: cluster-monitoring-view
 rules:
 - apiGroups:

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -346,6 +346,9 @@ function(params) {
     kind: 'ClusterRole',
     metadata: {
       name: 'cluster-monitoring-view',
+      labels: {
+        'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+      },
     },
     rules: [
       {


### PR DESCRIPTION
Since OpenShift 4.15.0, AlertManager requires the user to have an RBAC
to the subresource of 'prometheuses/api'. The ClusterRole
'cluster-monitoring-view' is not configured to use aggregate-to-view [1]

This commit adds the rbac.authorization.k8s.io/aggregate-to-view: 'true'
label to the cluster-monitoring-view ClusterRole.

---
[1] https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>