### PR TITLE
MON-3789: add a golangci-lint-fix makefile target to fix golangci-lint errros when possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,11 @@ go-fmt:
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT_BIN)
-	$(GOLANGCI_LINT_BIN) run --verbose --print-resources-usage -c .golangci.yaml
+	$(GOLANGCI_LINT_BIN) run --verbose --print-resources-usage
+
+.PHONY: golangci-lint-fix
+golangci-lint-fix: $(GOLANGCI_LINT_BIN)
+	$(GOLANGCI_LINT_BIN) run --verbose --print-resources-usage --fix
 
 .PHONY:
 misspell:


### PR DESCRIPTION
…hen possible

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
