### PR TITLE
Increase e2e test timeout to 150 min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ test-unit:
 .PHONY: test-e2e
 test-e2e: KUBECONFIG?=$(HOME)/.kube/config
 test-e2e:
-	go test -v -timeout=120m ./test/e2e/ --kubeconfig $(KUBECONFIG)
+	go test -v -timeout=150m ./test/e2e/ --kubeconfig $(KUBECONFIG)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)


### PR DESCRIPTION
This commit extends the timeout of CMO e2e tests to 150' in order to
avoid being cut by the CI when they run closer to the time limit.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>