### PR TITLE
MON-3380: adjust prometheus-k8s service openshift.io/description

### DIFF
--- a/Documentation/resources.adoc
+++ b/Documentation/resources.adoc
@@ -109,7 +109,7 @@ Expose the `prometheus-adapter` web server on port 443. This port is for interna
 
 Expose the Prometheus web server within the cluster on the following ports:
 * Port 9091 provides access to all the Prometheus endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
-* Port 9092 provides access the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
+* Port 9092 provides access the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
 
 === openshift-user-workload-monitoring/prometheus-operator
 

--- a/Documentation/resources.md
+++ b/Documentation/resources.md
@@ -90,7 +90,7 @@ Expose the `prometheus-adapter` web server on port 443. This port is for interna
 
 Expose the Prometheus web server within the cluster on the following ports:
 * Port 9091 provides access to all the Prometheus endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
-* Port 9092 provides access the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
+* Port 9092 provides access the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
 
 ### openshift-user-workload-monitoring/prometheus-operator
 

--- a/assets/prometheus-k8s/service.yaml
+++ b/assets/prometheus-k8s/service.yaml
@@ -5,7 +5,7 @@ metadata:
     openshift.io/description: |-
       Expose the Prometheus web server within the cluster on the following ports:
       * Port 9091 provides access to all the Prometheus endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
-      * Port 9092 provides access the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
+      * Port 9092 provides access the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
     service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls
   labels:
     app.kubernetes.io/component: prometheus

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -103,7 +103,7 @@ function(params)
           |||
             Expose the Prometheus web server within the cluster on the following ports:
             * Port %d provides access to all the Prometheus endpoints. %s
-            * Port %d provides access the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
+            * Port %d provides access the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
           ||| % [
             $.service.spec.ports[0].port,
             requiredClusterRoles(['cluster-monitoring-view'], true),


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
