### PR TITLE
MON-3748: Enable audit logs by default for metrics-server

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -190,6 +190,7 @@ The `MetricsServerConfig` resource defines settings for the Metrics Server compo
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
+| audit | *Audit | Defines the audit configuration used by the Metrics Server instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`. |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#toleration-v1-core) | Defines tolerations for the pods. |
 | resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core) | Defines resource requests and limits for the Metrics Server container. |

--- a/Documentation/openshiftdocs/modules/metricsserverconfig.adoc
+++ b/Documentation/openshiftdocs/modules/metricsserverconfig.adoc
@@ -18,6 +18,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 [options="header"]
 |===
 | Property | Type | Description 
+|audit|*Audit|Defines the audit configuration used by the Metrics Server instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`.
+
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.

--- a/assets/metrics-server/configmap-audit-profiles.yaml
+++ b/assets/metrics-server/configmap-audit-profiles.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+data:
+  metadata-profile.yaml: |-
+    "apiVersion": "audit.k8s.io/v1"
+    "kind": "Policy"
+    "metadata":
+      "name": "Metadata"
+    "omitStages":
+    - "RequestReceived"
+    "rules":
+    - "level": "Metadata"
+  none-profile.yaml: |-
+    "apiVersion": "audit.k8s.io/v1"
+    "kind": "Policy"
+    "metadata":
+      "name": "None"
+    "omitStages":
+    - "RequestReceived"
+    "rules":
+    - "level": "None"
+  request-profile.yaml: |-
+    "apiVersion": "audit.k8s.io/v1"
+    "kind": "Policy"
+    "metadata":
+      "name": "Request"
+    "omitStages":
+    - "RequestReceived"
+    "rules":
+    - "level": "Request"
+  requestresponse-profile.yaml: |-
+    "apiVersion": "audit.k8s.io/v1"
+    "kind": "Policy"
+    "metadata":
+      "name": "RequestResponse"
+    "omitStages":
+    - "RequestReceived"
+    "rules":
+    - "level": "RequestResponse"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: metrics-server-audit-profiles
+  namespace: openshift-monitoring

--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -88,6 +88,12 @@ spec:
           name: secret-metrics-client-certs
         - mountPath: /etc/tls/kubelet-serving-ca-bundle
           name: configmap-kubelet-serving-ca-bundle
+        - mountPath: /etc/audit
+          name: metrics-server-audit-profiles
+          readOnly: true
+        - mountPath: /var/log/metrics-server
+          name: audit-log
+          readOnly: false
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
@@ -102,3 +108,8 @@ spec:
       - configMap:
           name: kubelet-serving-ca-bundle
         name: configmap-kubelet-serving-ca-bundle
+      - emptyDir: {}
+        name: audit-log
+      - configMap:
+          name: metrics-server-audit-profiles
+        name: metrics-server-audit-profiles

--- a/jsonnet/components/metrics-server-audit.libsonnet
+++ b/jsonnet/components/metrics-server-audit.libsonnet
@@ -1,0 +1,70 @@
+local profile(level) = {
+  apiVersion: 'audit.k8s.io/v1',
+  kind: 'Policy',
+  metadata: {
+    name: level,
+  },
+  // omit stage RequestReceived to avoid duplication of logs for both stages
+  // RequestReceived and ResponseComplete
+  omitStages: ['RequestReceived'],
+  rules: [{ level: level }],
+};
+
+
+{
+  values+:: {
+    audit_profiles_name: 'metrics-server-audit-profiles',
+  },
+  metricsServer+: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers:
+              std.map(
+                function(c)
+                  if c.name == 'metrics-server' then
+                    c {
+                      volumeMounts+: [{
+                        mountPath: '/etc/audit',
+                        name: $.values.audit_profiles_name,
+                        readOnly: true,
+                      }, {
+                        mountPath: '/var/log/metrics-server',
+                        name: 'audit-log',
+                        readOnly: false,
+                      }],
+                    }
+                  else
+                    c,
+                super.containers,
+              ),
+
+            volumes+: [{
+              name: 'audit-log',
+              emptyDir: {},
+            }, {
+              name: $.values.audit_profiles_name,
+              configMap: {
+                name: $.values.audit_profiles_name,
+              },
+            }],
+          },
+        },
+      },
+    },
+
+    configmapAuditProfiles: {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: $.values.audit_profiles_name,
+        namespace: $.values.common.namespace,
+      },
+      data: {
+        [std.asciiLower(x) + '-profile.yaml']: std.manifestYamlDoc(profile(x))
+        for x in ['None', 'Metadata', 'Request', 'RequestResponse']
+      },
+    },
+  },
+}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -438,6 +438,7 @@ local inCluster =
   (import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet') +
   (import './utils/ibm-cloud-managed-profile.libsonnet') +
   (import './components/prometheus-adapter-audit.libsonnet') +
+  (import './components/metrics-server-audit.libsonnet') +
   {};  // Including empty object to simplify adding and removing imports during development
 
 // objects deployed in openshift-user-workload-monitoring namespace

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -267,6 +267,16 @@ func (c *Config) applyDefaults() {
 		}
 	}
 
+	if c.ClusterMonitoringConfiguration.MetricsServerConfig == nil {
+		c.ClusterMonitoringConfiguration.MetricsServerConfig = &MetricsServerConfig{}
+	}
+	if c.ClusterMonitoringConfiguration.MetricsServerConfig.Audit == nil {
+		c.ClusterMonitoringConfiguration.MetricsServerConfig.Audit = &Audit{}
+	}
+	if c.ClusterMonitoringConfiguration.MetricsServerConfig.Audit.Profile == "" {
+		c.ClusterMonitoringConfiguration.MetricsServerConfig.Audit.Profile = auditv1.LevelMetadata
+	}
+
 	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter == nil {
 		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter = &K8sPrometheusAdapter{}
 	}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -203,6 +203,7 @@ var (
 	MetricsServerClusterRoleBinding              = "metrics-server/cluster-role-binding.yaml"
 	MetricsServerClusterRoleBindingAuthDelegator = "metrics-server/cluster-role-binding-auth-delegator.yaml"
 	MetricsServerRoleBindingAuthReader           = "metrics-server/role-binding-auth-reader.yaml"
+	MetricsServerConfigMapAuditPolicy            = "metrics-server/configmap-audit-profiles.yaml"
 	MetricsServerDeployment                      = "metrics-server/deployment.yaml"
 	MetricsServerService                         = "metrics-server/service.yaml"
 	MetricsServerServiceMonitor                  = "metrics-server/service-monitor.yaml"
@@ -2041,6 +2042,10 @@ func (f *Factory) PrometheusAdapterAPIService() (*apiregistrationv1.APIService, 
 	return f.NewAPIService(f.assets.MustNewAssetSlice(PrometheusAdapterAPIService))
 }
 
+func (f *Factory) MetricsServerConfigMapAuditPolicy() (*v1.ConfigMap, error) {
+	return f.NewConfigMap(f.assets.MustNewAssetSlice(MetricsServerConfigMapAuditPolicy))
+}
+
 func (f *Factory) MetricsServerServiceAccount() (*v1.ServiceAccount, error) {
 	return f.NewServiceAccount(f.assets.MustNewAssetSlice(MetricsServerServiceAccount))
 }
@@ -2097,6 +2102,19 @@ func (f *Factory) MetricsServerDeployment(kubeletCABundle *v1.ConfigMap, tlsSecr
 	if config == nil {
 		return dep, nil
 	}
+
+	if err := validateAuditProfile(config.Audit.Profile); err != nil {
+		return nil, err
+	}
+
+	profile := strings.ToLower(string(config.Audit.Profile))
+	containers[idx].Args = append(containers[idx].Args,
+		fmt.Sprintf("--audit-policy-file=/etc/audit/%s-profile.yaml", profile),
+		"--audit-log-path=/var/log/metrics-server/audit.log",
+		"--audit-log-maxsize=100", // 100 MB
+		"--audit-log-maxbackup=5", // limit space consumed by restricting backups
+		"--audit-log-compress=true",
+	)
 
 	if len(config.NodeSelector) > 0 {
 		podSpec.NodeSelector = config.NodeSelector

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -124,6 +124,10 @@ type K8sPrometheusAdapter struct {
 // The `MetricsServerConfig` resource defines settings for the Metrics Server component.
 // Note that this setting only applies when the MetricsServer feature gate is enabled.
 type MetricsServerConfig struct {
+	// Defines the audit configuration used by the Metrics Server instance.
+	// Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`.
+	// The default value is `metadata`.
+	Audit *Audit `json:"audit,omitempty"`
 	// Defines the nodes on which the pods are scheduled.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines tolerations for the pods.

--- a/pkg/tasks/metricsserver.go
+++ b/pkg/tasks/metricsserver.go
@@ -143,6 +143,18 @@ func (t *MetricsServerTask) create(ctx context.Context) error {
 			return err
 		}
 
+		{
+			cm, err := t.factory.MetricsServerConfigMapAuditPolicy()
+			if err != nil {
+				return fmt.Errorf("initializing MetricsServer AuditPolicy ConfigMap failed: %w", err)
+			}
+
+			err = t.client.CreateOrUpdateConfigMap(ctx, cm)
+			if err != nil {
+				return fmt.Errorf("reconciling MetricsServer AuditPolicy ConfigMap failed: %w", err)
+			}
+		}
+
 		dep, err := t.factory.MetricsServerDeployment(cacm, scas, mcs)
 		if err != nil {
 			return fmt.Errorf("initializing MetricsServer Deployment failed: %w", err)


### PR DESCRIPTION
Enabling audit logs helps troubleshoot issues in Metrics Server. The details of the audit level can be tweaked by selecting an audit profile which corresponds to audit Log Level.
See: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy

The following profiles are provided:
  - Metadata:  The default audit profile
  - None
  - Request
  - RequestResponse

User can pick any of the profile by modifying the CMO configmap as follows

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: cluster-monitoring-config
  namespace: openshift-monitoring
data:
  config.yaml: |
    metricsServer:
      audit:
        profile: Request
```

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->


**Adapted the change as in Prometheus Adapter**

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
