### PR TITLE
[CI TEST] Set go test timeout to 4h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ test-unit:
 .PHONY: test-e2e
 test-e2e: KUBECONFIG?=$(HOME)/.kube/config
 test-e2e:
-	go test -v -timeout=150m ./test/e2e/ --kubeconfig $(KUBECONFIG)
+	go test -v -timeout=4h ./test/e2e/ --kubeconfig $(KUBECONFIG)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)


### PR DESCRIPTION
This commit changes the duration of the test timeout in e2e tests to 4h
in order to test a possible flake in the prow runs which are being
stopped at 2h when running these tests in openshift/thanos.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>