### PR TITLE
MON-3850: Lint CMO tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  tests: false
+  tests: true
   skip-dirs:
     - vendor
     - test
@@ -28,6 +28,31 @@ linters:
     - wastedassign
     - whitespace
     - gci
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        # The list of linters below is exhaustive with respect to the linters defined above, and as such, and linter
+        # that needs to be run on test files should be dropped from here.
+        - depguard
+        - errcheck
+        - errorlint
+        - bodyclose
+        - exportloopref
+        - gosimple
+        - ineffassign
+        - misspell
+        - nolintlint
+        - nosprintfhostport
+        - staticcheck
+        - tenv
+        - typecheck
+        - unconvert
+        - unused
+        - wastedassign
+        - whitespace
+        - gci
 
 linters-settings:
   depguard:

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2237,7 +2237,8 @@ func TestPollUntil(t *testing.T) {
 	require.ErrorContains(t, err, "context deadline exceeded")
 
 	// the parent context times out before poll times out.
-	parentCtx1, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	parentCtx1, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
 	err = Poll(parentCtx1, func(ctx context.Context) (bool, error) {
 		// This also ensures that when the parent context is Done, the condition context is cancelled as well.
 		select {


### PR DESCRIPTION
Adds an explicit `vet` target and also integrates it into the `verify` flow to catch any such violations within the source code.

***

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
