### PR TITLE
MON-3801: remove oauth-redirectreference annotations

### DIFF
--- a/assets/alertmanager/service-account.yaml
+++ b/assets/alertmanager/service-account.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.alertmanager-main-: ""
   labels:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/instance: main

--- a/assets/prometheus-k8s/service-account.yaml
+++ b/assets/prometheus-k8s/service-account.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s-: ""
   labels:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/instance: k8s

--- a/assets/thanos-querier/service-account.yaml
+++ b/assets/thanos-querier/service-account.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    serviceaccounts.openshift.io/oauth-redirectreference.thanos-querier: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"thanos-querier"}}'
+    serviceaccounts.openshift.io/oauth-redirectreference.thanos-querier-: ""
   labels:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -44,6 +44,14 @@ function(params)
     },
 
     serviceAccount+: {
+      metadata+: {
+        annotations+: {
+          // TODO(simonpasquier): remove this step after OCP 4.16 is released.
+          // https://issues.redhat.com/browse/MON-3801.
+          'serviceaccounts.openshift.io/oauth-redirectreference.alertmanager-main-': '',
+        },
+      },
+
       // Alertmanager can mount the token into the pod since
       // https://github.com/prometheus-operator/prometheus-operator/pull/5474
       // and v0.66.0

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -83,6 +83,13 @@ function(params)
     serviceAccount+: {
       // service account token is managed by the operator.
       automountServiceAccountToken: false,
+      metadata+: {
+        annotations+: {
+          // TODO(simonpasquier): remove this step after OCP 4.16 is released.
+          // https://issues.redhat.com/browse/MON-3801.
+          'serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s-': '',
+        },
+      },
     },
 
     // Adding the serving certs annotation causes the serving certs controller

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -190,7 +190,9 @@ function(params)
         namespace: cfg.namespace,
         labels: tq.config.commonLabels,
         annotations: {
-          'serviceaccounts.openshift.io/oauth-redirectreference.thanos-querier': '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"thanos-querier"}}',
+          // TODO(simonpasquier): remove this step after OCP 4.16 is released.
+          // https://issues.redhat.com/browse/MON-3801.
+          'serviceaccounts.openshift.io/oauth-redirectreference.thanos-querier-': '',
         },
       },
     },


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
