### PR TITLE
MON-3621: Enable `extra-scrape-metrics` feature in PrometheusUWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.16
+
+- [#2302](https://github.com/openshift/cluster-monitoring-operator/issues/2302) Enable feature `extra-scrape-metrics` in Prometheus user-workload
+
 ## 4.15
 
 - [#2022](https://github.com/openshift/cluster-monitoring-operator/pull/2022) Add support to switch to metrics server from prometheus-adapter when the `MetricsServer` feature gate is enabled.

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -165,7 +165,8 @@ spec:
       name: secret-grpc-tls
   - name: prometheus
     terminationMessagePolicy: FallbackToLogsOnError
-  enableFeatures: []
+  enableFeatures:
+  - extra-scrape-metrics
   enforcedNamespaceLabel: namespace
   externalLabels: {}
   ignoreNamespaceSelectors: true

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -292,6 +292,8 @@ function(params)
 
     prometheus+: {
       spec+: {
+        // Enable experimental additional scrape metrics feature
+        enableFeatures+: ['extra-scrape-metrics'],
         overrideHonorTimestamps: true,
         overrideHonorLabels: true,
         ignoreNamespaceSelectors: true,

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -654,7 +654,7 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
 					expectCatchAllToleration(),
 					expectMatchingRequests(podName, containerName, mem, cpu),
 					// Set by default.
-					expectContainerArg("--enable-feature=exemplar-storage", containerName),
+					expectContainerArg("--enable-feature=extra-scrape-metrics,exemplar-storage", containerName),
 					// Set via the config above.
 					expectContainerArg("--log.level=debug", containerName),
 					expectContainerArg("--storage.tsdb.retention.time=10h", containerName),


### PR DESCRIPTION
Update Prometheus user-workload to enable additional scrape metrics
As part of epic [MON-3256](https://issues.redhat.com/browse/MON-3256)

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
