### PR TITLE
[release-4.12] OCPBUGS-28766: fix generation of telemeter token hash

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -16,7 +16,6 @@ package manifests
 
 import (
 	"crypto/md5"
-	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -3617,8 +3616,9 @@ func (f *Factory) TelemeterClientDeployment(proxyCABundleCM *v1.ConfigMap, s *v1
 
 	// Set annotation on deployment to trigger redeployments
 	if s != nil {
-		hash := sha256.New()
-		d.Spec.Template.Annotations["telemeter-token-hash"] = string(hash.Sum(s.Data["token"]))
+		h := fnv.New64()
+		h.Write(s.Data["token"])
+		d.Spec.Template.Annotations["telemeter-token-hash"] = strconv.FormatUint(h.Sum64(), 32)
 	}
 
 	for i, container := range d.Spec.Template.Spec.Containers {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -16,7 +16,6 @@ package manifests
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/url"
@@ -3194,8 +3193,7 @@ func TestTelemeterConfiguration(t *testing.T) {
 		}
 	}
 
-	hash := sha256.New()
-	expectedTokenHash := string(hash.Sum([]byte("test")))
+	expectedTokenHash := "8o29vfqfspfr9"
 
 	if tokenHash, ok := d.Spec.Template.Annotations["telemeter-token-hash"]; !ok {
 		t.Fatalf("telemeter-token-hash annotation not set in telemeter-client deployment")


### PR DESCRIPTION
It also changes the hash algorithm from sha256 to fnv to be consistent with the rest of code and to signal that the use of the function is non-cryptographic.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
