### PR TITLE
MON-3802: implement cross-namespace rules for UWM

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,39 +112,32 @@ This targets needs `docker` to be installed on host and was not tested with othe
 
 ## Testing
 
-Supposing $KUBECONFIG is set to the config file of a Kubernetes cluster running the codes to test. We can run all tests by using this command `make test`.
+Assuming that the `KUBECONFIG` environment variable is set to the config file of an OpenShift cluster against which the tests will run, you can execute all the tests running `make test`.
 
-The testing consist of 3 aspects:
-- unit tests, can be run separately by `make test-unit`.
-- Prometheus rule tests, can be run separately by `make test-rules`.
-- end-to-end tests, can be run separately by `make test-e2e`.
+Testing entails 3 types of tests:
+- Unit tests which can be run separately with `make test-unit`.
+- Prometheus rule tests which can be run separately with `make test-rules`.
+- End-to-end tests which can be run separately with `make test-e2e`.
 
-If we need to run a specific test case of the E2E test, we can use the following command.
+If you need to run a specific unit test (for example `TestHashSecret`), you can use the following command:
+
 ```bash
-go test -v -timeout=120m ./test/e2e/ --kubeconfig $KUBECONFIG -run TestBodySizeLimit
-```
-Attention that we have to pass a valid $KUBECONFIG explicitly `--kubeconfig $KUBECONFIG` even if ~/.kube/config exists.
-
-To run a specific test case of unit tests, we can use the command `go test -v $PACKAGE_DIR -run $TEST_FUNC_NAME`.
-The `$PACKAGE_DIR` is where the source files of a Go package lives. The `$TEST_FUNC_NAME` is the test function whose name always starts with "Test" (regex pattern `TEST\w+`).
-For example, we have a test function `TestImageParsing` in package `manifests`.The source file `./pkg/manifests/image_test.go` and other source code files of this package lives in `./pkg/manifests`. So we can use the following command to run the test function `TestImageParsing` in package `manifests`.
-```bash
-go test -v ./pkg/manifests -run TestImageParsing
+go test -v ./pkg/... -run TestHashSecret
 ```
 
+If you need to run a specific test case from the E2E test suite (for instance `TestBodySizeLimit`), you can use the following command:
 
-## Coding Style
-
-cluster-monitoring-operator projects written in Go follow a set of style guidelines that we've documented [here](https://github.com/coreos/docs/tree/master/golang).
-Please follow them when working on your contributions.
+```bash
+go test -v -timeout=120m -run TestBodySizeLimit ./test/e2e/ --kubeconfig $KUBECONFIG
+```
+Note: you have to set the `KUBECONFIG` environment variable even if `~/.kube/config` exists.
 
 ## Format of Pull Requests
-We are making heavy use of bots and integrations.
-In order for those to work properly, your Pull Request should match the following structure:
 
-```
-Bug 123456: this is the exact problem or fix
-```
+We are making heavy use of bots and integrations which expect the pull request title to contain a reference to a JIRA ticket:
+
+* For bug fixes, `OCPBUGS-12345: ...`
+* For features, `MON-1234: ...`
 
 ## Format of the Commit Message
 
@@ -175,7 +168,5 @@ The first line is the subject and should be no longer than 70 characters, the
 second line is always blank, and other lines should be wrapped at 80 characters.
 This allows the message to be easier to read on GitHub as well as in various
 git tools.
-
-
 
 Thank you for contributing!

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -47,6 +47,7 @@ Configuring Cluster Monitoring is optional. If the config does not exist or is e
 * [TelemeterClientConfig](#telemeterclientconfig)
 * [ThanosQuerierConfig](#thanosquerierconfig)
 * [ThanosRulerConfig](#thanosrulerconfig)
+* [UserWorkloadConfig](#userworkloadconfig)
 * [UserWorkloadConfiguration](#userworkloadconfiguration)
 
 ## AdditionalAlertmanagerConfig
@@ -128,6 +129,7 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 | -------- | ---- | ----------- |
 | alertmanagerMain | *[AlertmanagerMainConfig](#alertmanagermainconfig) | `AlertmanagerMainConfig` defines settings for the Alertmanager component in the `openshift-monitoring` namespace. |
 | enableUserWorkload | *bool | `UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects. |
+| userWorkload | *[UserWorkloadConfig](#userworkloadconfig) | `UserWorkload` defines settings for the monitoring of user-defined projects. |
 | metricsServer | *[MetricsServerConfig](#metricsserverconfig) | `MetricsServer` defines settings for the MetricsServer component. |
 | kubeStateMetrics | *[KubeStateMetricsConfig](#kubestatemetricsconfig) | `KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent. |
 | prometheusK8s | *[PrometheusK8sConfig](#prometheusk8sconfig) | `PrometheusK8sConfig` defines settings for the Prometheus component. |
@@ -618,6 +620,21 @@ The `ThanosRulerConfig` resource defines configuration for the Thanos Ruler inst
 
 [Back to TOC](#table-of-contents)
 
+## UserWorkloadConfig
+
+#### Description
+
+The `UserWorkloadConfig` resource defines settings for the monitoring of user-defined projects.
+
+
+<em>appears in: [ClusterMonitoringConfiguration](#clustermonitoringconfiguration)</em>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| rulesWithoutLabelEnforcementAllowed | *bool | A Boolean flag that enables or disables the ability to deploy user-defined `PrometheusRules` objects for which the `namespace` label isn't enforced to the namespace of the object. Such objects should be created in a namespace configured under the `namespacesWithoutLabelEnforcement` property of the `UserWorkloadConfiguration` resource. The default value is `true`. |
+
+[Back to TOC](#table-of-contents)
+
 ## UserWorkloadConfiguration
 
 #### Description
@@ -630,5 +647,6 @@ The `UserWorkloadConfiguration` resource defines the settings responsible for us
 | prometheus | *[PrometheusRestrictedConfig](#prometheusrestrictedconfig) | Defines the settings for the Prometheus component in user workload monitoring. |
 | prometheusOperator | *[PrometheusOperatorConfig](#prometheusoperatorconfig) | Defines the settings for the Prometheus Operator component in user workload monitoring. |
 | thanosRuler | *[ThanosRulerConfig](#thanosrulerconfig) | Defines the settings for the Thanos Ruler component in user workload monitoring. |
+| namespacesWithoutLabelEnforcement | []string | Defines the list of namespaces for which Prometheus and Thanos Ruler in user-defined monitoring don't enforce the `namespace` label value in `PrometheusRule` objects.\n\nIt allows to define recording and alerting rules that can query across multiple projects (not limited to user-defined projects) instead of deploying identical `PrometheusRule` objects in each user project.\n\nTo make the resulting alerts and metrics visible to project users, the query expressions should return a `namespace` label with a non-empty value. |
 
 [Back to TOC](#table-of-contents)

--- a/Documentation/openshiftdocs/index.adoc
+++ b/Documentation/openshiftdocs/index.adoc
@@ -67,4 +67,5 @@ The configuration file itself is always defined under the `config.yaml` key in t
 * link:modules/telemeterclientconfig.adoc[TelemeterClientConfig]
 * link:modules/thanosquerierconfig.adoc[ThanosQuerierConfig]
 * link:modules/thanosrulerconfig.adoc[ThanosRulerConfig]
+* link:modules/userworkloadconfig.adoc[UserWorkloadConfig]
 * link:modules/userworkloadconfiguration.adoc[UserWorkloadConfiguration]

--- a/Documentation/openshiftdocs/modules/clustermonitoringconfiguration.adoc
+++ b/Documentation/openshiftdocs/modules/clustermonitoringconfiguration.adoc
@@ -19,6 +19,8 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 |enableUserWorkload|*bool|`UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects.
 
+|userWorkload|*link:userworkloadconfig.adoc[UserWorkloadConfig]|`UserWorkload` defines settings for the monitoring of user-defined projects.
+
 |metricsServer|*link:metricsserverconfig.adoc[MetricsServerConfig]|`MetricsServer` defines settings for the MetricsServer component.
 
 |kubeStateMetrics|*link:kubestatemetricsconfig.adoc[KubeStateMetricsConfig]|`KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent.

--- a/Documentation/openshiftdocs/modules/userworkloadconfig.adoc
+++ b/Documentation/openshiftdocs/modules/userworkloadconfig.adoc
@@ -1,0 +1,25 @@
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
+	// source code for the Cluster Monitoring Operator. Any changes made to this 
+	// file will be overwritten when the content is re-generated. If you wish to 
+	// make edits, read the docgen utility instructions in the source code for the 
+	// CMO.
+	:_content-type: ASSEMBLY
+
+== UserWorkloadConfig
+
+=== Description
+
+The `UserWorkloadConfig` resource defines settings for the monitoring of user-defined projects.
+
+
+
+Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|rulesWithoutLabelEnforcementAllowed|*bool|A Boolean flag that enables or disables the ability to deploy user-defined `PrometheusRules` objects for which the `namespace` label isn't enforced to the namespace of the object. Such objects should be created in a namespace configured under the `namespacesWithoutLabelEnforcement` property of the `UserWorkloadConfiguration` resource. The default value is `true`.
+
+|===
+
+link:../index.adoc[Back to TOC]

--- a/Documentation/openshiftdocs/modules/userworkloadconfiguration.adoc
+++ b/Documentation/openshiftdocs/modules/userworkloadconfiguration.adoc
@@ -23,6 +23,8 @@ The `UserWorkloadConfiguration` resource defines the settings responsible for us
 
 |thanosRuler|*link:thanosrulerconfig.adoc[ThanosRulerConfig]|Defines the settings for the Thanos Ruler component in user workload monitoring.
 
+|namespacesWithoutLabelEnforcement|[]string|Defines the list of namespaces for which Prometheus and Thanos Ruler in user-defined monitoring don't enforce the `namespace` label value in `PrometheusRule` objects.\n\nIt allows to define recording and alerting rules that can query across multiple projects (not limited to user-defined projects) instead of deploying identical `PrometheusRule` objects in each user project.\n\nTo make the resulting alerts and metrics visible to project users, the query expressions should return a `namespace` label with a non-empty value.
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -168,6 +168,7 @@ spec:
         - --label=namespace
         - --enable-label-apis
         - --error-on-replace
+        - --rules-with-active-alerts
         image: quay.io/prometheuscommunity/prom-label-proxy:v0.11.0
         name: prom-label-proxy
         resources:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -514,6 +514,7 @@ function(params)
                   '--label=namespace',
                   '--enable-label-apis',
                   '--error-on-replace',
+                  '--rules-with-active-alerts',
                 ],
                 resources: {
                   requests: {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -36,6 +36,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/library-go/pkg/crypto"
+	mon "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"golang.org/x/net/http/httpproxy"
 	yaml2 "gopkg.in/yaml.v2"
@@ -1823,7 +1824,26 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		p.Spec.Secrets = append(p.Spec.Secrets, getAdditionalAlertmanagerSecrets(alertManagerConfigs)...)
 	}
 
+	p.Spec.ExcludedFromEnforcement = f.excludedFromEnforcement()
+
 	return p, nil
+}
+
+func (f *Factory) excludedFromEnforcement() []monv1.ObjectReference {
+	if !*f.config.ClusterMonitoringConfiguration.UserWorkload.RulesWithoutLabelEnforcementAllowed {
+		return nil
+	}
+
+	refs := make([]monv1.ObjectReference, 0, len(f.config.UserWorkloadConfiguration.NamespacesWithoutLabelEnforcement))
+	for _, ns := range f.config.UserWorkloadConfiguration.NamespacesWithoutLabelEnforcement {
+		refs = append(refs, monv1.ObjectReference{
+			Group:     mon.GroupName,
+			Resource:  mon.PrometheusRuleName,
+			Namespace: ns,
+		})
+	}
+
+	return refs
 }
 
 func (f *Factory) PrometheusK8sPrometheusServiceMonitor() (*monv1.ServiceMonitor, error) {
@@ -3236,6 +3256,8 @@ func (f *Factory) ThanosRulerCustomResource(
 		return nil, err
 	}
 	t.Spec.AlertQueryURL = alertGeneratorURL
+
+	t.Spec.ExcludedFromEnforcement = f.excludedFromEnforcement()
 
 	t.Namespace = f.namespaceUserWorkload
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -39,6 +39,8 @@ type ClusterMonitoringConfiguration struct {
 	AlertmanagerMainConfig *AlertmanagerMainConfig `json:"alertmanagerMain,omitempty"`
 	// `UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects.
 	UserWorkloadEnabled *bool `json:"enableUserWorkload,omitempty"`
+	// `UserWorkload` defines settings for the monitoring of user-defined projects.
+	UserWorkload *UserWorkloadConfig `json:"userWorkload,omitempty"`
 	// OmitFromDoc
 	HTTPConfig *HTTPConfig `json:"http,omitempty"`
 	// OmitFromDoc: `K8sPrometheusAdapter` defines settings for the Prometheus Adapter component.
@@ -64,6 +66,19 @@ type ClusterMonitoringConfiguration struct {
 	NodeExporterConfig NodeExporterConfig `json:"nodeExporter,omitempty"`
 	// `MonitoringPluginConfig` defines settings for the monitoring `console-plugin`.
 	MonitoringPluginConfig *MonitoringPluginConfig `json:"monitoringPlugin,omitempty"`
+}
+
+// The `UserWorkloadConfig` resource defines settings for the monitoring of
+// user-defined projects.
+type UserWorkloadConfig struct {
+	// A Boolean flag that enables or disables the ability to deploy
+	// user-defined `PrometheusRules` objects for which the `namespace` label
+	// isn't enforced to the namespace of the object. Such objects should be
+	// created in a namespace configured under the
+	// `namespacesWithoutLabelEnforcement` property of the
+	// `UserWorkloadConfiguration` resource.
+	// The default value is `true`.
+	RulesWithoutLabelEnforcementAllowed *bool `json:"rulesWithoutLabelEnforcementAllowed,omitempty"`
 }
 
 // The `AlertmanagerMainConfig` resource defines settings for the
@@ -532,6 +547,19 @@ type UserWorkloadConfiguration struct {
 	// Defines the settings for the Thanos Ruler component in user workload
 	// monitoring.
 	ThanosRuler *ThanosRulerConfig `json:"thanosRuler,omitempty"`
+
+	// Defines the list of namespaces for which Prometheus and Thanos Ruler in
+	// user-defined monitoring don't enforce the `namespace` label value in
+	// `PrometheusRule` objects.
+	//
+	// It allows to define recording and alerting rules that can query across
+	// multiple projects (not limited to user-defined projects) instead of
+	// deploying identical `PrometheusRule` objects in each user project.
+	//
+	// To make the resulting alerts and metrics visible to project users, the
+	// query expressions should return a `namespace` label with a non-empty
+	// value.
+	NamespacesWithoutLabelEnforcement []string `json:"namespacesWithoutLabelEnforcement,omitempty"`
 }
 
 // The `AlertmanagerUserWorkloadConfig` resource defines the settings for the Alertmanager instance used for user-defined projects.

--- a/test/e2e/alertmanager_helpers.go
+++ b/test/e2e/alertmanager_helpers.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -92,7 +93,7 @@ func setupWebhookReceiver(t *testing.T, f *framework.Framework, namespace string
 			Namespace: namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: toInt32(1),
+			Replicas: ptr.To(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": webhookReceiverService,

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -862,7 +862,7 @@ func testAlertmanagerConfigPipeline(t *testing.T, wr *webhookReceiver, am *monit
 		t.Fatal(err)
 	}
 
-	if err := createUWMTestNsIfNotExist(t, f); err != nil {
+	if err := createNamespaceIfNotExist(f, userWorkloadTestNs); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/image_registry_test.go
+++ b/test/e2e/image_registry_test.go
@@ -63,7 +63,9 @@ func TestImageRegistryPods(t *testing.T) {
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
 	f.AssertStatefulSetExistsAndRollout("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
-	setupUserApplication(t, f)
+	if err := deployUserApplication(f); err != nil {
+		t.Fatal(err)
+	}
 
 	pods = f.MustGetPods(t, f.UserWorkloadMonitoringNs)
 


### PR DESCRIPTION
This change introduces a way to deploy user-defined rules which are not
    scoped to their namespace of origin.
    
To enable the feature, a user-defined monitoring admin needs to
    configure at least one namespace in the UWM ConfigMap:
    
````
    kind: ConfigMap
    apiVersion: v1
    metadata:
      name: user-workload-monitoring-config
      namespace: openshift-user-workload-monitoring
    data:
      config.yaml: |-
        namespacesWithoutLabelEnforcement: [ user-monitoring-shared ]
````
    
For all `PrometheusRule` objects defined in the `user-monitoring-shared`
    namespace, Prometheus and Thanos Ruler evaluate the PromQL expressions
    without enforcing the namespace label of origin. It makes it possible to
    have generic rules that get applied to all (or a subset of) the user
    projects instead of having individual rule objects in each user project.
    
 The capability is enabled by default but a cluster admin can decide to
    disable it in the CMO ConfigMap:
    

````
    kind: ConfigMap
    apiVersion: v1
    metadata:
      name: cluster-monitoring-config
      namespace: openshift-monitoring
    data:
      config.yaml: |-
        userWorkloadEnabled: true
        userWorkload:
         rulesWithoutLabelEnforcementAllowed: false
````

For example, a user-defined admin can create a single rule that fires
    when a user namespace doesn't enforce the Restricted pod security
    policy.
    
````
    apiVersion: monitoring.coreos.com/v1
    kind: PrometheusRule
    metadata:
      name: security
      namespace: user-monitoring-shared
    spec:
      groups:
        - name: pod-security-policy
          rules:
            - alert: "NamespaceNotEnforcingRestrictedPolicy"
              expr: kube_namespace_labels{namespace!~"(openshift|kube).*|default",label_pod_security_kubernetes_io_enforce!="restricted"}
              for: 5m
              annotations:
                summary: "Restricted policy not enforced"
                description: "Namespace {{ $labels.namespace }} doesn't enforce the Restricted pod security policy."
              labels:
                severity: warning
````

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
