### PR TITLE
MON-3701: remove references to OAuth proxy

### DIFF
--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -75,7 +75,6 @@ local commonConfig = {
     thanos: 'quay.io/thanos/thanos:v' + $.versions.thanos,
     kubeRbacProxy: 'quay.io/brancz/kube-rbac-proxy:v' + $.versions.kubeRbacProxy,
     monitoringPlugin: 'quay.io/openshift/origin-monitoring-plugin:' + $.versions.monitoringPlugin,
-    openshiftOauthProxy: 'quay.io/openshift/oauth-proxy:latest',
   },
   // Labels applied to every object
   commonLabels: {

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -30,10 +30,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-prometheus-alertmanager:latest
-  - name: oauth-proxy
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-oauth-proxy:latest
   - name: prometheus-node-exporter
     from:
       kind: DockerImage

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -134,7 +134,6 @@ type Images struct {
 	PrometheusConfigReloader           string
 	Prometheus                         string
 	Alertmanager                       string
-	OauthProxy                         string
 	NodeExporter                       string
 	KubeStateMetrics                   string
 	OpenShiftStateMetrics              string
@@ -327,7 +326,6 @@ func (c *Config) SetImages(images map[string]string) {
 	c.Images.PrometheusConfigReloader = images["prometheus-config-reloader"]
 	c.Images.Prometheus = images["prometheus"]
 	c.Images.Alertmanager = images["alertmanager"]
-	c.Images.OauthProxy = images["oauth-proxy"]
 	c.Images.NodeExporter = images["node-exporter"]
 	c.Images.KubeStateMetrics = images["kube-state-metrics"]
 	c.Images.KubeRbacProxy = images["kube-rbac-proxy"]

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -482,8 +482,8 @@ func TestAlertmanagerDataReplication(t *testing.T) {
 	}
 }
 
-// The Alertmanager API should be protected by the OAuth proxy.
-func TestAlertmanagerOAuthProxy(t *testing.T) {
+// The Alertmanager API should be protected by authentication/authorization.
+func TestAlertmanagerAPI(t *testing.T) {
 	err := framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		body, err := f.AlertmanagerClient.GetAlertmanagerAlerts(
 			"filter", `alertname="Watchdog"`,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
