### PR TITLE
MON-3783: add controller-id annotation to pods deployments and operator

### DIFF
--- a/assets/alertmanager-user-workload/alertmanager.yaml
+++ b/assets/alertmanager-user-workload/alertmanager.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
+  annotations:
+    operator.prometheus.io/controller-id: openshift-user-workload-monitoring/prometheus-operator
   labels:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/instance: user-workload

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
+  annotations:
+    operator.prometheus.io/controller-id: openshift-monitoring/prometheus-operator
   labels:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/instance: main

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
+  annotations:
+    operator.prometheus.io/controller-id: openshift-monitoring/prometheus-operator
   labels:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/instance: k8s

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -40,6 +40,7 @@ spec:
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
         - --web.listen-address=127.0.0.1:8080
+        - --controller-id=openshift-user-workload-monitoring/prometheus-operator
         env:
         - name: GOGC
           value: "30"

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - --config-reloader-cpu-request=1m
         - --config-reloader-memory-request=10Mi
         - --web.listen-address=127.0.0.1:8080
+        - --controller-id=openshift-monitoring/prometheus-operator
         env:
         - name: GOGC
           value: "30"

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
+  annotations:
+    operator.prometheus.io/controller-id: openshift-user-workload-monitoring/prometheus-operator
   labels:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/instance: user-workload

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ThanosRuler
 metadata:
+  annotations:
+    operator.prometheus.io/controller-id: openshift-user-workload-monitoring/prometheus-operator
   labels:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -203,6 +203,11 @@ function(params)
     },
 
     alertmanager+: {
+      metadata+: {
+        annotations+: {
+          'operator.prometheus.io/controller-id': 'openshift-user-workload-monitoring/prometheus-operator',
+        },
+      },
       spec+: {
         securityContext: {
           fsGroup: 65534,

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -240,6 +240,11 @@ function(params)
     },
 
     alertmanager+: {
+      metadata+: {
+        annotations+: {
+          'operator.prometheus.io/controller-id': 'openshift-monitoring/prometheus-operator',
+        },
+      },
       spec+: {
         securityContext: {
           fsGroup: 65534,

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -97,6 +97,7 @@ function(params)
                         '--config-reloader-cpu-request=1m',
                         '--config-reloader-memory-request=10Mi',
                         '--web.listen-address=127.0.0.1:8080',
+                        '--controller-id=openshift-user-workload-monitoring/prometheus-operator',
                       ],
                       ports: [],
                       resources: {

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -75,6 +75,7 @@ function(params)
                         '--config-reloader-cpu-request=1m',
                         '--config-reloader-memory-request=10Mi',
                         '--web.listen-address=127.0.0.1:8080',
+                        '--controller-id=openshift-monitoring/prometheus-operator',
                       ],
                       ports: [],
                       resources: {

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -291,6 +291,11 @@ function(params)
     },
 
     prometheus+: {
+      metadata+: {
+        annotations+: {
+          'operator.prometheus.io/controller-id': 'openshift-user-workload-monitoring/prometheus-operator',
+        },
+      },
       spec+: {
         // Enable experimental additional scrape metrics feature
         enableFeatures+: ['extra-scrape-metrics'],

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -328,6 +328,11 @@ function(params)
     // TLS. Additionally as the Alertmanager is protected with TLS, authN and
     // authZ it requires some additonal configuration.
     prometheus+: {
+      metadata+: {
+        annotations+: {
+          'operator.prometheus.io/controller-id': 'openshift-monitoring/prometheus-operator',
+        },
+      },
       spec+: {
         alerting+: {
           alertmanagers:

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -337,6 +337,9 @@ function(params)
         labels: {
           thanosRulerName: cfg.crName,
         },
+        annotations+: {
+          'operator.prometheus.io/controller-id': 'openshift-user-workload-monitoring/prometheus-operator',
+        },
       },
       spec: {
         affinity: {

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -40,7 +40,7 @@ func (f Framework) MakePrometheusWithWebTLSRemoteReceive(name, tlsSecretName str
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   f.Ns,
-			Annotations: map[string]string{},
+			Annotations: map[string]string{"operator.prometheus.io/controller-id": "openshift-monitoring/prometheus-operator"},
 			Labels: map[string]string{
 				E2eTestLabelName: E2eTestLabelValue,
 			},

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -64,6 +64,9 @@ func createAlertmanager(t *testing.T) {
 			Labels: map[string]string{
 				framework.E2eTestLabelName: framework.E2eTestLabelValue,
 			},
+			Annotations: map[string]string{
+				"operator.prometheus.io/controller-id": "openshift-user-workload-monitoring/prometheus-operator",
+			},
 		},
 		Spec: monitoringv1.AlertmanagerSpec{
 			Replicas: &replicas,


### PR DESCRIPTION
Add controller-id annotatoins to prometheus, alertmanager, thanos, and prometheus user workload, alertmanager user workload in order to implement prometheus-operator controller id feature https://github.com/prometheus-operator/prometheus-operator/pull/6319 to avoid issues when multiple operators are running.

E.g:  
```
annotations:
    operator.prometheus.io/controller-id: openshift-monitoring/prometheus-operator
```

Different id for user workload.
