### PR TITLE
MON-3701: clean-up injection of trusted CA bundle for main Alertmanager

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -143,10 +143,19 @@ spec:
     runAsUser: 65534
   serviceAccountName: alertmanager-main
   version: 0.26.0
+  volumeMounts:
+  - mountPath: /etc/pki/ca-trust/extracted/pem/
+    name: alertmanager-trusted-ca-bundle
   volumes:
   - configMap:
       name: metrics-client-ca
     name: metrics-client-ca
+  - configMap:
+      items:
+      - key: ca-bundle.crt
+        path: tls-ca-bundle.pem
+      name: alertmanager-trusted-ca-bundle
+    name: alertmanager-trusted-ca-bundle
   web:
     httpConfig:
       headers:

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -16,7 +16,6 @@ function(params)
     trustedCaBundle: generateCertInjection.trustedCNOCaBundleCM(cfg.namespace, 'alertmanager-trusted-ca-bundle'),
 
     // OpenShift route to access the Alertmanager UI.
-
     route: {
       apiVersion: 'v1',
       kind: 'Route',
@@ -410,6 +409,22 @@ function(params)
             configMap: {
               name: 'metrics-client-ca',
             },
+          },
+          {
+            name: $.trustedCaBundle.metadata.name,
+            configMap: {
+              name: $.trustedCaBundle.metadata.name,
+              items: [{
+                key: 'ca-bundle.crt',
+                path: 'tls-ca-bundle.pem',
+              }],
+            },
+          },
+        ],
+        volumeMounts+: [
+          {
+            name: $.trustedCaBundle.metadata.name,
+            mountPath: '/etc/pki/ca-trust/extracted/pem/',
           },
         ],
       },

--- a/jsonnet/utils/generate-certificate-injection.libsonnet
+++ b/jsonnet/utils/generate-certificate-injection.libsonnet
@@ -15,6 +15,7 @@
     },
     data: {},
   },
+
   // This CA bundle is injected by the service-ca-operator.
   SCOCaBundleCM(cfgNamespace, cfgName):: {
     apiVersion: 'v1',
@@ -28,6 +29,7 @@
     },
     data: {},
   },
+
   SCOCaBundleVolume(volName):: {
     name: volName,
     configmap: {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -586,7 +586,7 @@ func setupStartupProbe(a *monv1.Alertmanager) {
 	)
 }
 
-func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Alertmanager, error) {
+func (f *Factory) AlertmanagerMain() (*monv1.Alertmanager, error) {
 	a, err := f.NewAlertmanager(f.assets.MustNewAssetSlice(AlertmanagerMain))
 	if err != nil {
 		return nil, err
@@ -649,18 +649,6 @@ func (f *Factory) AlertmanagerMain(trustedCABundleCM *v1.ConfigMap) (*monv1.Aler
 	if len(f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.TopologySpreadConstraints) > 0 {
 		a.Spec.TopologySpreadConstraints =
 			f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.TopologySpreadConstraints
-	}
-
-	if trustedCABundleCM != nil {
-		volumeName := "alertmanager-trusted-ca-bundle"
-		a.Spec.VolumeMounts = append(a.Spec.VolumeMounts, trustedCABundleVolumeMount(volumeName))
-
-		volume := trustedCABundleVolume(trustedCABundleCM.Name, volumeName)
-		volume.VolumeSource.ConfigMap.Items = append(volume.VolumeSource.ConfigMap.Items, v1.KeyToPath{
-			Key:  TrustedCABundleKey,
-			Path: "tls-ca-bundle.pem",
-		})
-		a.Spec.Volumes = append(a.Spec.Volumes, volume)
 	}
 
 	for i, c := range a.Spec.Containers {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
