### PR TITLE
WINC-1180: assets, jsonnet: Add container_network openshift-kubernetes.rules

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -46,6 +46,16 @@ spec:
       record: cluster:container_spec_cpu_shares:ratio
     - expr: sum(rate(container_cpu_usage_seconds_total{container="",pod!=""}[5m])) / sum(machine_cpu_cores)
       record: cluster:container_cpu_usage:ratio
+    - expr: |
+        sum by(namespace,pod, interface) (irate(container_network_receive_bytes_total{pod!=""}[5m]))
+        +
+        on(namespace,pod, interface) group_left(network_name) topk by(namespace,pod, interface) (1, pod_network_name_info)
+      record: pod_interface_network:container_network_receive_bytes:irate5m
+    - expr: |
+        sum by(namespace,pod, interface) (irate(container_network_transmit_bytes_total{pod!=""}[5m]))
+        +
+        on(namespace,pod, interface) group_left(network_name) topk by(namespace,pod, interface) (1, pod_network_name_info)
+      record: pod_interface_network:container_network_transmit_bytes_total:irate5m
     - expr: max without(endpoint, instance, job, pod, service) (kube_node_labels and on(node) kube_node_role{role="master"})
       labels:
         label_node_role_kubernetes_io: master

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -73,6 +73,22 @@ function(params) {
           record: 'cluster:container_cpu_usage:ratio',
         },
         {
+          expr: |||
+            sum by(namespace,pod, interface) (irate(container_network_receive_bytes_total{pod!=""}[5m]))
+            +
+            on(namespace,pod, interface) group_left(network_name) topk by(namespace,pod, interface) (1, pod_network_name_info)
+          |||,
+          record: 'pod_interface_network:container_network_receive_bytes:irate5m',
+        },
+        {
+          expr: |||
+            sum by(namespace,pod, interface) (irate(container_network_transmit_bytes_total{pod!=""}[5m]))
+            +
+            on(namespace,pod, interface) group_left(network_name) topk by(namespace,pod, interface) (1, pod_network_name_info)
+          |||,
+          record: 'pod_interface_network:container_network_transmit_bytes_total:irate5m',
+        },
+        {
           expr: 'max without(%s) (kube_node_labels and on(node) kube_node_role{role="master"})' % droppedKsmLabels,
           labels: {
             label_node_role_kubernetes_io: 'master',


### PR DESCRIPTION
This PR adds the openshift-kubernetes recording rules for container_network metrics.
* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
