### PR TITLE
MON-3839: test: add skip tests for prometheus adapter tests

### DIFF
--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -488,6 +488,7 @@ func TestTelemeterClientSecret(t *testing.T) {
 }
 
 func TestClusterMonitorK8sPromAdapterConfig(t *testing.T) {
+	skipPrometheusAdapterTests(t)
 	const (
 		deploymentName = "prometheus-adapter"
 	)

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -102,9 +102,6 @@ func TestTLSSecurityProfileConfiguration(t *testing.T) {
 			assertCorrectTLSConfiguration(t, "prometheus-operator", "deployment",
 				manifests.KubeRbacProxyTLSCipherSuitesFlag,
 				manifests.KubeRbacProxyMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
-			assertCorrectTLSConfiguration(t, "prometheus-adapter", "deployment",
-				manifests.PrometheusAdapterTLSCipherSuitesFlag,
-				manifests.PrometheusAdapterTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
 			assertCorrectTLSConfiguration(t, "kube-state-metrics", "deployment",
 				manifests.KubeRbacProxyTLSCipherSuitesFlag,
 				manifests.KubeRbacProxyMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
@@ -126,6 +123,16 @@ func TestTLSSecurityProfileConfiguration(t *testing.T) {
 			assertCorrectTLSConfiguration(t, "prometheus-k8s", "statefulset",
 				manifests.KubeRbacProxyTLSCipherSuitesFlag,
 				manifests.KubeRbacProxyMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
+			if f.IsFeatureGateEnabled(t, MetricsServerFeatureGate) {
+				assertCorrectTLSConfiguration(t, "metrics-server", "deployment",
+					manifests.MetricsServerTLSCipherSuitesFlag,
+					manifests.MetricsServerTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
+			}
+			if !f.IsFeatureGateEnabled(t, MetricsServerFeatureGate) {
+				assertCorrectTLSConfiguration(t, "prometheus-adapter", "deployment",
+					manifests.PrometheusAdapterTLSCipherSuitesFlag,
+					manifests.PrometheusAdapterTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
