### PR TITLE
MON-3866: create separate metrics client cert for metrics server

### DIFF
--- a/assets/cluster-monitoring-operator/metrics-server-client-certs.yaml
+++ b/assets/cluster-monitoring-operator/metrics-server-client-certs.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: metrics-server-client-certs
+  namespace: openshift-monitoring
+type: Opaque

--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -45,8 +45,8 @@ spec:
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
         - --kubelet-certificate-authority=/etc/tls/kubelet-serving-ca-bundle/ca-bundle.crt
-        - --kubelet-client-certificate=/etc/tls/metrics-client-certs/tls.crt
-        - --kubelet-client-key=/etc/tls/metrics-client-certs/tls.key
+        - --kubelet-client-certificate=/etc/tls/metrics-server-client-certs/tls.crt
+        - --kubelet-client-key=/etc/tls/metrics-server-client-certs/tls.key
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
@@ -84,8 +84,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/tls/private
           name: secret-metrics-server-tls
-        - mountPath: /etc/tls/metrics-client-certs
-          name: secret-metrics-client-certs
+        - mountPath: /etc/tls/metrics-server-client-certs
+          name: secret-metrics-server-client-certs
         - mountPath: /etc/tls/kubelet-serving-ca-bundle
           name: configmap-kubelet-serving-ca-bundle
         - mountPath: /etc/audit
@@ -99,9 +99,9 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       volumes:
-      - name: secret-metrics-client-certs
+      - name: secret-metrics-server-client-certs
         secret:
-          secretName: metrics-client-certs
+          secretName: metrics-server-client-certs
       - name: secret-metrics-server-tls
         secret:
           secretName: metrics-server-tls

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -69,6 +69,17 @@ function(params) {
     },
   },
 
+  metricsServerClientCerts: {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name: 'metrics-server-client-certs',
+      namespace: cfg.namespace,
+    },
+    type: 'Opaque',
+    data: {},
+  },
+
   metricsClientCerts: {
     apiVersion: 'v1',
     kind: 'Secret',

--- a/jsonnet/components/metrics-server.libsonnet
+++ b/jsonnet/components/metrics-server.libsonnet
@@ -194,8 +194,8 @@ function(params) {
                 '--kubelet-use-node-status-port',
                 '--metric-resolution=15s',
                 '--kubelet-certificate-authority=/etc/tls/kubelet-serving-ca-bundle/ca-bundle.crt',
-                '--kubelet-client-certificate=/etc/tls/metrics-client-certs/tls.crt',
-                '--kubelet-client-key=/etc/tls/metrics-client-certs/tls.key',
+                '--kubelet-client-certificate=/etc/tls/metrics-server-client-certs/tls.crt',
+                '--kubelet-client-key=/etc/tls/metrics-server-client-certs/tls.key',
                 '--tls-cert-file=/etc/tls/private/tls.crt',
                 '--tls-private-key-file=/etc/tls/private/tls.key',
                 '--tls-cipher-suites=' + cfg.tlsCipherSuites,
@@ -248,8 +248,8 @@ function(params) {
                   name: 'secret-metrics-server-tls',
                 },
                 {
-                  mountPath: '/etc/tls/metrics-client-certs',
-                  name: 'secret-metrics-client-certs',
+                  mountPath: '/etc/tls/metrics-server-client-certs',
+                  name: 'secret-metrics-server-client-certs',
                 },
                 {
                   mountPath: '/etc/tls/kubelet-serving-ca-bundle',
@@ -265,9 +265,9 @@ function(params) {
           serviceAccountName: 'metrics-server',
           volumes: [
             {
-              name: 'secret-metrics-client-certs',
+              name: 'secret-metrics-server-client-certs',
               secret: {
-                secretName: 'metrics-client-certs',
+                secretName: 'metrics-server-client-certs',
               },
             },
             {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2805,7 +2805,7 @@ metricsServer:
 	}
 	metricsClientSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "metrics-client-cert",
+			Name:      "metrics-server-client-certs",
 			Namespace: "openshift-monitoring",
 		},
 		Data: map[string][]byte{
@@ -2865,7 +2865,7 @@ metricsServer:
 
 	podAnnotations := d.Spec.Template.Annotations
 	require.Equal(t, "eplue2a9srfkb", podAnnotations["monitoring.openshift.io/kubelet-serving-ca-bundle-hash"])
-	require.Equal(t, "arprfan3mk728", podAnnotations["monitoring.openshift.io/metrics-client-cert-hash"])
+	require.Equal(t, "arprfan3mk728", podAnnotations["monitoring.openshift.io/metrics-server-client-certs-hash"])
 	require.Equal(t, "383c7cmidrae2", podAnnotations["monitoring.openshift.io/serving-ca-secret-hash"])
 }
 

--- a/pkg/manifests/tls.go
+++ b/pkg/manifests/tls.go
@@ -53,6 +53,19 @@ func (f *Factory) GRPCSecret() (*v1.Secret, error) {
 	return s, nil
 }
 
+func (f *Factory) MetricsServerClientCerts() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetSlice(ClusterMonitoringMetricsServerClientCertsSecret))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespace
+	s.Data = make(map[string][]byte)
+	s.Annotations = make(map[string]string)
+
+	return s, nil
+}
+
 func (f *Factory) MetricsClientCerts() (*v1.Secret, error) {
 	s, err := f.NewSecret(f.assets.MustNewAssetSlice(ClusterMonitoringMetricsClientCertsSecret))
 	if err != nil {

--- a/pkg/tasks/metricsserver.go
+++ b/pkg/tasks/metricsserver.go
@@ -106,20 +106,21 @@ func (t *MetricsServerTask) create(ctx context.Context) error {
 			return fmt.Errorf("reconciling MetricsServer Service failed: %w", err)
 		}
 
-		cacm, err := t.factory.PrometheusK8sKubeletServingCABundle(map[string]string{})
+		kubeletServingCA, err := t.factory.PrometheusK8sKubeletServingCABundle(map[string]string{})
+
 		if err != nil {
 			return fmt.Errorf("initializing kubelet serving CA Bundle ConfigMap failed: %w", err)
 		}
 
-		cacm, err = t.client.WaitForConfigMap(
+		kubeletServingCA, err = t.client.WaitForConfigMap(
 			ctx,
-			cacm,
+			kubeletServingCA,
 		)
 		if err != nil {
 			return err
 		}
 
-		scas, err := t.client.WaitForSecretByNsName(
+		servingCASecret, err := t.client.WaitForSecretByNsName(
 			ctx,
 			types.NamespacedName{
 				Namespace: s.Namespace,
@@ -130,19 +131,15 @@ func (t *MetricsServerTask) create(ctx context.Context) error {
 			return err
 		}
 
-		mcs, err := t.factory.MetricsClientCerts()
+		metricsServerClientCerts, err := t.factory.MetricsServerClientCerts()
 		if err != nil {
-			return fmt.Errorf("initializing metrics-client-cert failed: %w", err)
+			return fmt.Errorf("initializing metrics-server-client-certs secret failed: %w", err)
 		}
 
-		mcs, err = t.client.WaitForSecret(
-			ctx,
-			mcs,
-		)
+		metricsServerClientCerts, err = t.client.WaitForSecret(ctx, metricsServerClientCerts)
 		if err != nil {
-			return err
+			return fmt.Errorf("waiting for metrics-server-client-certs secret failed: %w", err)
 		}
-
 		{
 			cm, err := t.factory.MetricsServerConfigMapAuditPolicy()
 			if err != nil {
@@ -155,19 +152,14 @@ func (t *MetricsServerTask) create(ctx context.Context) error {
 			}
 		}
 
-		tlsSecret, err := t.client.WaitForSecretByNsName(ctx, types.NamespacedName{Namespace: t.namespace, Name: "metrics-server-tls"})
-		if err != nil {
-			return fmt.Errorf("failed to wait for metrics-server-tls secret: %w", err)
-		}
-
 		apiAuthConfigmap, err := t.client.WaitForConfigMapByNsName(ctx, types.NamespacedName{Namespace: "kube-system", Name: "extension-apiserver-authentication"})
 		if err != nil {
 			return fmt.Errorf("failed to wait for kube-system/extension-apiserver-authentication configmap: %w", err)
 		}
 
-		secret, err := t.factory.MetricsServerSecret(tlsSecret, apiAuthConfigmap)
+		secret, err := t.factory.MetricsServerClientCASecret(apiAuthConfigmap)
 		if err != nil {
-			return fmt.Errorf("failed to create metrics-server secret: %w", err)
+			return fmt.Errorf("failed to create metrics-server client-ca secret: %w", err)
 		}
 
 		err = t.deleteOldMetricsServerSecrets(secret.Labels["monitoring.openshift.io/hash"])
@@ -177,10 +169,10 @@ func (t *MetricsServerTask) create(ctx context.Context) error {
 
 		err = t.client.CreateOrUpdateSecret(ctx, secret)
 		if err != nil {
-			return fmt.Errorf("reconciling MetricsServer Secret failed: %w", err)
+			return fmt.Errorf("reconciling metrics-server client-ca secret failed: %w", err)
 		}
 
-		dep, err := t.factory.MetricsServerDeployment(secret.Name, cacm, scas, mcs, apiAuthConfigmap.Data)
+		dep, err := t.factory.MetricsServerDeployment(secret.Name, kubeletServingCA, servingCASecret, metricsServerClientCerts, apiAuthConfigmap.Data)
 		if err != nil {
 			return fmt.Errorf("initializing MetricsServer Deployment failed: %w", err)
 		}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
