### PR TITLE
OBSDOCS-883: Fix the wrong retention time comment for user-defined project monitoring

### DIFF
--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -639,7 +639,7 @@ type PrometheusRestrictedConfig struct {
 	// This definition must be specified using the following regular
 	// expression pattern: `[0-9]+(ms|s|m|h|d|w|y)` (ms = milliseconds,
 	// s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years).
-	// The default value is `15d`.
+	// The default value is `24h`.
 	Retention string `json:"retention,omitempty"`
 	// Defines the maximum amount of disk space used by data blocks plus the
 	// write-ahead log (WAL).


### PR DESCRIPTION
Issue: [OBSDOCS-883](https://issues.redhat.com/browse/OBSDOCS-883)

This is to fix the wrong comment about retention time for user-defined project monitoring.