### PR TITLE
MON-3846: create separate kubelet-serving-ca cm for metrics-server

### DIFF
--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -106,7 +106,7 @@ spec:
         secret:
           secretName: metrics-server-tls
       - configMap:
-          name: kubelet-serving-ca-bundle
+          name: metrics-server-kubelet-serving-ca-bundle
         name: configmap-kubelet-serving-ca-bundle
       - emptyDir: {}
         name: audit-log

--- a/assets/metrics-server/kubelet-serving-ca-bundle.yaml
+++ b/assets/metrics-server/kubelet-serving-ca-bundle.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  annotations:
+    openshift.io/owning-component: Monitoring
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: metrics-server-kubelet-serving-ca-bundle
+  namespace: openshift-monitoring

--- a/jsonnet/components/metrics-server.libsonnet
+++ b/jsonnet/components/metrics-server.libsonnet
@@ -108,6 +108,18 @@ function(params) {
     ],
   },
 
+  kubeletServingCaBundle+: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata+: {
+      name: 'metrics-server-kubelet-serving-ca-bundle',
+      namespace: cfg.namespace,
+      annotations: {
+        'openshift.io/owning-component': 'Monitoring',
+      },
+    },
+    data: {},
+  },
   service: {
     apiVersion: 'v1',
     kind: 'Service',
@@ -278,7 +290,7 @@ function(params) {
             },
             {
               configMap: {
-                name: 'kubelet-serving-ca-bundle',
+                name: 'metrics-server-kubelet-serving-ca-bundle',
               },
               name: 'configmap-kubelet-serving-ca-bundle',
             },

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -198,6 +198,7 @@ var (
 	PrometheusAdapterMinimalServiceMonitor       = "prometheus-adapter/minimal-service-monitor.yaml"
 	PrometheusAdapterServiceAccount              = "prometheus-adapter/service-account.yaml"
 
+	MetricsServerKubeletServingCABundle          = "metrics-server/kubelet-serving-ca-bundle.yaml"
 	MetricsServerAPIService                      = "metrics-server/api-service.yaml"
 	MetricsServerServiceAccount                  = "metrics-server/service-account.yaml"
 	MetricsServerClusterRole                     = "metrics-server/cluster-role.yaml"
@@ -2033,6 +2034,16 @@ func (f *Factory) MetricsServerClusterRoleBindingAuthDelegator() (*rbacv1.Cluste
 
 func (f *Factory) MetricsServerRoleBindingAuthReader() (*rbacv1.RoleBinding, error) {
 	return f.NewRoleBinding(f.assets.MustNewAssetSlice(MetricsServerRoleBindingAuthReader))
+}
+
+func (f *Factory) MetricsServerKubeletServingCABundle(data map[string]string) (*v1.ConfigMap, error) {
+	c, err := f.NewConfigMap(f.assets.MustNewAssetSlice(MetricsServerKubeletServingCABundle))
+	if err != nil {
+		return nil, err
+	}
+
+	c.Data = data
+	return c, nil
 }
 
 func (f *Factory) MetricsServerDeployment(apiAuthSecretName string, kubeletCABundle *v1.ConfigMap, servingCASecret, metricsClientCert *v1.Secret, requestheader map[string]string) (*appsv1.Deployment, error) {


### PR DESCRIPTION
This is to avoid similar situation like https://issues.redhat.com/browse/OCPBUGS-32510 so that metrics-server
doesn't need to wait for prometheus task to create the configmap

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.


cc: @machine424 @simonpasquier @jan--f 