### PR TITLE
OCPBUGS-32510: tweak Prometheus RBAC setup as a temp fix.

### DIFF
--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -65,13 +65,13 @@ spec:
           name: https
           protocol: TCP
         readinessProbe:
-          failureThreshold: 3
+          failureThreshold: 6
           httpGet:
             path: /readyz
             port: https
             scheme: HTTPS
           initialDelaySeconds: 20
-          periodSeconds: 10
+          periodSeconds: 20
         resources:
           requests:
             cpu: 1m


### PR DESCRIPTION
OCPBUGS-32510: adapt the metrics-server readiness probe config.

See the added comments and https://docs.google.com/document/d/1VpGBbV30-bb-eq-JYi2q5B8Hyll37tp30OrHcnCifpo/edit?usp=sharing for more details

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

/cc @slashpai 
/cc @simonpasquier 