### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/assets/admission-webhook/deployment.yaml
+++ b/assets/admission-webhook/deployment.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: prometheus-operator-admission-webhook
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/managed-by: cluster-monitoring-operator

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -132,6 +132,7 @@ spec:
     kubernetes.io/os: linux
   podMetadata:
     annotations:
+      openshift.io/required-scc: nonroot
       target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: alert-router

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: kube-state-metrics
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter

--- a/assets/monitoring-plugin/deployment.yaml
+++ b/assets/monitoring-plugin/deployment.yaml
@@ -23,6 +23,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: monitoring-plugin

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: node-exporter
+        openshift.io/required-scc: node-exporter
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter

--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: exporter

--- a/assets/prometheus-adapter/deployment.yaml
+++ b/assets/prometheus-adapter/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     metadata:
       annotations:
         checksum.config/md5: c7fb4696aad1a53eaad3f90f16b9905b
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: metrics-adapter

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -169,6 +169,7 @@ spec:
     kubernetes.io/os: linux
   podMetadata:
     annotations:
+      openshift.io/required-scc: nonroot
       target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: prometheus

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: prometheus-operator
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: controller

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: prometheus-operator
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: controller

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -177,6 +177,7 @@ spec:
   overrideHonorTimestamps: true
   podMetadata:
     annotations:
+      openshift.io/required-scc: nonroot-v2
       target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     labels:
       app.kubernetes.io/component: prometheus

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: telemetry-metrics-collector

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: query-layer

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -118,6 +118,7 @@ spec:
   listenLocal: true
   podMetadata:
     annotations:
+      openshift.io/required-scc: nonroot-v2
       target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   priorityClassName: openshift-user-critical
   queryConfig:

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -24,6 +24,9 @@ function(params)
             labels+: {
               'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
             },
+            annotations+: {
+              'openshift.io/required-scc': 'restricted-v2',
+            },
           },
           spec+: {
             // TODO(simonpasquier): configure client certificate authority to

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -213,6 +213,11 @@ function(params)
     // TLS.
     alertmanager+: {
       spec+: {
+        podMetadata+: {
+          annotations+: {
+            'openshift.io/required-scc': 'nonroot',
+          },
+        },
         securityContext: {
           fsGroup: 65534,
           runAsNonRoot: true,

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -155,6 +155,9 @@ function(params)
             labels+: {
               'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
             },
+            annotations+: {
+              'openshift.io/required-scc': 'restricted-v2',
+            },
           },
           spec+: {
             containers:

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -187,6 +187,7 @@ function(params)
           metadata: $.metadata(noName=true, noNamespace=true) + {
             annotations: {
               'target.workload.openshift.io/management': '{"effect": "PreferredDuringScheduling"}',
+              'openshift.io/required-scc': 'restricted-v2',
             },
           },
           spec: {

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -168,6 +168,9 @@ function(params)
             labels+: {
               'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
             },
+            annotations+: {
+              'openshift.io/required-scc': 'node-exporter',
+            },
           },
           spec+: {
             initContainers+: [

--- a/jsonnet/components/openshift-state-metrics.libsonnet
+++ b/jsonnet/components/openshift-state-metrics.libsonnet
@@ -30,6 +30,9 @@ function(params) {
           labels+: {
             'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
           } + cfg.commonLabels,
+          annotations+: {
+            'openshift.io/required-scc': 'restricted-v2',
+          },
         },
         spec+: {
           containers:

--- a/jsonnet/components/prometheus-adapter.libsonnet
+++ b/jsonnet/components/prometheus-adapter.libsonnet
@@ -92,6 +92,9 @@ function(params)
               labels+: {
                 'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
               },
+              annotations+: {
+                'openshift.io/required-scc': 'restricted-v2',
+              },
             },
             spec+: {
               containers:

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -60,6 +60,9 @@ function(params)
             labels+: {
               'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
             },
+            annotations+: {
+              'openshift.io/required-scc': 'restricted-v2',
+            },
           },
           spec+: {
             nodeSelector+: {

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -45,6 +45,9 @@ function(params)
             labels+: {
               'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
             },
+            annotations+: {
+              'openshift.io/required-scc': 'restricted-v2',
+            },
           },
           spec+: {
             nodeSelector+: {

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -307,6 +307,11 @@ function(params)
               super.alertmanagers,
             ),
         },
+        podMetadata+: {
+          annotations+: {
+            'openshift.io/required-scc': 'nonroot-v2',
+          },
+        },
         securityContext: {
           fsGroup: 65534,
           runAsNonRoot: true,

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -345,6 +345,11 @@ function(params)
             },
           },
         },
+        podMetadata+: {
+          annotations+: {
+            'openshift.io/required-scc': 'nonroot',
+          },
+        },
         securityContext: {
           fsGroup: 65534,
           runAsNonRoot: true,

--- a/jsonnet/components/telemeter-client.libsonnet
+++ b/jsonnet/components/telemeter-client.libsonnet
@@ -53,6 +53,9 @@ function(params) {
           labels+: {
             'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
           } + cfg.commonLabels,
+          annotations+: {
+            'openshift.io/required-scc': 'restricted-v2',
+          },
         },
         spec+: {
           containers:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -282,6 +282,9 @@ function(params)
             labels+: {
               'app.kubernetes.io/managed-by': 'cluster-monitoring-operator',
             },
+            annotations+: {
+              'openshift.io/required-scc': 'restricted-v2',
+            },
           },
           spec+: {
             // TODO(slashpai): remove once new kube-thanos is released which has this change

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -326,6 +326,11 @@ function(params)
             }],
           },
         },
+        podMetadata+: {
+          annotations+: {
+            'openshift.io/required-scc': 'nonroot-v2',
+          },
+        },
         securityContext: {
           fsGroup: 65534,
           runAsNonRoot: true,

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: cluster-monitoring-operator

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/name: cluster-monitoring-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: cluster-monitoring-operator
       nodeSelector:


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

This PR sets the required SCC explicitly on each workload in `openshift-*` namespaces. The SCC chosen is the one that the pods are getting admitted with, so no change expected there. This is to protect the pods from getting admitted with a different custom SCC than the one intended.

This PR
- updates `manifests/`
- updates any workloads defined in `jsonnet/`
- generates new manifests in `assets/` based on jsonnet changes