### PR TITLE
OCPBUGS-33512: fix Thanos ruler alert generator url

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1732,6 +1732,13 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret, trustedCABundleCM *
 
 	p.Spec.Image = &f.config.Images.Prometheus
 
+	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
+		p.Spec.ExternalURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if f.config.UserWorkloadConfiguration.Prometheus.Resources != nil {
 		p.Spec.Resources = *f.config.UserWorkloadConfiguration.Prometheus.Resources
 	}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3174,7 +3174,6 @@ func (f *Factory) ThanosRulerRBACProxyMetricsSecret() (*v1.Secret, error) {
 }
 
 func (f *Factory) ThanosRulerCustomResource(
-	queryURL string,
 	trustedCA *v1.ConfigMap,
 	grpcTLS *v1.Secret,
 	alertmanagerConfig *v1.Secret,
@@ -3265,8 +3264,11 @@ func (f *Factory) ThanosRulerCustomResource(
 	f.mountThanosRulerAlertmanagerSecrets(t)
 	f.injectThanosRulerAlertmanagerDigest(t, alertmanagerConfig)
 
-	if queryURL != "" {
-		t.Spec.AlertQueryURL = queryURL
+	if f.consoleConfig != nil && f.consoleConfig.Status.ConsoleURL != "" {
+		t.Spec.AlertQueryURL, err = url.JoinPath(f.consoleConfig.Status.ConsoleURL, "monitoring")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	t.Namespace = f.namespaceUserWorkload

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -16,7 +16,6 @@ package tasks
 
 import (
 	"context"
-	"net/url"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
@@ -230,22 +229,6 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 			return errors.Wrap(err, "error deleting expired UserWorkload Thanos Ruler GRPC TLS secret")
 		}
 
-		hasRoutes, err := t.client.HasRouteCapability(ctx)
-		if err != nil {
-			return errors.Wrap(err, "checking for Route capability failed")
-		}
-		var queryURL *url.URL
-		if hasRoutes {
-			querierRoute, err := t.factory.ThanosQuerierRoute()
-			if err != nil {
-				return errors.Wrap(err, "initializing Thanos Querier Route failed")
-			}
-			queryURL, err = t.client.GetRouteURL(ctx, querierRoute)
-			if err != nil {
-				return errors.Wrap(err, "error getting Thanos Querier Route url")
-			}
-		}
-
 		pdb, err := t.factory.ThanosRulerPodDisruptionBudget()
 		if err != nil {
 			return errors.Wrap(err, "initializing Thanos Ruler PodDisruptionBudget object failed")
@@ -258,7 +241,7 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 			}
 		}
 
-		tr, err := t.factory.ThanosRulerCustomResource(queryURL.String(), trustedCA, grpcSecret, acs)
+		tr, err := t.factory.ThanosRulerCustomResource(trustedCA, grpcSecret, acs)
 		if err != nil {
 			return errors.Wrap(err, "initializing ThanosRuler object failed")
 		}
@@ -448,7 +431,7 @@ func (t *ThanosRulerUserWorkloadTask) destroy(ctx context.Context) error {
 		}
 	}
 
-	tr, err := t.factory.ThanosRulerCustomResource("", trustedCA, grpcSecret, acs)
+	tr, err := t.factory.ThanosRulerCustomResource(trustedCA, grpcSecret, acs)
 	if err != nil {
 		return errors.Wrap(err, "initializing ThanosRuler object failed")
 	}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
