### PR TITLE
OCPBUGS-23000: node-exporter: Prevent cluster-autoscaler from evicting

### DIFF
--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
         kubectl.kubernetes.io/default-container: node-exporter
         openshift.io/required-scc: node-exporter
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -171,6 +171,7 @@ function(params)
             },
             annotations+: {
               'openshift.io/required-scc': 'node-exporter',
+              'cluster-autoscaler.kubernetes.io/enable-ds-eviction': 'false',
             },
           },
           spec+: {


### PR DESCRIPTION
Adds the 'enable-ds-eviction' annotation to prevent the cluster autoscaler from removing the node-exporter daemonset during a scaling event.

The motivation for doing this to prevent blocks when node critical pods get evicted prior to workloads.


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
