### PR TITLE
OCPBUGS-32696: opt-out of multi-cluster Prometheus dashboard

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -233,8 +233,8 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "594b317ecca7f619f308589fefce836aa5bd7d7d",
-      "sum": "u/Fpz2MPkezy71/q+c7mF0vc3hE9fWt2W/YbvF0LP/8=",
+      "version": "0b1a0c04d857d4bcdb559f827e6fc207563b9f31",
+      "sum": "vGD+MxGadIBvvDC+/71BRKWEA8vHgcuBP5PcuCKZGEs=",
       "name": "prometheus"
     },
     {

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -240,6 +240,7 @@ local inCluster =
         mixin+: {
           ruleLabels: $.values.common.ruleLabels,
           _config+: {
+            showMultiCluster: false,
             prometheusSelector: 'job=~"prometheus-k8s|prometheus-user-workload"',
             thanos+: {
               sidecar+: {

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -19429,7 +19429,7 @@ data:
                                 "unit": "s"
                             },
                             {
-                                "alias": "Cluster",
+                                "alias": "",
                                 "colorMode": null,
                                 "colors": [
 
@@ -19522,14 +19522,14 @@ data:
                         ],
                         "targets": [
                             {
-                                "expr": "count by (cluster, job, instance, version) (prometheus_build_info{cluster=~\"$cluster\", job=~\"$job\", instance=~\"$instance\"})",
+                                "expr": "count by (job, instance, version) (prometheus_build_info{job=~\"$job\", instance=~\"$instance\"})",
                                 "format": "table",
                                 "instant": true,
                                 "legendFormat": "",
                                 "refId": "A"
                             },
                             {
-                                "expr": "max by (cluster, job, instance) (time() - process_start_time_seconds{cluster=~\"$cluster\", job=~\"$job\", instance=~\"$instance\"})",
+                                "expr": "max by (job, instance) (time() - process_start_time_seconds{job=~\"$job\", instance=~\"$instance\"})",
                                 "format": "table",
                                 "instant": true,
                                 "legendFormat": "",
@@ -19627,9 +19627,9 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(prometheus_target_sync_length_seconds_sum{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\"}[5m])) by (cluster, job, scrape_job, instance) * 1e3",
+                                "expr": "sum(rate(prometheus_target_sync_length_seconds_sum{job=~\"$job\",instance=~\"$instance\"}[5m])) by (scrape_job) * 1e3",
                                 "format": "time_series",
-                                "legendFormat": "{{cluster}}:{{job}}:{{instance}}:{{scrape_job}}",
+                                "legendFormat": "{{scrape_job}}",
                                 "legendLink": null
                             }
                         ],
@@ -19711,9 +19711,9 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum by (cluster, job, instance) (prometheus_sd_discovered_targets{cluster=~\"$cluster\", job=~\"$job\",instance=~\"$instance\"})",
+                                "expr": "sum(prometheus_sd_discovered_targets{job=~\"$job\",instance=~\"$instance\"})",
                                 "format": "time_series",
-                                "legendFormat": "{{cluster}}:{{job}}:{{instance}}",
+                                "legendFormat": "Targets",
                                 "legendLink": null
                             }
                         ],
@@ -19807,9 +19807,9 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "rate(prometheus_target_interval_length_seconds_sum{cluster=~\"$cluster\", job=~\"$job\",instance=~\"$instance\"}[5m]) / rate(prometheus_target_interval_length_seconds_count{cluster=~\"$cluster\", job=~\"$job\",instance=~\"$instance\"}[5m]) * 1e3",
+                                "expr": "rate(prometheus_target_interval_length_seconds_sum{job=~\"$job\",instance=~\"$instance\"}[5m]) / rate(prometheus_target_interval_length_seconds_count{job=~\"$job\",instance=~\"$instance\"}[5m]) * 1e3",
                                 "format": "time_series",
-                                "legendFormat": "{{cluster}}:{{job}}:{{instance}} {{interval}} configured",
+                                "legendFormat": "{{interval}} configured",
                                 "legendLink": null
                             }
                         ],
@@ -19891,33 +19891,33 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum by (cluster, job, instance) (rate(prometheus_target_scrapes_exceeded_body_size_limit_total{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\"}[1m]))",
+                                "expr": "sum by (job) (rate(prometheus_target_scrapes_exceeded_body_size_limit_total[1m]))",
                                 "format": "time_series",
-                                "legendFormat": "exceeded body size limit: {{cluster}} {{job}} {{instance}}",
+                                "legendFormat": "exceeded body size limit: {{job}}",
                                 "legendLink": null
                             },
                             {
-                                "expr": "sum by (cluster, job, instance) (rate(prometheus_target_scrapes_exceeded_sample_limit_total{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\"}[1m]))",
+                                "expr": "sum by (job) (rate(prometheus_target_scrapes_exceeded_sample_limit_total[1m]))",
                                 "format": "time_series",
-                                "legendFormat": "exceeded sample limit: {{cluster}} {{job}} {{instance}}",
+                                "legendFormat": "exceeded sample limit: {{job}}",
                                 "legendLink": null
                             },
                             {
-                                "expr": "sum by (cluster, job, instance) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\"}[1m]))",
+                                "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total[1m]))",
                                 "format": "time_series",
-                                "legendFormat": "duplicate timestamp: {{cluster}} {{job}} {{instance}}",
+                                "legendFormat": "duplicate timestamp: {{job}}",
                                 "legendLink": null
                             },
                             {
-                                "expr": "sum by (cluster, job, instance) (rate(prometheus_target_scrapes_sample_out_of_bounds_total{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\"}[1m]))",
+                                "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_out_of_bounds_total[1m]))",
                                 "format": "time_series",
-                                "legendFormat": "out of bounds: {{cluster}} {{job}} {{instance}}",
+                                "legendFormat": "out of bounds: {{job}}",
                                 "legendLink": null
                             },
                             {
-                                "expr": "sum by (cluster, job, instance) (rate(prometheus_target_scrapes_sample_out_of_order_total{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\"}[1m]))",
+                                "expr": "sum by (job) (rate(prometheus_target_scrapes_sample_out_of_order_total[1m]))",
                                 "format": "time_series",
-                                "legendFormat": "out of order: {{cluster}} {{job}} {{instance}}",
+                                "legendFormat": "out of order: {{job}}",
                                 "legendLink": null
                             }
                         ],
@@ -19999,9 +19999,9 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "rate(prometheus_tsdb_head_samples_appended_total{cluster=~\"$cluster\", job=~\"$job\",instance=~\"$instance\"}[5m])",
+                                "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=~\"$job\",instance=~\"$instance\"}[5m])",
                                 "format": "time_series",
-                                "legendFormat": "{{cluster}} {{job}} {{instance}}",
+                                "legendFormat": "{{job}} {{instance}}",
                                 "legendLink": null
                             }
                         ],
@@ -20095,9 +20095,9 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "prometheus_tsdb_head_series{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\"}",
+                                "expr": "prometheus_tsdb_head_series{job=~\"$job\",instance=~\"$instance\"}",
                                 "format": "time_series",
-                                "legendFormat": "{{cluster}} {{job}} {{instance}} head series",
+                                "legendFormat": "{{job}} {{instance}} head series",
                                 "legendLink": null
                             }
                         ],
@@ -20179,9 +20179,9 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "prometheus_tsdb_head_chunks{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\"}",
+                                "expr": "prometheus_tsdb_head_chunks{job=~\"$job\",instance=~\"$instance\"}",
                                 "format": "time_series",
-                                "legendFormat": "{{cluster}} {{job}} {{instance}} head chunks",
+                                "legendFormat": "{{job}} {{instance}} head chunks",
                                 "legendLink": null
                             }
                         ],
@@ -20275,9 +20275,9 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "rate(prometheus_engine_query_duration_seconds_count{cluster=~\"$cluster\",job=~\"$job\",instance=~\"$instance\",slice=\"inner_eval\"}[5m])",
+                                "expr": "rate(prometheus_engine_query_duration_seconds_count{job=~\"$job\",instance=~\"$instance\",slice=\"inner_eval\"}[5m])",
                                 "format": "time_series",
-                                "legendFormat": "{{cluster}} {{job}} {{instance}}",
+                                "legendFormat": "{{job}} {{instance}}",
                                 "legendLink": null
                             }
                         ],
@@ -20359,7 +20359,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "max by (slice) (prometheus_engine_query_duration_seconds{quantile=\"0.9\",cluster=~\"$cluster\", job=~\"$job\",instance=~\"$instance\"}) * 1e3",
+                                "expr": "max by (slice) (prometheus_engine_query_duration_seconds{quantile=\"0.9\",job=~\"$job\",instance=~\"$instance\"}) * 1e3",
                                 "format": "time_series",
                                 "legendFormat": "{{slice}}",
                                 "legendLink": null
@@ -20447,41 +20447,13 @@ data:
                     "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": true,
-                    "label": "cluster",
-                    "multi": true,
-                    "name": "cluster",
-                    "options": [
-
-                    ],
-                    "query": "label_values(prometheus_build_info{job=~\"prometheus-k8s|prometheus-user-workload\"}, cluster)",
-                    "refresh": 1,
-                    "regex": "",
-                    "sort": 2,
-                    "tagValuesQuery": "",
-                    "tags": [
-
-                    ],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                },
-                {
-                    "allValue": ".+",
-                    "current": {
-                        "selected": true,
-                        "text": "All",
-                        "value": "$__all"
-                    },
-                    "datasource": "$datasource",
-                    "hide": 0,
-                    "includeAll": true,
                     "label": "job",
                     "multi": true,
                     "name": "job",
                     "options": [
 
                     ],
-                    "query": "label_values(prometheus_build_info{cluster=~\"$cluster\"}, job)",
+                    "query": "label_values(prometheus_build_info{job=~\"prometheus-k8s|prometheus-user-workload\"}, job)",
                     "refresh": 1,
                     "regex": "",
                     "sort": 2,
@@ -20509,7 +20481,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(prometheus_build_info{cluster=~\"$cluster\", job=~\"$job\"}, instance)",
+                    "query": "label_values(prometheus_build_info{job=~\"$job\"}, instance)",
                     "refresh": 1,
                     "regex": "",
                     "sort": 2,


### PR DESCRIPTION
Addresses the Prometheus dashboard showing up empty in console.

<details>
<summary>Visuals</summary>

<img width="1452" alt="Screenshot 2024-05-16 at 2 52 00 AM" src="https://github.com/openshift/cluster-monitoring-operator/assets/33557095/babffebb-da66-4ccd-a88d-98c6239c9a35">

</details>

***
* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
