### PR TITLE
OCPBUGS-33620: define *probes for KSM

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
         livenessProbe:
           httpGet:
-            path: livez
+            path: /livez
             port: main
             scheme: HTTPS
         name: kube-state-metrics
@@ -70,7 +70,7 @@ spec:
           name: self
         readinessProbe:
           httpGet:
-            path: metrics
+            path: /readyz
             port: self
             scheme: HTTPS
         resources:
@@ -124,7 +124,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
-        - --ignore-paths=/metrics
+        - --ignore-paths=/readyz
         image: quay.io/brancz/kube-rbac-proxy:v0.17.1
         name: kube-rbac-proxy-self
         ports:

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -57,7 +57,22 @@ spec:
           ^kube_pod_completion_time$,
           ^kube_pod_status_scheduled$
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        livenessProbe:
+          httpGet:
+            path: livez
+            port: main
+            scheme: HTTPS
         name: kube-state-metrics
+        ports:
+        - containerPort: 8443
+          name: main
+        - containerPort: 9443
+          name: self
+        readinessProbe:
+          httpGet:
+            path: metrics
+            port: self
+            scheme: HTTPS
         resources:
           requests:
             cpu: 2m
@@ -79,6 +94,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
+        - --ignore-paths=/livez
         image: quay.io/brancz/kube-rbac-proxy:v0.17.1
         name: kube-rbac-proxy-main
         ports:
@@ -108,6 +124,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
+        - --ignore-paths=/metrics
         image: quay.io/brancz/kube-rbac-proxy:v0.17.1
         name: kube-rbac-proxy-self
         ports:

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -208,6 +208,7 @@ function(params)
                         '--tls-private-key-file=/etc/tls/private/tls.key',
                         '--client-ca-file=/etc/tls/client/client-ca.crt',
                         '--config-file=/etc/kube-rbac-policy/config.yaml',
+                        '--ignore-paths=' + std.join(',', if std.endsWith(c.name, '-self') then ['/metrics'] else ['/livez']),
                       ],
                       volumeMounts: [
                         {
@@ -266,6 +267,36 @@ function(params)
                           readOnly: true,
                         },
                       ],
+                      local mainPort = 8443,
+                      local mainPortName = 'main',
+                      local selfPort = 9443,
+                      local selfPortName = 'self',
+                      ports::: [
+                        {
+                          containerPort: mainPort,
+                          name: mainPortName,
+                        },
+                        {
+                          containerPort: selfPort,
+                          name: selfPortName,
+                        },
+                      ],
+                      local livenessProbePath = 'livez',
+                      local readinessProbePath = 'metrics',
+                      livenessProbe::: {
+                        httpGet: {
+                          path: livenessProbePath,
+                          port: mainPortName,
+                          scheme: 'HTTPS',
+                        },
+                      },
+                      readinessProbe::: {
+                        httpGet: {
+                          path: readinessProbePath,
+                          port: selfPortName,
+                          scheme: 'HTTPS',
+                        },
+                      },
                     },
                 super.containers,
               ),

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -208,7 +208,7 @@ function(params)
                         '--tls-private-key-file=/etc/tls/private/tls.key',
                         '--client-ca-file=/etc/tls/client/client-ca.crt',
                         '--config-file=/etc/kube-rbac-policy/config.yaml',
-                        '--ignore-paths=' + std.join(',', if std.endsWith(c.name, '-self') then ['/metrics'] else ['/livez']),
+                        '--ignore-paths=' + std.join(',', if std.endsWith(c.name, '-self') then ['/readyz'] else ['/livez']),
                       ],
                       volumeMounts: [
                         {
@@ -281,8 +281,8 @@ function(params)
                           name: selfPortName,
                         },
                       ],
-                      local livenessProbePath = 'livez',
-                      local readinessProbePath = 'metrics',
+                      local livenessProbePath = '/livez',
+                      local readinessProbePath = '/readyz',
                       livenessProbe::: {
                         httpGet: {
                           path: livenessProbePath,


### PR DESCRIPTION
Will set a target version post-4.16 branching.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
