### PR TITLE
MON-3874: chore: poll immediately in the e2e tests

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -133,8 +133,6 @@ func testAlertmanagerReady(t *testing.T, name, ns string, validator ...validator
 }
 
 func testAlertmanagerTenancyAPI(t *testing.T, host string) {
-	t.Helper()
-
 	ctx := context.Background()
 	const testNs = "tenancy-api-e2e-test"
 
@@ -204,44 +202,53 @@ func testAlertmanagerTenancyAPI(t *testing.T, host string) {
 		now.Add(time.Hour).Format(time.RFC3339),
 	))
 
-	assertDo := func(user string, expectedCode int, do func() (*http.Response, error)) []byte {
-		t.Helper()
+	do := func(user string, expectedCode int, do func() (*http.Response, error)) ([]byte, error) {
+		var b []byte
+		err := framework.Poll(5*time.Second, time.Minute, func() error {
+			var err error
+			resp, err := do()
+			if err != nil {
+				return fmt.Errorf("user[%s]: %s %s: request failed: %w", user, resp.Request.Method, resp.Request.URL.String(), err)
+			}
+			defer resp.Body.Close()
 
-		resp, err := do()
-		if err != nil {
-			t.Fatalf("user[%s]: request failed: %v", user, err)
-		}
-		defer resp.Body.Close()
+			b, err = io.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("user[%s]: %s %s: fail to read response body: %w", user, resp.Request.Method, resp.Request.URL.String(), err)
+			}
 
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatalf("user[%s]: fail to read response body: %v", user, err)
-		}
+			if resp.StatusCode != expectedCode {
+				return fmt.Errorf("user[%s]: %s %s: expecting %d status code, got %d (%q)", user, resp.Request.Method, resp.Request.URL.String(), expectedCode, resp.StatusCode, framework.ClampMax(b))
+			}
 
-		if resp.StatusCode != expectedCode {
-			t.Fatalf("user[%s]: expecting %d status code, got %d (%q)", user, expectedCode, resp.StatusCode, framework.ClampMax(b))
-		}
+			return nil
+		})
 
-		return b
+		return b, err
 	}
 
 	for _, sa := range []string{"viewer", "anonymous"} {
-		assertDo(
+		if _, err := do(
 			sa,
 			http.StatusForbidden,
 			func() (*http.Response, error) {
 				return clients[sa].Do("POST", "/api/v2/silences", sil)
 			},
-		)
+		); err != nil {
+			t.Fatalf("user[%s]: %v", sa, err)
+		}
 	}
 
-	b := assertDo(
+	b, err := do(
 		"editor",
 		http.StatusOK,
 		func() (*http.Response, error) {
 			return clients["editor"].Do("POST", "/api/v2/silences", sil)
 		},
 	)
+	if err != nil {
+		t.Fatalf("user[editor]: %v", err)
+	}
 
 	// Save silence ID for deletion.
 	parsed, err := gabs.ParseJSON(b)
@@ -259,23 +266,29 @@ func testAlertmanagerTenancyAPI(t *testing.T, host string) {
 		}
 	})
 
-	assertDo(
+	_, err = do(
 		"anonymous",
 		http.StatusForbidden,
 		func() (*http.Response, error) {
 			return clients["anonymous"].Do("GET", "/api/v2/silences", nil)
 		},
 	)
+	if err != nil {
+		t.Fatalf("user[anonymous]: %v", err)
+	}
 
 	// List silences and check that the 'namespace' label matcher has been overwritten.
 	for _, sa := range []string{"viewer", "editor"} {
-		b = assertDo(
+		b, err := do(
 			sa,
 			http.StatusOK,
 			func() (*http.Response, error) {
 				return clients[sa].Do("GET", "/api/v2/silences", nil)
 			},
 		)
+		if err != nil {
+			t.Fatalf("user[%s]: %v", sa, err)
+		}
 
 		parsed, err = gabs.ParseJSON(b)
 		if err != nil {
@@ -327,23 +340,29 @@ func testAlertmanagerTenancyAPI(t *testing.T, host string) {
 
 	// Try to delete the silence without permissions.
 	for _, sa := range []string{"viewer", "anonymous"} {
-		assertDo(
+		_, err = do(
 			sa,
 			http.StatusForbidden,
 			func() (*http.Response, error) {
 				return clients[sa].Do("DELETE", fmt.Sprintf("/api/v2/silence/%s", silID), nil)
 			},
 		)
+		if err != nil {
+			t.Fatalf("user[%s]: %v", sa, err)
+		}
 	}
 
 	// Delete the silence with permissions.
-	assertDo(
+	_, err = do(
 		"editor",
 		http.StatusOK,
 		func() (*http.Response, error) {
 			return clients["editor"].Do("DELETE", fmt.Sprintf("/api/v2/silence/%s", silID), sil)
 		},
 	)
+	if err != nil {
+		t.Fatalf("user[editor]: %v", err)
+	}
 }
 
 // Even when no persistent storage is configured, silences (and notifications)

--- a/test/e2e/alertmanager_user_workload_test.go
+++ b/test/e2e/alertmanager_user_workload_test.go
@@ -36,6 +36,7 @@ func TestUserWorkloadAlertmanager(t *testing.T) {
 	defer f.MustDeleteConfigMap(t, uwmCM)
 
 	f.AssertStatefulSetExistsAndRollout("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
+	f.AssertServiceExists("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
 
 	for _, scenario := range []struct {
 		name string

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -445,9 +445,16 @@ func (f *Framework) AssertOperatorConditionMessageContains(conditionType configv
 
 func (f *Framework) AssertValueInConfigMapEquals(name, namespace, key, compareWith string) func(t *testing.T) {
 	return func(t *testing.T) {
-		cm := f.MustGetConfigMap(t, name, namespace)
-		if cm.Data[key] != compareWith {
-			t.Fatalf("wanted value %s for key %s but got %s", compareWith, key, cm.Data[key])
+		err := Poll(time.Second, time.Minute, func() error {
+			cm := f.MustGetConfigMap(t, name, namespace)
+			if cm.Data[key] != compareWith {
+				return fmt.Errorf("wanted value %s for key %s but got %s", compareWith, key, cm.Data[key])
+			}
+
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -655,7 +655,7 @@ func (f *Framework) ForwardPort(t *testing.T, ns, svc string, port int) (string,
 func Poll(interval, timeout time.Duration, f func() error) error {
 	var lastErr error
 
-	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(context.Context) (bool, error) {
 		lastErr = f()
 		if lastErr != nil {
 			return false, nil

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -549,6 +549,7 @@ func assertTenancyForMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check that the service account can request the tenancy-aware /api/v1/query API endpoint using HTTP GET.
 	for _, tc := range []struct {
 		name      string
 		query     string
@@ -665,7 +666,7 @@ func assertTenancyForMetrics(t *testing.T) {
 		})
 	}
 
-	// Check that the account doesn't have to access the rules and alerts endpoint.
+	// Check that the account doesn't have to access the rules and alerts endpoints.
 	for _, path := range []string{"/api/v1/rules", "/api/v1/alerts"} {
 		err = framework.Poll(5*time.Second, time.Minute, func() error {
 			// The tenancy port (9092) is only exposed in-cluster, so we need to use
@@ -800,25 +801,33 @@ func assertTenancyForMetrics(t *testing.T) {
 				},
 			)
 
-			resp, err := client.Do(tc.method, "/api/v1/query?namespace="+userWorkloadTestNs+"&query=up", nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer resp.Body.Close()
-			// Body: {"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up",...},"value":[1695582946.784,"1"]}]}}
-			respBodyBytes, err := io.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
+			// It might take some time for kube-rbac-proxy to catch up the updated permission.
+			err = framework.Poll(time.Second, time.Minute, func() error {
+				resp, err := client.Do(tc.method, "/api/v1/query?namespace="+userWorkloadTestNs+"&query=up", nil)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				// Body: {"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up",...},"value":[1695582946.784,"1"]}]}}
+				respBodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
 
-			if tc.expectNotOKOnQuery {
-				if resp.StatusCode == http.StatusOK {
-					t.Fatal("expected request to be rejected, but succeeded")
+				if tc.expectNotOKOnQuery {
+					if resp.StatusCode == http.StatusOK {
+						return fmt.Errorf("expected request to be rejected, but succeeded")
+					}
+				} else {
+					if resp.StatusCode != http.StatusOK {
+						return fmt.Errorf("expected request to be accepted, but got status code %d (%s)", resp.StatusCode, respBodyBytes)
+					}
 				}
-			} else {
-				if resp.StatusCode != http.StatusOK {
-					t.Fatalf("expected request to be accepted, but got status code %d (%s)", resp.StatusCode, respBodyBytes)
-				}
+
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
 			}
 		})
 	}


### PR DESCRIPTION
This reverts commit 10160fd3fefb3791121ad8f5b8bf043938085884.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
