### PR TITLE
MON-3801: clean-up unused OAuth proxy references

### DIFF
--- a/assets/alertmanager/service-account.yaml
+++ b/assets/alertmanager/service-account.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
-  annotations:
-    serviceaccounts.openshift.io/oauth-redirectreference.alertmanager-main-: ""
   labels:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/instance: main

--- a/assets/cluster-monitoring-operator/monitoring-alertmanager-edit-role.yaml
+++ b/assets/cluster-monitoring-operator/monitoring-alertmanager-edit-role.yaml
@@ -10,14 +10,6 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resourceNames:
-  - non-existant
-  resources:
-  - alertmanagers
-  verbs:
-  - patch
-- apiGroups:
-  - monitoring.coreos.com
-  resourceNames:
   - main
   resources:
   - alertmanagers/api

--- a/assets/prometheus-k8s/service-account.yaml
+++ b/assets/prometheus-k8s/service-account.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
-  annotations:
-    serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s-: ""
   labels:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/instance: k8s

--- a/assets/thanos-querier/service-account.yaml
+++ b/assets/thanos-querier/service-account.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    serviceaccounts.openshift.io/oauth-redirectreference.thanos-querier-: ""
   labels:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-querier

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -43,14 +43,6 @@ function(params)
     },
 
     serviceAccount+: {
-      metadata+: {
-        annotations+: {
-          // TODO(simonpasquier): remove this step after OCP 4.16 is released.
-          // https://issues.redhat.com/browse/MON-3801.
-          'serviceaccounts.openshift.io/oauth-redirectreference.alertmanager-main-': '',
-        },
-      },
-
       // Alertmanager can mount the token into the pod since
       // https://github.com/prometheus-operator/prometheus-operator/pull/5474
       // and v0.66.0

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -393,14 +393,6 @@ function(params) {
     },
     rules: [
       {
-        // this permission used to be required when Alertmanager was protected via OAuth proxy.
-        // TODO: remove it after OCP 4.16 is released.
-        apiGroups: ['monitoring.coreos.com'],
-        resources: ['alertmanagers'],
-        verbs: ['patch'],
-        resourceNames: ['non-existant'],
-      },
-      {
         apiGroups: ['monitoring.coreos.com'],
         resources: ['alertmanagers/api'],
         resourceNames: ['main'],

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -83,13 +83,6 @@ function(params)
     serviceAccount+: {
       // service account token is managed by the operator.
       automountServiceAccountToken: false,
-      metadata+: {
-        annotations+: {
-          // TODO(simonpasquier): remove this step after OCP 4.16 is released.
-          // https://issues.redhat.com/browse/MON-3801.
-          'serviceaccounts.openshift.io/oauth-redirectreference.prometheus-k8s-': '',
-        },
-      },
     },
 
     // Adding the serving certs annotation causes the serving certs controller

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -186,11 +186,6 @@ function(params)
         name: 'thanos-querier',
         namespace: cfg.namespace,
         labels: tq.config.commonLabels,
-        annotations: {
-          // TODO(simonpasquier): remove this step after OCP 4.16 is released.
-          // https://issues.redhat.com/browse/MON-3801.
-          'serviceaccounts.openshift.io/oauth-redirectreference.thanos-querier-': '',
-        },
       },
     },
 

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
@@ -221,23 +219,6 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 	err = t.client.CreateOrUpdateServiceMonitor(ctx, smam)
 	if err != nil {
 		return fmt.Errorf("reconciling Alertmanager ServiceMonitor failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteSecret(ctx, &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "alertmanager-main-proxy",
-			Namespace: "openshift-monitoring",
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("deleting Alertmanager proxy Secret failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteHashedConfigMap(ctx, "openshift-monitoring", "alertmanager-trusted-ca-bundle", "")
-	if err != nil {
-		return fmt.Errorf("deleting all hashed Alertmanager trusted CA bundle ConfigMap failed: %w", err)
 	}
 
 	return nil

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 
@@ -413,23 +411,6 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 	err = t.client.CreateOrUpdateServiceMonitor(ctx, smt)
 	if err != nil {
 		return fmt.Errorf("reconciling Prometheus Thanos sidecar ServiceMonitor failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteSecret(ctx, &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "prometheus-k8s-proxy",
-			Namespace: "openshift-monitoring",
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("deleting Prometheus proxy Secret failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteHashedConfigMap(ctx, "openshift-monitoring", "prometheus-trusted-ca-bundle", "")
-	if err != nil {
-		return fmt.Errorf("deleting all hashed Prometheus trusted CA bundle ConfigMap failed: %w", err)
 	}
 
 	return nil

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -18,9 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 )
@@ -227,23 +224,6 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 	err = t.client.CreateOrUpdatePrometheusRule(ctx, tqpr)
 	if err != nil {
 		return fmt.Errorf("reconciling Thanos Querier PrometheusRule failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteHashedConfigMap(ctx, "openshift-monitoring", "thanos-querier-trusted-ca-bundle", "")
-	if err != nil {
-		return fmt.Errorf("deleting all hashed Thanos Querier trusted CA bundle ConfigMap failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteConfigMap(ctx, &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "thanos-querier-trusted-ca-bundle",
-			Namespace: "openshift-monitoring",
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("deleting Thanos Querier trusted CA bundle ConfigMap failed: %w", err)
 	}
 
 	return nil

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -18,9 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 )
@@ -278,35 +275,6 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 		}
 	}
 
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteSecret(ctx, &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "thanos-ruler-oauth-cookie",
-			Namespace: "openshift-user-workload-monitoring",
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("deleting Thanos Ruler OAuth Cookie Secret failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	trustedCA := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "thanos-ruler-trusted-ca-bundle",
-			Namespace: "openshift-user-workload-monitoring",
-		},
-	}
-	err = t.client.DeleteConfigMap(ctx, trustedCA)
-	if err != nil {
-		return fmt.Errorf("deleting Thanos Ruler trusted CA bundle ConfigMap failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteHashedConfigMap(ctx, trustedCA.GetNamespace(), "thanos-ruler", "")
-	if err != nil {
-		return fmt.Errorf("deleting all hashed Thanos Ruler trusted CA bundle ConfigMap failed: %w", err)
-	}
-
 	return nil
 }
 
@@ -480,17 +448,6 @@ func (t *ThanosRulerUserWorkloadTask) destroy(ctx context.Context) error {
 	err = t.client.DeleteServiceMonitor(ctx, trsm)
 	if err != nil {
 		return fmt.Errorf("deleting Thanos Ruler ServiceMonitor failed: %w", err)
-	}
-
-	// TODO(simonpasquier): remove this step after OCP 4.16 is released.
-	err = t.client.DeleteSecret(ctx, &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "thanos-ruler-oauth-cookie",
-			Namespace: "openshift-user-workload-monitoring",
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("deleting Thanos Ruler OAuth Cookie Secret failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
After the 4.16-release branch being cut, we have code related to OAuth proxy that can be removed now.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
