### PR TITLE
MON-3701: clean-up injection of CA bundle for user Alertmanager

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -466,7 +466,7 @@ func (f *Factory) injectProxyVariables(container *v1.Container) {
 	}
 }
 
-func (f *Factory) AlertmanagerUserWorkload(trustedCABundleCM *v1.ConfigMap) (*monv1.Alertmanager, error) {
+func (f *Factory) AlertmanagerUserWorkload() (*monv1.Alertmanager, error) {
 	a, err := f.NewAlertmanager(f.assets.MustNewAssetSlice(AlertmanagerUserWorkload))
 	if err != nil {
 		return nil, err

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3349,9 +3349,7 @@ func TestAlertManagerUserWorkloadConfiguration(t *testing.T) {
 	c.UserWorkloadConfiguration = uwc
 
 	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{Status: configv1.ConsoleStatus{ConsoleURL: "https://console-openshift-console.apps.foo.devcluster.openshift.com"}})
-	a, err := f.AlertmanagerUserWorkload(
-		&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-	)
+	a, err := f.AlertmanagerUserWorkload()
 
 	if err != nil {
 		t.Fatal(err)
@@ -4475,9 +4473,7 @@ func TestNonHighlyAvailableInfrastructure(t *testing.T) {
 		{
 			name: "Alertmanager (user-workload)",
 			getSpec: func(f *Factory) (spec, error) {
-				p, err := f.AlertmanagerUserWorkload(
-					&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-				)
+				p, err := f.AlertmanagerUserWorkload()
 				if err != nil {
 					return spec{}, err
 				}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
