### PR TITLE
OCPBUGS-31250: Exclude windows nodes from kubelet servicemonitor

### DIFF
--- a/assets/control-plane/minimal-service-monitor-kubelet.yaml
+++ b/assets/control-plane/minimal-service-monitor-kubelet.yaml
@@ -10,6 +10,8 @@ metadata:
   name: kubelet-minimal
   namespace: openshift-monitoring
 spec:
+  attachMetadata:
+    node: true
   endpoints:
   - bearerTokenFile: ""
     honorLabels: true
@@ -89,6 +91,10 @@ spec:
       - __name__
     port: https-metrics
     relabelings:
+    - action: keep
+      regex: (linux|)
+      sourceLabels:
+      - __meta_kubernetes_node_label_kubernetes_io_os
     - action: replace
       regex: (.+)(?::\d+)
       replacement: $1:9637

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -10,6 +10,8 @@ metadata:
   name: kubelet
   namespace: openshift-monitoring
 spec:
+  attachMetadata:
+    node: true
   endpoints:
   - bearerTokenFile: ""
     honorLabels: true
@@ -133,6 +135,10 @@ spec:
     interval: 30s
     port: https-metrics
     relabelings:
+    - action: keep
+      regex: (linux|)
+      sourceLabels:
+      - __meta_kubernetes_node_label_kubernetes_io_os
     - action: replace
       regex: (.+)(?::\d+)
       replacement: $1:9637

--- a/assets/prometheus-k8s/cluster-role.yaml
+++ b/assets/prometheus-k8s/cluster-role.yaml
@@ -39,6 +39,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - nonroot

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -26,6 +26,9 @@ function(params)
             'k8s-app': 'kubelet',
           },
         },
+        attachMetadata: {
+          node: true,
+        },
         endpoints:
           std.map(
             function(e)
@@ -92,6 +95,11 @@ function(params)
               caFile: '/etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt',
             },
             relabelings: [
+              {
+                sourceLabels: ['__meta_kubernetes_node_label_kubernetes_io_os'],
+                action: 'keep',
+                regex: '(linux|)',
+              },
               {
                 sourceLabels: ['__address__'],
                 action: 'replace',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -172,6 +172,12 @@ function(params)
           resources: ['namespaces'],
           verbs: ['get'],
         },
+        // This is required for the "prometheus-k8s" service account to be able to query the node metadata
+        {
+          apiGroups: [''],
+          resources: ['nodes'],
+          verbs: ['get', 'list', 'watch'],
+        },
         {
           // By default authenticated service accounts are assigned to the `restricted` SCC which implies MustRunAsRange.
           // This is problematic with statefulsets as UIDs (and file permissions) can change if SCCs are elevated.

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -496,6 +496,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - nonroot


### PR DESCRIPTION
CRIO is not running on windows nodes hence exclude them from kubelet servicemonitor

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
