### PR TITLE
[release-4.14] OCPBUGS-34023: fix KRP permissions for Thanos Querier

### DIFF
--- a/assets/thanos-querier/kube-rbac-proxy-secret.yaml
+++ b/assets/thanos-querier/kube-rbac-proxy-secret.yaml
@@ -15,7 +15,8 @@ stringData:
   config.yaml: |-
     "authorization":
       "resourceAttributes":
-        "apiVersion": "metrics.k8s.io/v1beta1"
+        "apiGroup": "metrics.k8s.io"
+        "apiVersion": "v1beta1"
         "namespace": "{{ .Value }}"
         "resource": "pods"
       "rewrites":

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -144,7 +144,8 @@ function(params)
               },
             },
             resourceAttributes: {
-              apiVersion: 'metrics.k8s.io/v1beta1',
+              apiVersion: 'v1beta1',
+              apiGroup: 'metrics.k8s.io',
               resource: 'pods',
               namespace: '{{ .Value }}',
             },


### PR DESCRIPTION
fix KRP configuration for thanos-querier in order to enforce restricted access only to entities allowed to [http-verb] for pods.metrics.k8s.io

