### PR TITLE
MON-3894: revert(monitoring-plugin): undo nginx caching tweaks as the issue was…

### DIFF
--- a/assets/monitoring-plugin/config-map.yaml
+++ b/assets/monitoring-plugin/config-map.yaml
@@ -12,20 +12,6 @@ data:
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /usr/share/nginx/html;
-
-        # Prevent caching for plugin-manifest.json
-        location = /plugin-manifest.json {
-          add_header Cache-Control 'no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0';
-          add_header Pragma 'no-cache';
-          add_header Expires '0';
-        }
-
-        # Prevent caching for plugin-entry.js
-        location = /plugin-entry.js {
-          add_header Cache-Control 'no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0';
-          add_header Pragma 'no-cache';
-          add_header Expires '0';
-        }
       }
     }
 kind: ConfigMap

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -28,20 +28,6 @@ function(params)
         ssl_certificate     %(tlsPath)s/tls.crt;
         ssl_certificate_key %(tlsPath)s/tls.key;
         root                /usr/share/nginx/html;
-
-        # Prevent caching for plugin-manifest.json
-        location = /plugin-manifest.json {
-          add_header Cache-Control 'no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0';
-          add_header Pragma 'no-cache';
-          add_header Expires '0';
-        }
-
-        # Prevent caching for plugin-entry.js
-        location = /plugin-entry.js {
-          add_header Cache-Control 'no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0';
-          add_header Pragma 'no-cache';
-          add_header Expires '0';
-        }
       }
     }
   ||| % { tlsPath: tlsMountPath, nginxPort: nginxPort };


### PR DESCRIPTION
… resolved at its root cause.

Revert "prevent plugin entry assets from caching"

This reverts commit c6652ade52bd56bb5f4c4af10cfd28b6b350eccd.

Revert "Move config to jsonnet code and regenerate"

This reverts commit eb6a40c4ea30304c03eb4709d7e82ece7b98bd1a.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
