### PR TITLE
OCPBUGS-35480: Add deprecation for prometheus adapter

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -146,7 +146,7 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 #### Description
 
-The `K8sPrometheusAdapter` resource defines settings for the Prometheus Adapter component.
+The `K8sPrometheusAdapter` resource defines settings for the Prometheus Adapter component. This is deprecated and will be removed in a future version.
 
 
 <em>appears in: [ClusterMonitoringConfiguration](#clustermonitoringconfiguration)</em>
@@ -183,7 +183,7 @@ The `KubeStateMetricsConfig` resource defines settings for the `kube-state-metri
 
 #### Description
 
-The `MetricsServerConfig` resource defines settings for the Metrics Server component. Note that this setting only applies when the MetricsServer feature gate is enabled.
+The `MetricsServerConfig` resource defines settings for the Metrics Server component.
 
 
 <em>appears in: [ClusterMonitoringConfiguration](#clustermonitoringconfiguration)</em>

--- a/Documentation/openshiftdocs/modules/k8sprometheusadapter.adoc
+++ b/Documentation/openshiftdocs/modules/k8sprometheusadapter.adoc
@@ -9,7 +9,7 @@
 
 === Description
 
-The `K8sPrometheusAdapter` resource defines settings for the Prometheus Adapter component.
+The `K8sPrometheusAdapter` resource defines settings for the Prometheus Adapter component. This is deprecated and will be removed in a future version.
 
 
 

--- a/Documentation/openshiftdocs/modules/metricsserverconfig.adoc
+++ b/Documentation/openshiftdocs/modules/metricsserverconfig.adoc
@@ -9,7 +9,7 @@
 
 === Description
 
-The `MetricsServerConfig` resource defines settings for the Metrics Server component. Note that this setting only applies when the MetricsServer feature gate is enabled.
+The `MetricsServerConfig` resource defines settings for the Metrics Server component.
 
 
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -276,16 +276,6 @@ func (c *Config) applyDefaults() {
 		c.ClusterMonitoringConfiguration.MetricsServerConfig.Audit.Profile = auditv1.LevelMetadata
 	}
 
-	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter == nil {
-		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter = &K8sPrometheusAdapter{}
-	}
-	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit == nil {
-		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit = &Audit{}
-	}
-	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit.Profile == "" {
-		c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit.Profile = auditv1.LevelMetadata
-	}
-
 	if c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile == "" {
 		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile = FullCollectionProfile
 	}
@@ -456,11 +446,12 @@ func (c *Config) Precheck() error {
 
 	// Highlight deprecated config fields.
 	var d float64
-	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter.DedicatedServiceMonitors != nil {
+	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter != nil {
+		klog.Infof("k8sPrometheusAdapter is a deprecated config use metricsServer instead")
 		d = 1
 	}
-	// Deprecated in https://github.com/openshift/cluster-monitoring-operator/pull/2160
-	metrics.DeprecatedConfig.WithLabelValues("openshift-monitoring/cluster-monitoring-config", "k8sPrometheusAdapter.dedicatedServiceMonitors", "4.15").Set(d)
+	// Prometheus-Adapter is replaced with Metrics Server by default from 4.16
+	metrics.DeprecatedConfig.WithLabelValues("openshift-monitoring/cluster-monitoring-config", "k8sPrometheusAdapter", "4.16").Set(d)
 	return nil
 }
 

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -376,36 +376,23 @@ func TestDeprecatedConfig(t *testing.T) {
 		expectedMetricValue float64
 	}{
 		{
-			name: "enabled",
+			name: "setting a field in k8sPrometheusAdapter",
 			config: `k8sPrometheusAdapter:
-  dedicatedServiceMonitors:
-    enabled: true
+  resources:
+    requests:
+      cpu: 1m
+      memory: 20Mi
   `,
 			expectedMetricValue: 1,
 		},
 		{
-			name: "default",
-			config: `k8sPrometheusAdapter:
-  dedicatedServiceMonitors:
-  `,
-			expectedMetricValue: 0,
-		},
-		{
-			name: "default",
-			config: `k8sPrometheusAdapter:
-  dedicatedServiceMonitors:
-    enabled: false
-  `,
-			expectedMetricValue: 1,
-		},
-		{
-			name: "default",
+			name: "k8sPrometheusAdapter nil",
 			config: `k8sPrometheusAdapter:
   `,
 			expectedMetricValue: 0,
 		},
 		{
-			name:                "default",
+			name:                "no config set",
 			config:              "",
 			expectedMetricValue: 0,
 		},

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1842,6 +1842,18 @@ func (f *Factory) PrometheusAdapterDeployment(apiAuthSecretName string, requesth
 
 	spec.Containers[0].Image = f.config.Images.K8sPrometheusAdapter
 
+	if f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter == nil {
+		f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter = &K8sPrometheusAdapter{}
+	}
+
+	if f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit == nil {
+		f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit = &Audit{}
+	}
+
+	if f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit.Profile == "" {
+		f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter.Audit.Profile = auditv1.LevelMetadata
+	}
+
 	config := f.config.ClusterMonitoringConfiguration.K8sPrometheusAdapter
 	if config != nil && len(config.NodeSelector) > 0 {
 		spec.NodeSelector = config.NodeSelector

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -104,6 +104,7 @@ type AlertmanagerMainConfig struct {
 }
 
 // The `K8sPrometheusAdapter` resource defines settings for the Prometheus Adapter component.
+// This is deprecated and will be removed in a future version.
 type K8sPrometheusAdapter struct {
 	// Defines the audit configuration used by the Prometheus Adapter instance.
 	// Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`.
@@ -122,7 +123,6 @@ type K8sPrometheusAdapter struct {
 }
 
 // The `MetricsServerConfig` resource defines settings for the Metrics Server component.
-// Note that this setting only applies when the MetricsServer feature gate is enabled.
 type MetricsServerConfig struct {
 	// Defines the audit configuration used by the Metrics Server instance.
 	// Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`.

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -808,7 +808,7 @@ func TestClusterMonitoringDeprecatedConfig(t *testing.T) {
 	checkMetricValue := func(value float64) {
 		t.Helper()
 		f.PrometheusK8sClient.WaitForQueryReturn(
-			t, 5*time.Minute, fmt.Sprintf(`%s{configmap="openshift-monitoring/cluster-monitoring-config", field="k8sPrometheusAdapter.dedicatedServiceMonitors", deprecation_version="4.15"}`, metricName),
+			t, 5*time.Minute, fmt.Sprintf(`%s{configmap="openshift-monitoring/cluster-monitoring-config", field="k8sPrometheusAdapter", deprecation_version="4.16"}`, metricName),
 			func(v float64) error {
 				if v != value {
 					return fmt.Errorf("expected %s to be of value %f.", metricName, value)
@@ -820,11 +820,11 @@ func TestClusterMonitoringDeprecatedConfig(t *testing.T) {
 	// No deprecated config should have been used.
 	checkMetricValue(0)
 
-	// Use deprecated config.
+	// Set a field for k8sPrometheusAdapter.
 	data := `
 k8sPrometheusAdapter:
-  dedicatedServiceMonitors:
-    enabled: true`
+  audit:
+    profile: Request`
 	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, data))
 	checkMetricValue(1)
 


### PR DESCRIPTION
* Add deprecation for prometheus-adapter

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
