### PR TITLE
OCPBUGS-17113: Lazy updates for Prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOPROXY?=http://proxy.golang.org
 export GO111MODULE
 export GOPROXY
 
-# go pakages for unit tests, excluding e2e tests
+# go packages for unit tests, excluding e2e tests
 PKGS=$(shell go list ./... | grep -v /test/e2e)
 GOLANG_FILES:=$(shell find . -name \*.go -print)
 # NOTE: grep -v %.yaml is needed  because "%s-policy.yaml" is used
@@ -248,6 +248,10 @@ check-runbooks:
 ###########
 # Testing #
 ###########
+
+.PHONY: bench
+bench:
+	go test -run NONE -bench=. -benchmem $(PKGS)
 
 .PHONY: test
 test: test-unit test-rules test-e2e

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-kit/log v0.2.1
 	github.com/go-openapi/strfmt v0.23.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/imdario/mergo v0.3.16
 	github.com/mattn/go-shellwords v1.0.12
@@ -82,7 +83,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/cel-go v0.20.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -50,6 +50,7 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -58,6 +59,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
@@ -81,6 +83,7 @@ type Client struct {
 	userWorkloadNamespace string
 
 	kclient     kubernetes.Interface
+	dclient     dynamic.Interface
 	mdataclient metadata.Interface
 	osmclient   openshiftmonitoringclientset.Interface
 	oscclient   openshiftconfigclientset.Interface
@@ -105,6 +108,14 @@ func NewForConfig(cfg *rest.Config, version string, namespace, userWorkloadNames
 			return nil, fmt.Errorf("creating kubernetes clientset client: %w", err)
 		}
 		client.kclient = kclient
+	}
+
+	if client.dclient == nil {
+		dclient, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("creating dynamic clientset client: %w", err)
+		}
+		client.dclient = dclient
 	}
 
 	if client.eclient == nil {
@@ -200,6 +211,12 @@ type Option = func(*Client)
 func KubernetesClient(kclient kubernetes.Interface) Option {
 	return func(c *Client) {
 		c.kclient = kclient
+	}
+}
+
+func DynamicClient(dclient *dynamic.DynamicClient) Option {
+	return func(c *Client) {
+		c.dclient = dclient
 	}
 }
 
@@ -632,29 +649,75 @@ func (c *Client) GetAlertingRule(ctx context.Context, namespace, name string) (*
 	return c.osmclient.MonitoringV1().AlertingRules(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
-func (c *Client) CreateOrUpdatePrometheus(ctx context.Context, p *monv1.Prometheus) error {
-	pclient := c.mclient.MonitoringV1().Prometheuses(p.GetNamespace())
-	existing, err := pclient.Get(ctx, p.GetName(), metav1.GetOptions{})
+// CreateOrUpdatePrometheus does not use a defaulting function, and resorts only to the caching mechanism, since,
+// * defaults for Prometheus should be introduced from its operator level, and,
+// * the defaulting approach generally requires hardcoding the default values, which adds on to the maintenance overhead.
+// NOTE: The return values establish the following matrix (w.r.t. the create or update verbs):
+// * true, nil   : verb action needed; operation successful,
+// * false, nil  : verb action not needed; operation skipped,
+// * true, error : verb action needed, operation unsuccessful.
+// * false, error: verb action may or may not be needed; operation unsuccessful,
+func (c *Client) CreateOrUpdatePrometheus(ctx context.Context, structuredRequiredPrometheus *monv1.Prometheus) (bool, error) {
+	unstructuredRequiredPrometheusObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(structuredRequiredPrometheus)
+	if err != nil {
+		return false, fmt.Errorf("converting Prometheus object to unstructured failed: %w", err)
+	}
+	unstructuredRequiredPrometheus := &unstructured.Unstructured{}
+	unstructuredRequiredPrometheus.SetUnstructuredContent(unstructuredRequiredPrometheusObject)
+
+	// Set the GVK for the unstructured object, since these are not inferred automatically, unlike their structured counterparts.
+	unstructuredRequiredPrometheus.SetGroupVersionKind(monv1.SchemeGroupVersion.WithKind(monv1.PrometheusesKind))
+
+	// Preserve the original behavior: always merge the metadata, never replace.
+	// Refer: https://github.com/openshift/cluster-monitoring-operator/pull/942.
+	prometheusGVR := unstructuredRequiredPrometheus.GroupVersionKind().GroupVersion().WithResource(monv1.PrometheusName)
+	unstructuredExistingPrometheus, err := c.dclient.
+		Resource(prometheusGVR).
+		Namespace(structuredRequiredPrometheus.GetNamespace()).
+		Get(ctx, structuredRequiredPrometheus.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err := pclient.Create(ctx, p, metav1.CreateOptions{})
+		_, didUpdate, err := resourceapply.ApplyUnstructuredResourceImproved(
+			ctx,
+			c.dclient,
+			c.eventRecorder,
+			unstructuredRequiredPrometheus,
+			c.resourceCache,
+			prometheusGVR,
+			nil,
+			nil,
+		)
 		if err != nil {
-			return fmt.Errorf("creating Prometheus object failed: %w", err)
+			return didUpdate, fmt.Errorf("creating Prometheus object failed: %w", err)
 		}
-		return nil
+
+		return true, nil
 	}
 	if err != nil {
-		return fmt.Errorf("retrieving Prometheus object failed: %w", err)
+		return false, fmt.Errorf("retrieving Prometheus object failed: %w", err)
 	}
+	unstructuredRequiredPrometheusMetadataLabels := unstructuredRequiredPrometheus.GetLabels()
+	unstructuredRequiredPrometheusMetadataAnnotations := unstructuredRequiredPrometheus.GetAnnotations()
+	mergeMetadataLabels(unstructuredRequiredPrometheusMetadataLabels, unstructuredExistingPrometheus.GetLabels())
+	mergeMetadataAnnotations(unstructuredRequiredPrometheusMetadataAnnotations, unstructuredExistingPrometheus.GetAnnotations())
+	unstructuredRequiredPrometheus.SetLabels(unstructuredRequiredPrometheusMetadataLabels)
+	unstructuredRequiredPrometheus.SetAnnotations(unstructuredRequiredPrometheusMetadataAnnotations)
+	unstructuredRequiredPrometheus.SetResourceVersion(unstructuredExistingPrometheus.GetResourceVersion())
 
-	required := p.DeepCopy()
-	mergeMetadata(&required.ObjectMeta, existing.ObjectMeta)
-
-	required.ResourceVersion = existing.ResourceVersion
-	_, err = pclient.Update(ctx, required, metav1.UpdateOptions{})
+	_, didUpdate, err := resourceapply.ApplyUnstructuredResourceImproved(
+		ctx,
+		c.dclient,
+		c.eventRecorder,
+		unstructuredRequiredPrometheus,
+		c.resourceCache,
+		prometheusGVR,
+		nil,
+		nil,
+	)
 	if err != nil {
-		return fmt.Errorf("updating Prometheus object failed: %w", err)
+		return didUpdate, fmt.Errorf("updating Prometheus object failed: %w", err)
 	}
-	return nil
+
+	return didUpdate, nil
 }
 
 func (c *Client) CreateOrUpdatePrometheusRule(ctx context.Context, p *monv1.PrometheusRule) error {
@@ -1878,20 +1941,28 @@ func (c *Client) VPACustomResourceDefinitionPresent(ctx context.Context, lastKno
 // where keys starting from string defined in `metadataPrefix` are deleted. This prevents issues with preserving stale
 // metadata defined by the operator
 func mergeMetadata(required *metav1.ObjectMeta, existing metav1.ObjectMeta) {
-	for k := range existing.Annotations {
+	mergeMetadataLabels(required.Labels, existing.Labels)
+	mergeMetadataAnnotations(required.Annotations, existing.Annotations)
+}
+
+func mergeMetadataLabels(requiredLabels map[string]string, existingLabels map[string]string) {
+	for k := range existingLabels {
 		if strings.HasPrefix(k, metadataPrefix) {
-			delete(existing.Annotations, k)
+			delete(existingLabels, k)
 		}
 	}
 
-	for k := range existing.Labels {
+	_ = mergo.Merge(&requiredLabels, existingLabels)
+}
+
+func mergeMetadataAnnotations(requiredAnnotations map[string]string, existingAnnotations map[string]string) {
+	for k := range existingAnnotations {
 		if strings.HasPrefix(k, metadataPrefix) {
-			delete(existing.Labels, k)
+			delete(existingAnnotations, k)
 		}
 	}
 
-	_ = mergo.Merge(&required.Annotations, existing.Annotations)
-	_ = mergo.Merge(&required.Labels, existing.Labels)
+	_ = mergo.Merge(&requiredAnnotations, existingAnnotations)
 }
 
 type jsonPatch struct {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -17,11 +17,31 @@ package client
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"reflect"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	dynamicFake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+
+	"github.com/google/go-cmp/cmp"
 	routev1 "github.com/openshift/api/route/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	osrfake "github.com/openshift/client-go/route/clientset/versioned/fake"
@@ -31,17 +51,6 @@ import (
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monfake "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
 	"github.com/stretchr/testify/require"
-	admissionv1 "k8s.io/api/admissionregistration/v1"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -1729,17 +1738,17 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 		name                string
 		initialLabels       map[string]string
 		initialAnnotations  map[string]string
-		updatedLabels       map[string]string
-		updatedAnnotations  map[string]string
+		appliedLabels       map[string]string
+		appliedAnnotations  map[string]string
 		expectedLabels      map[string]string
 		expectedAnnotations map[string]string
 	}{
 		{
 			name: "inital labels/annotations are empty",
-			updatedLabels: map[string]string{
+			appliedLabels: map[string]string{
 				"app.kubernetes.io/name": "app",
 			},
-			updatedAnnotations: map[string]string{
+			appliedAnnotations: map[string]string{
 				"monitoring.openshift.io/foo": "bar",
 			},
 			expectedLabels: map[string]string{
@@ -1760,10 +1769,10 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 				"monitoring.openshift.io/bar": "",
 				"annotation":                  "value",
 			},
-			updatedLabels: map[string]string{
+			appliedLabels: map[string]string{
 				"app.kubernetes.io/name": "app",
 			},
-			updatedAnnotations: map[string]string{
+			appliedAnnotations: map[string]string{
 				"monitoring.openshift.io/foo": "bar",
 			},
 			expectedLabels: map[string]string{
@@ -1772,6 +1781,7 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 			},
 			expectedAnnotations: map[string]string{
 				"monitoring.openshift.io/foo": "bar",
+				"monitoring.openshift.io/bar": "",
 				"annotation":                  "value",
 			},
 		},
@@ -1780,6 +1790,10 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(st *testing.T) {
 			prometheus := &monv1.Prometheus{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Prometheus",
+					APIVersion: "monitoring.coreos.com/v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "k8s",
 					Namespace:   ns,
@@ -1788,32 +1802,277 @@ func TestCreateOrUpdatePrometheus(t *testing.T) {
 				},
 			}
 
+			// Initialize the type registry for the fake client, and populate that with the necessary definition(s).
+			s := runtime.NewScheme()
+			_ = monv1.AddToScheme(s)
+
 			c := Client{
-				mclient: monfake.NewSimpleClientset(prometheus.DeepCopy()),
+				dclient:       dynamicFake.NewSimpleDynamicClient(s, prometheus.DeepCopy()),
+				eventRecorder: events.NewInMemoryRecorder("test-create-or-update-prometheus"),
 			}
-			if _, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(ctx, prometheus.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err := c.dclient.Resource(monv1.SchemeGroupVersion.WithResource("prometheuses")).Namespace(ns).Get(ctx, prometheus.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
-			prometheus.SetLabels(tc.updatedLabels)
-			prometheus.SetAnnotations(tc.updatedAnnotations)
-			if err := c.CreateOrUpdatePrometheus(ctx, prometheus); err != nil {
+			prometheus.SetLabels(tc.appliedLabels)
+			prometheus.SetAnnotations(tc.appliedAnnotations)
+			if _, err := c.CreateOrUpdatePrometheus(ctx, prometheus); err != nil {
 				t.Fatal(err)
 			}
 
-			after, err := c.mclient.MonitoringV1().Prometheuses(ns).Get(ctx, prometheus.GetName(), metav1.GetOptions{})
+			after, err := c.dclient.Resource(monv1.SchemeGroupVersion.WithResource("prometheuses")).Namespace(ns).Get(ctx, prometheus.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !reflect.DeepEqual(tc.expectedAnnotations, after.Annotations) {
-				t.Errorf("expected annotations %q, got %q", tc.expectedAnnotations, after.Annotations)
+			if !reflect.DeepEqual(tc.expectedAnnotations, after.GetAnnotations()) {
+				t.Errorf("expected annotations %q, got %q", tc.expectedAnnotations, after.GetAnnotations())
 			}
-			if !reflect.DeepEqual(tc.expectedLabels, after.Labels) {
-				t.Errorf("expected labels %q, got %q", tc.expectedLabels, after.Labels)
+			if !reflect.DeepEqual(tc.expectedLabels, after.GetLabels()) {
+				t.Errorf("expected labels %q, got %q", tc.expectedLabels, after.GetLabels())
 			}
 		})
 	}
+
+	initialPrometheus := &monv1.Prometheus{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Prometheus",
+			APIVersion: "monitoring.coreos.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-prometheus",
+			Namespace: "test-namespace",
+		},
+	}
+	prometheusGVR := initialPrometheus.GroupVersionKind().GroupVersion().WithResource("prometheuses")
+
+	c := &Client{}
+	c.dclient = dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), initialPrometheus.DeepCopy())
+	c.eventRecorder = events.NewInMemoryRecorder("create-or-update-prometheus-test")
+	c.resourceCache = resourceapply.NewResourceCache()
+
+	testcases := []struct {
+		description  string
+		prometheus   *monv1.Prometheus
+		shouldUpdate bool
+	}{
+		{
+			description: "initially, apply all default values to the existing prometheus",
+			prometheus:  initialPrometheus,
+		},
+		{
+			description: "apply a default value to the existing prometheus",
+			prometheus: &monv1.Prometheus{
+				TypeMeta:   initialPrometheus.TypeMeta,
+				ObjectMeta: initialPrometheus.ObjectMeta,
+				Spec: monv1.PrometheusSpec{
+					Thanos: &monv1.ThanosSpec{
+						BlockDuration: "2h",
+					},
+				},
+			},
+			shouldUpdate: true,
+		},
+		{
+			description: "apply no value to the existing prometheus",
+			prometheus: &monv1.Prometheus{
+				TypeMeta:   initialPrometheus.TypeMeta,
+				ObjectMeta: initialPrometheus.ObjectMeta,
+			},
+			shouldUpdate: true,
+		},
+		{
+			description: "apply a non-default value to the existing prometheus",
+			prometheus: &monv1.Prometheus{
+				TypeMeta:   initialPrometheus.TypeMeta,
+				ObjectMeta: initialPrometheus.ObjectMeta,
+				Spec: monv1.PrometheusSpec{
+					Thanos: &monv1.ThanosSpec{
+						BlockDuration: "3h",
+					},
+				},
+			},
+			shouldUpdate: true,
+		},
+		{
+			description: "apply a label to the existing prometheus",
+			prometheus: &monv1.Prometheus{
+				TypeMeta: initialPrometheus.TypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      initialPrometheus.Name,
+					Namespace: initialPrometheus.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "prometheus",
+					},
+				},
+			},
+			shouldUpdate: true,
+		},
+		{
+			description: "apply the same label to the existing prometheus",
+			prometheus: &monv1.Prometheus{
+				TypeMeta: initialPrometheus.TypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      initialPrometheus.Name,
+					Namespace: initialPrometheus.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "prometheus",
+					},
+				},
+			},
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.description, func(t *testing.T) {
+			existingPreUpdate, err := c.dclient.Resource(prometheusGVR).Namespace(testcase.prometheus.GetNamespace()).Get(context.Background(), testcase.prometheus.GetName(), metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			didUpdate, err := c.CreateOrUpdatePrometheus(context.Background(), testcase.prometheus)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if didUpdate != testcase.shouldUpdate {
+				t.Fatalf("expected update: %v, got %v", testcase.shouldUpdate, didUpdate)
+			}
+			existingPostUpdate, err := c.dclient.Resource(prometheusGVR).Namespace(testcase.prometheus.GetNamespace()).Get(context.Background(), testcase.prometheus.GetName(), metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if didUpdate && reflect.DeepEqual(existingPreUpdate, existingPostUpdate) {
+				t.Fatalf("expected update: %s", cmp.Diff(existingPreUpdate, existingPostUpdate))
+			}
+		})
+	}
+}
+
+func BenchmarkCreateOrUpdatePrometheus(b *testing.B) {
+	initialPrometheus := &monv1.Prometheus{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Prometheus",
+			APIVersion: "monitoring.coreos.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-prometheus",
+			Namespace: "test-namespace",
+		},
+	}
+	prometheusGVR := initialPrometheus.GroupVersionKind().GroupVersion().WithResource("prometheuses")
+
+	c := &Client{}
+	c.dclient = dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), initialPrometheus.DeepCopy())
+	c.eventRecorder = events.NewInMemoryRecorder("create-or-update-prometheus-test")
+	c.resourceCache = resourceapply.NewResourceCache()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w, err := c.dclient.Resource(prometheusGVR).Namespace(initialPrometheus.GetNamespace()).Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		b.Fatalf("unexpected error: %v", err)
+	}
+	updateCounter := new(int)
+	go func(updateCounter *int) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case e := <-w.ResultChan():
+				if e.Type == watch.Modified || e.Type == watch.Added {
+					*updateCounter++
+				}
+			default:
+			}
+		}
+	}(updateCounter)
+
+	randomDuration := func() monv1.Duration {
+		return monv1.Duration(strconv.Itoa(rand.Intn(999) + 1))
+	}
+	benchmarks := []struct {
+		description          string
+		prometheus           func() *monv1.Prometheus
+		requiresInitialApply bool
+	}{
+		{
+			description: "apply random non-default values to the existing prometheus",
+			prometheus: func() *monv1.Prometheus {
+				return &monv1.Prometheus{
+					TypeMeta:   initialPrometheus.TypeMeta,
+					ObjectMeta: initialPrometheus.ObjectMeta,
+					Spec: monv1.PrometheusSpec{
+						Thanos: &monv1.ThanosSpec{
+							BlockDuration: randomDuration() + "h",
+						},
+					},
+				}
+			},
+		},
+		{
+			// Benchmark the library-go `spec` behavior.
+			description: "apply the same default value to the existing prometheus",
+			prometheus: func() *monv1.Prometheus {
+				return &monv1.Prometheus{
+					TypeMeta:   initialPrometheus.TypeMeta,
+					ObjectMeta: initialPrometheus.ObjectMeta,
+					Spec: monv1.PrometheusSpec{
+						Thanos: &monv1.ThanosSpec{
+							BlockDuration: "2h",
+						},
+					},
+				}
+			},
+			requiresInitialApply: true,
+		},
+		{
+			// Benchmark the library-go `metadata` behavior.
+			description: "apply the same custom label to the existing prometheus",
+			prometheus: func() *monv1.Prometheus {
+				return &monv1.Prometheus{
+					TypeMeta: initialPrometheus.TypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      initialPrometheus.Name,
+						Namespace: initialPrometheus.Namespace,
+						Labels: map[string]string{
+							"app.kubernetes.io/name": "prometheus",
+						},
+					},
+				}
+			},
+			requiresInitialApply: true,
+		},
+	}
+	for _, benchmark := range benchmarks {
+		if benchmark.requiresInitialApply {
+			err = defaultingCreateOrUpdatePrometheus(ctx, c, initialPrometheus)
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
+		}
+
+		b.Run("[library-go]"+benchmark.description, func(b *testing.B) {
+			*updateCounter = 0
+			for i := 0; i < 1_000; i++ {
+				err = defaultingCreateOrUpdatePrometheus(ctx, c, benchmark.prometheus())
+				if err != nil {
+					b.Fatalf("unexpected error: %v", err)
+				}
+			}
+			b.ReportMetric(float64(*updateCounter), "updates")
+		})
+
+		b.Run(benchmark.description, func(b *testing.B) {
+			*updateCounter = 0
+			for i := 0; i < 1_000; i++ {
+				err = nonDefaultingCreateOrUpdatePrometheus(ctx, c, benchmark.prometheus())
+				if err != nil {
+					b.Fatalf("unexpected error: %v", err)
+				}
+			}
+			b.ReportMetric(float64(*updateCounter), "updates")
+		})
+	}
+
+	w.Stop()
+	cancel()
 }
 
 func TestCreateOrUpdateAlertmanager(t *testing.T) {
@@ -2330,4 +2589,39 @@ func TestPollUntil(t *testing.T) {
 	cancelParentCtx3()
 	wg.Wait()
 	require.ErrorContains(t, pollErr, "context deadline exceeded")
+}
+
+func defaultingCreateOrUpdatePrometheus(ctx context.Context, c *Client, p *monv1.Prometheus) error {
+	_, err := c.CreateOrUpdatePrometheus(ctx, p)
+	return err
+}
+
+func nonDefaultingCreateOrUpdatePrometheus(ctx context.Context, c *Client, p *monv1.Prometheus) error {
+	var err error
+	unstructuredRequiredPrometheus := &unstructured.Unstructured{}
+	unstructuredRequiredPrometheus.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(p)
+	if err != nil {
+		return fmt.Errorf("failed to convert structured to unstructured Prometheus: %w", err)
+	}
+	pclient := c.dclient.Resource(p.GroupVersionKind().GroupVersion().WithResource("prometheuses")).Namespace(p.GetNamespace())
+	existing, err := pclient.Get(ctx, p.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := pclient.Create(ctx, unstructuredRequiredPrometheus, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("creating Prometheus object failed: %w", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("retrieving Prometheus object failed: %w", err)
+	}
+
+	required := p.DeepCopy()
+	mergeMetadata(&required.ObjectMeta, p.ObjectMeta)
+	required.ResourceVersion = existing.GetResourceVersion()
+	_, err = pclient.Update(ctx, unstructuredRequiredPrometheus, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating Prometheus object failed: %w", err)
+	}
+	return nil
 }

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -387,7 +387,7 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 		}
 
 		klog.V(4).Info("reconciling Prometheus object")
-		err = t.client.CreateOrUpdatePrometheus(ctx, p)
+		_, err = t.client.CreateOrUpdatePrometheus(ctx, p)
 		if err != nil {
 			return fmt.Errorf("reconciling Prometheus object failed: %w", err)
 		}

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -261,7 +261,7 @@ func (t *PrometheusUserWorkloadTask) create(ctx context.Context) error {
 	}
 
 	klog.V(4).Info("reconciling UserWorkload Prometheus object")
-	err = t.client.CreateOrUpdatePrometheus(ctx, p)
+	_, err = t.client.CreateOrUpdatePrometheus(ctx, p)
 	if err != nil {
 		return fmt.Errorf("reconciling UserWorkload Prometheus object failed: %w", err)
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/prometheus/prometheus/discovery/kubernetes" // required for promConfig.Load to parse kubernetes_sd_configs
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	_ "github.com/prometheus/prometheus/discovery/kubernetes" // required for promConfig.Load to parse kubernetes_sd_configs
 
 	osConfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
@@ -299,7 +300,7 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// deploy remote write target
 			prometheusReceiver := f.MakePrometheusWithWebTLSRemoteReceive(name, secName, image)
-			if err := f.OperatorClient.CreateOrUpdatePrometheus(ctx, prometheusReceiver); err != nil {
+			if _, err := f.OperatorClient.CreateOrUpdatePrometheus(ctx, prometheusReceiver); err != nil {
 				t.Fatal(err)
 			}
 			if err := f.OperatorClient.ValidatePrometheus(ctx, types.NamespacedName{


### PR DESCRIPTION
Incorporate https://github.com/openshift/library-go/pull/1575 downstream.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
