### PR TITLE
MON-3934: Clean up and parallelize some e2e tests for faster runs

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1488,25 +1488,6 @@ func (c *Client) CreateOrUpdateConfigMap(ctx context.Context, cm *v1.ConfigMap) 
 	return err
 }
 
-func (c *Client) DeleteIfExists(ctx context.Context, nsName string) error {
-	nClient := c.kclient.CoreV1().Namespaces()
-	_, err := nClient.Get(ctx, nsName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		// Namespace already deleted
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("retrieving Namespace object failed: %w", err)
-	}
-
-	err = nClient.Delete(ctx, nsName, metav1.DeleteOptions{})
-	if err != nil {
-		return fmt.Errorf("deleting ConfigMap object failed: %w", err)
-	}
-	return nil
-}
-
 func (c *Client) CreateIfNotExistConfigMap(ctx context.Context, cm *v1.ConfigMap) (*v1.ConfigMap, error) {
 	cClient := c.kclient.CoreV1().ConfigMaps(cm.GetNamespace())
 	res, err := cClient.Get(ctx, cm.GetName(), metav1.GetOptions{})

--- a/test/e2e/alert_relabel_config_test.go
+++ b/test/e2e/alert_relabel_config_test.go
@@ -40,6 +40,8 @@ const (
 )
 
 func TestAlertRelabelConfig(t *testing.T) {
+	// The test shouldn't be disruptive, safe to run in parallel with others.
+	t.Parallel()
 	initialRelabelConfig := prometheusRelabelConfig(t)
 
 	// By default, we drop prometheus_replica label + add openshift_io_alert_source = 2

--- a/test/e2e/alerting_rule_test.go
+++ b/test/e2e/alerting_rule_test.go
@@ -39,6 +39,8 @@ const (
 )
 
 func TestAlertingRule(t *testing.T) {
+	// The test shouldn't be disruptive, safe to run in parallel with others.
+	t.Parallel()
 	ctx := context.Background()
 	alertingRules := f.OpenShiftMonitoringClient.MonitoringV1().AlertingRules(f.Ns)
 
@@ -167,6 +169,7 @@ func prometheusRuleCount(t *testing.T) int {
 }
 
 func assertPrometheusRuleCount(t *testing.T, count int) {
+	t.Helper()
 	currentCount := prometheusRuleCount(t)
 	if currentCount != count {
 		t.Fatalf("Different generated PrometheusRule count (%d != %d)", currentCount, count)

--- a/test/e2e/alertmanager_helpers.go
+++ b/test/e2e/alertmanager_helpers.go
@@ -183,7 +183,7 @@ func (wr *webhookReceiver) getAlertsByID(id string) ([]alert, error) {
 func (wr *webhookReceiver) tearDown(t *testing.T, f *framework.Framework) {
 	t.Helper()
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
-		return f.OperatorClient.DeleteIfExists(ctx, wr.namespace)
+		return f.DeleteNamespace(t, wr.namespace)
 	})
 
 	if err != nil {

--- a/test/e2e/alertmanager_user_workload_test.go
+++ b/test/e2e/alertmanager_user_workload_test.go
@@ -38,17 +38,7 @@ func TestUserWorkloadAlertmanager(t *testing.T) {
 	f.AssertStatefulSetExistsAndRollout("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
 	f.AssertServiceExists("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
 
-	for _, scenario := range []struct {
-		name string
-		f    func(*testing.T)
-	}{
-		{
-			name: "assert UWM alert access",
-			f:    assertUWMAlertsAccess,
-		},
-	} {
-		t.Run(scenario.name, scenario.f)
-	}
+	t.Run("assert UWM alert access", assertUWMAlertsAccess)
 }
 
 // assertUWMAlertsAccess ensures that a user can't access all alerts from the UWM alertmanager via the api.
@@ -79,17 +69,16 @@ func assertUWMAlertsAccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The uwm alerts port (9095) is only exposed in-cluster, so we need to use
-	// port forwarding to access kube-rbac-proxy.
-	host, cleanUp, err := f.ForwardPort(t, f.UserWorkloadMonitoringNs, "alertmanager-user-workload", 9095)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanUp()
-
-	client := framework.NewPrometheusClient(host, token)
-
 	err = framework.Poll(5*time.Second, time.Minute, func() error {
+		// The uwm alerts port (9095) is only exposed in-cluster, so we need to use
+		// port forwarding to access kube-rbac-proxy.
+		host, cleanUp, err := f.ForwardPort(t, f.UserWorkloadMonitoringNs, "alertmanager-user-workload", 9095)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanUp()
+
+		client := framework.NewPrometheusClient(host, token)
 		resp, err := client.Do("GET", "/api/v2/alerts", nil)
 		if err != nil {
 			return err

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -292,7 +292,10 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 			assertion: f.AssertPrometheusRuleExists(thanosRule, f.Ns),
 		},
 	} {
-		t.Run(tc.name, tc.assertion)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertion(t)
+		})
 	}
 }
 
@@ -344,7 +347,10 @@ func TestClusterMonitorAlertManagerConfig(t *testing.T) {
 			),
 		},
 	} {
-		t.Run(tc.name, tc.assertion)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertion(t)
+		})
 	}
 }
 
@@ -664,7 +670,10 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
 			assertion: assertQueryLogValueEquals(f.UserWorkloadMonitoringNs, crName, "/tmp/test.log"),
 		},
 	} {
-		t.Run(tc.name, tc.assertion)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertion(t)
+		})
 	}
 }
 
@@ -721,7 +730,10 @@ func TestUserWorkloadMonitorThanosRulerConfig(t *testing.T) {
 			),
 		},
 	} {
-		t.Run(tc.name, tc.assertion)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertion(t)
+		})
 	}
 }
 
@@ -767,7 +779,10 @@ monitoringPlugin:
 			),
 		},
 	} {
-		t.Run(tc.name, tc.assertion)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertion(t)
+		})
 	}
 }
 

--- a/test/e2e/kube_state_metrics_test.go
+++ b/test/e2e/kube_state_metrics_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestKSMMetricsSuppression(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 
 	suppressedPattern, _ := regexp.Compile("kube_.*_annotations")
 
@@ -74,6 +76,8 @@ func TestKSMMetricsSuppression(t *testing.T) {
 }
 
 func TestKSMCRSMetrics(t *testing.T) {
+	// The test shouldn't be disruptive, safe to run in parallel with others.
+	t.Parallel()
 	const timeout = 5 * time.Minute
 	assetsDir := "./assets"
 	ksmCRSMetricPrefix := "kube_customresource"

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -182,6 +182,8 @@ func testTargetsUp(t *testing.T) {
 // Once we have the need to test multiple recording rules, we can unite them in
 // a single test function.
 func TestMemoryUsageRecordingRule(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	f.ThanosQuerierClient.WaitForQueryReturnGreaterEqualOne(
 		t,
 		time.Minute,

--- a/test/e2e/metrics_adapter_test.go
+++ b/test/e2e/metrics_adapter_test.go
@@ -58,6 +58,8 @@ func isAPIServiceAvailable(conditions []apiservicesv1.APIServiceCondition) bool 
 }
 
 func TestMetricsAPIAvailability(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	ctx := context.Background()
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -85,6 +87,8 @@ func TestMetricsAPIAvailability(t *testing.T) {
 }
 
 func TestNodeMetricsPresence(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	ctx := context.Background()
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -123,6 +127,8 @@ func TestNodeMetricsPresence(t *testing.T) {
 }
 
 func TestPodMetricsPresence(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	var lastErr error
 	ctx := context.Background()
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -164,6 +170,8 @@ func TestPodMetricsPresence(t *testing.T) {
 }
 
 func TestAggregatedMetricPermissions(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	ctx := context.Background()
 	present := func(where []string, what string) bool {
 		sort.Strings(where)
@@ -230,6 +238,8 @@ func TestAggregatedMetricPermissions(t *testing.T) {
 }
 
 func TestMetricsServerRollout(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	for _, test := range []scenario{
 		{
 			name:      "assert metrics-server deployment is rolled out",

--- a/test/e2e/priority_class_test.go
+++ b/test/e2e/priority_class_test.go
@@ -27,6 +27,8 @@ import (
 // system-cluster-critical   2000000000   false            114m
 // system-node-critical      2000001000   false            114m
 func TestToEnsureUserPriorityClassIsPresentAndLower(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	ctx := context.Background()
 
 	// Get system priority class values.

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestPrometheusMetrics(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	expected := map[string]int{
 		"prometheus-operator":           1,
 		"prometheus-k8s":                2,
@@ -44,6 +46,7 @@ func TestPrometheusMetrics(t *testing.T) {
 
 	for service, metric := range expected {
 		t.Run(service, func(t *testing.T) {
+			t.Parallel()
 			f.ThanosQuerierClient.WaitForQueryReturn(
 				t, 10*time.Minute, fmt.Sprintf(`count(up{service="%s",namespace="openshift-monitoring"} == 1)`, service),
 				func(v float64) error {
@@ -63,6 +66,8 @@ func TestPrometheusMetrics(t *testing.T) {
 // consider whether the new default value is still suitable.
 // Refer to this link for some points that may need to be examined https://github.com/openshift/prometheus/pull/206#issuecomment-2182168575.
 func TestPrometheusGOGC(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	gogc := 75
 	f.ThanosQuerierClient.WaitForQueryReturn(
 		t, 5*time.Minute, `min(go_gc_gogc_percent{namespace="openshift-monitoring", service="prometheus-k8s", container="kube-rbac-proxy"})`, // kube-rbac-proxy exposes prometheus container's metrics.
@@ -77,6 +82,8 @@ func TestPrometheusGOGC(t *testing.T) {
 }
 
 func TestAntiAffinity(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	for _, tc := range []struct {
 		name     string
 		instance string

--- a/test/e2e/security_headers_test.go
+++ b/test/e2e/security_headers_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestAlertmanagerPolicyHeaders(t *testing.T) {
+	// The test shouldn't be disruptive, safe to run in parallel with others.
+	t.Parallel()
 	// The tenancy port (9092) is only exposed in-cluster, so we need to use
 	// port forwarding to access kube-rbac-proxy.
 	host, cleanUp, err := f.ForwardPort(t, f.Ns, "alertmanager-main", 9092)
@@ -36,6 +38,8 @@ func TestAlertmanagerPolicyHeaders(t *testing.T) {
 }
 
 func TestPrometheusPolicyHeaders(t *testing.T) {
+	// The test shouldn't be disruptive, safe to run in parallel with others.
+	t.Parallel()
 	host, cleanUp, err := f.ForwardPort(t, f.Ns, "prometheus-k8s", 9091)
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -90,6 +90,8 @@ func TestTelemeterRemoteWrite(t *testing.T) {
 
 // TestTelemeterClient verifies that the telemeter client can collect metrics from the monitoring stack and forward them to the telemeter server.
 func TestTelemeterClient(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	{
 		f.PrometheusK8sClient.WaitForQueryReturn(
 			t,

--- a/test/e2e/thanos_querier_test.go
+++ b/test/e2e/thanos_querier_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestThanosQueryCanQueryWatchdogAlert(t *testing.T) {
+	// The test is "read-only", safe to run in parallel with others.
+	t.Parallel()
 	// The 2-minute timeout is what console CI tests set.
 	// If this test is flaky, we should increase until
 	// we can fix the possible DNS resolve issues.
@@ -43,6 +45,8 @@ const (
 )
 
 func TestMonitoringApiRoles(t *testing.T) {
+	// The test shouldn't be disruptive, safe to run in parallel with others.
+	t.Parallel()
 
 	cf, err := f.CreateNamespace(testNamespaceTQ)
 	if err != nil {


### PR DESCRIPTION
    MON-3934: Parallelize some readonly/non disruptive e2e tests for faster runs
    
    Isolate specific tests to enable parallel execution
    
    Enhance the resilience of some tests and fix those prone to errors.
    
    Fix some tests that were running wrong checks.
    
    Make some the tests idempotent to be easily debugged and run locally





<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
