### PR TITLE
[release-4.15] OCPBUGS-36312: inject trusted CA bundle into UWM Alertmanager

### DIFF
--- a/assets/alertmanager-user-workload/alertmanager.yaml
+++ b/assets/alertmanager-user-workload/alertmanager.yaml
@@ -165,7 +165,16 @@ spec:
       type: RuntimeDefault
   serviceAccountName: alertmanager-user-workload
   version: 0.26.0
+  volumeMounts:
+  - mountPath: /etc/pki/ca-trust/extracted/pem/
+    name: alertmanager-trusted-ca-bundle
   volumes:
   - configMap:
       name: metrics-client-ca
     name: metrics-client-ca
+  - configMap:
+      items:
+      - key: ca-bundle.crt
+        path: tls-ca-bundle.pem
+      name: alertmanager-trusted-ca-bundle
+    name: alertmanager-trusted-ca-bundle

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -380,6 +380,22 @@ function(params)
               name: 'metrics-client-ca',
             },
           },
+          {
+            name: $.trustedCaBundle.metadata.name,
+            configMap: {
+              name: $.trustedCaBundle.metadata.name,
+              items: [{
+                key: 'ca-bundle.crt',
+                path: 'tls-ca-bundle.pem',
+              }],
+            },
+          },
+        ],
+        volumeMounts+: [
+          {
+            name: $.trustedCaBundle.metadata.name,
+            mountPath: '/etc/pki/ca-trust/extracted/pem/',
+          },
         ],
       },
     },

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3114,18 +3114,26 @@ func TestAlertManagerUserWorkloadConfiguration(t *testing.T) {
 		t.Fatalf("Alertmanager external URL is not configured correctly, expected %s, but got %s", expectedExternalURL, a.Spec.ExternalURL)
 	}
 
-	if !slices.ContainsFunc(a.Spec.Volumes, func(v v1.Volume) bool {
-		if v.VolumeSource.ConfigMap == nil {
-			return false
+	var found bool
+	for i := range a.Spec.Volumes {
+		if a.Spec.Volumes[i].VolumeSource.ConfigMap == nil {
+			continue
 		}
-		return v.VolumeSource.ConfigMap.Name == "alertmanager-trusted-ca-bundle"
-	}) {
+
+		if a.Spec.Volumes[i].VolumeSource.ConfigMap.Name == "alertmanager-trusted-ca-bundle" {
+			found = true
+			break
+		}
+	}
+	if !found {
 		t.Fatal("Alertmanager volumes is not configured correctly")
 	}
 
-	if !slices.ContainsFunc(a.Spec.VolumeMounts, func(vm v1.VolumeMount) bool {
-		return vm.Name == "alertmanager-trusted-ca-bundle"
-	}) {
+	found = false
+	for i := range a.Spec.VolumeMounts {
+		found = found || a.Spec.VolumeMounts[i].Name == "alertmanager-trusted-ca-bundle"
+	}
+	if !found {
 		t.Fatal("Alertmanager volumeMounts is not configured correctly")
 	}
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3113,6 +3113,21 @@ func TestAlertManagerUserWorkloadConfiguration(t *testing.T) {
 	if a.Spec.ExternalURL != expectedExternalURL {
 		t.Fatalf("Alertmanager external URL is not configured correctly, expected %s, but got %s", expectedExternalURL, a.Spec.ExternalURL)
 	}
+
+	if !slices.ContainsFunc(a.Spec.Volumes, func(v v1.Volume) bool {
+		if v.VolumeSource.ConfigMap == nil {
+			return false
+		}
+		return v.VolumeSource.ConfigMap.Name == "alertmanager-trusted-ca-bundle"
+	}) {
+		t.Fatal("Alertmanager volumes is not configured correctly")
+	}
+
+	if !slices.ContainsFunc(a.Spec.VolumeMounts, func(vm v1.VolumeMount) bool {
+		return vm.Name == "alertmanager-trusted-ca-bundle"
+	}) {
+		t.Fatal("Alertmanager volumeMounts is not configured correctly")
+	}
 }
 
 func TestNodeExporter(t *testing.T) {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/cluster-monitoring-operator/pull/2373.

Replaces https://github.com/openshift/cluster-monitoring-operator/pull/2399