### PR TITLE
OCPBUGS-36406: add runbook_url annotations

### DIFF
--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -134,6 +134,7 @@ spec:
     - alert: PrometheusRemoteStorageFailures
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to send {{ printf "%.1f" $value }}% of the samples to {{ $labels.remote_name}}:{{ $labels.url }}
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/PrometheusRemoteStorageFailures.md
         summary: Prometheus fails to send samples to remote storage.
       expr: |
         (
@@ -221,6 +222,7 @@ spec:
     - alert: PrometheusScrapeBodySizeLimitHit
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed {{ printf "%.0f" $value }} scrapes in the last 5m because some targets exceeded the configured body_size_limit.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/PrometheusScrapeBodySizeLimitHit.md
         summary: Prometheus has dropped some targets that exceeded body size limit.
       expr: |
         increase(prometheus_target_scrapes_exceeded_body_size_limit_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0

--- a/assets/prometheus-operator/prometheus-rule.yaml
+++ b/assets/prometheus-operator/prometheus-rule.yaml
@@ -81,6 +81,7 @@ spec:
     - alert: PrometheusOperatorRejectedResources
       annotations:
         description: Prometheus operator in {{ $labels.namespace }} namespace rejected {{ printf "%0.0f" $value }} {{ $labels.controller }}/{{ $labels.resource }} resources.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/PrometheusOperatorRejectedResources.md
         summary: Resources rejected by Prometheus operator
       expr: |
         min_over_time(prometheus_operator_managed_resources{state="rejected",job="prometheus-operator", namespace=~"openshift-monitoring|openshift-user-workload-monitoring"}[5m]) > 0

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -469,9 +469,9 @@ local openShiftRunbookCMO(runbook) =
   openShiftRunbook('alerts/cluster-monitoring-operator/' + runbook);
 
 local includeRunbooks = {
+  AlertmanagerClusterFailedToSendAlerts: openShiftRunbookCMO('AlertmanagerClusterFailedToSendAlerts.md'),
   AlertmanagerFailedReload: openShiftRunbookCMO('AlertmanagerFailedReload.md'),
   AlertmanagerFailedToSendAlerts: openShiftRunbookCMO('AlertmanagerFailedToSendAlerts.md'),
-  AlertmanagerClusterFailedToSendAlerts: openShiftRunbookCMO('AlertmanagerClusterFailedToSendAlerts.md'),
   ClusterOperatorDegraded: openShiftRunbookCMO('ClusterOperatorDegraded.md'),
   ClusterOperatorDown: openShiftRunbookCMO('ClusterOperatorDown.md'),
   KubeAggregatedAPIErrors: openShiftRunbookCMO('KubeAggregatedAPIErrors.md'),
@@ -490,8 +490,11 @@ local includeRunbooks = {
   NodeFilesystemSpaceFillingUp: openShiftRunbookCMO('NodeFilesystemSpaceFillingUp.md'),
   NodeRAIDDegraded: openShiftRunbookCMO('NodeRAIDDegraded.md'),
   NodeClockNotSynchronising: openShiftRunbookCMO('NodeClockNotSynchronising.md'),
-  PrometheusRuleFailures: openShiftRunbookCMO('PrometheusRuleFailures.md'),
+  PrometheusOperatorRejectedResources: openShiftRunbookCMO('PrometheusOperatorRejectedResources.md'),
   PrometheusDuplicateTimestamps: openShiftRunbookCMO('PrometheusDuplicateTimestamps.md'),
+  PrometheusRuleFailures: openShiftRunbookCMO('PrometheusRuleFailures.md'),
+  PrometheusRemoteStorageFailures: openShiftRunbookCMO('PrometheusRemoteStorageFailures.md'),
+  PrometheusScrapeBodySizeLimitHit: openShiftRunbookCMO('PrometheusScrapeBodySizeLimitHit.md'),
   PrometheusTargetSyncFailure: openShiftRunbookCMO('PrometheusTargetSyncFailure.md'),
   TargetDown: openShiftRunbookCMO('TargetDown.md'),
   ThanosRuleQueueIsDroppingAlerts: openShiftRunbookCMO('ThanosRuleQueueIsDroppingAlerts.md'),


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
