### PR TITLE
[release-4.14] OCPBUGS-36416: inject trusted CA bundle into UWM Alertmanager

### DIFF
--- a/assets/alertmanager-user-workload/alertmanager.yaml
+++ b/assets/alertmanager-user-workload/alertmanager.yaml
@@ -160,7 +160,16 @@ spec:
       type: RuntimeDefault
   serviceAccountName: alertmanager-user-workload
   version: 0.25.0
+  volumeMounts:
+  - mountPath: /etc/pki/ca-trust/extracted/pem/
+    name: alertmanager-trusted-ca-bundle
   volumes:
   - configMap:
       name: metrics-client-ca
     name: metrics-client-ca
+  - configMap:
+      items:
+      - key: ca-bundle.crt
+        path: tls-ca-bundle.pem
+      name: alertmanager-trusted-ca-bundle
+    name: alertmanager-trusted-ca-bundle

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -349,6 +349,22 @@ function(params)
               name: 'metrics-client-ca',
             },
           },
+          {
+            name: $.trustedCaBundle.metadata.name,
+            configMap: {
+              name: $.trustedCaBundle.metadata.name,
+              items: [{
+                key: 'ca-bundle.crt',
+                path: 'tls-ca-bundle.pem',
+              }],
+            },
+          },
+        ],
+        volumeMounts+: [
+          {
+            name: $.trustedCaBundle.metadata.name,
+            mountPath: '/etc/pki/ca-trust/extracted/pem/',
+          },
         ],
       },
     },

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2985,18 +2985,26 @@ func TestAlertManagerUserWorkloadConfiguration(t *testing.T) {
 		t.Fatalf("Alertmanager external URL is not configured correctly, expected %s, but got %s", expectedExternalURL, a.Spec.ExternalURL)
 	}
 
-	if !slices.ContainsFunc(a.Spec.Volumes, func(v v1.Volume) bool {
-		if v.VolumeSource.ConfigMap == nil {
-			return false
+	var found bool
+	for i := range a.Spec.Volumes {
+		if a.Spec.Volumes[i].VolumeSource.ConfigMap == nil {
+			continue
 		}
-		return v.VolumeSource.ConfigMap.Name == "alertmanager-trusted-ca-bundle"
-	}) {
+
+		if a.Spec.Volumes[i].VolumeSource.ConfigMap.Name == "alertmanager-trusted-ca-bundle" {
+			found = true
+			break
+		}
+	}
+	if !found {
 		t.Fatal("Alertmanager volumes is not configured correctly")
 	}
 
-	if !slices.ContainsFunc(a.Spec.VolumeMounts, func(vm v1.VolumeMount) bool {
-		return vm.Name == "alertmanager-trusted-ca-bundle"
-	}) {
+	found = false
+	for i := range a.Spec.VolumeMounts {
+		found = found || a.Spec.VolumeMounts[i].Name == "alertmanager-trusted-ca-bundle"
+	}
+	if !found {
 		t.Fatal("Alertmanager volumeMounts is not configured correctly")
 	}
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2984,6 +2984,21 @@ func TestAlertManagerUserWorkloadConfiguration(t *testing.T) {
 	if a.Spec.ExternalURL != expectedExternalURL {
 		t.Fatalf("Alertmanager external URL is not configured correctly, expected %s, but got %s", expectedExternalURL, a.Spec.ExternalURL)
 	}
+
+	if !slices.ContainsFunc(a.Spec.Volumes, func(v v1.Volume) bool {
+		if v.VolumeSource.ConfigMap == nil {
+			return false
+		}
+		return v.VolumeSource.ConfigMap.Name == "alertmanager-trusted-ca-bundle"
+	}) {
+		t.Fatal("Alertmanager volumes is not configured correctly")
+	}
+
+	if !slices.ContainsFunc(a.Spec.VolumeMounts, func(vm v1.VolumeMount) bool {
+		return vm.Name == "alertmanager-trusted-ca-bundle"
+	}) {
+		t.Fatal("Alertmanager volumeMounts is not configured correctly")
+	}
 }
 
 func TestNodeExporter(t *testing.T) {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
