### PR TITLE
MON-3921: Revert "Revert "Merge pull request #2392 from machine424/f-…

### DIFF
--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -36,6 +36,15 @@ spec:
       for: 20m
       labels:
         severity: warning
+    - alert: PrometheusKubernetesListWatchFailures
+      annotations:
+        description: Kubernetes service discovery of Prometheus {{$labels.namespace}}/{{$labels.pod}} is experiencing {{ printf "%.0f" $value }} failures with LIST/WATCH requests to the Kubernetes API in the last 5 minutes.
+        summary: Requests in Kubernetes SD are failing.
+      expr: |
+        increase(prometheus_sd_kubernetes_failures_total{job=~"prometheus-k8s|prometheus-user-workload"}[5m]) > 0
+      for: 15m
+      labels:
+        severity: warning
     - alert: PrometheusNotificationQueueRunningFull
       annotations:
         description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}} is running full.

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -65,6 +65,16 @@
         }
       },
       "version": "main"
+    },
+    {
+      "name": "kubernetes-mixin is pinned because newer versions are breaking MON-3837",
+      "source": {
+        "git": {
+          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin.git",
+          "subdir": ""
+        }
+      },
+      "version": "b247371d1780f530587a8d9dd04ccb19ea970ba0"
     }
   ],
   "legacyImports": true

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -18,8 +18,8 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "d3abeeca4713314c64874fdecf33e2649ce9e417",
-      "sum": "xuUBd2vqF7asyVDe5CE08uPT/RxAdy8O75EjFJoMXXU="
+      "version": "21e5876f7f0539509c277b4c2a3ba1b1599b1721",
+      "sum": "IXI3LQIT9NmTPJAk8WLUJd5+qZfcGpeNCyWIK7oEpws="
     },
     {
       "source": {
@@ -58,8 +58,8 @@
           "subdir": "gen/grafonnet-latest"
         }
       },
-      "version": "1c56af39815c4903e47c27194444456f005f65df",
-      "sum": "GxEO83uxgsDclLp/fmlUJZDbSGpeUZY6Ap3G2cgdL1g="
+      "version": "119d65363dff84a1976bba609f2ac3a8f450e760",
+      "sum": "eyuJ0jOXeA4MrobbNgU4/v5a7ASDHslHZ0eS6hDdWoI="
     },
     {
       "source": {
@@ -68,18 +68,18 @@
           "subdir": "gen/grafonnet-v10.0.0"
         }
       },
-      "version": "1c56af39815c4903e47c27194444456f005f65df",
+      "version": "119d65363dff84a1976bba609f2ac3a8f450e760",
       "sum": "xdcrJPJlpkq4+5LpGwN4tPAuheNNLXZjE6tDcyvFjr0="
     },
     {
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
-          "subdir": "gen/grafonnet-v10.4.0"
+          "subdir": "gen/grafonnet-v11.0.0"
         }
       },
-      "version": "1c56af39815c4903e47c27194444456f005f65df",
-      "sum": "DKj+Sn+rlI48g/aoJpzkfPge46ya0jLk5kcZoiZ2X/I="
+      "version": "119d65363dff84a1976bba609f2ac3a8f450e760",
+      "sum": "Fuo+qTZZzF+sHDBWX/8fkPsUmwW6qhH8hRVz45HznfI="
     },
     {
       "source": {
@@ -88,8 +88,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "a1443ef5924fcbcdd16c2245bc5d045b9325a333",
-      "sum": "+z5VY+bPBNqXcmNAV8xbJcbsRA+pro1R3IM7aIY8OlU="
+      "version": "68c12ed773b12dcf3bab70107496f73d70450581",
+      "sum": "EEPwMLfUIJT9iEUI/gCW9x6PxWoTBPSJOfabTF4rp1M="
     },
     {
       "source": {
@@ -130,7 +130,8 @@
         }
       },
       "version": "b247371d1780f530587a8d9dd04ccb19ea970ba0",
-      "sum": "7M2QHK3WhOc1xT7T7KhL9iKsCYTfsIXpmcItffAcbL0="
+      "sum": "7M2QHK3WhOc1xT7T7KhL9iKsCYTfsIXpmcItffAcbL0=",
+      "name": "kubernetes-mixin is pinned because newer versions are breaking MON-3837"
     },
     {
       "source": {
@@ -139,8 +140,8 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "9e855147a20f2539b0b8c3ea1aa7cd761c104797",
-      "sum": "msMZyUvcebzRILLzNlTIiSOwa1XgQKtP7jbZTkiqwM0="
+      "version": "d862cacaa68f26b7d66a240c5e94e7c833439047",
+      "sum": "vR59KSqhRDBmKpYbia5VBs/1QFNFXud47G3+RfWSGnQ="
     },
     {
       "source": {
@@ -149,7 +150,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "9e855147a20f2539b0b8c3ea1aa7cd761c104797",
+      "version": "d862cacaa68f26b7d66a240c5e94e7c833439047",
       "sum": "qclI7LwucTjBef3PkGBkKxF0mfZPbHnn4rlNWKGtR4c="
     },
     {
@@ -159,7 +160,7 @@
           "subdir": "jsonnet"
         }
       },
-      "version": "9e6cc59158ba3fb525ff379dad2ae1229309976d",
+      "version": "1e963eb5839e2408734e37765d4d6b8fc48b343d",
       "sum": "av+OVY/HFS87sJGoH3TJ7f0QkGZls/KmaAnMYw3Ou8Q=",
       "name": "openshift-state-metrics"
     },
@@ -170,8 +171,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "98f29eba931d35cdab4079834fa50061640ba641",
-      "sum": "IFJkQRq4+QFi0/7Rc5OVdqyV6KXNXeBp8hyFAcdEna8=",
+      "version": "18ddf550c26e68adc55644ebca3bc923859f6254",
+      "sum": "n4IkAE4vnL+b2TqSr0c8JDZ7jRhNrnuruUz4MyAKEfU=",
       "name": "telemeter-client"
     },
     {
@@ -181,8 +182,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "76f2e1ef95be0df752037baa040781c5219e1fb3",
-      "sum": "IgpAgyyBZ7VT2vr9kSYQP/lkZUNQnbqpGh2sYCtUKs0="
+      "version": "b5b59bc0b45508b85647eb7a84b96dc167be15f1",
+      "sum": "uFt2jnr0YaRncANw6qHGnD5U/dbeoBFa1NU/1eKKH7M="
     },
     {
       "source": {
@@ -212,7 +213,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "14cbe6301c732658d6fe877ec55ad5b738abcf06",
+      "version": "4c1a187fef2597c173c6b91c50e4f40b295294b1",
       "sum": "IpF46ZXsm+0wJJAPtAre8+yxTNZA57mBqGpBP/r7/kw=",
       "name": "alertmanager"
     },
@@ -223,7 +224,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "7d4103c08918db8e117032170beeba4cfea0ebac",
+      "version": "c6fa86ce90f2b207e260acd96f001baaccc39211",
       "sum": "R9ROsvpjZLgQJ78WAyD4HzrIq976Bpr4V2P2Fo2Kfns="
     },
     {
@@ -233,8 +234,8 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "0b1a0c04d857d4bcdb559f827e6fc207563b9f31",
-      "sum": "vGD+MxGadIBvvDC+/71BRKWEA8vHgcuBP5PcuCKZGEs=",
+      "version": "f24ce00320f8605add7c7c5e69f722193c066672",
+      "sum": "dYLcLzGH4yF3qB7OGC/7z4nqeTNjv42L7Q3BENU8XJI=",
       "name": "prometheus"
     },
     {
@@ -255,8 +256,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "48639958ccd4fa81fbb261ce4f9e790d69c71e2e",
-      "sum": "22UgIfAACAxg2HRyAXFIN8Qi+p8rEcbWoM5XsXu9Mdo="
+      "version": "a28d8ac336e4d7ca4309237fa79d4116e5364d7e",
+      "sum": "6WL0iZD2b4OkWVni3ppQ4n5TP3SsJFBYddacf2YU4gk="
     },
     {
       "source": {
@@ -265,7 +266,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "5280bb607b4cb2a836fb0318933ae4dcf0f5f6ee",
+      "version": "9a96e346ed2b26a02f903cd5ffeb809e54c97107",
       "sum": "HhSSbGGCNHCMy1ee5jElYDm0yS9Vesa7QB2/SHKdjsY="
     }
   ],


### PR DESCRIPTION
…alert""

This reverts commit e1fc00bd763d1c7e6d27b5b008eb3b322f06f057.

To re-introduce changes in https://github.com/openshift/cluster-monitoring-operator/pull/2392

This will be merged once the new e2e-hypershift-conformance test is green.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
