### PR TITLE
OCPBUGS-36495: Add deprecated config runbook

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -242,7 +242,8 @@ spec:
         severity: warning
     - alert: ClusterMonitoringOperatorDeprecatedConfig
       annotations:
-        description: The configuration field {{ $labels.field }} in {{ $labels.configmap }} was deprecated in {{ $labels.deprecation_version }} and has no effect, you can remove it.
+        description: The configuration field {{ $labels.field }} in {{ $labels.configmap }} was deprecated in {{ $labels.deprecation_version }} and has no effect.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterMonitoringOperatorDeprecatedConfig.md
         summary: Cluster Monitoring Operator is being used with deprecated configuration.
       expr: max by (configmap, field, deprecation_version) (cluster_monitoring_operator_deprecated_config_in_use) == 1
       for: 1h

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -376,7 +376,7 @@ function(params) {
           'for': '1h',
           annotations: {
             summary: 'Cluster Monitoring Operator is being used with deprecated configuration.',
-            description: 'The configuration field {{ $labels.field }} in {{ $labels.configmap }} was deprecated in {{ $labels.deprecation_version }} and has no effect, you can remove it.',
+            description: 'The configuration field {{ $labels.field }} in {{ $labels.configmap }} was deprecated in {{ $labels.deprecation_version }} and has no effect.',
           },
           labels: {
             severity: 'info',

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -472,6 +472,7 @@ local includeRunbooks = {
   AlertmanagerClusterFailedToSendAlerts: openShiftRunbookCMO('AlertmanagerClusterFailedToSendAlerts.md'),
   AlertmanagerFailedReload: openShiftRunbookCMO('AlertmanagerFailedReload.md'),
   AlertmanagerFailedToSendAlerts: openShiftRunbookCMO('AlertmanagerFailedToSendAlerts.md'),
+  ClusterMonitoringOperatorDeprecatedConfig: openShiftRunbookCMO('ClusterMonitoringOperatorDeprecatedConfig.md'),
   ClusterOperatorDegraded: openShiftRunbookCMO('ClusterOperatorDegraded.md'),
   ClusterOperatorDown: openShiftRunbookCMO('ClusterOperatorDown.md'),
   KubeAggregatedAPIErrors: openShiftRunbookCMO('KubeAggregatedAPIErrors.md'),


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
