### PR TITLE
OCPBUGS-17506: Make error messages clearer on poll timeouts

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2064,10 +2064,9 @@ func TestValidatePrometheus(t *testing.T) {
 	}{
 		{
 			name: "prometheus missing conditions",
-			// status: nil,
 			errs: []error{
-				NewUnknownAvailabiltyError("prometheus: failed to find condition type \"Available\""),
-				NewUnknownDegradedError("prometheus: failed to find condition type \"Available\""),
+				NewUnknownAvailabiltyError("Prometheus \"openshift-monitoring/k8s\": failed to find condition type \"Available\""),
+				NewUnknownDegradedError("Prometheus \"openshift-monitoring/k8s\": failed to find condition type \"Available\""),
 			},
 		}, {
 			name: "prometheus availabe but missing reconciled",
@@ -2080,7 +2079,7 @@ func TestValidatePrometheus(t *testing.T) {
 				},
 			},
 			errs: []error{
-				NewUnknownDegradedError("prometheus: failed to find condition type \"Reconciled\""),
+				NewUnknownDegradedError("Prometheus \"openshift-monitoring/k8s\": failed to find condition type \"Reconciled\""),
 			},
 		}, {
 			name: "prometheus availabe but not reconciled",
@@ -2098,7 +2097,7 @@ func TestValidatePrometheus(t *testing.T) {
 				},
 			},
 			errs: []error{
-				NewDegradedError("reason: human readable message"),
+				NewDegradedError("Prometheus \"openshift-monitoring/k8s\": reason: human readable message"),
 			},
 		}, {
 			name: "prometheus not availabe",
@@ -2113,8 +2112,8 @@ func TestValidatePrometheus(t *testing.T) {
 				},
 			},
 			errs: []error{
-				NewDegradedError("reason: human readable message"),
-				NewAvailabilityError("reason: human readable message"),
+				NewDegradedError("Prometheus \"openshift-monitoring/k8s\": reason: human readable message"),
+				NewAvailabilityError("Prometheus \"openshift-monitoring/k8s\": reason: human readable message"),
 			},
 		}, {
 			name: "prometheus availabe and reconciled",

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -2235,12 +2236,97 @@ func TestPollUntil(t *testing.T) {
 	}, nil)
 	require.ErrorContains(t, err, "context deadline exceeded")
 
-	// the parent context times out.
-	var lastErr6 error
-	parentCtx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	err = testPoll(parentCtx, func(ctx context.Context) (bool, error) {
-		return false, nil
-	}, &lastErr6)
-	require.Error(t, parentCtx.Err())
+	// the parent context times out before poll times out.
+	parentCtx1, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	err = Poll(parentCtx1, func(ctx context.Context) (bool, error) {
+		// This also ensures that when the parent context is Done, the condition context is cancelled as well.
+		select {
+		case <-ctx.Done():
+			return false, nil
+		}
+	}, WithPollInterval(10*time.Millisecond), WithPollTimeout(time.Hour))
+	require.Error(t, parentCtx1.Err())
 	require.ErrorContains(t, err, "context deadline exceeded")
+
+	// The error caught on context cancellation shouldn't override the previously recorded error.
+	var lastErr6 error
+	err = Poll(context.Background(), func(ctx context.Context) (bool, error) {
+		check := func(innCtx context.Context) (bool, error) {
+			// A "check" that returns when the passed context is Done.
+			// Such irrelevant error shouldn't hide the previous accurate errors that were caught below on previous loops.
+			time.Sleep(time.Millisecond) // Wait for the context to be Done
+			if innCtx.Err() != nil {
+				return false, fmt.Errorf("irrelevant error")
+			}
+			// After some work, it finds a more accurate error.
+			return false, fmt.Errorf("accurate error")
+		}
+
+		var done bool
+		done, lastErr6 = check(ctx)
+		return done, nil
+	}, WithPollInterval(10*time.Millisecond), WithPollTimeout(50*time.Millisecond), WithLastError(&lastErr6))
+	require.ErrorContains(t, err, "context deadline exceeded: accurate error")
+
+	// A background operation, relying on the passed context to be cancelled, may outlive the poll timeout.
+	parentCtx2, cancelParentCtx2 := context.WithCancel(context.Background())
+	waitCh2 := make(chan struct{})
+	pollTimeout2 := 50 * time.Millisecond
+	var wg sync.WaitGroup
+
+	err = Poll(parentCtx2, func(ctx context.Context) (bool, error) {
+		// Simulate a leaky background operation.
+		wg.Add(1)
+		go func(innCtx context.Context) {
+			<-innCtx.Done()
+
+			wg.Done()
+		}(ctx)
+
+		return false, nil
+	}, WithPollInterval(10*time.Millisecond), WithPollTimeout(pollTimeout2))
+	require.ErrorContains(t, err, "context deadline exceeded")
+
+	go func() {
+		wg.Wait()
+		close(waitCh2)
+	}()
+
+	// The goroutines should continue to live even after the poll timeout has been reached.
+	select {
+	case <-time.After(2 * pollTimeout2):
+	case <-waitCh2:
+		require.FailNow(t, "the channel shouldn't be closed yet")
+	}
+	cancelParentCtx2()
+	<-waitCh2
+
+	// A "condition" that relies on the passed context to be Done may make the poll hang.
+	parentCtx3, cancelParentCtx3 := context.WithCancel(context.Background())
+	waitCh3 := make(chan struct{})
+	pollTimeout3 := 50 * time.Millisecond
+
+	var pollErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		pollErr = Poll(parentCtx3, func(ctx context.Context) (bool, error) {
+			select {
+			case <-ctx.Done():
+				close(waitCh3)
+				return false, nil
+			}
+		}, WithPollInterval(10*time.Millisecond), WithPollTimeout(pollTimeout3))
+	}()
+
+	select {
+	case <-time.After(2 * pollTimeout3):
+	case <-waitCh3:
+		require.FailNow(t, "condition should make the poll hang")
+	}
+
+	// The poll was hanging, cancelling the parent context should unlock the "condition".
+	cancelParentCtx3()
+	wg.Wait()
+	require.ErrorContains(t, pollErr, "context deadline exceeded")
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
