### PR TITLE
MON-3961: inject proxy env variables in Alertmanager

### DIFF
--- a/assets/alertmanager-user-workload/alertmanager.yaml
+++ b/assets/alertmanager-user-workload/alertmanager.yaml
@@ -26,6 +26,15 @@ spec:
         - openshift-user-workload-monitoring
         topologyKey: kubernetes.io/hostname
   containers:
+  - env:
+    - name: HTTP_PROXY
+      value: ""
+    - name: HTTPS_PROXY
+      value: ""
+    - name: NO_PROXY
+      value: ""
+    name: alertmanager
+    terminationMessagePolicy: FallbackToLogsOnError
   - args:
     - --secure-listen-address=0.0.0.0:9095
     - --upstream=http://127.0.0.1:9093

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -27,6 +27,15 @@ spec:
         topologyKey: kubernetes.io/hostname
   automountServiceAccountToken: true
   containers:
+  - env:
+    - name: HTTP_PROXY
+      value: ""
+    - name: HTTPS_PROXY
+      value: ""
+    - name: NO_PROXY
+      value: ""
+    name: alertmanager
+    terminationMessagePolicy: FallbackToLogsOnError
   - args:
     - --secure-listen-address=0.0.0.0:9095
     - --upstream=http://127.0.0.1:9093

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -233,6 +233,19 @@ function(params)
         },
         containers: [
           {
+            name: 'alertmanager',
+            env: [{
+              name: 'HTTP_PROXY',
+              value: '',
+            }, {
+              name: 'HTTPS_PROXY',
+              value: '',
+            }, {
+              name: 'NO_PROXY',
+              value: '',
+            }],
+          },
+          {
             name: 'alertmanager-proxy',
             image: cfg.kubeRbacProxyImage,
             resources: {

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -271,6 +271,19 @@ function(params)
         automountServiceAccountToken: true,
         containers: [
           {
+            name: 'alertmanager',
+            env: [{
+              name: 'HTTP_PROXY',
+              value: '',
+            }, {
+              name: 'HTTPS_PROXY',
+              value: '',
+            }, {
+              name: 'NO_PROXY',
+              value: '',
+            }],
+          },
+          {
             name: 'kube-rbac-proxy-web',
             image: cfg.kubeRbacProxyImage,
             resources: {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
