### PR TITLE
MON-3900: follow-up: clean up operator logic and some tests now that metrics-server is the default Metrics API backend

### DIFF
--- a/pkg/tasks/metricsserver.go
+++ b/pkg/tasks/metricsserver.go
@@ -13,17 +13,15 @@ import (
 
 type MetricsServerTask struct {
 	client    *client.Client
-	enabled   bool
 	ctx       context.Context
 	factory   *manifests.Factory
 	config    *manifests.Config
 	namespace string
 }
 
-func NewMetricsServerTask(ctx context.Context, namespace string, client *client.Client, metricsServerEnabled bool, factory *manifests.Factory, config *manifests.Config) *MetricsServerTask {
+func NewMetricsServerTask(ctx context.Context, namespace string, client *client.Client, factory *manifests.Factory, config *manifests.Config) *MetricsServerTask {
 	return &MetricsServerTask{
 		client:    client,
-		enabled:   metricsServerEnabled,
 		factory:   factory,
 		config:    config,
 		namespace: namespace,
@@ -32,13 +30,6 @@ func NewMetricsServerTask(ctx context.Context, namespace string, client *client.
 }
 
 func (t *MetricsServerTask) Run(ctx context.Context) error {
-	if t.enabled {
-		return t.create(ctx)
-	}
-	return nil
-}
-
-func (t *MetricsServerTask) create(ctx context.Context) error {
 	{
 		// TODO: This is a temporary workaround until the requirements for https://github.com/openshift/cluster-monitoring-operator/pull/2329
 		// are ready.

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -197,41 +197,6 @@ func (f *Framework) GetClusterVersion(name string) (*configv1.ClusterVersion, er
 	return f.OpenShiftConfigClient.ConfigV1().ClusterVersions().Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func (f *Framework) IsFeatureGateEnabled(t *testing.T, name string) bool {
-	t.Helper()
-	var enabledFeatureGates []configv1.FeatureGateAttributes
-	// Get cluster version
-	clusterVersion, err := f.GetClusterVersion("version")
-	if err != nil {
-		t.Fatalf("failed to get cluster version: %s", err.Error())
-	}
-
-	// Get the desired cluster version
-	version := clusterVersion.Status.Desired.Version
-
-	// Get FeatureGates
-	featureGates, err := f.OpenShiftConfigClient.ConfigV1().FeatureGates().Get(context.Background(), "cluster", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("failed to get featuregate `cluster`: %s", err.Error())
-	}
-
-	// Get Enabled FeatureGates for the desired cluster version
-	for _, fg := range featureGates.Status.FeatureGates {
-		if fg.Version == version {
-			enabledFeatureGates = fg.Enabled
-			break
-		}
-	}
-
-	for _, g := range enabledFeatureGates {
-		if g.Name == configv1.FeatureGateName(name) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func ensureCreatedByTestLabel(obj metav1.Object) {
 	// only add the label if it doesn't exist yet, leave existing values
 	// untouched

--- a/test/e2e/metrics_adapter_test.go
+++ b/test/e2e/metrics_adapter_test.go
@@ -30,18 +30,6 @@ import (
 	apiservicesv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
-const MetricsServerFeatureGate string = "MetricsServer"
-
-func skipMetricsServerTests(t *testing.T) {
-	if !f.IsFeatureGateEnabled(t, MetricsServerFeatureGate) {
-		t.Skip("Skipping Metrics Server test")
-	}
-}
-
-func isAPIServicePointingToRightMetricsService(t *testing.T, metricsService *apiservicesv1.APIService) bool {
-	return metricsService.Spec.Service.Name == "metrics-server"
-}
-
 func isNodeInNodesList(node string, nodes []corev1.Node) bool {
 	for _, n := range nodes {
 		if n.Name == node {
@@ -242,7 +230,6 @@ func TestAggregatedMetricPermissions(t *testing.T) {
 }
 
 func TestMetricsServerRollout(t *testing.T) {
-	skipMetricsServerTests(t)
 	for _, test := range []scenario{
 		{
 			name:      "assert metrics-server deployment is rolled out",
@@ -265,18 +252,6 @@ func TestMetricsServerRollout(t *testing.T) {
 					expectContainerArg("--metric-resolution=15s", "metrics-server"),
 				},
 			),
-		},
-		{
-			name:      "assert prometheus-adapter service monitor is deleted",
-			assertion: f.AssertServiceMonitorDoesNotExist("prometheus-adapter", f.Ns),
-		},
-		{
-			name:      "assert prometheus-adapter service is deleted",
-			assertion: f.AssertServiceDoesNotExist("prometheus-adapter", f.Ns),
-		},
-		{
-			name:      "assert prometheus-adapter deployment is deleted",
-			assertion: f.AssertDeploymentDoesNotExist("prometheus-adapter", f.Ns),
 		},
 	} {
 		t.Run(test.name, test.assertion)

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -38,6 +38,7 @@ func atLeastVersionTLS12(v string) string {
 }
 
 func TestTLSSecurityProfileConfiguration(t *testing.T) {
+	t.Skip("Changing apiserverConfig.Spec.TLSSecurityProfile now makes MCO rollout nodes which is disruptive for other tests. See https://issues.redhat.com/browse/MON-3959")
 	testCases := []struct {
 		name                  string
 		profile               *configv1.TLSSecurityProfile

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -124,11 +124,9 @@ func TestTLSSecurityProfileConfiguration(t *testing.T) {
 			assertCorrectTLSConfiguration(t, "prometheus-k8s", "statefulset",
 				manifests.KubeRbacProxyTLSCipherSuitesFlag,
 				manifests.KubeRbacProxyMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
-			if f.IsFeatureGateEnabled(t, MetricsServerFeatureGate) {
-				assertCorrectTLSConfiguration(t, "metrics-server", "deployment",
-					manifests.MetricsServerTLSCipherSuitesFlag,
-					manifests.MetricsServerTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
-			}
+			assertCorrectTLSConfiguration(t, "metrics-server", "deployment",
+				manifests.MetricsServerTLSCipherSuitesFlag,
+				manifests.MetricsServerTLSMinTLSVersionFlag, tt.expectedCipherSuite, tt.expectedMinTLSVersion)
 		})
 	}
 }


### PR DESCRIPTION
Came across this while working on https://github.com/openshift/cluster-monitoring-operator/pull/2423

/cc @slashpai @jan--f 

/hold
let's wait for https://github.com/openshift/cluster-monitoring-operator/pull/2423 to get merged first.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
