### PR TITLE
OCPBUGS-37686: fix documentation typos

### DIFF
--- a/Documentation/resources.adoc
+++ b/Documentation/resources.adoc
@@ -66,7 +66,7 @@ Expose the admission webhook service which validates `PrometheusRules` and `Aler
 === openshift-user-workload-monitoring/alertmanager-user-workload
 
 Expose the user-defined Alertmanager web server within the cluster on the following ports:
-* Port 9095 provides access to the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-api-reader` role (for read-only operations) or `monitoritoring-alertmanager-api-writer` role in the `openshift-user-workload-monitoring` project.
+* Port 9095 provides access to the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-api-reader` role (for read-only operations) or `monitoring-alertmanager-api-writer` role in the `openshift-user-workload-monitoring` project.
 * Port 9092 provides access to the Alertmanager endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role or `monitoring-edit` cluster role in the project.
 * Port 9097 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
 
@@ -105,7 +105,7 @@ Expose openshift-state-metrics `/metrics` endpoints within the cluster on the fo
 
 Expose the Prometheus web server within the cluster on the following ports:
 * Port 9091 provides access to all the Prometheus endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
-* Port 9092 provides access the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
+* Port 9092 provides access to the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
 
 === openshift-user-workload-monitoring/prometheus-operator
 

--- a/Documentation/resources.md
+++ b/Documentation/resources.md
@@ -47,7 +47,7 @@ Expose the admission webhook service which validates `PrometheusRules` and `Aler
 ### openshift-user-workload-monitoring/alertmanager-user-workload
 
 Expose the user-defined Alertmanager web server within the cluster on the following ports:
-* Port 9095 provides access to the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-api-reader` role (for read-only operations) or `monitoritoring-alertmanager-api-writer` role in the `openshift-user-workload-monitoring` project.
+* Port 9095 provides access to the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-api-reader` role (for read-only operations) or `monitoring-alertmanager-api-writer` role in the `openshift-user-workload-monitoring` project.
 * Port 9092 provides access to the Alertmanager endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role or `monitoring-edit` cluster role in the project.
 * Port 9097 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
 
@@ -86,7 +86,7 @@ Expose openshift-state-metrics `/metrics` endpoints within the cluster on the fo
 
 Expose the Prometheus web server within the cluster on the following ports:
 * Port 9091 provides access to all the Prometheus endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
-* Port 9092 provides access the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
+* Port 9092 provides access to the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
 
 ### openshift-user-workload-monitoring/prometheus-operator
 

--- a/assets/alertmanager-user-workload/service.yaml
+++ b/assets/alertmanager-user-workload/service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     openshift.io/description: |-
       Expose the user-defined Alertmanager web server within the cluster on the following ports:
-      * Port 9095 provides access to the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-api-reader` role (for read-only operations) or `monitoritoring-alertmanager-api-writer` role in the `openshift-user-workload-monitoring` project.
+      * Port 9095 provides access to the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-api-reader` role (for read-only operations) or `monitoring-alertmanager-api-writer` role in the `openshift-user-workload-monitoring` project.
       * Port 9092 provides access to the Alertmanager endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role or `monitoring-edit` cluster role in the project.
       * Port 9097 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
     service.beta.openshift.io/serving-cert-secret-name: alertmanager-user-workload-tls

--- a/assets/prometheus-k8s/service.yaml
+++ b/assets/prometheus-k8s/service.yaml
@@ -5,7 +5,7 @@ metadata:
     openshift.io/description: |-
       Expose the Prometheus web server within the cluster on the following ports:
       * Port 9091 provides access to all the Prometheus endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
-      * Port 9092 provides access the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
+      * Port 9092 provides access to the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
     service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls
   labels:
     app.kubernetes.io/component: prometheus

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -44,7 +44,7 @@ function(params)
             * Port %d provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
           ||| % [
             $.service.spec.ports[0].port,
-            requiredRoles([['monitoring-alertmanager-api-reader', 'for read-only operations'], 'monitoritoring-alertmanager-api-writer'], 'openshift-user-workload-monitoring'),
+            requiredRoles([['monitoring-alertmanager-api-reader', 'for read-only operations'], 'monitoring-alertmanager-api-writer'], 'openshift-user-workload-monitoring'),
             $.service.spec.ports[1].port,
             requiredClusterRoles(['monitoring-rules-edit', 'monitoring-edit'], false, ''),
             $.service.spec.ports[2].port,

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -26,7 +26,7 @@ function(params)
       data: {},
     },
 
-    // OpenShift route to access the Prometheus api.
+    // OpenShift route to access to the Prometheus api.
     apiRoute: {
       apiVersion: 'v1',
       kind: 'Route',
@@ -53,7 +53,7 @@ function(params)
       },
     },
 
-    // OpenShift route to access the Prometheus federate endpoint.
+    // OpenShift route to access to the Prometheus federate endpoint.
     federateRoute: {
       apiVersion: 'v1',
       kind: 'Route',
@@ -103,7 +103,7 @@ function(params)
           |||
             Expose the Prometheus web server within the cluster on the following ports:
             * Port %d provides access to all the Prometheus endpoints. %s
-            * Port %d provides access the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
+            * Port %d provides access to the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
           ||| % [
             $.service.spec.ports[0].port,
             requiredClusterRoles(['cluster-monitoring-view'], true),


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
