### PR TITLE
Allow scrapping of OpenStack load-balancer-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.17
 
 - [#2409](https://github.com/openshift/cluster-monitoring-operator/issues/2409) Remove prometheus-adapter code from CMO
+- [#2428](https://github.com/openshift/cluster-monitoring-operator/issues/2428) Allow scrapping of OpenStack load-balancer-id
 
 ## 4.16
 

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -42,6 +42,7 @@ spec:
           ^kube_customresource_.+_annotations_info$,
           ^kube_customresource_.+_labels_info$,
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]
+        - --metric-annotations-allowlist=services=[loadbalancer.openstack.org/load-balancer-id]
         - |
           --metric-denylist=
           ^kube_.+_created$,

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -39,7 +39,6 @@ spec:
         - |
           --metric-denylist=
           ^kube_secret_labels$,
-          ^kube_.+_annotations$
           ^kube_customresource_.+_annotations_info$,
           ^kube_customresource_.+_labels_info$,
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -240,7 +240,6 @@ function(params)
                         |||
                           --metric-denylist=
                           ^kube_secret_labels$,
-                          ^kube_.+_annotations$
                           ^kube_customresource_.+_annotations_info$,
                           ^kube_customresource_.+_labels_info$,
                         |||,

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -244,6 +244,7 @@ function(params)
                           ^kube_customresource_.+_labels_info$,
                         |||,
                         '--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]',
+                        '--metric-annotations-allowlist=services=[loadbalancer.openstack.org/load-balancer-id]',
                       ],
                       securityContext: {},
                       resources: {


### PR DESCRIPTION
This PR is made of two separate changes.

The first one remove `kube_*_annotations` from the deny list, as it is no longer needed since https://github.com/kubernetes/kube-state-metrics/pull/2145 and prevents the collection of `kube_*_annotations`.

The second change effectively enables scrapping of OpenStack load-balancer-id.

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
