### PR TITLE
 MON-3964: set scrape timestamp tolerance for user workload monitoring

### DIFF
--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -13,6 +13,9 @@ metadata:
   name: user-workload
   namespace: openshift-user-workload-monitoring
 spec:
+  additionalArgs:
+  - name: scrape.timestamp-tolerance
+    value: 15ms
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -368,6 +368,18 @@ function(params)
         scrapeConfigNamespaceSelector: null,
         listenLocal: true,
         priorityClassName: 'openshift-user-critical',
+        additionalArgs: [
+          // This aligns any scrape timestamps <= 15ms to the a multiple of
+          // the scrape interval. This optmizes tsdb compression.
+          // 15ms was chosen for being a conservative value given our default
+          // recommended scrape interval of 30s. This adds at most a .1% error
+          // to the timestamp if users pick half that interval.
+          // For tighter scrape intervals this error goes up.
+          {
+            name: 'scrape.timestamp-tolerance',
+            value: '15ms',
+          },
+        ],
         containers: [
           {
             name: 'kube-rbac-proxy-federate',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -396,7 +396,7 @@ function(params)
           // the scrape interval. This optmizes tsdb compression.
           // 15ms was chosen for being a conservative value given our default
           // scrape interval of 30s. Even for half the default value we only
-          // move scrape interval timestamps by <= 1% of their absolute
+          // move scrape interval timestamps by <= .1% of their absolute
           // length.
           {
             name: 'scrape.timestamp-tolerance',


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
