### PR TITLE
Remove `kube_*_annotations` and `kube_*_labels` from deny list

### DIFF
--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -38,8 +38,6 @@ spec:
         - --telemetry-port=8082
         - |
           --metric-denylist=
-          ^kube_secret_labels$,
-          ^kube_.+_annotations$
           ^kube_customresource_.+_annotations_info$,
           ^kube_customresource_.+_labels_info$,
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -239,8 +239,6 @@ function(params)
                       args+: [
                         |||
                           --metric-denylist=
-                          ^kube_secret_labels$,
-                          ^kube_.+_annotations$
                           ^kube_customresource_.+_annotations_info$,
                           ^kube_customresource_.+_labels_info$,
                         |||,


### PR DESCRIPTION
Since https://github.com/kubernetes/kube-state-metrics/pull/2145, kube-state-metrics does not collect `kube_*_annotations` or `kube_*_labels` metrics by default. It's no longer necessary to add them to the metrics' deny list.

Removing `kube_*_annotations` from the deny list allows us to enable scrapping of annotation metrics via the `--metric-annotations-allowlist` option.

Additionally, we were missing a comma, which might have been a problem in the comma-separated list of arguments.

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
