### PR TITLE
OCPBUGS-33863: use UserWorkloadInvalidConfiguration reason when UWM config only is invalid

### DIFF
--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -57,6 +57,8 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 	t.Log("asserting that CMO goes degraded after an invalid configuration is pushed")
 	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionTrue)(t)
 	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionFalse)(t)
+	f.AssertOperatorConditionReason(configv1.OperatorDegraded, "InvalidConfiguration")
+	f.AssertOperatorConditionReason(configv1.OperatorAvailable, "InvalidConfiguration")
 	// Check that the previous setup hasn't been reverted
 	f.AssertStatefulsetExists("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
 


### PR DESCRIPTION
If the Platform configuration is invalid or both configurations are invalid, the reason will still be InvalidConfiguration

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
