### PR TITLE
OCPBUGS-38289: fix(prometheus): avoid passing the cluster-wide proxy config to a remote endpoint when noProxy will prevent the proxuying anyway

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -522,7 +522,7 @@ The `RemoteWriteSpec` resource defines the settings for remote write storage.
 | metadataConfig | *[monv1.MetadataConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.76.0/Documentation/api.md#metadataconfig) | Defines settings for sending series metadata to remote write storage. |
 | name | string | Defines the name of the remote write queue. This name is used in metrics and logging to differentiate queues. If specified, this name must be unique. |
 | oauth2 | *monv1.OAuth2 | Defines OAuth2 authentication settings for the remote write endpoint. |
-| proxyUrl | string | Defines an optional proxy URL. |
+| proxyUrl | string | Defines an optional proxy URL. It is superseded by the cluster-wide proxy, if enabled. |
 | queueConfig | *[monv1.QueueConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.76.0/Documentation/api.md#queueconfig) | Allows tuning configuration for remote write queue parameters. |
 | remoteTimeout | string | Defines the timeout value for requests to the remote write endpoint. |
 | sendExemplars | *bool | Enables sending exemplars via remote write. When enabled, Prometheus is configured to store a maximum of 100,000 exemplars in memory. Note that this setting only applies to user-defined monitoring. It is not applicable to default in-cluster monitoring. |

--- a/Documentation/openshiftdocs/modules/remotewritespec.adoc
+++ b/Documentation/openshiftdocs/modules/remotewritespec.adoc
@@ -35,7 +35,7 @@ link:prometheusrestrictedconfig.adoc[PrometheusRestrictedConfig]
 
 |oauth2|*monv1.OAuth2|Defines OAuth2 authentication settings for the remote write endpoint.
 
-|proxyUrl|string|Defines an optional proxy URL.
+|proxyUrl|string|Defines an optional proxy URL. It is superseded by the cluster-wide proxy, if enabled.
 
 |queueConfig|*monv1.QueueConfig|Allows tuning configuration for remote write queue parameters.
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/prometheus/common v0.46.0
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/net v0.28.0
 	golang.org/x/sync v0.8.0
 	golang.org/x/text v0.17.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -127,7 +128,6 @@ require (
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
-	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/term v0.23.0 // indirect

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -37,6 +37,7 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"golang.org/x/net/http/httpproxy"
 	yaml2 "gopkg.in/yaml.v2"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1424,12 +1425,41 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, telemetrySecret *v1.Secret) 
 	for k := range p.Spec.RemoteWrite {
 		rw := &p.Spec.RemoteWrite[k]
 
+		var tmpRWProxyURL *string
 		if f.proxy.HTTPProxy() != "" {
-			rw.ProxyURL = ptr.To(f.proxy.HTTPProxy())
+			tmpRWProxyURL = ptr.To(f.proxy.HTTPProxy())
 		}
 		if f.proxy.HTTPSProxy() != "" {
-			rw.ProxyURL = ptr.To(f.proxy.HTTPSProxy())
+			tmpRWProxyURL = ptr.To(f.proxy.HTTPSProxy())
 		}
+
+		// Fixes: https://issues.redhat.com/browse/OCPBUGS-38289
+		// The code is condensed here to simplify backporting.
+		// This is a temporary workaround because the NoProxy field isn't exported on the Prometheus CRD in older versions.
+		// If the cluster proxy or remoteWrite config change, this code will re-run, ensuring no stale state.
+		// The httpproxy package used here is the same as used by Prometheus, which helps with consistency.
+
+		// proxy URL is not to be set/overwritten in here, nothing to do.
+		if tmpRWProxyURL == nil {
+			continue
+		}
+		// Suppose that CMO has set the proxy URL.
+		proxyConfig := &httpproxy.Config{
+			HTTPProxy:  *tmpRWProxyURL,
+			HTTPSProxy: *tmpRWProxyURL,
+			NoProxy:    f.proxy.NoProxy(),
+		}
+		proxyFunc := proxyConfig.ProxyFunc()
+		// Ignore errors here.
+		u, _ := url.Parse(rw.URL)
+		// Check if the endpoint URL will be using that proxy URL.
+		proxyURL, err := proxyFunc(u)
+		if err == nil && proxyURL == nil {
+			// Proxing will not be used, no need to set it.
+			continue
+		}
+		// The proxy will be used, set it.
+		rw.ProxyURL = tmpRWProxyURL
 	}
 
 	if f.config.Images.Thanos != "" {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1424,48 +1424,108 @@ func TestRemoteWriteAuthorizationConfig(t *testing.T) {
 }
 
 func TestPrometheusK8sRemoteWriteProxy(t *testing.T) {
-	config := func() *Config {
+	config := func(remoteURL string) *Config {
 		c, err := NewConfigFromString("", false)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.RemoteWrite = []RemoteWriteSpec{{URL: "http://custom"}}
-
+		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.RemoteWrite = []RemoteWriteSpec{{URL: remoteURL}}
 		return c
 	}
 
 	for _, tc := range []struct {
 		name                        string
+		remoteURL                   string
 		proxyReader                 ProxyReader
 		expectedRemoteWriteProxyURL *string
 	}{
 		{
-			name:                        "no proxy",
+			name:                        "proxy not set",
+			remoteURL:                   "http://custom.foo.bar",
 			proxyReader:                 &fakeProxyReader{},
 			expectedRemoteWriteProxyURL: nil,
 		},
 
 		{
 			name:                        "HTTP proxy",
+			remoteURL:                   "http://custom.foo.bar",
 			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy"},
 			expectedRemoteWriteProxyURL: ptr.To("http://my-proxy"),
 		},
 
 		{
+			name:                        "HTTP proxy wrong scheme",
+			remoteURL:                   "https://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy"},
+			expectedRemoteWriteProxyURL: ptr.To("http://my-proxy"),
+		},
+
+		{
+			name:                        "HTTP proxy with noProxy set",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", noProxy: ".baz"},
+			expectedRemoteWriteProxyURL: ptr.To("http://my-proxy"),
+		},
+
+		{
+			name:                        "HTTP proxy should be ignored due to noProxy ",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", noProxy: ".foo.bar"},
+			expectedRemoteWriteProxyURL: nil,
+		},
+
+		{
 			name:                        "HTTPS proxy",
+			remoteURL:                   "https://custom.foo.bar",
 			proxyReader:                 &fakeProxyReader{httpsProxy: "https://my-secured-proxy"},
 			expectedRemoteWriteProxyURL: ptr.To("https://my-secured-proxy"),
 		},
 
 		{
+			name:                        "HTTPS proxy wrong scheme",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpsProxy: "https://my-secured-proxy"},
+			expectedRemoteWriteProxyURL: ptr.To("https://my-secured-proxy"),
+		},
+
+		{
+			name:                        "HTTPS proxy with noProxy set",
+			remoteURL:                   "https://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpsProxy: "https://my-secured-proxy", noProxy: ".fox.daz"},
+			expectedRemoteWriteProxyURL: ptr.To("https://my-secured-proxy"),
+		},
+
+		{
+			name:                        "HTTPS proxy should be ignored due to noProxy",
+			remoteURL:                   "https://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpsProxy: "https://my-secured-proxy", noProxy: ".foo.bar"},
+			expectedRemoteWriteProxyURL: nil,
+		},
+
+		{
 			name:                        "HTTP & HTTPS proxy",
+			remoteURL:                   "http://custom.foo.bar",
 			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", httpsProxy: "https://my-secured-proxy"},
 			expectedRemoteWriteProxyURL: ptr.To("https://my-secured-proxy"),
 		},
+
+		{
+			name:                        "HTTP & HTTPS proxy with noProxy set",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", httpsProxy: "https://my-secured-proxy", noProxy: ".fox.daz"},
+			expectedRemoteWriteProxyURL: ptr.To("https://my-secured-proxy"),
+		},
+
+		{
+			name:                        "HTTP & HTTPS proxy should be ignored due to noProxy",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", httpsProxy: "https://my-secured-proxy", noProxy: ".foo.bar"},
+			expectedRemoteWriteProxyURL: nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", config(), defaultInfrastructureReader(), tc.proxyReader, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", config(tc.remoteURL), defaultInfrastructureReader(), tc.proxyReader, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 			p, err := f.PrometheusK8s(
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				nil,

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -758,6 +758,7 @@ type RemoteWriteSpec struct {
 	// Defines OAuth2 authentication settings for the remote write endpoint.
 	OAuth2 *monv1.OAuth2 `json:"oauth2,omitempty"`
 	// Defines an optional proxy URL.
+	// It is superseded by the cluster-wide proxy, if enabled.
 	ProxyURL string `json:"proxyUrl,omitempty"`
 	// Allows tuning configuration for remote write queue parameters.
 	QueueConfig *monv1.QueueConfig `json:"queueConfig,omitempty"`


### PR DESCRIPTION
Also

docs: hide PrometheusK8sConfig.RemoteWrite.ProxyURL from docs until its usage is clarified


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
