### PR TITLE
MON-4021: feat: add the required utils for automated tests and integration with the docs

### DIFF
--- a/Documentation/resources.adoc
+++ b/Documentation/resources.adoc
@@ -74,6 +74,43 @@ Expose the user-defined Alertmanager web server within the cluster on the follow
 
 Expose the Alertmanager web server within the cluster on the following ports:
 * Port 9094 provides access to all the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-view` role (for read-only operations) or `monitoring-alertmanager-edit` role in the `openshift-monitoring` project.
+----
+# monitoring-alertmanager-view grants read permissions.
+$ oc project openshift-monitoring
+$ oc create serviceaccount am-ro-client
+$ oc adm policy add-role-to-user monitoring-alertmanager-view \
+  --role-namespace=openshift-monitoring --rolebinding-name=am-ro-client \
+  --serviceaccount=am-ro-client
+$ TOKEN=$(oc create token am-ro-client)
+$ ROUTE=$(oc get route alertmanager-main -n openshift-monitoring -ojsonpath={.spec.host})
+$ curl -H "Authorization: Bearer $TOKEN" -k --fail-with-body "https://$ROUTE/api/v2/alerts?filter=alertname=Watchdog"
+----
+----
+# monitoring-alertmanager-edit grants edit permissions.
+$ oc project openshift-monitoring
+$ oc create serviceaccount am-rw-client
+$ oc adm policy add-role-to-user monitoring-alertmanager-edit \
+  --role-namespace=openshift-monitoring --rolebinding-name=am-rw-client \
+  --serviceaccount=am-rw-client
+$ TOKEN=$(oc create token am-rw-client)
+$ ROUTE=$(oc get route alertmanager-main -n openshift-monitoring -ojsonpath={.spec.host})
+$ curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "matchers": [
+      {
+        "name": "alertname",
+        "value": "MyTestAlert",
+        "isRegex": false
+      }
+    ],
+    "startsAt": "2044-01-01T00:00:00Z",
+    "endsAt": "2044-01-01T00:00:01Z",
+    "createdBy": "am-rw-client",
+    "comment": "Silence test"
+  }' \
+  -k --fail-with-body "https://$ROUTE/api/v2/silences"
+----
+
 * Port 9092 provides access to the Alertmanager endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role or `monitoring-edit` cluster role in the project.
 * Port 9097 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
 

--- a/Documentation/resources.md
+++ b/Documentation/resources.md
@@ -55,6 +55,43 @@ Expose the user-defined Alertmanager web server within the cluster on the follow
 
 Expose the Alertmanager web server within the cluster on the following ports:
 * Port 9094 provides access to all the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-view` role (for read-only operations) or `monitoring-alertmanager-edit` role in the `openshift-monitoring` project.
+```
+# monitoring-alertmanager-view grants read permissions.
+$ oc project openshift-monitoring
+$ oc create serviceaccount am-ro-client
+$ oc adm policy add-role-to-user monitoring-alertmanager-view \
+  --role-namespace=openshift-monitoring --rolebinding-name=am-ro-client \
+  --serviceaccount=am-ro-client
+$ TOKEN=$(oc create token am-ro-client)
+$ ROUTE=$(oc get route alertmanager-main -n openshift-monitoring -ojsonpath={.spec.host})
+$ curl -H "Authorization: Bearer $TOKEN" -k --fail-with-body "https://$ROUTE/api/v2/alerts?filter=alertname=Watchdog"
+```
+```
+# monitoring-alertmanager-edit grants edit permissions.
+$ oc project openshift-monitoring
+$ oc create serviceaccount am-rw-client
+$ oc adm policy add-role-to-user monitoring-alertmanager-edit \
+  --role-namespace=openshift-monitoring --rolebinding-name=am-rw-client \
+  --serviceaccount=am-rw-client
+$ TOKEN=$(oc create token am-rw-client)
+$ ROUTE=$(oc get route alertmanager-main -n openshift-monitoring -ojsonpath={.spec.host})
+$ curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "matchers": [
+      {
+        "name": "alertname",
+        "value": "MyTestAlert",
+        "isRegex": false
+      }
+    ],
+    "startsAt": "2044-01-01T00:00:00Z",
+    "endsAt": "2044-01-01T00:00:01Z",
+    "createdBy": "am-rw-client",
+    "comment": "Silence test"
+  }' \
+  -k --fail-with-body "https://$ROUTE/api/v2/silences"
+```
+
 * Port 9092 provides access to the Alertmanager endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role or `monitoring-edit` cluster role in the project.
 * Port 9097 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
 

--- a/assets/alertmanager/service.yaml
+++ b/assets/alertmanager/service.yaml
@@ -5,6 +5,7 @@ metadata:
     openshift.io/description: |-
       Expose the Alertmanager web server within the cluster on the following ports:
       * Port 9094 provides access to all the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-view` role (for read-only operations) or `monitoring-alertmanager-edit` role in the `openshift-monitoring` project.
+      xx_omitted_before_deploy__test_file_name:openshift-monitoring_alertmanager-main_service_port_9094.yaml
       * Port 9092 provides access to the Alertmanager endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role or `monitoring-edit` cluster role in the project.
       * Port 9097 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
     service.beta.openshift.io/serving-cert-secret-name: alertmanager-main-tls

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/uuid v1.6.0
 	github.com/imdario/mergo v0.3.16
+	github.com/mattn/go-shellwords v1.0.12
 	github.com/openshift/api v0.0.0-20240919193929-2669d1ebc910
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
 	github.com/openshift/library-go v0.0.0-20240619120114-0c65da30ad30

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.61 h1:nLxbwF3XxhwVSm8g9Dghm9MHPaUZuqhPiGL+675ZmEs=
 github.com/miekg/dns v1.1.61/go.mod h1:mnAarhS3nWaW+NVP2wTkYVIZyHNJ098SJZUki3eykwQ=

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -4,6 +4,7 @@ local alertmanager = import 'github.com/prometheus-operator/kube-prometheus/json
 local generateCertInjection = import '../utils/generate-certificate-injection.libsonnet';
 local generateSecret = import '../utils/generate-secret.libsonnet';
 local withDescription = (import '../utils/add-annotations.libsonnet').withDescription;
+local testFilePlaceholder = (import '../utils/add-annotations.libsonnet').testFilePlaceholder;
 local requiredRoles = (import '../utils/add-annotations.libsonnet').requiredRoles;
 local requiredClusterRoles = (import '../utils/add-annotations.libsonnet').requiredClusterRoles;
 
@@ -68,11 +69,13 @@ function(params)
           |||
             Expose the Alertmanager web server within the cluster on the following ports:
             * Port %d provides access to all the Alertmanager endpoints. %s
+            %s
             * Port %d provides access to the Alertmanager endpoints restricted to a given project. %s
             * Port %d provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
           ||| % [
             $.service.spec.ports[0].port,
             requiredRoles([['monitoring-alertmanager-view', 'for read-only operations'], 'monitoring-alertmanager-edit'], 'openshift-monitoring'),
+            testFilePlaceholder('openshift-monitoring', 'alertmanager-main', $.service.spec.ports[0].port),
             $.service.spec.ports[1].port,
             requiredClusterRoles(['monitoring-rules-edit', 'monitoring-edit'], false, ''),
             $.service.spec.ports[2].port,

--- a/jsonnet/utils/add-annotations.libsonnet
+++ b/jsonnet/utils/add-annotations.libsonnet
@@ -54,6 +54,9 @@
     'openshift.io/description': std.rstripChars(s, '\n'),
   },
 
+  testFilePlaceholder(namespace, service, port):
+    'xx_omitted_before_deploy__test_file_name:%s_%s_service_port_%d.yaml' % [namespace, service, port],
+
   requiredRoles(roles, namespace=''):
     assert std.length(roles) > 0 : 'needs at least one role';
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -4899,3 +4899,38 @@ func TestAlertmanagerProxy(t *testing.T) {
 		})
 	}
 }
+
+func TestDescriptionWithoutPlaceholder(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "With placeholder",
+			input: `Expose blabla
+* Port 0000 blabla foo
+xx_omitted_before_deploy__test_file_name:foo.yaml
+* Port 1111 blabla bar
+xx_omitted_before_deploy__test_file_name:foo.yaml`,
+			expected: `Expose blabla
+* Port 0000 blabla foo
+* Port 1111 blabla bar`,
+		},
+		{
+			name: "Without placeholder",
+			input: `Expose blabla
+* Port 2222 blabla foo
+* Port 3333 blabla bar`,
+			expected: `Expose blabla
+* Port 2222 blabla foo
+* Port 3333 blabla bar`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, descriptionWithoutPlaceholder(tt.input))
+		})
+	}
+}

--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/test_command"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDocExamples(t *testing.T) {
+	filesDir := "test_command/scripts/"
+	tempDir := t.TempDir()
+	kubeConfigPath := f.KubeConfigPath
+
+	entries, err := os.ReadDir(filesDir)
+	require.NoError(t, err)
+	// In case there is a wiring issue.
+	require.Greater(t, len(entries), 0)
+
+	for _, entry := range entries {
+		file, err := os.Open(filepath.Join(filesDir, entry.Name()))
+		require.NoError(t, err)
+		defer file.Close()
+
+		var suite test_command.Suite
+		decoder := yaml.NewDecoder(file)
+		decoder.KnownFields(true)
+		err = decoder.Decode(&suite)
+		require.NoError(t, err)
+
+		for _, test := range suite.Tests {
+			// TODO: run in //
+			t.Run(entry.Name(), func(t *testing.T) {
+				// Set up cleaners
+				t.Cleanup(func() {
+					for _, c := range test.TearDown {
+						c.Run(t, tempDir, kubeConfigPath)
+					}
+				})
+
+				// Setup
+				envVars := map[string]string{}
+				for _, setup := range test.SetUp {
+					require.NoError(t, setup.Run(t, tempDir, kubeConfigPath))
+					if setup.EnvVarValue() == "" {
+						continue
+					}
+					// Check duplicated env vars.
+					require.NotContains(t, envVars, setup.EnvVar)
+					envVars[setup.EnvVar] = setup.EnvVarValue()
+				}
+
+				// Run the checks
+				for _, g := range test.Checks {
+					require.NoError(t, g.Run(t, tempDir, kubeConfigPath, envVars))
+				}
+			})
+		}
+	}
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -78,7 +78,7 @@ type Framework struct {
 	SchedulingClient      *schedulingv1client.SchedulingV1Client
 	APIExtensionsClient   *apiextensionsclient.Clientset
 	VPAClient             *vpaclient.AutoscalingV1Client
-	kubeConfigPath        string
+	KubeConfigPath        string
 
 	OpenShiftMonitoringClient    openshiftmonitoringclientset.Interface
 	MonitoringClient             *monClient.MonitoringV1Client
@@ -178,7 +178,7 @@ func New(kubeConfigPath string) (*Framework, CleanUpFunc, error) {
 		MonitoringBetaClient:      mBetaClient,
 		Ns:                        namespaceName,
 		UserWorkloadMonitoringNs:  userWorkloadNamespaceName,
-		kubeConfigPath:            kubeConfigPath,
+		KubeConfigPath:            kubeConfigPath,
 		SchedulingClient:          schedulingClient,
 		OpenShiftMonitoringClient: osmClient,
 		APIExtensionsClient:       apiExtensionsClient,
@@ -588,7 +588,7 @@ func (f *Framework) ForwardPort(t *testing.T, ns, svc string, port int) (string,
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// Taken from github.com/openshift/origin/test/extended/etcd/etcd_test_runner.go
-	cmd := exec.CommandContext(ctx, "oc", "port-forward", fmt.Sprintf("service/%s", svc), fmt.Sprintf(":%d", port), "-n", ns, "--kubeconfig", f.kubeConfigPath)
+	cmd := exec.CommandContext(ctx, "oc", "port-forward", fmt.Sprintf("service/%s", svc), fmt.Sprintf(":%d", port), "-n", ns, "--kubeconfig", f.KubeConfigPath)
 
 	cleanUp := func() {
 		cancel()

--- a/test/e2e/test_command/scripts/openshift-monitoring_alertmanager-main_service_port_9094.yaml
+++ b/test/e2e/test_command/scripts/openshift-monitoring_alertmanager-main_service_port_9094.yaml
@@ -1,0 +1,62 @@
+tests:
+- header: >-
+    # monitoring-alertmanager-view grants read permissions.
+  setUp:
+    - run: "oc project openshift-monitoring"
+    - run: "oc create serviceaccount am-ro-client"
+    - run: >-
+        oc adm policy add-role-to-user monitoring-alertmanager-view \
+          --role-namespace=openshift-monitoring --rolebinding-name=am-ro-client \
+          --serviceaccount=am-ro-client
+    - run: "oc create token am-ro-client"
+      toEnvVar: TOKEN
+      # TODO: use Route's status.
+    - run: "oc get route alertmanager-main -n openshift-monitoring -ojsonpath={.spec.host}"
+      toEnvVar: ROUTE
+  checks:
+    - run: >
+        curl -H "Authorization: Bearer $TOKEN" -k --fail-with-body "https://$ROUTE/api/v2/alerts?filter=alertname=Watchdog"
+  tearDown:
+    - run: >-
+        oc adm policy remove-role-from-user monitoring-alertmanager-view \
+          --role-namespace=openshift-monitoring --rolebinding-name=am-ro-client \
+          --serviceaccount=am-ro-client
+    - run: "oc delete serviceaccount am-ro-client"
+    - run: "oc project default"
+- header: >-
+    # monitoring-alertmanager-edit grants edit permissions.
+  setUp:
+    - run: "oc project openshift-monitoring"
+    - run: "oc create serviceaccount am-rw-client"
+    - run: >-
+        oc adm policy add-role-to-user monitoring-alertmanager-edit \
+          --role-namespace=openshift-monitoring --rolebinding-name=am-rw-client \
+          --serviceaccount=am-rw-client
+    - run: "oc create token am-rw-client"
+      toEnvVar: TOKEN
+    - run: "oc get route alertmanager-main -n openshift-monitoring -ojsonpath={.spec.host}"
+      toEnvVar: ROUTE
+  checks:
+    - run: >
+        curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+          -d '{
+            "matchers": [
+              {
+                "name": "alertname",
+                "value": "MyTestAlert",
+                "isRegex": false
+              }
+            ],
+            "startsAt": "2044-01-01T00:00:00Z",
+            "endsAt": "2044-01-01T00:00:01Z",
+            "createdBy": "am-rw-client",
+            "comment": "Silence test"
+          }' \
+          -k --fail-with-body "https://$ROUTE/api/v2/silences"
+  tearDown:
+    - run: >-
+        oc adm policy remove-role-from-user monitoring-alertmanager-edit \
+          --role-namespace=openshift-monitoring --rolebinding-name=am-rw-client \
+          --serviceaccount=am-rw-client
+    - run: "oc delete serviceaccount am-rw-client"
+    - run: "oc project default"

--- a/test/e2e/test_command/test_command.go
+++ b/test/e2e/test_command/test_command.go
@@ -1,0 +1,154 @@
+// Copyright 2024 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test_command
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"strings"
+
+	"github.com/mattn/go-shellwords"
+	"github.com/stretchr/testify/require"
+)
+
+var commandTimeout time.Duration = 5 * time.Second
+
+type SetUpTearDownCommand struct {
+	// This isn't run in a shell.
+	Command string `yaml:"run"`
+	EnvVar  string `yaml:"toEnvVar"`
+	// the Commands' stdout
+	envVarValue string
+}
+
+type CheckCommand struct {
+	// This isn't run in a shell.
+	Command string `yaml:"run"`
+}
+
+type Test struct {
+	Header string `yaml:"header"`
+	// Run by a user having the needed permissions.
+	// Env vars defined in SetUp, can only be used in Checks
+	SetUp []SetUpTearDownCommand `yaml:"setUp"`
+	//
+	Checks []CheckCommand `yaml:"checks"`
+
+	TearDown []SetUpTearDownCommand `yaml:"tearDown"`
+}
+
+type Suite struct {
+	Tests []Test `yaml:"tests"`
+}
+
+func (stc *SetUpTearDownCommand) String() string {
+	if stc.EnvVar != "" {
+		return fmt.Sprintf("$ %s=$(%s)", stc.EnvVar, stc.Command)
+	}
+	return fmt.Sprintf("$ %s", stc.Command)
+}
+
+func (stc *SetUpTearDownCommand) EnvVarValue() string {
+	return stc.envVarValue
+}
+
+func (cc *CheckCommand) String() string {
+	return fmt.Sprintf("$ %s", cc.Command)
+}
+
+func (test *Test) String() string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+	sb.WriteString(test.Header)
+	for _, s := range test.SetUp {
+		sb.WriteString("\n")
+		sb.WriteString(s.String())
+	}
+	for _, c := range test.Checks {
+		sb.WriteString("\n")
+		sb.WriteString(c.String())
+	}
+	return sb.String()
+}
+
+func (suite *Suite) intoCodeBlocks(delimiter string) string {
+	var sb strings.Builder
+	for _, t := range suite.Tests {
+		sb.WriteString(delimiter)
+		sb.WriteString(t.String())
+		sb.WriteString(delimiter)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func (suite *Suite) StringMarkdown() string {
+	return suite.intoCodeBlocks("```")
+}
+
+func (suite *Suite) StringAscii() string {
+	return suite.intoCodeBlocks("----")
+}
+
+func (stc *SetUpTearDownCommand) Run(t *testing.T, wDir, kubeConfigPath string) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	args, err := shellwords.Parse(stc.Command)
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stderr = bytes.NewBuffer(nil)
+	cmd.Dir = wDir
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeConfigPath))
+
+	if stc.EnvVar != "" {
+		out, err := cmd.Output()
+		require.NoError(t, err, "getting stdout failed: %v: command stderr %v", err, cmd.Stderr)
+		stc.envVarValue = string(out)
+		return nil
+	}
+
+	require.NoError(t, cmd.Run(), "running %s failed: command stderr: %v", stc.Command, cmd.Stderr)
+	return nil
+}
+
+func (cc *CheckCommand) Run(t *testing.T, wDir, kubeConfigPath string, envVars map[string]string) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	parser := shellwords.NewParser()
+	// To avoid running a shell.
+	parser.ParseEnv = true
+	envVars["KUBECONFIG"] = kubeConfigPath
+	parser.Getenv = func(s string) string { return envVars[s] }
+	args, err := parser.Parse(cc.Command)
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stderr = bytes.NewBuffer(nil)
+	cmd.Dir = wDir
+
+	require.NoError(t, cmd.Run(), "running %s failed: command stderr: %v", cc.Command, cmd.Stderr)
+	return nil
+}

--- a/vendor/github.com/mattn/go-shellwords/.travis.yml
+++ b/vendor/github.com/mattn/go-shellwords/.travis.yml
@@ -1,0 +1,16 @@
+arch:
+  - amd64
+  - ppc64le
+language: go
+sudo: false
+go:
+  - tip
+
+before_install:
+  - go get -t -v ./...
+
+script:
+  - ./go.test.sh
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/mattn/go-shellwords/LICENSE
+++ b/vendor/github.com/mattn/go-shellwords/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mattn/go-shellwords/README.md
+++ b/vendor/github.com/mattn/go-shellwords/README.md
@@ -1,0 +1,55 @@
+# go-shellwords
+
+[![codecov](https://codecov.io/gh/mattn/go-shellwords/branch/master/graph/badge.svg)](https://codecov.io/gh/mattn/go-shellwords)
+[![Build Status](https://travis-ci.org/mattn/go-shellwords.svg?branch=master)](https://travis-ci.org/mattn/go-shellwords)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/mattn/go-shellwords)](https://pkg.go.dev/github.com/mattn/go-shellwords)
+[![ci](https://github.com/mattn/go-shellwords/ci/badge.svg)](https://github.com/mattn/go-shellwords/actions)
+
+Parse line as shell words.
+
+## Usage
+
+```go
+args, err := shellwords.Parse("./foo --bar=baz")
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
+envs, args, err := shellwords.ParseWithEnvs("FOO=foo BAR=baz ./foo --bar=baz")
+// envs should be ["FOO=foo", "BAR=baz"]
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
+os.Setenv("FOO", "bar")
+p := shellwords.NewParser()
+p.ParseEnv = true
+args, err := p.Parse("./foo $FOO")
+// args should be ["./foo", "bar"]
+```
+
+```go
+p := shellwords.NewParser()
+p.ParseBacktick = true
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+```go
+shellwords.ParseBacktick = true
+p := shellwords.NewParser()
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+# Thanks
+
+This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).
+
+# License
+
+under the MIT License: http://mattn.mit-license.org/2017
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/vendor/github.com/mattn/go-shellwords/go.test.sh
+++ b/vendor/github.com/mattn/go-shellwords/go.test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -coverprofile=profile.out -covermode=atomic "$d"
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done

--- a/vendor/github.com/mattn/go-shellwords/shellwords.go
+++ b/vendor/github.com/mattn/go-shellwords/shellwords.go
@@ -1,0 +1,317 @@
+package shellwords
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"unicode"
+)
+
+var (
+	ParseEnv      bool = false
+	ParseBacktick bool = false
+)
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\r', '\n':
+		return true
+	}
+	return false
+}
+
+func replaceEnv(getenv func(string) string, s string) string {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+
+	var buf bytes.Buffer
+	rs := []rune(s)
+	for i := 0; i < len(rs); i++ {
+		r := rs[i]
+		if r == '\\' {
+			i++
+			if i == len(rs) {
+				break
+			}
+			buf.WriteRune(rs[i])
+			continue
+		} else if r == '$' {
+			i++
+			if i == len(rs) {
+				buf.WriteRune(r)
+				break
+			}
+			if rs[i] == 0x7b {
+				i++
+				p := i
+				for ; i < len(rs); i++ {
+					r = rs[i]
+					if r == '\\' {
+						i++
+						if i == len(rs) {
+							return s
+						}
+						continue
+					}
+					if r == 0x7d || (!unicode.IsLetter(r) && r != '_' && !unicode.IsDigit(r)) {
+						break
+					}
+				}
+				if r != 0x7d {
+					return s
+				}
+				if i > p {
+					buf.WriteString(getenv(s[p:i]))
+				}
+			} else {
+				p := i
+				for ; i < len(rs); i++ {
+					r := rs[i]
+					if r == '\\' {
+						i++
+						if i == len(rs) {
+							return s
+						}
+						continue
+					}
+					if !unicode.IsLetter(r) && r != '_' && !unicode.IsDigit(r) {
+						break
+					}
+				}
+				if i > p {
+					buf.WriteString(getenv(s[p:i]))
+					i--
+				} else {
+					buf.WriteString(s[p:])
+				}
+			}
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
+}
+
+type Parser struct {
+	ParseEnv      bool
+	ParseBacktick bool
+	Position      int
+	Dir           string
+
+	// If ParseEnv is true, use this for getenv.
+	// If nil, use os.Getenv.
+	Getenv func(string) string
+}
+
+func NewParser() *Parser {
+	return &Parser{
+		ParseEnv:      ParseEnv,
+		ParseBacktick: ParseBacktick,
+		Position:      0,
+		Dir:           "",
+	}
+}
+
+type argType int
+
+const (
+	argNo argType = iota
+	argSingle
+	argQuoted
+)
+
+func (p *Parser) Parse(line string) ([]string, error) {
+	args := []string{}
+	buf := ""
+	var escaped, doubleQuoted, singleQuoted, backQuote, dollarQuote bool
+	backtick := ""
+
+	pos := -1
+	got := argNo
+
+	i := -1
+loop:
+	for _, r := range line {
+		i++
+		if escaped {
+			buf += string(r)
+			escaped = false
+			got = argSingle
+			continue
+		}
+
+		if r == '\\' {
+			if singleQuoted {
+				buf += string(r)
+			} else {
+				escaped = true
+			}
+			continue
+		}
+
+		if isSpace(r) {
+			if singleQuoted || doubleQuoted || backQuote || dollarQuote {
+				buf += string(r)
+				backtick += string(r)
+			} else if got != argNo {
+				if p.ParseEnv {
+					if got == argSingle {
+						parser := &Parser{ParseEnv: false, ParseBacktick: false, Position: 0, Dir: p.Dir}
+						strs, err := parser.Parse(replaceEnv(p.Getenv, buf))
+						if err != nil {
+							return nil, err
+						}
+						args = append(args, strs...)
+					} else {
+						args = append(args, replaceEnv(p.Getenv, buf))
+					}
+				} else {
+					args = append(args, buf)
+				}
+				buf = ""
+				got = argNo
+			}
+			continue
+		}
+
+		switch r {
+		case '`':
+			if !singleQuoted && !doubleQuoted && !dollarQuote {
+				if p.ParseBacktick {
+					if backQuote {
+						out, err := shellRun(backtick, p.Dir)
+						if err != nil {
+							return nil, err
+						}
+						buf = buf[:len(buf)-len(backtick)] + out
+					}
+					backtick = ""
+					backQuote = !backQuote
+					continue
+				}
+				backtick = ""
+				backQuote = !backQuote
+			}
+		case ')':
+			if !singleQuoted && !doubleQuoted && !backQuote {
+				if p.ParseBacktick {
+					if dollarQuote {
+						out, err := shellRun(backtick, p.Dir)
+						if err != nil {
+							return nil, err
+						}
+						buf = buf[:len(buf)-len(backtick)-2] + out
+					}
+					backtick = ""
+					dollarQuote = !dollarQuote
+					continue
+				}
+				backtick = ""
+				dollarQuote = !dollarQuote
+			}
+		case '(':
+			if !singleQuoted && !doubleQuoted && !backQuote {
+				if !dollarQuote && strings.HasSuffix(buf, "$") {
+					dollarQuote = true
+					buf += "("
+					continue
+				} else {
+					return nil, errors.New("invalid command line string")
+				}
+			}
+		case '"':
+			if !singleQuoted && !dollarQuote {
+				if doubleQuoted {
+					got = argQuoted
+				}
+				doubleQuoted = !doubleQuoted
+				continue
+			}
+		case '\'':
+			if !doubleQuoted && !dollarQuote {
+				if singleQuoted {
+					got = argQuoted
+				}
+				singleQuoted = !singleQuoted
+				continue
+			}
+		case ';', '&', '|', '<', '>':
+			if !(escaped || singleQuoted || doubleQuoted || backQuote || dollarQuote) {
+				if r == '>' && len(buf) > 0 {
+					if c := buf[0]; '0' <= c && c <= '9' {
+						i -= 1
+						got = argNo
+					}
+				}
+				pos = i
+				break loop
+			}
+		}
+
+		got = argSingle
+		buf += string(r)
+		if backQuote || dollarQuote {
+			backtick += string(r)
+		}
+	}
+
+	if got != argNo {
+		if p.ParseEnv {
+			if got == argSingle {
+				parser := &Parser{ParseEnv: false, ParseBacktick: false, Position: 0, Dir: p.Dir}
+				strs, err := parser.Parse(replaceEnv(p.Getenv, buf))
+				if err != nil {
+					return nil, err
+				}
+				args = append(args, strs...)
+			} else {
+				args = append(args, replaceEnv(p.Getenv, buf))
+			}
+		} else {
+			args = append(args, buf)
+		}
+	}
+
+	if escaped || singleQuoted || doubleQuoted || backQuote || dollarQuote {
+		return nil, errors.New("invalid command line string")
+	}
+
+	p.Position = pos
+
+	return args, nil
+}
+
+func (p *Parser) ParseWithEnvs(line string) (envs []string, args []string, err error) {
+	_args, err := p.Parse(line)
+	if err != nil {
+		return nil, nil, err
+	}
+	envs = []string{}
+	args = []string{}
+	parsingEnv := true
+	for _, arg := range _args {
+		if parsingEnv && isEnv(arg) {
+			envs = append(envs, arg)
+		} else {
+			if parsingEnv {
+				parsingEnv = false
+			}
+			args = append(args, arg)
+		}
+	}
+	return envs, args, nil
+}
+
+func isEnv(arg string) bool {
+	return len(strings.Split(arg, "=")) == 2
+}
+
+func Parse(line string) ([]string, error) {
+	return NewParser().Parse(line)
+}
+
+func ParseWithEnvs(line string) (envs []string, args []string, err error) {
+	return NewParser().ParseWithEnvs(line)
+}

--- a/vendor/github.com/mattn/go-shellwords/util_posix.go
+++ b/vendor/github.com/mattn/go-shellwords/util_posix.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+package shellwords
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line, dir string) (string, error) {
+	var shell string
+	if shell = os.Getenv("SHELL"); shell == "" {
+		shell = "/bin/sh"
+	}
+	cmd := exec.Command(shell, "-c", line)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	b, err := cmd.Output()
+	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			b = eerr.Stderr
+		}
+		return "", fmt.Errorf("%s: %w", string(b), err)
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/github.com/mattn/go-shellwords/util_windows.go
+++ b/vendor/github.com/mattn/go-shellwords/util_windows.go
@@ -1,0 +1,29 @@
+// +build windows
+
+package shellwords
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line, dir string) (string, error) {
+	var shell string
+	if shell = os.Getenv("COMSPEC"); shell == "" {
+		shell = "cmd"
+	}
+	cmd := exec.Command(shell, "/c", line)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	b, err := cmd.Output()
+	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			b = eerr.Stderr
+		}
+		return "", fmt.Errorf("%s: %w", string(b), err)
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -321,6 +321,9 @@ github.com/kylelemons/godebug/pretty
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
+# github.com/mattn/go-shellwords v1.0.12
+## explicit; go 1.13
+github.com/mattn/go-shellwords
 # github.com/mitchellh/mapstructure v1.5.0
 ## explicit; go 1.14
 github.com/mitchellh/mapstructure


### PR DESCRIPTION
add the required utils to integrate the scenarios scripts testing into CMO e2e tests.
    
add utils to integrate the scripts with the docs, for now in "Documentation/resources" below the corresponding
    'port/RBAC permission'
    
add an example for how to setup RBAC and access the APIs exposed at openshift-monitoring/alertmanager-main port 9094



<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
