### PR TITLE
OCPBUGS-39176: Backport #2441 for 4.14

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -522,7 +522,7 @@ The `RemoteWriteSpec` resource defines the settings for remote write storage.
 | metadataConfig | *[monv1.MetadataConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#metadataconfig) | Defines settings for sending series metadata to remote write storage. |
 | name | string | Defines the name of the remote write queue. This name is used in metrics and logging to differentiate queues. If specified, this name must be unique. |
 | oauth2 | *monv1.OAuth2 | Defines OAuth2 authentication settings for the remote write endpoint. |
-| proxyUrl | string | Defines an optional proxy URL. |
+| proxyUrl | string | Defines an optional proxy URL. It is superseded by the cluster-wide proxy, if enabled. |
 | queueConfig | *[monv1.QueueConfig](https://github.com/prometheus-operator/prometheus-operator/blob/v0.66.0/Documentation/api.md#queueconfig) | Allows tuning configuration for remote write queue parameters. |
 | remoteTimeout | string | Defines the timeout value for requests to the remote write endpoint. |
 | sigv4 | *monv1.Sigv4 | Defines AWS Signature Version 4 authentication settings. |

--- a/Documentation/openshiftdocs/modules/remotewritespec.adoc
+++ b/Documentation/openshiftdocs/modules/remotewritespec.adoc
@@ -35,7 +35,7 @@ link:prometheusrestrictedconfig.adoc[PrometheusRestrictedConfig]
 
 |oauth2|*monv1.OAuth2|Defines OAuth2 authentication settings for the remote write endpoint.
 
-|proxyUrl|string|Defines an optional proxy URL.
+|proxyUrl|string|Defines an optional proxy URL. It is superseded by the cluster-wide proxy, if enabled.
 
 |queueConfig|*monv1.QueueConfig|Allows tuning configuration for remote write queue parameters.
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/prometheus/prometheus v0.44.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	golang.org/x/net v0.17.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/text v0.13.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -127,7 +128,6 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pkg/errors"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"golang.org/x/exp/slices"
+	"golang.org/x/net/http/httpproxy"
 	yaml2 "gopkg.in/yaml.v2"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1450,12 +1451,41 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, trustedCABundleCM *v1.Config
 	for k := range p.Spec.RemoteWrite {
 		rw := &p.Spec.RemoteWrite[k]
 
+		var tmpRWProxyURL string
 		if f.proxy.HTTPProxy() != "" {
-			rw.ProxyURL = f.proxy.HTTPProxy()
+			tmpRWProxyURL = f.proxy.HTTPProxy()
 		}
 		if f.proxy.HTTPSProxy() != "" {
-			rw.ProxyURL = f.proxy.HTTPSProxy()
+			tmpRWProxyURL = f.proxy.HTTPSProxy()
 		}
+
+		// Fixes: https://issues.redhat.com/browse/OCPBUGS-38289
+		// The code is condensed here to simplify backporting.
+		// This is a temporary workaround because the NoProxy field isn't exported on the Prometheus CRD in older versions.
+		// If the cluster proxy or remoteWrite config change, this code will re-run, ensuring no stale state.
+		// The httpproxy package used here is the same as used by Prometheus, which helps with consistency.
+
+		// proxy URL is not to be set/overwritten in here, nothing to do.
+		if tmpRWProxyURL == "" {
+			continue
+		}
+		// Suppose that CMO has set the proxy URL.
+		proxyConfig := &httpproxy.Config{
+			HTTPProxy:  tmpRWProxyURL,
+			HTTPSProxy: tmpRWProxyURL,
+			NoProxy:    f.proxy.NoProxy(),
+		}
+		proxyFunc := proxyConfig.ProxyFunc()
+		// Ignore errors here.
+		u, _ := url.Parse(rw.URL)
+		// Check if the endpoint URL will be using that proxy URL.
+		proxyURL, err := proxyFunc(u)
+		if err == nil && proxyURL == nil {
+			// Proxing will not be used, no need to set it.
+			continue
+		}
+		// The proxy will be used, set it.
+		rw.ProxyURL = tmpRWProxyURL
 	}
 
 	if f.config.Images.Thanos != "" {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1488,48 +1488,108 @@ func TestRemoteWriteAuthorizationConfig(t *testing.T) {
 }
 
 func TestPrometheusK8sRemoteWriteProxy(t *testing.T) {
-	config := func() *Config {
+	config := func(remoteURL string) *Config {
 		c, err := NewConfigFromString("", false)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.RemoteWrite = []RemoteWriteSpec{{URL: "http://custom"}}
-
+		c.ClusterMonitoringConfiguration.PrometheusK8sConfig.RemoteWrite = []RemoteWriteSpec{{URL: remoteURL}}
 		return c
 	}
 
 	for _, tc := range []struct {
 		name                        string
+		remoteURL                   string
 		proxyReader                 ProxyReader
 		expectedRemoteWriteProxyURL string
 	}{
 		{
-			name:                        "no proxy",
+			name:                        "proxy not set",
+			remoteURL:                   "http://custom.foo.bar",
 			proxyReader:                 &fakeProxyReader{},
 			expectedRemoteWriteProxyURL: "",
 		},
 
 		{
 			name:                        "HTTP proxy",
+			remoteURL:                   "http://custom.foo.bar",
 			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy"},
 			expectedRemoteWriteProxyURL: "http://my-proxy",
 		},
 
 		{
+			name:                        "HTTP proxy wrong scheme",
+			remoteURL:                   "https://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy"},
+			expectedRemoteWriteProxyURL: "http://my-proxy",
+		},
+
+		{
+			name:                        "HTTP proxy with noProxy set",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", noProxy: ".baz"},
+			expectedRemoteWriteProxyURL: "http://my-proxy",
+		},
+
+		{
+			name:                        "HTTP proxy should be ignored due to noProxy ",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", noProxy: ".foo.bar"},
+			expectedRemoteWriteProxyURL: "",
+		},
+
+		{
 			name:                        "HTTPS proxy",
+			remoteURL:                   "https://custom.foo.bar",
 			proxyReader:                 &fakeProxyReader{httpsProxy: "https://my-secured-proxy"},
 			expectedRemoteWriteProxyURL: "https://my-secured-proxy",
 		},
 
 		{
+			name:                        "HTTPS proxy wrong scheme",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpsProxy: "https://my-secured-proxy"},
+			expectedRemoteWriteProxyURL: "https://my-secured-proxy",
+		},
+
+		{
+			name:                        "HTTPS proxy with noProxy set",
+			remoteURL:                   "https://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpsProxy: "https://my-secured-proxy", noProxy: ".fox.daz"},
+			expectedRemoteWriteProxyURL: "https://my-secured-proxy",
+		},
+
+		{
+			name:                        "HTTPS proxy should be ignored due to noProxy",
+			remoteURL:                   "https://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpsProxy: "https://my-secured-proxy", noProxy: ".foo.bar"},
+			expectedRemoteWriteProxyURL: "",
+		},
+
+		{
 			name:                        "HTTP & HTTPS proxy",
+			remoteURL:                   "http://custom.foo.bar",
 			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", httpsProxy: "https://my-secured-proxy"},
 			expectedRemoteWriteProxyURL: "https://my-secured-proxy",
 		},
+
+		{
+			name:                        "HTTP & HTTPS proxy with noProxy set",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", httpsProxy: "https://my-secured-proxy", noProxy: ".fox.daz"},
+			expectedRemoteWriteProxyURL: "https://my-secured-proxy",
+		},
+
+		{
+			name:                        "HTTP & HTTPS proxy should be ignored due to noProxy",
+			remoteURL:                   "http://custom.foo.bar",
+			proxyReader:                 &fakeProxyReader{httpProxy: "http://my-proxy", httpsProxy: "https://my-secured-proxy", noProxy: ".foo.bar"},
+			expectedRemoteWriteProxyURL: "",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", config(), defaultInfrastructureReader(), tc.proxyReader, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", config(tc.remoteURL), defaultInfrastructureReader(), tc.proxyReader, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 			p, err := f.PrometheusK8s(
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -748,6 +748,7 @@ type RemoteWriteSpec struct {
 	// Defines OAuth2 authentication settings for the remote write endpoint.
 	OAuth2 *monv1.OAuth2 `json:"oauth2,omitempty"`
 	// Defines an optional proxy URL.
+	// It is superseded by the cluster-wide proxy, if enabled.
 	ProxyURL string `json:"proxyUrl,omitempty"`
 	// Allows tuning configuration for remote write queue parameters.
 	QueueConfig *monv1.QueueConfig `json:"queueConfig,omitempty"`


### PR DESCRIPTION
Backports https://github.com/openshift/cluster-monitoring-operator/pull/2441

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
