### PR TITLE
OCPBUGS-39126: disable user-defined monitoring per object

### DIFF
--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -204,7 +204,12 @@ spec:
       operator: NotIn
       values:
       - "false"
-  podMonitorSelector: {}
+  podMonitorSelector:
+    matchExpressions:
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
   priorityClassName: openshift-user-critical
   probeNamespaceSelector:
     matchExpressions:
@@ -216,7 +221,12 @@ spec:
       operator: NotIn
       values:
       - "false"
-  probeSelector: {}
+  probeSelector:
+    matchExpressions:
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
   replicas: 2
   resources:
     requests:
@@ -233,8 +243,15 @@ spec:
       values:
       - "false"
   ruleSelector:
-    matchLabels:
-      openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
+    matchExpressions:
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
+    - key: openshift.io/prometheus-rule-evaluation-scope
+      operator: In
+      values:
+      - leaf-prometheus
   scrapeConfigNamespaceSelector: null
   scrapeConfigSelector: null
   secrets:
@@ -259,7 +276,12 @@ spec:
       operator: NotIn
       values:
       - "false"
-  serviceMonitorSelector: {}
+  serviceMonitorSelector:
+    matchExpressions:
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
   thanos:
     image: quay.io/thanos/thanos:v0.36.1
     resources:

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -129,6 +129,10 @@ spec:
       - "false"
   ruleSelector:
     matchExpressions:
+    - key: openshift.io/user-monitoring
+      operator: NotIn
+      values:
+      - "false"
     - key: openshift.io/prometheus-rule-evaluation-scope
       operator: NotIn
       values:

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -352,16 +352,20 @@ function(params)
           $.kubeRbacProxyFederateSecret.metadata.name,
         ],
         configMaps: ['serving-certs-ca-bundle', 'metrics-client-ca'],
-        probeSelector: {},
+        probeSelector: cfg.resourceSelector,
         probeNamespaceSelector: cfg.namespaceSelector,
-        podMonitorSelector: {},
+        podMonitorSelector: cfg.resourceSelector,
         podMonitorNamespaceSelector: cfg.namespaceSelector,
-        serviceMonitorSelector: {},
+        serviceMonitorSelector: cfg.resourceSelector,
         serviceMonitorNamespaceSelector: cfg.namespaceSelector,
-        ruleSelector: {
-          matchLabels: {
-            'openshift.io/prometheus-rule-evaluation-scope': 'leaf-prometheus',
-          },
+        ruleSelector: cfg.resourceSelector {
+          matchExpressions+: [
+            {
+              key: 'openshift.io/prometheus-rule-evaluation-scope',
+              operator: 'In',
+              values: ['leaf-prometheus'],
+            },
+          ],
         },
         ruleNamespaceSelector: cfg.namespaceSelector,
         scrapeConfigSelector: null,

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -389,8 +389,8 @@ function(params)
         },
         enforcedNamespaceLabel: 'namespace',
         listenLocal: true,
-        ruleSelector: {
-          matchExpressions:
+        ruleSelector: cfg.resourceSelector {
+          matchExpressions+:
             [
               {
                 key: 'openshift.io/prometheus-rule-evaluation-scope',

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -36,6 +36,15 @@ local commonConfig = {
       'openshift.io/cluster-monitoring': 'true',
     },
   },
+  userWorkloadMonitoringResourceSelector: {
+    matchExpressions: [
+      {
+        key: 'openshift.io/user-monitoring',
+        operator: 'NotIn',
+        values: ['false'],
+      },
+    ],
+  },
   userWorkloadMonitoringNamespaceSelector: {
     matchExpressions: [
       {
@@ -326,6 +335,7 @@ local inCluster =
           'app.kubernetes.io/name': 'thanos-ruler',
           'thanos-ruler': 'user-workload',
         },
+        resourceSelector: $.values.common.userWorkloadMonitoringResourceSelector,
         namespaceSelector: $.values.common.userWorkloadMonitoringNamespaceSelector,
         commonLabels+: $.values.common.commonLabels,
         kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
@@ -478,6 +488,7 @@ local userWorkload =
           requests: { memory: '30Mi', cpu: '6m' },
         },
         namespaces: [$.values.common.namespaceUserWorkload],
+        resourceSelector: $.values.common.userWorkloadMonitoringResourceSelector,
         namespaceSelector: $.values.common.userWorkloadMonitoringNamespaceSelector,
         thanos: inCluster.values.prometheus.thanos,
         tlsCipherSuites: $.values.common.tlsCipherSuites,

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -63,6 +63,9 @@ const (
 
 	nodeSelectorMaster = "node-role.kubernetes.io/master"
 
+	userMonitoringLabel    = "openshift.io/user-monitoring"
+	clusterMonitoringLabel = "openshift.io/cluster-monitoring"
+
 	platformAlertmanagerService     = "alertmanager-main"
 	userWorkloadAlertmanagerService = "alertmanager-user-workload"
 
@@ -477,17 +480,24 @@ func (f *Factory) AlertmanagerUserWorkload() (*monv1.Alertmanager, error) {
 	a.Spec.Secrets = append(a.Spec.Secrets, alertmanagerConfig.Secrets...)
 
 	if alertmanagerConfig.EnableAlertmanagerConfig {
-		a.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{}
-
+		a.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      userMonitoringLabel,
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"false"},
+				},
+			},
+		}
 		a.Spec.AlertmanagerConfigNamespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
-					Key:      "openshift.io/cluster-monitoring",
+					Key:      clusterMonitoringLabel,
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{"true"},
 				},
 				{
-					Key:      "openshift.io/user-monitoring",
+					Key:      userMonitoringLabel,
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{"false"},
 				},
@@ -609,17 +619,25 @@ func (f *Factory) AlertmanagerMain() (*monv1.Alertmanager, error) {
 
 	if f.config.ClusterMonitoringConfiguration.AlertmanagerMainConfig.EnableUserAlertManagerConfig &&
 		!f.config.UserWorkloadConfiguration.Alertmanager.Enabled {
-		a.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{}
+		a.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      userMonitoringLabel,
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"false"},
+				},
+			},
+		}
 
 		a.Spec.AlertmanagerConfigNamespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
-					Key:      "openshift.io/cluster-monitoring",
+					Key:      clusterMonitoringLabel,
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{"true"},
 				},
 				{
-					Key:      "openshift.io/user-monitoring",
+					Key:      userMonitoringLabel,
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{"false"},
 				},

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3085,7 +3085,17 @@ ingress:
 			t.Fatal("expected 'alertmanagerConfigSelector' to configure selector")
 		}
 
-		if !reflect.DeepEqual(a.Spec.AlertmanagerConfigSelector, &metav1.LabelSelector{}) {
+		if !reflect.DeepEqual(
+			a.Spec.AlertmanagerConfigSelector,
+			&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      userMonitoringLabel,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"false"},
+					},
+				},
+			}) {
 			t.Fatal("expected match all alertmanagerConfigSelector")
 		}
 
@@ -3098,13 +3108,13 @@ ingress:
 		}
 
 		expectPlatformOptIn := metav1.LabelSelectorRequirement{
-			Key:      "openshift.io/cluster-monitoring",
+			Key:      clusterMonitoringLabel,
 			Operator: metav1.LabelSelectorOpNotIn,
 			Values:   []string{"true"},
 		}
 
 		expectUWMOptIn := metav1.LabelSelectorRequirement{
-			Key:      "openshift.io/user-monitoring",
+			Key:      userMonitoringLabel,
 			Operator: metav1.LabelSelectorOpNotIn,
 			Values:   []string{"false"},
 		}

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	userWorkloadTestNs = "user-workload-test"
+	userWorkloadTestNs     = "user-workload-test"
+	serviceMonitorTestName = "prometheus-example-monitor"
 )
 
 var (
@@ -171,9 +172,9 @@ func deployUserApplication(t *testing.T, f *framework.Framework) error {
 
 	_, err = f.MonitoringClient.ServiceMonitors(userWorkloadTestNs).Create(ctx, &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "prometheus-example-monitor",
+			Name: serviceMonitorTestName,
 			Labels: map[string]string{
-				"k8s-app":                  "prometheus-example-monitor",
+				"k8s-app":                  serviceMonitorTestName,
 				framework.E2eTestLabelName: framework.E2eTestLabelValue,
 			},
 		},


### PR DESCRIPTION
Before this change, a project owner could only disable user-defined monitoring per namespace/project (typically to prevent the `PrometheusOperatorRejectedResources` alert from firing).

To provide greater flexibility, it is now possible to exclude individual objects (e.g. `ServiceMonitor`, `PodMonitor` and `PrometheusRule`) by adding the `openshift.io/user-monitoring="true"` label to them.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
