### PR TITLE
Clarify service.yaml comment about role bindings.

### DIFF
--- a/assets/thanos-querier/service.yaml
+++ b/assets/thanos-querier/service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     openshift.io/description: |-
       Expose the Thanos Querier web server within the cluster on the following ports:
-      * Port 9091 provides access to all the Thanos Querier endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
+      * Port 9091 provides access to all the Thanos Querier endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role in the `openshift-monitoring` namespace.
       * Port 9092 provides access to the `/api/v1/query`, `/api/v1/query_range/`, `/api/v1/labels`, `/api/v1/label/*/values`, and `/api/v1/series` endpoints restricted to a given project. Granting access requires binding a user to the `view` cluster role in the project.
       * Port 9093 provides access to the `/api/v1/alerts`, and `/api/v1/rules` endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role or `monitoring-edit` cluster role or `monitoring-rules-view` cluster role in the project.
       * Port 9094 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.


### PR DESCRIPTION
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
