### PR TITLE
OCPBUGS-41580: Configure graceful shutdown for metrics-server (4.17 backport)

### DIFF
--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -50,6 +50,8 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --shutdown-send-retry-after=true
+        - --shutdown-delay-duration=150s
         image: registry.k8s.io/metrics-server/metrics-server:v0.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -98,6 +100,7 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      terminationGracePeriodSeconds: 170
       volumes:
       - name: secret-metrics-client-certs
         secret:

--- a/jsonnet/components/metrics-server.libsonnet
+++ b/jsonnet/components/metrics-server.libsonnet
@@ -199,6 +199,9 @@ function(params) {
                 '--tls-cert-file=/etc/tls/private/tls.crt',
                 '--tls-private-key-file=/etc/tls/private/tls.key',
                 '--tls-cipher-suites=' + cfg.tlsCipherSuites,
+                '--shutdown-send-retry-after=true',
+                // wait long enough for the readiness probe's failure threshold to be breached
+                '--shutdown-delay-duration=150s',
               ],
               imagePullPolicy: 'IfNotPresent',
               livenessProbe: {
@@ -268,6 +271,7 @@ function(params) {
           },
           priorityClassName: 'system-cluster-critical',
           serviceAccountName: 'metrics-server',
+          terminationGracePeriodSeconds: 170,
           volumes: [
             {
               name: 'secret-metrics-client-certs',


### PR DESCRIPTION
backports https://github.com/openshift/cluster-monitoring-operator/pull/2460

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
