### PR TITLE
MON-3934: merge TestAlertManagerHasAdditionalAlertRelabelConfigs into…

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1507,25 +1507,6 @@ func (c *Client) CreateOrUpdateConfigMap(ctx context.Context, cm *v1.ConfigMap) 
 	return err
 }
 
-func (c *Client) DeleteIfExists(ctx context.Context, nsName string) error {
-	nClient := c.kclient.CoreV1().Namespaces()
-	_, err := nClient.Get(ctx, nsName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		// Namespace already deleted
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("retrieving Namespace object failed: %w", err)
-	}
-
-	err = nClient.Delete(ctx, nsName, metav1.DeleteOptions{})
-	if err != nil {
-		return fmt.Errorf("deleting ConfigMap object failed: %w", err)
-	}
-	return nil
-}
-
 func (c *Client) CreateIfNotExistConfigMap(ctx context.Context, cm *v1.ConfigMap) (*v1.ConfigMap, error) {
 	cClient := c.kclient.CoreV1().ConfigMaps(cm.GetNamespace())
 	res, err := cClient.Get(ctx, cm.GetName(), metav1.GetOptions{})

--- a/test/e2e/alertmanager_helpers.go
+++ b/test/e2e/alertmanager_helpers.go
@@ -183,7 +183,7 @@ func (wr *webhookReceiver) getAlertsByID(id string) ([]alert, error) {
 func (wr *webhookReceiver) tearDown(t *testing.T, f *framework.Framework) {
 	t.Helper()
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
-		return f.OperatorClient.DeleteIfExists(ctx, wr.namespace)
+		return f.DeleteNamespace(t, wr.namespace)
 	})
 
 	if err != nil {

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -747,51 +747,6 @@ func TestAlertmanagerDisabling(t *testing.T) {
 	})
 }
 
-func TestAlertManagerHasAdditionalAlertRelabelConfigs(t *testing.T) {
-	const (
-		expectPlatformLabel      = "openshift_io_alert_source"
-		expectPlatformLabelValue = "platform"
-	)
-
-	type Alerts []struct {
-		Labels map[string]string `json:"labels"`
-	}
-
-	var alerts Alerts
-
-	err := framework.Poll(5*time.Second, time.Minute, func() error {
-		resp, err := f.AlertmanagerClient.Do("GET", "/api/v2/alerts", nil)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("expecting 200 status code, got %d (%q)", resp.StatusCode, resp.Body)
-		}
-
-		if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
-			return fmt.Errorf("error decoding alert response")
-		}
-
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, alert := range alerts {
-		v, found := alert.Labels[expectPlatformLabel]
-		if !found {
-			t.Fatal("expected correct label to be present")
-		}
-
-		if v != expectPlatformLabelValue {
-			t.Fatalf("expected correct value for %s but got %s", expectPlatformLabel, v)
-		}
-	}
-}
-
 // TestAlertmanagerConfigPipeline ensures that the AlertManagerConfig CR's
 // created in a user namespace can be reconciled and have alerts sent to the
 // correct Alertmanager (depending on whether user-defined Alertmanager is

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -755,3 +755,13 @@ func (f *Framework) CreateNamespace(namespace string) (CleanUpFunc, error) {
 		return f.KubeClient.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
 	}, nil
 }
+
+func (f *Framework) DeleteNamespace(t *testing.T, nsName string) error {
+	t.Helper()
+
+	err := f.KubeClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting Namespace object failed: %w", err)
+	}
+	return nil
+}

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -16,28 +16,23 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
+	"github.com/stretchr/testify/require"
 
-	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestMultinamespacePrometheusRule(t *testing.T) {
-	ctx := context.Background()
-	nsName := "openshift-test-prometheus-rules" + strconv.FormatInt(time.Now().Unix(), 36)
+	// The test shouldn't be disruptive, safe to run in parallel with others.
 	t.Parallel()
-
-	t.Cleanup(func() {
-		f.OperatorClient.DeleteIfExists(ctx, nsName)
-	})
+	nsName := "openshift-test-prometheus-rules"
+	firingAlertName := "FiringAlertInNamespace"
 
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -48,58 +43,74 @@ func TestMultinamespacePrometheusRule(t *testing.T) {
 			},
 		},
 	}
-	_, err := f.KubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = f.OperatorClient.CreateOrUpdatePrometheusRule(ctx, &monv1.PrometheusRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "non-monitoring-prometheus-rules",
-			Namespace: nsName,
-			Labels: map[string]string{
-				framework.E2eTestLabelName: framework.E2eTestLabelValue,
-			},
-		},
-		Spec: monv1.PrometheusRuleSpec{
-			Groups: []monv1.RuleGroup{
-				{
-					Name: "test-group",
-					Rules: []monv1.Rule{
-						{
-							Alert: "AdditionalTestAlertRule",
-							Expr:  intstr.FromString("vector(1)"),
-						},
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var lastErr error
-	// wait for proxies bootstrap
-	err = wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := f.ThanosQuerierClient.Do("GET", "/-/ready", nil)
-		if err != nil {
-			lastErr = fmt.Errorf("establishing connection to thanos proxy failed: %w", err)
-			return false, nil
-		}
-		return true, nil
+	_, err := f.KubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		f.DeleteNamespace(t, nsName)
 	})
 
-	if err != nil {
-		if err == wait.ErrWaitTimeout && lastErr != nil {
-			err = lastErr
-		}
-		t.Fatal(err)
+	createPrometheusRuleWithAlert(t, nsName, "non-monitoring-prometheus-rules", firingAlertName)
+
+	for _, check := range []struct {
+		name string
+		f    func(*testing.T)
+	}{
+		{
+			name: "the alert was taken into account by Thanos",
+			f: func(t *testing.T) {
+				f.ThanosQuerierClient.WaitForQueryReturnOne(
+					t,
+					5*time.Minute,
+					fmt.Sprintf(`count(ALERTS{alertname="%s"} == 1)`, firingAlertName),
+				)
+			},
+		},
+		{
+			name: "the alert has the default platform labels in Alertmanager",
+			f: func(t *testing.T) {
+				checkAlertHasPlatformLabels(t, firingAlertName)
+			},
+		},
+	} {
+		t.Run(check.name, func(t *testing.T) {
+			t.Parallel()
+			check.f(t)
+		})
 	}
 
-	f.ThanosQuerierClient.WaitForQueryReturnOne(
-		t,
-		10*time.Minute,
-		`count(ALERTS{alertname="AdditionalTestAlertRule"} == 1)`,
+}
+
+func checkAlertHasPlatformLabels(t *testing.T, alertName string) {
+	const (
+		expectPlatformLabel      = "openshift_io_alert_source"
+		expectPlatformLabelValue = "platform"
 	)
+
+	type Alerts []struct {
+		Labels map[string]string `json:"labels"`
+	}
+
+	var alerts Alerts
+
+	err := framework.Poll(5*time.Second, 5*time.Minute, func() error {
+		body, err := f.AlertmanagerClient.GetAlertmanagerAlerts(
+			"filter", fmt.Sprintf(`alertname="%s"`, alertName),
+			"active", "true",
+		)
+		if err != nil {
+			return err
+		}
+
+		if err = json.Unmarshal(body, &alerts); err != nil {
+			return err
+		}
+
+		if len(alerts) != 1 {
+			return fmt.Errorf("couldn't find the firing alert")
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Subset(t, alerts[0].Labels, map[string]string{expectPlatformLabel: expectPlatformLabelValue})
 }

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -76,7 +76,7 @@ func setupUserApplication(t *testing.T, f *framework.Framework) {
 func tearDownUserApplication(t *testing.T, f *framework.Framework) {
 	// check if its deleted and return if true
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
-		return f.OperatorClient.DeleteIfExists(ctx, userWorkloadTestNs)
+		return f.DeleteNamespace(t, userWorkloadTestNs)
 	})
 
 	if err != nil {


### PR DESCRIPTION
… TestMultinamespacePrometheusRule to ensure the existence of an alert with the labels the check is looking for.

move client.DeleteIfExists into framework.

clean TestMultinamespacePrometheusRule and fix the namespace.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
