### PR TITLE
MON-3934: make TestImageRegistryPods more robust and split it into Pl…

### DIFF
--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -174,12 +174,12 @@ func (f *Framework) MustGetStatefulSet(t *testing.T, name, namespace string) *ap
 	return statefulSet
 }
 
-// MustGetPods return all pods from `namespace` within 5 minutes or fail
-func (f *Framework) MustGetPods(t *testing.T, namespace string) *v1.PodList {
+// MustListPods returns all pods matching labelSelector from `namespace` within 5 minutes or fails.
+func (f *Framework) MustListPods(t *testing.T, namespace, labelSelector string) *v1.PodList {
 	t.Helper()
 	var pods *v1.PodList
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
-		pl, err := f.KubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+		pl, err := f.KubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			return false, nil
 		}

--- a/test/e2e/image_registry_test.go
+++ b/test/e2e/image_registry_test.go
@@ -2,88 +2,55 @@ package e2e
 
 import (
 	"net/url"
-	"strings"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	"github.com/stretchr/testify/require"
 )
 
+// TestImageRegistryPods ensure that all the containers images in openshift-monitoring
+// are from the same registry than the CMO's image.
 func TestImageRegistryPods(t *testing.T) {
-	var pods *v1.PodList
+	cmoImageRegistryIsUsedInNsAssert(t, f.Ns)
+}
 
-	// Get all pods in openshift-monitoring namespace.
-	var urlRegistry string
-	pods = f.MustGetPods(t, f.Ns)
+func cmoImageRegistryIsUsedInNsAssert(t *testing.T, ns string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assertCMOImageRegistryIsUsed(t, ns)
+	}
+}
 
-	// use CMO image's registry as a reference for all other containers
-	for _, pod := range pods.Items {
-		if strings.Contains(pod.Name, "cluster-monitoring-operator") {
-			imageUrl, err := url.Parse("stubheader://" + pod.Spec.Containers[0].Image)
-			if err != nil {
-				t.Fatalf("Fail to decode host: %v", err)
-			}
-			urlRegistry = imageUrl.Host
-			break
+func assertCMOImageRegistryIsUsed(t *testing.T, ns string) {
+	getRegistry := func(t *testing.T, image string) string {
+		// This first attempt is needed; otherwise, we may blindly add a second scheme,
+		// and the initial one will be considered the hostname.
+		u, err := url.ParseRequestURI(image)
+		if err == nil {
+			return u.Host
 		}
+		// Maybe no scheme, add one.
+		u, err = url.ParseRequestURI("stubheader://" + image)
+		require.NoError(t, err)
+		return u.Host
 	}
 
-	if urlRegistry == "" {
-		t.Fatalf("CMO pod not found")
-	}
+	cmoPod := f.MustListPods(t, f.Ns, "app.kubernetes.io/name=cluster-monitoring-operator")
+	require.Len(t, cmoPod.Items, 1)
 
+	// Get CMO registry
+	cmoContainers := cmoPod.Items[0].Spec.Containers
+	require.Len(t, cmoContainers, 1, "the check assumes only one container is present")
+	cmoRegistry := getRegistry(t, cmoContainers[0].Image)
+	require.NotEmpty(t, cmoRegistry)
+
+	// Get all pods
+	pods := f.MustListPods(t, ns, "")
+	require.GreaterOrEqual(t, len(pods.Items), 2)
+
+	// Check equality with the others'
 	for _, pod := range pods.Items {
-
 		for _, container := range pod.Spec.Containers {
-
-			// We consider the hostname part of image URL be the image registry
-			imageUrl, err := url.Parse("stubheader://" + container.Image)
-			if err != nil {
-				t.Fatalf("Fail to decode host: %v", err)
-			}
-
-			if imageUrl.Host != urlRegistry {
-				t.Fatalf("Pod %s Container %s registry %s differs from CMO registry %s", pod.Name, container.Name, imageUrl.Host, urlRegistry)
-			}
+			require.Equal(t, cmoRegistry, getRegistry(t, container.Image))
 		}
 
 	}
-
-	setupUserWorkloadAssetsWithTeardownHook(t, f)
-	uwmCM := f.BuildUserWorkloadConfigMap(t,
-		`prometheus:
-  enforcedTargetLimit: 10
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 2Gi
-`,
-	)
-	f.MustCreateOrUpdateConfigMap(t, uwmCM)
-	defer f.MustDeleteConfigMap(t, uwmCM)
-
-	f.AssertStatefulSetExistsAndRollout("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
-	if err := deployUserApplication(f); err != nil {
-		t.Fatal(err)
-	}
-
-	pods = f.MustGetPods(t, f.UserWorkloadMonitoringNs)
-
-	for _, pod := range pods.Items {
-
-		for _, container := range pod.Spec.Containers {
-
-			// We consider the hostname part of image URL be the image registry
-			imageUrl, err := url.Parse("stubheader://" + container.Image)
-			if err != nil {
-				t.Fatalf("Fail to decode host: %v", err)
-			}
-
-			if imageUrl.Host != urlRegistry {
-				t.Fatalf("UWM Pod %s Container %s registry %s differs from CMO registry %s", pod.Name, container.Name, imageUrl.Host, urlRegistry)
-			}
-		}
-
-	}
-
 }

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -45,7 +45,9 @@ func TestPrometheusMetrics(t *testing.T) {
 	for service, metric := range expected {
 		t.Run(service, func(t *testing.T) {
 			f.ThanosQuerierClient.WaitForQueryReturn(
-				t, 10*time.Minute, fmt.Sprintf(`count(up{service="%s",namespace="openshift-monitoring"} == 1)`, service),
+				// To avoid making the test wait for more than lookback-delta in case Prometheus
+				// wasn't able to write stale markers (because it was down), reduce the lookup period.
+				t, time.Minute, fmt.Sprintf(`count(last_over_time(up{service="%s",namespace="openshift-monitoring"}[1m]) == 1)`, service),
 				func(v float64) error {
 					if v != float64(metric) {
 						return fmt.Errorf("expected %d targets to be up but got %f", metric, v)


### PR DESCRIPTION
…atform and UWM checks

to avoid an extra turn-UWM-on-and-off.

TestUserWorkloadThanosRulerWithAdditionalAlertmanagers: check the alert on the additional altermanager instead of the Platform one and rework it.

Avoid double counting issues in assertMetricsForMonitoringComponents and TestPrometheusMetrics
checks by reducing the lookup period.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
