### PR TITLE
MON-3367: chore: enable delayed-compaction feature flag on Platform and UWM Prometheuses

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -159,7 +159,8 @@ spec:
     volumeMounts:
     - mountPath: /etc/pki/ca-trust/extracted/pem/
       name: prometheus-trusted-ca-bundle
-  enableFeatures: []
+  enableFeatures:
+  - delayed-compaction
   externalLabels: {}
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091
   image: quay.io/prometheus/prometheus:v2.54.1

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -175,6 +175,7 @@ spec:
       name: prometheus-user-workload-trusted-ca-bundle
   enableFeatures:
   - extra-scrape-metrics
+  - delayed-compaction
   enforcedNamespaceLabel: namespace
   externalLabels: {}
   ignoreNamespaceSelectors: true

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -297,8 +297,8 @@ function(params)
         },
       },
       spec+: {
-        // Enable experimental additional scrape metrics feature
-        enableFeatures+: ['extra-scrape-metrics'],
+        // Enable experimental additional scrape metrics and delayed compaction features.
+        enableFeatures+: ['extra-scrape-metrics', 'delayed-compaction'],
         overrideHonorTimestamps: true,
         overrideHonorLabels: true,
         ignoreNamespaceSelectors: true,

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -333,6 +333,8 @@ function(params)
         },
       },
       spec+: {
+        // Enable experimental delayed compaction feature.
+        enableFeatures+: ['delayed-compaction'],
         alerting+: {
           alertmanagers:
             std.map(

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -275,6 +275,7 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 					expectMatchingRequests(podName, containerName, mem, cpu),
 					// Set by default.
 					expectContainerArg("--scrape.timestamp-tolerance=15ms", containerName),
+					expectContainerArg("--enable-feature=delayed-compaction", containerName),
 					// Set via the config above.
 					expectContainerArg("--log.level=debug", containerName),
 					expectContainerArg("--storage.tsdb.retention.time=10h", containerName),
@@ -630,7 +631,7 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
 					expectCatchAllToleration(),
 					expectMatchingRequests(podName, containerName, mem, cpu),
 					// Set by default.
-					expectContainerArg("--enable-feature=extra-scrape-metrics,exemplar-storage", containerName),
+					expectContainerArg("--enable-feature=extra-scrape-metrics,delayed-compaction,exemplar-storage", containerName),
 					// Set via the config above.
 					expectContainerArg("--log.level=debug", containerName),
 					expectContainerArg("--storage.tsdb.retention.time=10h", containerName),


### PR DESCRIPTION
…metheuses

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
