### PR TITLE
OCPBUGS-41158: add pod-metrics-reader cluster role

### DIFF
--- a/assets/cluster-monitoring-operator/cluster-role-pod-metrics-reader.yaml
+++ b/assets/cluster-monitoring-operator/cluster-role-pod-metrics-reader.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: pod-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - create

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -406,6 +406,7 @@ local inCluster =
                 inCluster.clusterMonitoringOperator.clusterRoleView.rules +
                 inCluster.clusterMonitoringOperator.userWorkloadConfigEditRole.rules +
                 inCluster.clusterMonitoringOperator.clusterRoleAggregatedMetricsReader.rules +
+                inCluster.clusterMonitoringOperator.clusterRolePodMetricsReader.rules +
                 inCluster.kubeStateMetrics.clusterRole.rules +
                 inCluster.nodeExporter.clusterRole.rules +
                 inCluster.openshiftStateMetrics.clusterRole.rules +

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -234,6 +234,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - create
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -224,6 +224,7 @@ var (
 	ClusterMonitoringOperatorServiceMonitor                = "cluster-monitoring-operator/service-monitor.yaml"
 	ClusterMonitoringClusterRoleView                       = "cluster-monitoring-operator/cluster-role-view.yaml"
 	ClusterMonitoringClusterRoleAggregatedMetricsReader    = "cluster-monitoring-operator/cluster-role-aggregated-metrics-reader.yaml"
+	ClusterMonitoringClusterRolePodMetricsReader           = "cluster-monitoring-operator/cluster-role-pod-metrics-reader.yaml"
 	ClusterMonitoringAlertmanagerViewRole                  = "cluster-monitoring-operator/monitoring-alertmanager-view-role.yaml"
 	ClusterMonitoringAlertmanagerEditRole                  = "cluster-monitoring-operator/monitoring-alertmanager-edit-role.yaml"
 	ClusterMonitoringApiReaderRole                         = "cluster-monitoring-operator/cluster-monitoring-api-role.yaml"
@@ -2396,6 +2397,10 @@ func (f *Factory) ClusterMonitoringClusterRoleView() (*rbacv1.ClusterRole, error
 
 func (f *Factory) ClusterMonitoringClusterRoleAggregatedMetricsReader() (*rbacv1.ClusterRole, error) {
 	return f.NewClusterRole(f.assets.MustNewAssetSlice(ClusterMonitoringClusterRoleAggregatedMetricsReader))
+}
+
+func (f *Factory) ClusterMonitoringClusterRolePodMetricsReader() (*rbacv1.ClusterRole, error) {
+	return f.NewClusterRole(f.assets.MustNewAssetSlice(ClusterMonitoringClusterRolePodMetricsReader))
 }
 
 func (f *Factory) ClusterMonitoringRulesEditClusterRole() (*rbacv1.ClusterRole, error) {

--- a/pkg/tasks/clustermonitoringoperator.go
+++ b/pkg/tasks/clustermonitoringoperator.go
@@ -48,6 +48,7 @@ func (t *ClusterMonitoringOperatorTask) Run(ctx context.Context) error {
 	for name, crf := range map[string]func() (*rbacv1.ClusterRole, error){
 		"cluster-monitoring-view":          t.factory.ClusterMonitoringClusterRoleView,
 		"system:aggregated-metrics-reader": t.factory.ClusterMonitoringClusterRoleAggregatedMetricsReader,
+		"pod-metrics-reader":               t.factory.ClusterMonitoringClusterRolePodMetricsReader,
 		"monitoring-rules-edit":            t.factory.ClusterMonitoringRulesEditClusterRole,
 		"monitoring-rules-view":            t.factory.ClusterMonitoringRulesViewClusterRole,
 		"monitoring-edit":                  t.factory.ClusterMonitoringEditClusterRole,


### PR DESCRIPTION
The new `pod-metrics-reader` cluster role allows GET *and* POST requests to the namespace-aware Thanos Querier API endpoint.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
