### PR TITLE
NO-JIRA: clean-up generated dashboards

### DIFF
--- a/jsonnet/components/dashboards.libsonnet
+++ b/jsonnet/components/dashboards.libsonnet
@@ -149,33 +149,16 @@ function(params)
           local name = d.metadata.name;
           if std.startsWith(name, 'grafana-') then
             [
-              // Strip the "grafana-" from all dashboard configmaps.
+              // Strip the "grafana-" prefix from all configmap names.
               d {
                 metadata+: {
                   name: if std.startsWith(name, 'grafana-') then std.substr(name, std.length('grafana-'), std.length(name)) else name,
                 },
               },
-              // Tell CVO to remove the old dashboard configmaps prefixed by "grafana-".
-              // It can be removed after OCP 4.16 branch is cut.
-              // See https://issues.redhat.com/browse/OCPBUGS-18326.
-              {
-                apiVersion: 'v1',
-                kind: 'ConfigMap',
-                metadata: {
-                  name: name,
-                  namespace: d.metadata.namespace,
-                  annotations: {
-                    'release.openshift.io/delete': 'true',
-                  },
-                },
-              },
             ]
           else
             [d],
-        std.filterMap(
-          // etcd dashboard is deployed by cluster-etcd-operator
-          // PR: https://github.com/openshift/cluster-etcd-operator/pull/837
-          function(d) d.metadata.name != 'grafana-dashboard-etcd',
+        std.map(
           function(d)
             d {
               metadata+: {

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -4,15 +4,6 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/etcd-io/etcd",
-          "subdir": "contrib/mixin"
-        }
-      },
-      "version": "main"
-    },
-    {
-      "source": {
-        "git": {
           "remote": "https://github.com/prometheus-operator/kube-prometheus",
           "subdir": "jsonnet/kube-prometheus"
         }

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "21e5876f7f0539509c277b4c2a3ba1b1599b1721",
+      "version": "9fc3b2ad40f8b681c31ce66ebb27fdcec7c930e6",
       "sum": "IXI3LQIT9NmTPJAk8WLUJd5+qZfcGpeNCyWIK7oEpws="
     },
     {

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -177,12 +177,10 @@ local inCluster =
         local allDashboards =
           $.nodeExporter.mixin.grafanaDashboards +
           $.prometheus.mixin.grafanaDashboards +
-          $.controlPlane.mixin.grafanaDashboards +
-          $.controlPlane.etcdMixin.grafanaDashboards,
+          $.controlPlane.mixin.grafanaDashboards,
         // Allow-listing dashboards that are going into the product. List needs to be sorted for std.setMember to work
         local includeDashboards = std.set([
           'cluster-total.json',
-          'etcd.json',
           'k8s-resources-cluster.json',
           'k8s-resources-namespace.json',
           'k8s-resources-node.json',

--- a/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_01-dashboards.yaml
@@ -1877,18 +1877,6 @@ metadata:
   namespace: openshift-config-managed
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-cluster-total
-  namespace: openshift-config-managed
----
-apiVersion: v1
 data:
   k8s-resources-cluster.json: |-
     {
@@ -4824,18 +4812,6 @@ metadata:
   namespace: openshift-config-managed
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-k8s-resources-cluster
-  namespace: openshift-config-managed
----
-apiVersion: v1
 data:
   k8s-resources-namespace.json: |-
     {
@@ -7492,18 +7468,6 @@ metadata:
   namespace: openshift-config-managed
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-k8s-resources-namespace
-  namespace: openshift-config-managed
----
-apiVersion: v1
 data:
   k8s-resources-node.json: |-
     {
@@ -8502,18 +8466,6 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
   name: dashboard-k8s-resources-node
-  namespace: openshift-config-managed
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-k8s-resources-node
   namespace: openshift-config-managed
 ---
 apiVersion: v1
@@ -10380,18 +10332,6 @@ metadata:
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: dashboard-k8s-resources-pod
-  namespace: openshift-config-managed
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-k8s-resources-pod
   namespace: openshift-config-managed
 ---
 apiVersion: v1
@@ -12320,18 +12260,6 @@ metadata:
     console.openshift.io/dashboard: "true"
     console.openshift.io/odc-dashboard: "true"
   name: dashboard-k8s-resources-workload
-  namespace: openshift-config-managed
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-k8s-resources-workload
   namespace: openshift-config-managed
 ---
 apiVersion: v1
@@ -14416,18 +14344,6 @@ metadata:
   namespace: openshift-config-managed
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-k8s-resources-workloads-namespace
-  namespace: openshift-config-managed
----
-apiVersion: v1
 data:
   namespace-by-pod.json: |-
     {
@@ -15887,18 +15803,6 @@ metadata:
   namespace: openshift-config-managed
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-namespace-by-pod
-  namespace: openshift-config-managed
----
-apiVersion: v1
 data:
   node-cluster-rsrc-use.json: |-
     {
@@ -16953,18 +16857,6 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
   name: dashboard-node-cluster-rsrc-use
-  namespace: openshift-config-managed
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-node-cluster-rsrc-use
   namespace: openshift-config-managed
 ---
 apiVersion: v1
@@ -18076,18 +17968,6 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
   name: dashboard-node-rsrc-use
-  namespace: openshift-config-managed
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-node-rsrc-use
   namespace: openshift-config-managed
 ---
 apiVersion: v1
@@ -19314,18 +19194,6 @@ metadata:
   namespace: openshift-config-managed
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-pod-total
-  namespace: openshift-config-managed
----
-apiVersion: v1
 data:
   prometheus.json: |-
     {
@@ -20541,16 +20409,4 @@ metadata:
     app.kubernetes.io/part-of: openshift-monitoring
     console.openshift.io/dashboard: "true"
   name: dashboard-prometheus
-  namespace: openshift-config-managed
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/delete: "true"
-  name: grafana-dashboard-prometheus
   namespace: openshift-config-managed


### PR DESCRIPTION
This change also removes the dependency on the etcd mixin since everything is now managed by the etcd operator.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
