### PR TITLE
[release-4.14] OCPBUGS-42603: Exclude windows nodes from kubelet servicemonitor

### DIFF
--- a/assets/control-plane/minimal-service-monitor-kubelet.yaml
+++ b/assets/control-plane/minimal-service-monitor-kubelet.yaml
@@ -10,6 +10,8 @@ metadata:
   name: kubelet-minimal
   namespace: openshift-monitoring
 spec:
+  attachMetadata:
+    node: true
   endpoints:
   - bearerTokenFile: ""
     honorLabels: true
@@ -87,6 +89,10 @@ spec:
       - __name__
     port: https-metrics
     relabelings:
+    - action: keep
+      regex: (linux|)
+      sourceLabels:
+      - __meta_kubernetes_node_label_kubernetes_io_os
     - action: replace
       regex: (.+)(?::\d+)
       replacement: $1:9537

--- a/assets/control-plane/service-monitor-kubelet-resource-metrics.yaml
+++ b/assets/control-plane/service-monitor-kubelet-resource-metrics.yaml
@@ -10,6 +10,8 @@ metadata:
   name: kubelet-resource-metrics
   namespace: openshift-monitoring
 spec:
+  attachMetadata:
+    node: true
   endpoints:
   - bearerTokenFile: ""
     honorLabels: true

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -10,6 +10,8 @@ metadata:
   name: kubelet
   namespace: openshift-monitoring
 spec:
+  attachMetadata:
+    node: true
   endpoints:
   - bearerTokenFile: ""
     honorLabels: true
@@ -131,6 +133,10 @@ spec:
   - interval: 30s
     port: https-metrics
     relabelings:
+    - action: keep
+      regex: (linux|)
+      sourceLabels:
+      - __meta_kubernetes_node_label_kubernetes_io_os
     - action: replace
       regex: (.+)(?::\d+)
       replacement: $1:9537

--- a/assets/prometheus-k8s/cluster-role.yaml
+++ b/assets/prometheus-k8s/cluster-role.yaml
@@ -39,6 +39,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - nonroot

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -26,6 +26,9 @@ function(params)
             'k8s-app': 'kubelet',
           },
         },
+        attachMetadata: {
+          node: true,
+        },
         endpoints:
           std.map(
             function(e)
@@ -78,6 +81,11 @@ function(params)
             interval: '30s',
             port: 'https-metrics',
             relabelings: [
+              {
+                sourceLabels: ['__meta_kubernetes_node_label_kubernetes_io_os'],
+                action: 'keep',
+                regex: '(linux|)',
+              },
               {
                 sourceLabels: ['__address__'],
                 action: 'replace',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -157,6 +157,12 @@ function(params)
           resources: ['namespaces'],
           verbs: ['get'],
         },
+        // This is required for the "prometheus-k8s" service account to be able to query the node metadata
+        {
+          apiGroups: [''],
+          resources: ['nodes'],
+          verbs: ['get', 'list', 'watch'],
+        },
         {
           // By default authenticated service accounts are assigned to the `restricted` SCC which implies MustRunAsRange.
           // This is problematic with statefulsets as UIDs (and file permissions) can change if SCCs are elevated.

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -453,6 +453,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - nonroot


### PR DESCRIPTION
overrides https://github.com/openshift/cluster-monitoring-operator/pull/2488