### PR TITLE
NO-JIRA: use scrape class to avoid TLS config repetitions

### DIFF
--- a/assets/alertmanager-user-workload/service-monitor.yaml
+++ b/assets/alertmanager-user-workload/service-monitor.yaml
@@ -17,11 +17,9 @@ spec:
     port: metrics
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: alertmanager-user-workload.openshift-user-workload-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: alert-router

--- a/assets/alertmanager/service-monitor.yaml
+++ b/assets/alertmanager/service-monitor.yaml
@@ -17,11 +17,9 @@ spec:
     port: metrics
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: alertmanager-main.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: alert-router

--- a/assets/cluster-monitoring-operator/service-monitor.yaml
+++ b/assets/cluster-monitoring-operator/service-monitor.yaml
@@ -18,11 +18,9 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: cluster-monitoring-operator.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/name: cluster-monitoring-operator

--- a/assets/control-plane/minimal-service-monitor-kubelet.yaml
+++ b/assets/control-plane/minimal-service-monitor-kubelet.yaml
@@ -31,9 +31,7 @@ spec:
     scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   - bearerTokenFile: ""
     honorLabels: true
     honorTimestamps: true
@@ -56,9 +54,7 @@ spec:
     scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
     trackTimestampsStaleness: true
   - bearerTokenFile: ""
     honorLabels: true
@@ -79,9 +75,7 @@ spec:
     scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   - bearerTokenFile: ""
     interval: 30s
     metricRelabelings:
@@ -112,13 +106,12 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:
     - kube-system
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       k8s-app: kubelet

--- a/assets/control-plane/service-monitor-kubelet.yaml
+++ b/assets/control-plane/service-monitor-kubelet.yaml
@@ -59,9 +59,7 @@ spec:
     scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   - bearerTokenFile: ""
     honorLabels: true
     honorTimestamps: true
@@ -110,9 +108,7 @@ spec:
     scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
     trackTimestampsStaleness: true
   - bearerTokenFile: ""
     honorLabels: true
@@ -128,9 +124,7 @@ spec:
     scrapeTimeout: 30s
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   - bearerTokenFile: ""
     interval: 30s
     port: https-metrics
@@ -156,13 +150,12 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:
     - kube-system
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       k8s-app: kubelet

--- a/assets/kube-state-metrics/minimal-service-monitor.yaml
+++ b/assets/kube-state-metrics/minimal-service-monitor.yaml
@@ -29,10 +29,7 @@ spec:
     scheme: https
     scrapeTimeout: 1m
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: kube-state-metrics.openshift-monitoring.svc
   - bearerTokenFile: ""
     interval: 1m
@@ -45,12 +42,10 @@ spec:
     scheme: https
     scrapeTimeout: 1m
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: kube-state-metrics.openshift-monitoring.svc
   jobLabel: app.kubernetes.io/name
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter

--- a/assets/kube-state-metrics/service-monitor.yaml
+++ b/assets/kube-state-metrics/service-monitor.yaml
@@ -25,10 +25,7 @@ spec:
     scheme: https
     scrapeTimeout: 1m
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: kube-state-metrics.openshift-monitoring.svc
   - bearerTokenFile: ""
     interval: 1m
@@ -36,12 +33,10 @@ spec:
     scheme: https
     scrapeTimeout: 1m
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: kube-state-metrics.openshift-monitoring.svc
   jobLabel: app.kubernetes.io/name
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter

--- a/assets/metrics-server/service-monitor.yaml
+++ b/assets/metrics-server/service-monitor.yaml
@@ -14,11 +14,9 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: metrics-server.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: metrics-server

--- a/assets/node-exporter/minimal-service-monitor.yaml
+++ b/assets/node-exporter/minimal-service-monitor.yaml
@@ -29,12 +29,10 @@ spec:
       targetLabel: instance
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: node-exporter.openshift-monitoring.svc
   jobLabel: app.kubernetes.io/name
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter

--- a/assets/node-exporter/service-monitor.yaml
+++ b/assets/node-exporter/service-monitor.yaml
@@ -38,12 +38,10 @@ spec:
       targetLabel: instance
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: node-exporter.openshift-monitoring.svc
   jobLabel: app.kubernetes.io/name
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: exporter

--- a/assets/openshift-state-metrics/service-monitor.yaml
+++ b/assets/openshift-state-metrics/service-monitor.yaml
@@ -17,9 +17,7 @@ spec:
     scrapeTimeout: 2m
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: openshift-state-metrics.openshift-monitoring.svc
   - bearerTokenFile: ""
     interval: 2m
@@ -28,11 +26,10 @@ spec:
     scrapeTimeout: 2m
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: openshift-state-metrics.openshift-monitoring.svc
   jobLabel: k8s-app
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       k8s-app: openshift-state-metrics

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -196,6 +196,13 @@ spec:
     matchLabels:
       openshift.io/cluster-monitoring: "true"
   ruleSelector: {}
+  scrapeClasses:
+  - name: tls-client-certificate-auth
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      insecureSkipVerify: false
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   scrapeConfigNamespaceSelector: null
   scrapeConfigSelector: null
   secrets:

--- a/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-k8s/service-monitor-thanos-sidecar.yaml
@@ -22,6 +22,7 @@ spec:
       insecureSkipVerify: false
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: prometheus-k8s-thanos-sidecar.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: thanos-sidecar

--- a/assets/prometheus-k8s/service-monitor.yaml
+++ b/assets/prometheus-k8s/service-monitor.yaml
@@ -17,11 +17,9 @@ spec:
     port: metrics
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: prometheus-k8s.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus

--- a/assets/prometheus-operator-user-workload/service-monitor.yaml
+++ b/assets/prometheus-operator-user-workload/service-monitor.yaml
@@ -16,11 +16,9 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: prometheus-operator.openshift-user-workload-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: controller

--- a/assets/prometheus-operator/service-monitor.yaml
+++ b/assets/prometheus-operator/service-monitor.yaml
@@ -16,11 +16,9 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: prometheus-operator.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: controller

--- a/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
+++ b/assets/prometheus-user-workload/service-monitor-thanos-sidecar.yaml
@@ -22,6 +22,7 @@ spec:
       insecureSkipVerify: false
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: prometheus-user-workload-thanos-sidecar.openshift-user-workload-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: thanos-sidecar

--- a/assets/prometheus-user-workload/service-monitor.yaml
+++ b/assets/prometheus-user-workload/service-monitor.yaml
@@ -17,11 +17,9 @@ spec:
     port: metrics
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: prometheus-user-workload.openshift-user-workload-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus

--- a/assets/telemeter-client/service-monitor.yaml
+++ b/assets/telemeter-client/service-monitor.yaml
@@ -14,12 +14,10 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: telemeter-client.openshift-monitoring.svc
   jobLabel: k8s-app
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       k8s-app: telemeter-client

--- a/assets/thanos-querier/service-monitor.yaml
+++ b/assets/thanos-querier/service-monitor.yaml
@@ -17,11 +17,9 @@ spec:
     port: metrics
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: thanos-querier.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: query-layer

--- a/assets/thanos-ruler/service-monitor.yaml
+++ b/assets/thanos-ruler/service-monitor.yaml
@@ -17,11 +17,9 @@ spec:
     port: metrics
     scheme: https
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       insecureSkipVerify: false
-      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
       serverName: thanos-ruler.openshift-user-workload-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
   selector:
     matchLabels:
       app.kubernetes.io/component: rule-evaluation-engine

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -73,8 +73,6 @@ function(params)
       },
     },
 
-    // This changes the alertmanager to be scraped with TLS, authN and authZ,
-    // which are not present in kube-prometheus.
     serviceMonitor+: {
       spec+: {
         endpoints: [
@@ -82,11 +80,6 @@ function(params)
             port: 'metrics',
             interval: '30s',
             scheme: 'https',
-            tlsConfig: {
-              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
-              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
-            },
           },
         ],
       },

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -211,8 +211,6 @@ function(params)
       },
     },
 
-    // This changes the alertmanager to be scraped with TLS, authN and authZ,
-    // which are not present in kube-prometheus.
     serviceMonitor+: {
       spec+: {
         endpoints: [
@@ -220,11 +218,6 @@ function(params)
             port: 'metrics',
             interval: '30s',
             scheme: 'https',
-            tlsConfig: {
-              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
-              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
-            },
           },
         ],
       },

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -130,13 +130,6 @@ function(params) {
         {
           port: 'https',
           scheme: 'https',
-          tlsConfig: {
-            certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
-            keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
-            insecureSkipVerify: false,
-            caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-            serverName: std.format('%s.%s.svc', [cfg.name, cfg.namespace]),
-          },
           metricRelabelings: [
             // Drop metrics that come automatically from the Kubernetes
             // apiserver package but aren't interesting for the cluster

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -212,8 +212,6 @@ function(params)
       }],
     },
 
-    // This changes the Prometheuses to be scraped with TLS, authN and
-    // authZ, which are not present in kube-prometheus.
     serviceMonitor+: {
       spec+: {
         endpoints: [
@@ -221,11 +219,6 @@ function(params)
             port: 'metrics',
             interval: '30s',
             scheme: 'https',
-            tlsConfig: {
-              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
-              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
-            },
           },
         ],
       },

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -270,9 +270,6 @@ function(params)
       data: {},
     },
 
-    // This changes the Prometheuses to be scraped with TLS, authN and
-    // authZ, which are not present in kube-prometheus.
-
     serviceMonitor+: {
       spec+: {
         endpoints: [
@@ -280,11 +277,6 @@ function(params)
             port: 'metrics',
             interval: '30s',
             scheme: 'https',
-            tlsConfig: {
-              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
-              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
-            },
           },
         ],
       },
@@ -576,6 +568,17 @@ function(params)
                 mountPath: '/etc/pki/ca-trust/extracted/pem/',
               },
             ],
+          },
+        ],
+        scrapeClasses: [
+          {
+            name: 'tls-client-certificate-auth',
+            tlsConfig: {
+              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
+              certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
+              keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
+              insecureSkipVerify: false,
+            },
           },
         ],
         volumes+: [

--- a/jsonnet/utils/configure-authentication-for-monitors.libsonnet
+++ b/jsonnet/utils/configure-authentication-for-monitors.libsonnet
@@ -2,40 +2,37 @@
   configureAuthenticationForMonitors(o): {
     local configureAuthentication(o) = o {
       [if o.kind == 'ServiceMonitor' || o.kind == 'PodMonitor' then 'spec']+: {
+        scrapeClass: 'tls-client-certificate-auth',
         [if o.kind == 'ServiceMonitor' then 'endpoints' else 'podMetricsEndpoints']: [
           if std.objectHas(e, 'scheme') && e.scheme == 'https' then
             e {
               bearerTokenFile: '',
-              tlsConfig+: {
-                            certFile: '/etc/prometheus/secrets/metrics-client-certs/tls.crt',
-                            keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
-                            insecureSkipVerify: false,
-                          } +
-                          if !(std.objectHas(o.metadata.labels, 'app.kubernetes.io/name') && o.metadata.labels['app.kubernetes.io/name'] == 'kubelet') then
-                            {
-                              caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt',
-                              // For setting serverName the following logic is applied:
-                              // 1. Prometheus thanos sidecar, the SA that is created for thanos sidescars has a
-                              //    different name than the ServiceMonitor. The name format follows the following convention
-                              //    "prometheus-$PROM_INSTANCE-thanos-sidecar", $PROM_INSTANCE is either "k8s" or "user-workload"
-                              // 2. ServiceMonitors that adopted CollectionProfiles end with -$COLLECTION_PROFILE,
-                              //    thus we strip - and $PROFILE_NAME from o.metadata.name
-                              // 3. Default behaviour for the majority of ServiceMonitors. ServiceMonitor has the same
-                              //    name as the SA
-                              serverName: std.format('%s.%s.svc',
-                                                     [
-                                                       if o.metadata.name == 'thanos-sidecar' then
-                                                         'prometheus-' + o.metadata.labels['app.kubernetes.io/instance'] + '-' + o.metadata.name
-                                                       else
-                                                         if std.objectHas(o.metadata.labels, 'monitoring.openshift.io/collection-profile') then
-                                                           std.rstripChars(o.metadata.name, '-' + o.metadata.labels['monitoring.openshift.io/collection-profile'])
-                                                         else
-                                                           o.metadata.name,
-                                                       o.metadata.namespace,
-                                                     ]),
-                            }
-                          else
-                            {},
+              tlsConfig+:
+                { insecureSkipVerify: false } +
+                if !(std.objectHas(o.metadata.labels, 'app.kubernetes.io/name') && o.metadata.labels['app.kubernetes.io/name'] == 'kubelet') then
+                  {
+                    // For setting serverName the following logic is applied:
+                    // 1. Prometheus thanos sidecar, the SA that is created for thanos sidescars has a
+                    //    different name than the ServiceMonitor. The name format follows the following convention
+                    //    "prometheus-$PROM_INSTANCE-thanos-sidecar", $PROM_INSTANCE is either "k8s" or "user-workload"
+                    // 2. ServiceMonitors that adopted CollectionProfiles end with -$COLLECTION_PROFILE,
+                    //    thus we strip - and $PROFILE_NAME from o.metadata.name
+                    // 3. Default behaviour for the majority of ServiceMonitors. ServiceMonitor has the same
+                    //    name as the SA
+                    serverName: std.format('%s.%s.svc',
+                                           [
+                                             if o.metadata.name == 'thanos-sidecar' then
+                                               'prometheus-' + o.metadata.labels['app.kubernetes.io/instance'] + '-' + o.metadata.name
+                                             else
+                                               if std.objectHas(o.metadata.labels, 'monitoring.openshift.io/collection-profile') then
+                                                 std.rstripChars(o.metadata.name, '-' + o.metadata.labels['monitoring.openshift.io/collection-profile'])
+                                               else
+                                                 o.metadata.name,
+                                             o.metadata.namespace,
+                                           ]),
+                  }
+                else
+                  {},
             }
           else
             e


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
