### PR TITLE
NO-JIRA: fix CMO config for Alertmanager e2e tests

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -19,15 +19,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-openapi/strfmt"
-	"github.com/google/uuid"
 	"io"
-	"k8s.io/utils/ptr"
 	"net/http"
 	"reflect"
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"k8s.io/utils/ptr"
 
 	"github.com/Jeffail/gabs/v2"
 	statusv1 "github.com/openshift/api/config/v1"
@@ -52,10 +53,8 @@ func TestAlertmanagerTenancyAPI(t *testing.T) {
 		amNamespace        string
 	}{
 		{
-			name: "platform-alertmanager",
-			config: `alertmanagerMain:
-  enableUserAlertmanagerConfig: true
-enableUserWorkload: true`,
+			name:               "platform-alertmanager",
+			config:             "",
 			userWorkloadConfig: "",
 			amName:             "main",
 			amNamespace:        f.Ns,
@@ -64,7 +63,6 @@ enableUserWorkload: true`,
 			name:   "user-workload-alertmanager",
 			config: `enableUserWorkload: true`,
 			userWorkloadConfig: `alertmanager:
-  enableUserAlertmanagerConfig: true
   enabled: true`,
 			amName:      "user-workload",
 			amNamespace: f.UserWorkloadMonitoringNs,


### PR DESCRIPTION
From https://github.com/openshift/cluster-monitoring-operator/pull/2493#discussion_r1801187426
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
