### PR TITLE
OCPBUGS-43678: Remove temporary no more needed code

### DIFF
--- a/assets/prometheus-operator/operator-certs-ca-bundle.yaml
+++ b/assets/prometheus-operator/operator-certs-ca-bundle.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/managed-by: cluster-monitoring-operator
-    app.kubernetes.io/part-of: openshift-monitoring
-  name: operator-certs-ca-bundle
-  namespace: openshift-monitoring

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -175,14 +175,4 @@ function(params)
         ],
       },
     },
-
-    // TODO(simonpasquier): remove once 4.13 branch opens.
-    operatorCertsCaBundle: {
-      apiVersion: 'v1',
-      kind: 'ConfigMap',
-      metadata: {
-        name: 'operator-certs-ca-bundle',
-        namespace: params.namespace,
-      },
-    },
   }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -210,7 +210,6 @@ var (
 	PrometheusOperatorDeployment          = "prometheus-operator/deployment.yaml"
 	PrometheusOperatorService             = "prometheus-operator/service.yaml"
 	PrometheusOperatorServiceMonitor      = "prometheus-operator/service-monitor.yaml"
-	PrometheusOperatorCertsCABundle       = "prometheus-operator/operator-certs-ca-bundle.yaml"
 	PrometheusOperatorPrometheusRule      = "prometheus-operator/prometheus-rule.yaml"
 	PrometheusOperatorKubeRbacProxySecret = "prometheus-operator/kube-rbac-proxy-secret.yaml"
 
@@ -1240,10 +1239,6 @@ func (f *Factory) PrometheusK8sKubeletServingCABundle(data map[string]string) (*
 
 	c.Data = data
 	return c, nil
-}
-
-func (f *Factory) PrometheusOperatorCertsCABundle() (*v1.ConfigMap, error) {
-	return f.NewConfigMap(f.assets.MustNewAssetReader(PrometheusOperatorCertsCABundle))
 }
 
 func (f *Factory) PrometheusK8sThanosSidecarServiceMonitor() (*monv1.ServiceMonitor, error) {

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -20,8 +20,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
@@ -419,22 +417,5 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Prometheus Thanos sidecar ServiceMonitor failed")
 	}
 
-	return t.cleanup(ctx)
-}
-
-// Delete unwanted objects related to Grafana
-// This can be removed in 4.13 release
-func (t *PrometheusTask) cleanup(ctx context.Context) error {
-	htpasswdSecret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "openshift-monitoring",
-			Name:      "prometheus-k8s-htpasswd",
-		},
-		Type: v1.SecretTypeOpaque,
-	}
-	err := t.client.DeleteSecret(ctx, htpasswdSecret)
-	if err != nil {
-		return errors.Wrap(err, "deleting prometheus Htpasswd Secret failed")
-	}
 	return nil
 }

--- a/pkg/tasks/prometheusoperator.go
+++ b/pkg/tasks/prometheusoperator.go
@@ -35,18 +35,6 @@ func NewPrometheusOperatorTask(client *client.Client, factory *manifests.Factory
 }
 
 func (t *PrometheusOperatorTask) Run(ctx context.Context) error {
-	// TODO(simonpasquier): remove this section once 4.13 branch opens.
-	cacm, err := t.factory.PrometheusOperatorCertsCABundle()
-	if err != nil {
-		return errors.Wrap(err, "initializing serving certs CA Bundle ConfigMap failed")
-	}
-
-	err = t.client.DeleteConfigMap(ctx, cacm)
-	if err != nil {
-		return errors.Wrap(err, "deleting serving certs CA Bundle ConfigMap failed")
-	}
-	// TODO(simonpasquier): end
-
 	sa, err := t.factory.PrometheusOperatorServiceAccount()
 	if err != nil {
 		return errors.Wrap(err, "initializing Prometheus Operator ServiceAccount failed")

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -20,8 +20,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ThanosQuerierTask struct {
@@ -245,22 +243,5 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "reconciling Thanos Querier PrometheusRule failed")
 	}
 
-	return t.cleanup(ctx)
-}
-
-// Delete unwanted objects related to Grafana
-// This can be removed in 4.13 release
-func (t *ThanosQuerierTask) cleanup(ctx context.Context) error {
-	htpasswdSecret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "openshift-monitoring",
-			Name:      "thanos-querier-oauth-htpasswd",
-		},
-		Type: v1.SecretTypeOpaque,
-	}
-	err := t.client.DeleteSecret(ctx, htpasswdSecret)
-	if err != nil {
-		return errors.Wrap(err, "deleting Thanos Querier Htpasswd Secret failed")
-	}
 	return nil
 }

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -20,8 +20,6 @@ import (
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ThanosRulerUserWorkloadTask struct {
@@ -283,7 +281,7 @@ func (t *ThanosRulerUserWorkloadTask) create(ctx context.Context) error {
 		}
 	}
 
-	return t.cleanup(ctx)
+	return nil
 }
 
 func (t *ThanosRulerUserWorkloadTask) destroy(ctx context.Context) error {
@@ -462,24 +460,6 @@ func (t *ThanosRulerUserWorkloadTask) destroy(ctx context.Context) error {
 	err = t.client.DeleteServiceMonitor(ctx, trsm)
 	if err != nil {
 		return errors.Wrap(err, "deleting Thanos Ruler ServiceMonitor failed")
-	}
-	return t.cleanup(ctx)
-}
-
-// Delete unwanted objects related to Grafana
-// This can be removed in 4.13 release
-func (t *ThanosRulerUserWorkloadTask) cleanup(ctx context.Context) error {
-	htpasswdSecret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "openshift-user-workload-monitoring",
-			Name:      "thanos-ruler-oauth-htpasswd",
-		},
-		Type: v1.SecretTypeOpaque,
-	}
-
-	err := t.client.DeleteSecret(ctx, htpasswdSecret)
-	if err != nil {
-		return errors.Wrap(err, "deleting Thanos Ruler oauth Htpasswd Secret failed")
 	}
 	return nil
 }


### PR DESCRIPTION
pkg/tasks/prometheusoperator.go: Remove code introduced in https://github.com/openshift/cluster-monitoring-operator/pull/1806

pkg/tasks/{prometheus.go, thanos_ruler_user_workload.go, thanos_querier.go}: Remove cleanup code added in https://github.com/openshift/cluster-monitoring-operator/pull/1731

Was done for 4.15 in https://github.com/openshift/cluster-monitoring-operator/pull/2132

Make some users who don't want to see the unnecessary 404 on 4.14, happy. 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
