### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -21,6 +21,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app.kubernetes.io/component: metrics-server

--- a/jsonnet/components/metrics-server.libsonnet
+++ b/jsonnet/components/metrics-server.libsonnet
@@ -167,6 +167,9 @@ function(params) {
             'app.kubernetes.io/name': 'metrics-server',
             'app.kubernetes.io/component': 'metrics-server',
           } + cfg.commonLabels,
+          annotations+: {
+            'openshift.io/required-scc': 'restricted-v2',
+          },
         },
         spec: {
           affinity: {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.

This PR sets the required SCC explicitly on each workload in openshift-* namespaces. The SCC chosen is the one that the pods are getting admitted with, so no change expected there. This is to protect the pods from getting admitted with a different custom SCC than the one intended.

