### PR TITLE
[release-4.17] OCPBUGS-43545: Fix api doc on Thanos Ruler default retention

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -611,7 +611,7 @@ The `ThanosRulerConfig` resource defines configuration for the Thanos Ruler inst
 | logLevel | string | Defines the log level setting for Thanos Ruler. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`. |
 | nodeSelector | map[string]string | Defines the nodes on which the Pods are scheduled. |
 | resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core) | Defines resource requests and limits for the Thanos Ruler container. |
-| retention | string | Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`. |
+| retention | string | Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `24h`. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#toleration-v1-core) | Defines tolerations for the pods. |
 | topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines topology spread constraints for the pods. |
 | volumeClaimTemplate | *[monv1.EmbeddedPersistentVolumeClaim](https://github.com/prometheus-operator/prometheus-operator/blob/v0.74.0/Documentation/api.md#embeddedpersistentvolumeclaim) | Defines persistent storage for Thanos Ruler. Use this setting to configure the storage class and size of a volume. |

--- a/Documentation/openshiftdocs/modules/thanosrulerconfig.adoc
+++ b/Documentation/openshiftdocs/modules/thanosrulerconfig.adoc
@@ -26,7 +26,7 @@ Appears in: link:userworkloadconfiguration.adoc[UserWorkloadConfiguration]
 
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the Thanos Ruler container.
 
-|retention|string|Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`.
+|retention|string|Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `24h`.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -675,7 +675,7 @@ type ThanosRulerConfig struct {
 	// This definition must be specified using the following regular
 	// expression pattern: `[0-9]+(ms|s|m|h|d|w|y)` (ms = milliseconds,
 	// s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years).
-	// The default value is `15d`.
+	// The default value is `24h`.
 	Retention string `json:"retention,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
