### PR TITLE
Use protobuf if possible for core kubernetes clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -150,3 +150,5 @@ require (
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace k8s.io/client-go => github.com/vrutkovs/client-go v0.0.0-20241029114452-7f4b7d7b258d

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
+github.com/vrutkovs/client-go v0.0.0-20241029114452-7f4b7d7b258d h1:NCiralpoWwjr976MaOHpFivNUZAzdgMxY4mbj3w1EE8=
+github.com/vrutkovs/client-go v0.0.0-20241029114452-7f4b7d7b258d/go.mod h1:2bbCJ3Sd+yFlCoexz86XNKsJ8hBFUVTeHsjEhrODbfE=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
@@ -864,8 +866,6 @@ k8s.io/apiserver v0.31.1 h1:Sars5ejQDCRBY5f7R3QFHdqN3s61nhkpaX8/k1iEw1c=
 k8s.io/apiserver v0.31.1/go.mod h1:lzDhpeToamVZJmmFlaLwdYZwd7zB+WYRYIboqA1kGxM=
 k8s.io/autoscaler/vertical-pod-autoscaler v1.0.0 h1:y0TgWoHaeYEv3L1MfLC+D2WVxyN1fGr6axURHXq+wHE=
 k8s.io/autoscaler/vertical-pod-autoscaler v1.0.0/go.mod h1:w6/LjLR3DPQd57vlgvgbpzpuJKsCiily0+OzQI+nyfI=
-k8s.io/client-go v0.31.1 h1:f0ugtWSbWpxHR7sjVpQwuvw9a3ZKLXX0u0itkFXufb0=
-k8s.io/client-go v0.31.1/go.mod h1:sKI8871MJN2OyeqRlmA4W4KM9KBdBUpDLu/43eGemCg=
 k8s.io/component-base v0.31.1 h1:UpOepcrX3rQ3ab5NB6g5iP0tvsgJWzxTyAo20sgYSy8=
 k8s.io/component-base v0.31.1/go.mod h1:WGeaw7t/kTsqpVTaCoVEtillbqAhF2/JgvO0LDOMa0w=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=

--- a/vendor/k8s.io/client-go/gentype/type.go
+++ b/vendor/k8s.io/client-go/gentype/type.go
@@ -51,6 +51,8 @@ type Client[T objectWithMeta] struct {
 	namespace      string // "" for non-namespaced clients
 	newObject      func() T
 	parameterCodec runtime.ParameterCodec
+
+	prefersProtobuf bool
 }
 
 // ClientWithList represents a client with support for lists.
@@ -82,26 +84,37 @@ type alsoApplier[T objectWithMeta, C namedObject] struct {
 	client *Client[T]
 }
 
+type Option[T objectWithMeta] func(*Client[T])
+
+func PrefersProtobuf[T objectWithMeta]() Option[T] {
+	return func(c *Client[T]) { c.prefersProtobuf = true }
+}
+
 // NewClient constructs a client, namespaced or not, with no support for lists or apply.
 // Non-namespaced clients are constructed by passing an empty namespace ("").
 func NewClient[T objectWithMeta](
 	resource string, client rest.Interface, parameterCodec runtime.ParameterCodec, namespace string, emptyObjectCreator func() T,
+	options ...Option[T],
 ) *Client[T] {
-	return &Client[T]{
+	c := &Client[T]{
 		resource:       resource,
 		client:         client,
 		parameterCodec: parameterCodec,
 		namespace:      namespace,
 		newObject:      emptyObjectCreator,
 	}
+	for _, option := range options {
+		option(c)
+	}
+	return c
 }
 
 // NewClientWithList constructs a namespaced client with support for lists.
 func NewClientWithList[T objectWithMeta, L runtime.Object](
 	resource string, client rest.Interface, parameterCodec runtime.ParameterCodec, namespace string, emptyObjectCreator func() T,
-	emptyListCreator func() L,
+	emptyListCreator func() L, options ...Option[T],
 ) *ClientWithList[T, L] {
-	typeClient := NewClient[T](resource, client, parameterCodec, namespace, emptyObjectCreator)
+	typeClient := NewClient[T](resource, client, parameterCodec, namespace, emptyObjectCreator, options...)
 	return &ClientWithList[T, L]{
 		typeClient,
 		alsoLister[T, L]{typeClient, emptyListCreator},
@@ -111,8 +124,9 @@ func NewClientWithList[T objectWithMeta, L runtime.Object](
 // NewClientWithApply constructs a namespaced client with support for apply declarative configurations.
 func NewClientWithApply[T objectWithMeta, C namedObject](
 	resource string, client rest.Interface, parameterCodec runtime.ParameterCodec, namespace string, emptyObjectCreator func() T,
+	options ...Option[T],
 ) *ClientWithApply[T, C] {
-	typeClient := NewClient[T](resource, client, parameterCodec, namespace, emptyObjectCreator)
+	typeClient := NewClient[T](resource, client, parameterCodec, namespace, emptyObjectCreator, options...)
 	return &ClientWithApply[T, C]{
 		typeClient,
 		alsoApplier[T, C]{typeClient},
@@ -122,9 +136,9 @@ func NewClientWithApply[T objectWithMeta, C namedObject](
 // NewClientWithListAndApply constructs a client with support for lists and applying declarative configurations.
 func NewClientWithListAndApply[T objectWithMeta, L runtime.Object, C namedObject](
 	resource string, client rest.Interface, parameterCodec runtime.ParameterCodec, namespace string, emptyObjectCreator func() T,
-	emptyListCreator func() L,
+	emptyListCreator func() L, options ...Option[T],
 ) *ClientWithListAndApply[T, L, C] {
-	typeClient := NewClient[T](resource, client, parameterCodec, namespace, emptyObjectCreator)
+	typeClient := NewClient[T](resource, client, parameterCodec, namespace, emptyObjectCreator, options...)
 	return &ClientWithListAndApply[T, L, C]{
 		typeClient,
 		alsoLister[T, L]{typeClient, emptyListCreator},
@@ -146,6 +160,7 @@ func (c *Client[T]) GetNamespace() string {
 func (c *Client[T]) Get(ctx context.Context, name string, options metav1.GetOptions) (T, error) {
 	result := c.newObject()
 	err := c.client.Get().
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
 		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(c.resource).
 		Name(name).
@@ -181,6 +196,7 @@ func (l *alsoLister[T, L]) list(ctx context.Context, opts metav1.ListOptions) (L
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	err := l.client.client.Get().
+		UseProtobufAsDefaultIfPreferred(l.client.prefersProtobuf).
 		NamespaceIfScoped(l.client.namespace, l.client.namespace != "").
 		Resource(l.client.resource).
 		VersionedParams(&opts, l.client.parameterCodec).
@@ -198,6 +214,7 @@ func (l *alsoLister[T, L]) watchList(ctx context.Context, opts metav1.ListOption
 	}
 	result = l.newList()
 	err = l.client.client.Get().
+		UseProtobufAsDefaultIfPreferred(l.client.prefersProtobuf).
 		NamespaceIfScoped(l.client.namespace, l.client.namespace != "").
 		Resource(l.client.resource).
 		VersionedParams(&opts, l.client.parameterCodec).
@@ -215,6 +232,7 @@ func (c *Client[T]) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 	}
 	opts.Watch = true
 	return c.client.Get().
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
 		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(c.resource).
 		VersionedParams(&opts, c.parameterCodec).
@@ -226,6 +244,7 @@ func (c *Client[T]) Watch(ctx context.Context, opts metav1.ListOptions) (watch.I
 func (c *Client[T]) Create(ctx context.Context, obj T, opts metav1.CreateOptions) (T, error) {
 	result := c.newObject()
 	err := c.client.Post().
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
 		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(c.resource).
 		VersionedParams(&opts, c.parameterCodec).
@@ -239,6 +258,7 @@ func (c *Client[T]) Create(ctx context.Context, obj T, opts metav1.CreateOptions
 func (c *Client[T]) Update(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error) {
 	result := c.newObject()
 	err := c.client.Put().
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
 		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(c.resource).
 		Name(obj.GetName()).
@@ -253,6 +273,7 @@ func (c *Client[T]) Update(ctx context.Context, obj T, opts metav1.UpdateOptions
 func (c *Client[T]) UpdateStatus(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error) {
 	result := c.newObject()
 	err := c.client.Put().
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
 		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(c.resource).
 		Name(obj.GetName()).
@@ -267,6 +288,7 @@ func (c *Client[T]) UpdateStatus(ctx context.Context, obj T, opts metav1.UpdateO
 // Delete takes name of the resource and deletes it. Returns an error if one occurs.
 func (c *Client[T]) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
 		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(c.resource).
 		Name(name).
@@ -282,6 +304,7 @@ func (l *alsoLister[T, L]) DeleteCollection(ctx context.Context, opts metav1.Del
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return l.client.client.Delete().
+		UseProtobufAsDefaultIfPreferred(l.client.prefersProtobuf).
 		NamespaceIfScoped(l.client.namespace, l.client.namespace != "").
 		Resource(l.client.resource).
 		VersionedParams(&listOpts, l.client.parameterCodec).
@@ -295,6 +318,7 @@ func (l *alsoLister[T, L]) DeleteCollection(ctx context.Context, opts metav1.Del
 func (c *Client[T]) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (T, error) {
 	result := c.newObject()
 	err := c.client.Patch(pt).
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
 		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(c.resource).
 		Name(name).
@@ -321,6 +345,7 @@ func (a *alsoApplier[T, C]) Apply(ctx context.Context, obj C, opts metav1.ApplyO
 		return *new(T), fmt.Errorf("obj.Name must be provided to Apply")
 	}
 	err = a.client.client.Patch(types.ApplyPatchType).
+		UseProtobufAsDefaultIfPreferred(a.client.prefersProtobuf).
 		NamespaceIfScoped(a.client.namespace, a.client.namespace != "").
 		Resource(a.client.resource).
 		Name(*obj.GetName()).
@@ -348,6 +373,7 @@ func (a *alsoApplier[T, C]) ApplyStatus(ctx context.Context, obj C, opts metav1.
 
 	result := a.client.newObject()
 	err = a.client.client.Patch(types.ApplyPatchType).
+		UseProtobufAsDefaultIfPreferred(a.client.prefersProtobuf).
 		NamespaceIfScoped(a.client.namespace, a.client.namespace != "").
 		Resource(a.client.resource).
 		Name(*obj.GetName()).

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -64,6 +64,8 @@ func newMutatingWebhookConfigurations(c *AdmissionregistrationV1Client) *mutatin
 			scheme.ParameterCodec,
 			"",
 			func() *v1.MutatingWebhookConfiguration { return &v1.MutatingWebhookConfiguration{} },
-			func() *v1.MutatingWebhookConfigurationList { return &v1.MutatingWebhookConfigurationList{} }),
+			func() *v1.MutatingWebhookConfigurationList { return &v1.MutatingWebhookConfigurationList{} },
+			gentype.PrefersProtobuf[*v1.MutatingWebhookConfiguration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicy.go
@@ -68,6 +68,8 @@ func newValidatingAdmissionPolicies(c *AdmissionregistrationV1Client) *validatin
 			scheme.ParameterCodec,
 			"",
 			func() *v1.ValidatingAdmissionPolicy { return &v1.ValidatingAdmissionPolicy{} },
-			func() *v1.ValidatingAdmissionPolicyList { return &v1.ValidatingAdmissionPolicyList{} }),
+			func() *v1.ValidatingAdmissionPolicyList { return &v1.ValidatingAdmissionPolicyList{} },
+			gentype.PrefersProtobuf[*v1.ValidatingAdmissionPolicy](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -64,6 +64,8 @@ func newValidatingAdmissionPolicyBindings(c *AdmissionregistrationV1Client) *val
 			scheme.ParameterCodec,
 			"",
 			func() *v1.ValidatingAdmissionPolicyBinding { return &v1.ValidatingAdmissionPolicyBinding{} },
-			func() *v1.ValidatingAdmissionPolicyBindingList { return &v1.ValidatingAdmissionPolicyBindingList{} }),
+			func() *v1.ValidatingAdmissionPolicyBindingList { return &v1.ValidatingAdmissionPolicyBindingList{} },
+			gentype.PrefersProtobuf[*v1.ValidatingAdmissionPolicyBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -64,6 +64,8 @@ func newValidatingWebhookConfigurations(c *AdmissionregistrationV1Client) *valid
 			scheme.ParameterCodec,
 			"",
 			func() *v1.ValidatingWebhookConfiguration { return &v1.ValidatingWebhookConfiguration{} },
-			func() *v1.ValidatingWebhookConfigurationList { return &v1.ValidatingWebhookConfigurationList{} }),
+			func() *v1.ValidatingWebhookConfigurationList { return &v1.ValidatingWebhookConfigurationList{} },
+			gentype.PrefersProtobuf[*v1.ValidatingWebhookConfiguration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -68,6 +68,8 @@ func newValidatingAdmissionPolicies(c *AdmissionregistrationV1alpha1Client) *val
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.ValidatingAdmissionPolicy { return &v1alpha1.ValidatingAdmissionPolicy{} },
-			func() *v1alpha1.ValidatingAdmissionPolicyList { return &v1alpha1.ValidatingAdmissionPolicyList{} }),
+			func() *v1alpha1.ValidatingAdmissionPolicyList { return &v1alpha1.ValidatingAdmissionPolicyList{} },
+			gentype.PrefersProtobuf[*v1alpha1.ValidatingAdmissionPolicy](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -66,6 +66,8 @@ func newValidatingAdmissionPolicyBindings(c *AdmissionregistrationV1alpha1Client
 			func() *v1alpha1.ValidatingAdmissionPolicyBinding { return &v1alpha1.ValidatingAdmissionPolicyBinding{} },
 			func() *v1alpha1.ValidatingAdmissionPolicyBindingList {
 				return &v1alpha1.ValidatingAdmissionPolicyBindingList{}
-			}),
+			},
+			gentype.PrefersProtobuf[*v1alpha1.ValidatingAdmissionPolicyBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -64,6 +64,8 @@ func newMutatingWebhookConfigurations(c *AdmissionregistrationV1beta1Client) *mu
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.MutatingWebhookConfiguration { return &v1beta1.MutatingWebhookConfiguration{} },
-			func() *v1beta1.MutatingWebhookConfigurationList { return &v1beta1.MutatingWebhookConfigurationList{} }),
+			func() *v1beta1.MutatingWebhookConfigurationList { return &v1beta1.MutatingWebhookConfigurationList{} },
+			gentype.PrefersProtobuf[*v1beta1.MutatingWebhookConfiguration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -68,6 +68,8 @@ func newValidatingAdmissionPolicies(c *AdmissionregistrationV1beta1Client) *vali
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.ValidatingAdmissionPolicy { return &v1beta1.ValidatingAdmissionPolicy{} },
-			func() *v1beta1.ValidatingAdmissionPolicyList { return &v1beta1.ValidatingAdmissionPolicyList{} }),
+			func() *v1beta1.ValidatingAdmissionPolicyList { return &v1beta1.ValidatingAdmissionPolicyList{} },
+			gentype.PrefersProtobuf[*v1beta1.ValidatingAdmissionPolicy](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -66,6 +66,8 @@ func newValidatingAdmissionPolicyBindings(c *AdmissionregistrationV1beta1Client)
 			func() *v1beta1.ValidatingAdmissionPolicyBinding { return &v1beta1.ValidatingAdmissionPolicyBinding{} },
 			func() *v1beta1.ValidatingAdmissionPolicyBindingList {
 				return &v1beta1.ValidatingAdmissionPolicyBindingList{}
-			}),
+			},
+			gentype.PrefersProtobuf[*v1beta1.ValidatingAdmissionPolicyBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -66,6 +66,8 @@ func newValidatingWebhookConfigurations(c *AdmissionregistrationV1beta1Client) *
 			func() *v1beta1.ValidatingWebhookConfiguration { return &v1beta1.ValidatingWebhookConfiguration{} },
 			func() *v1beta1.ValidatingWebhookConfigurationList {
 				return &v1beta1.ValidatingWebhookConfigurationList{}
-			}),
+			},
+			gentype.PrefersProtobuf[*v1beta1.ValidatingWebhookConfiguration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
@@ -68,6 +68,8 @@ func newStorageVersions(c *InternalV1alpha1Client) *storageVersions {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.StorageVersion { return &v1alpha1.StorageVersion{} },
-			func() *v1alpha1.StorageVersionList { return &v1alpha1.StorageVersionList{} }),
+			func() *v1alpha1.StorageVersionList { return &v1alpha1.StorageVersionList{} },
+			gentype.PrefersProtobuf[*v1alpha1.StorageVersion](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -64,6 +64,8 @@ func newControllerRevisions(c *AppsV1Client, namespace string) *controllerRevisi
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.ControllerRevision { return &v1.ControllerRevision{} },
-			func() *v1.ControllerRevisionList { return &v1.ControllerRevisionList{} }),
+			func() *v1.ControllerRevisionList { return &v1.ControllerRevisionList{} },
+			gentype.PrefersProtobuf[*v1.ControllerRevision](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -68,6 +68,8 @@ func newDaemonSets(c *AppsV1Client, namespace string) *daemonSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.DaemonSet { return &v1.DaemonSet{} },
-			func() *v1.DaemonSetList { return &v1.DaemonSetList{} }),
+			func() *v1.DaemonSetList { return &v1.DaemonSetList{} },
+			gentype.PrefersProtobuf[*v1.DaemonSet](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -76,7 +76,9 @@ func newDeployments(c *AppsV1Client, namespace string) *deployments {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Deployment { return &v1.Deployment{} },
-			func() *v1.DeploymentList { return &v1.DeploymentList{} }),
+			func() *v1.DeploymentList { return &v1.DeploymentList{} },
+			gentype.PrefersProtobuf[*v1.Deployment](),
+		),
 	}
 }
 
@@ -84,6 +86,7 @@ func newDeployments(c *AppsV1Client, namespace string) *deployments {
 func (c *deployments) GetScale(ctx context.Context, deploymentName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deployments").
 		Name(deploymentName).
@@ -98,6 +101,7 @@ func (c *deployments) GetScale(ctx context.Context, deploymentName string, optio
 func (c *deployments) UpdateScale(ctx context.Context, deploymentName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deployments").
 		Name(deploymentName).
@@ -123,6 +127,7 @@ func (c *deployments) ApplyScale(ctx context.Context, deploymentName string, sca
 
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Patch(types.ApplyPatchType).
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deployments").
 		Name(deploymentName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -76,7 +76,9 @@ func newReplicaSets(c *AppsV1Client, namespace string) *replicaSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.ReplicaSet { return &v1.ReplicaSet{} },
-			func() *v1.ReplicaSetList { return &v1.ReplicaSetList{} }),
+			func() *v1.ReplicaSetList { return &v1.ReplicaSetList{} },
+			gentype.PrefersProtobuf[*v1.ReplicaSet](),
+		),
 	}
 }
 
@@ -84,6 +86,7 @@ func newReplicaSets(c *AppsV1Client, namespace string) *replicaSets {
 func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("replicasets").
 		Name(replicaSetName).
@@ -98,6 +101,7 @@ func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, optio
 func (c *replicaSets) UpdateScale(ctx context.Context, replicaSetName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("replicasets").
 		Name(replicaSetName).
@@ -123,6 +127,7 @@ func (c *replicaSets) ApplyScale(ctx context.Context, replicaSetName string, sca
 
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Patch(types.ApplyPatchType).
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("replicasets").
 		Name(replicaSetName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -76,7 +76,9 @@ func newStatefulSets(c *AppsV1Client, namespace string) *statefulSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.StatefulSet { return &v1.StatefulSet{} },
-			func() *v1.StatefulSetList { return &v1.StatefulSetList{} }),
+			func() *v1.StatefulSetList { return &v1.StatefulSetList{} },
+			gentype.PrefersProtobuf[*v1.StatefulSet](),
+		),
 	}
 }
 
@@ -84,6 +86,7 @@ func newStatefulSets(c *AppsV1Client, namespace string) *statefulSets {
 func (c *statefulSets) GetScale(ctx context.Context, statefulSetName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("statefulsets").
 		Name(statefulSetName).
@@ -98,6 +101,7 @@ func (c *statefulSets) GetScale(ctx context.Context, statefulSetName string, opt
 func (c *statefulSets) UpdateScale(ctx context.Context, statefulSetName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("statefulsets").
 		Name(statefulSetName).
@@ -123,6 +127,7 @@ func (c *statefulSets) ApplyScale(ctx context.Context, statefulSetName string, s
 
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Patch(types.ApplyPatchType).
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("statefulsets").
 		Name(statefulSetName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -64,6 +64,8 @@ func newControllerRevisions(c *AppsV1beta1Client, namespace string) *controllerR
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.ControllerRevision { return &v1beta1.ControllerRevision{} },
-			func() *v1beta1.ControllerRevisionList { return &v1beta1.ControllerRevisionList{} }),
+			func() *v1beta1.ControllerRevisionList { return &v1beta1.ControllerRevisionList{} },
+			gentype.PrefersProtobuf[*v1beta1.ControllerRevision](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -68,6 +68,8 @@ func newDeployments(c *AppsV1beta1Client, namespace string) *deployments {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.Deployment { return &v1beta1.Deployment{} },
-			func() *v1beta1.DeploymentList { return &v1beta1.DeploymentList{} }),
+			func() *v1beta1.DeploymentList { return &v1beta1.DeploymentList{} },
+			gentype.PrefersProtobuf[*v1beta1.Deployment](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -68,6 +68,8 @@ func newStatefulSets(c *AppsV1beta1Client, namespace string) *statefulSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.StatefulSet { return &v1beta1.StatefulSet{} },
-			func() *v1beta1.StatefulSetList { return &v1beta1.StatefulSetList{} }),
+			func() *v1beta1.StatefulSetList { return &v1beta1.StatefulSetList{} },
+			gentype.PrefersProtobuf[*v1beta1.StatefulSet](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -64,6 +64,8 @@ func newControllerRevisions(c *AppsV1beta2Client, namespace string) *controllerR
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta2.ControllerRevision { return &v1beta2.ControllerRevision{} },
-			func() *v1beta2.ControllerRevisionList { return &v1beta2.ControllerRevisionList{} }),
+			func() *v1beta2.ControllerRevisionList { return &v1beta2.ControllerRevisionList{} },
+			gentype.PrefersProtobuf[*v1beta2.ControllerRevision](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -68,6 +68,8 @@ func newDaemonSets(c *AppsV1beta2Client, namespace string) *daemonSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta2.DaemonSet { return &v1beta2.DaemonSet{} },
-			func() *v1beta2.DaemonSetList { return &v1beta2.DaemonSetList{} }),
+			func() *v1beta2.DaemonSetList { return &v1beta2.DaemonSetList{} },
+			gentype.PrefersProtobuf[*v1beta2.DaemonSet](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -68,6 +68,8 @@ func newDeployments(c *AppsV1beta2Client, namespace string) *deployments {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta2.Deployment { return &v1beta2.Deployment{} },
-			func() *v1beta2.DeploymentList { return &v1beta2.DeploymentList{} }),
+			func() *v1beta2.DeploymentList { return &v1beta2.DeploymentList{} },
+			gentype.PrefersProtobuf[*v1beta2.Deployment](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -68,6 +68,8 @@ func newReplicaSets(c *AppsV1beta2Client, namespace string) *replicaSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta2.ReplicaSet { return &v1beta2.ReplicaSet{} },
-			func() *v1beta2.ReplicaSetList { return &v1beta2.ReplicaSetList{} }),
+			func() *v1beta2.ReplicaSetList { return &v1beta2.ReplicaSetList{} },
+			gentype.PrefersProtobuf[*v1beta2.ReplicaSet](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -74,7 +74,9 @@ func newStatefulSets(c *AppsV1beta2Client, namespace string) *statefulSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta2.StatefulSet { return &v1beta2.StatefulSet{} },
-			func() *v1beta2.StatefulSetList { return &v1beta2.StatefulSetList{} }),
+			func() *v1beta2.StatefulSetList { return &v1beta2.StatefulSetList{} },
+			gentype.PrefersProtobuf[*v1beta2.StatefulSet](),
+		),
 	}
 }
 
@@ -82,6 +84,7 @@ func newStatefulSets(c *AppsV1beta2Client, namespace string) *statefulSets {
 func (c *statefulSets) GetScale(ctx context.Context, statefulSetName string, options v1.GetOptions) (result *v1beta2.Scale, err error) {
 	result = &v1beta2.Scale{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("statefulsets").
 		Name(statefulSetName).
@@ -96,6 +99,7 @@ func (c *statefulSets) GetScale(ctx context.Context, statefulSetName string, opt
 func (c *statefulSets) UpdateScale(ctx context.Context, statefulSetName string, scale *v1beta2.Scale, opts v1.UpdateOptions) (result *v1beta2.Scale, err error) {
 	result = &v1beta2.Scale{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("statefulsets").
 		Name(statefulSetName).
@@ -121,6 +125,7 @@ func (c *statefulSets) ApplyScale(ctx context.Context, statefulSetName string, s
 
 	result = &v1beta2.Scale{}
 	err = c.GetClient().Patch(types.ApplyPatchType).
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("statefulsets").
 		Name(statefulSetName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1/selfsubjectreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1/selfsubjectreview.go
@@ -52,6 +52,8 @@ func newSelfSubjectReviews(c *AuthenticationV1Client) *selfSubjectReviews {
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1.SelfSubjectReview { return &v1.SelfSubjectReview{} }),
+			func() *v1.SelfSubjectReview { return &v1.SelfSubjectReview{} },
+			gentype.PrefersProtobuf[*v1.SelfSubjectReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview.go
@@ -52,6 +52,8 @@ func newTokenReviews(c *AuthenticationV1Client) *tokenReviews {
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1.TokenReview { return &v1.TokenReview{} }),
+			func() *v1.TokenReview { return &v1.TokenReview{} },
+			gentype.PrefersProtobuf[*v1.TokenReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1alpha1/selfsubjectreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1alpha1/selfsubjectreview.go
@@ -52,6 +52,8 @@ func newSelfSubjectReviews(c *AuthenticationV1alpha1Client) *selfSubjectReviews 
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1alpha1.SelfSubjectReview { return &v1alpha1.SelfSubjectReview{} }),
+			func() *v1alpha1.SelfSubjectReview { return &v1alpha1.SelfSubjectReview{} },
+			gentype.PrefersProtobuf[*v1alpha1.SelfSubjectReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/selfsubjectreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/selfsubjectreview.go
@@ -52,6 +52,8 @@ func newSelfSubjectReviews(c *AuthenticationV1beta1Client) *selfSubjectReviews {
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1beta1.SelfSubjectReview { return &v1beta1.SelfSubjectReview{} }),
+			func() *v1beta1.SelfSubjectReview { return &v1beta1.SelfSubjectReview{} },
+			gentype.PrefersProtobuf[*v1beta1.SelfSubjectReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
@@ -52,6 +52,8 @@ func newTokenReviews(c *AuthenticationV1beta1Client) *tokenReviews {
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1beta1.TokenReview { return &v1beta1.TokenReview{} }),
+			func() *v1beta1.TokenReview { return &v1beta1.TokenReview{} },
+			gentype.PrefersProtobuf[*v1beta1.TokenReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
@@ -52,6 +52,8 @@ func newLocalSubjectAccessReviews(c *AuthorizationV1Client, namespace string) *l
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1.LocalSubjectAccessReview { return &v1.LocalSubjectAccessReview{} }),
+			func() *v1.LocalSubjectAccessReview { return &v1.LocalSubjectAccessReview{} },
+			gentype.PrefersProtobuf[*v1.LocalSubjectAccessReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
@@ -52,6 +52,8 @@ func newSelfSubjectAccessReviews(c *AuthorizationV1Client) *selfSubjectAccessRev
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1.SelfSubjectAccessReview { return &v1.SelfSubjectAccessReview{} }),
+			func() *v1.SelfSubjectAccessReview { return &v1.SelfSubjectAccessReview{} },
+			gentype.PrefersProtobuf[*v1.SelfSubjectAccessReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
@@ -52,6 +52,8 @@ func newSelfSubjectRulesReviews(c *AuthorizationV1Client) *selfSubjectRulesRevie
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1.SelfSubjectRulesReview { return &v1.SelfSubjectRulesReview{} }),
+			func() *v1.SelfSubjectRulesReview { return &v1.SelfSubjectRulesReview{} },
+			gentype.PrefersProtobuf[*v1.SelfSubjectRulesReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
@@ -52,6 +52,8 @@ func newSubjectAccessReviews(c *AuthorizationV1Client) *subjectAccessReviews {
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1.SubjectAccessReview { return &v1.SubjectAccessReview{} }),
+			func() *v1.SubjectAccessReview { return &v1.SubjectAccessReview{} },
+			gentype.PrefersProtobuf[*v1.SubjectAccessReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
@@ -52,6 +52,8 @@ func newLocalSubjectAccessReviews(c *AuthorizationV1beta1Client, namespace strin
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1beta1.LocalSubjectAccessReview { return &v1beta1.LocalSubjectAccessReview{} }),
+			func() *v1beta1.LocalSubjectAccessReview { return &v1beta1.LocalSubjectAccessReview{} },
+			gentype.PrefersProtobuf[*v1beta1.LocalSubjectAccessReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
@@ -52,6 +52,8 @@ func newSelfSubjectAccessReviews(c *AuthorizationV1beta1Client) *selfSubjectAcce
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1beta1.SelfSubjectAccessReview { return &v1beta1.SelfSubjectAccessReview{} }),
+			func() *v1beta1.SelfSubjectAccessReview { return &v1beta1.SelfSubjectAccessReview{} },
+			gentype.PrefersProtobuf[*v1beta1.SelfSubjectAccessReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
@@ -52,6 +52,8 @@ func newSelfSubjectRulesReviews(c *AuthorizationV1beta1Client) *selfSubjectRules
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1beta1.SelfSubjectRulesReview { return &v1beta1.SelfSubjectRulesReview{} }),
+			func() *v1beta1.SelfSubjectRulesReview { return &v1beta1.SelfSubjectRulesReview{} },
+			gentype.PrefersProtobuf[*v1beta1.SelfSubjectRulesReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
@@ -52,6 +52,8 @@ func newSubjectAccessReviews(c *AuthorizationV1beta1Client) *subjectAccessReview
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",
-			func() *v1beta1.SubjectAccessReview { return &v1beta1.SubjectAccessReview{} }),
+			func() *v1beta1.SubjectAccessReview { return &v1beta1.SubjectAccessReview{} },
+			gentype.PrefersProtobuf[*v1beta1.SubjectAccessReview](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -68,6 +68,8 @@ func newHorizontalPodAutoscalers(c *AutoscalingV1Client, namespace string) *hori
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.HorizontalPodAutoscaler { return &v1.HorizontalPodAutoscaler{} },
-			func() *v1.HorizontalPodAutoscalerList { return &v1.HorizontalPodAutoscalerList{} }),
+			func() *v1.HorizontalPodAutoscalerList { return &v1.HorizontalPodAutoscalerList{} },
+			gentype.PrefersProtobuf[*v1.HorizontalPodAutoscaler](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/autoscaling/v2/horizontalpodautoscaler.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/autoscaling/v2/horizontalpodautoscaler.go
@@ -68,6 +68,8 @@ func newHorizontalPodAutoscalers(c *AutoscalingV2Client, namespace string) *hori
 			scheme.ParameterCodec,
 			namespace,
 			func() *v2.HorizontalPodAutoscaler { return &v2.HorizontalPodAutoscaler{} },
-			func() *v2.HorizontalPodAutoscalerList { return &v2.HorizontalPodAutoscalerList{} }),
+			func() *v2.HorizontalPodAutoscalerList { return &v2.HorizontalPodAutoscalerList{} },
+			gentype.PrefersProtobuf[*v2.HorizontalPodAutoscaler](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -68,6 +68,8 @@ func newHorizontalPodAutoscalers(c *AutoscalingV2beta1Client, namespace string) 
 			scheme.ParameterCodec,
 			namespace,
 			func() *v2beta1.HorizontalPodAutoscaler { return &v2beta1.HorizontalPodAutoscaler{} },
-			func() *v2beta1.HorizontalPodAutoscalerList { return &v2beta1.HorizontalPodAutoscalerList{} }),
+			func() *v2beta1.HorizontalPodAutoscalerList { return &v2beta1.HorizontalPodAutoscalerList{} },
+			gentype.PrefersProtobuf[*v2beta1.HorizontalPodAutoscaler](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -68,6 +68,8 @@ func newHorizontalPodAutoscalers(c *AutoscalingV2beta2Client, namespace string) 
 			scheme.ParameterCodec,
 			namespace,
 			func() *v2beta2.HorizontalPodAutoscaler { return &v2beta2.HorizontalPodAutoscaler{} },
-			func() *v2beta2.HorizontalPodAutoscalerList { return &v2beta2.HorizontalPodAutoscalerList{} }),
+			func() *v2beta2.HorizontalPodAutoscalerList { return &v2beta2.HorizontalPodAutoscalerList{} },
+			gentype.PrefersProtobuf[*v2beta2.HorizontalPodAutoscaler](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/batch/v1/cronjob.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/batch/v1/cronjob.go
@@ -68,6 +68,8 @@ func newCronJobs(c *BatchV1Client, namespace string) *cronJobs {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.CronJob { return &v1.CronJob{} },
-			func() *v1.CronJobList { return &v1.CronJobList{} }),
+			func() *v1.CronJobList { return &v1.CronJobList{} },
+			gentype.PrefersProtobuf[*v1.CronJob](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -68,6 +68,8 @@ func newJobs(c *BatchV1Client, namespace string) *jobs {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Job { return &v1.Job{} },
-			func() *v1.JobList { return &v1.JobList{} }),
+			func() *v1.JobList { return &v1.JobList{} },
+			gentype.PrefersProtobuf[*v1.Job](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -68,6 +68,8 @@ func newCronJobs(c *BatchV1beta1Client, namespace string) *cronJobs {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.CronJob { return &v1beta1.CronJob{} },
-			func() *v1beta1.CronJobList { return &v1beta1.CronJobList{} }),
+			func() *v1beta1.CronJobList { return &v1beta1.CronJobList{} },
+			gentype.PrefersProtobuf[*v1beta1.CronJob](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
@@ -70,7 +70,9 @@ func newCertificateSigningRequests(c *CertificatesV1Client) *certificateSigningR
 			scheme.ParameterCodec,
 			"",
 			func() *v1.CertificateSigningRequest { return &v1.CertificateSigningRequest{} },
-			func() *v1.CertificateSigningRequestList { return &v1.CertificateSigningRequestList{} }),
+			func() *v1.CertificateSigningRequestList { return &v1.CertificateSigningRequestList{} },
+			gentype.PrefersProtobuf[*v1.CertificateSigningRequest](),
+		),
 	}
 }
 
@@ -78,6 +80,7 @@ func newCertificateSigningRequests(c *CertificatesV1Client) *certificateSigningR
 func (c *certificateSigningRequests) UpdateApproval(ctx context.Context, certificateSigningRequestName string, certificateSigningRequest *v1.CertificateSigningRequest, opts metav1.UpdateOptions) (result *v1.CertificateSigningRequest, err error) {
 	result = &v1.CertificateSigningRequest{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequestName).
 		SubResource("approval").

--- a/vendor/k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/clustertrustbundle.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/clustertrustbundle.go
@@ -64,6 +64,8 @@ func newClusterTrustBundles(c *CertificatesV1alpha1Client) *clusterTrustBundles 
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.ClusterTrustBundle { return &v1alpha1.ClusterTrustBundle{} },
-			func() *v1alpha1.ClusterTrustBundleList { return &v1alpha1.ClusterTrustBundleList{} }),
+			func() *v1alpha1.ClusterTrustBundleList { return &v1alpha1.ClusterTrustBundleList{} },
+			gentype.PrefersProtobuf[*v1alpha1.ClusterTrustBundle](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -68,6 +68,8 @@ func newCertificateSigningRequests(c *CertificatesV1beta1Client) *certificateSig
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.CertificateSigningRequest { return &v1beta1.CertificateSigningRequest{} },
-			func() *v1beta1.CertificateSigningRequestList { return &v1beta1.CertificateSigningRequestList{} }),
+			func() *v1beta1.CertificateSigningRequestList { return &v1beta1.CertificateSigningRequestList{} },
+			gentype.PrefersProtobuf[*v1beta1.CertificateSigningRequest](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -64,6 +64,8 @@ func newLeases(c *CoordinationV1Client, namespace string) *leases {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Lease { return &v1.Lease{} },
-			func() *v1.LeaseList { return &v1.LeaseList{} }),
+			func() *v1.LeaseList { return &v1.LeaseList{} },
+			gentype.PrefersProtobuf[*v1.Lease](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/coordination/v1alpha1/leasecandidate.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/coordination/v1alpha1/leasecandidate.go
@@ -64,6 +64,8 @@ func newLeaseCandidates(c *CoordinationV1alpha1Client, namespace string) *leaseC
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1alpha1.LeaseCandidate { return &v1alpha1.LeaseCandidate{} },
-			func() *v1alpha1.LeaseCandidateList { return &v1alpha1.LeaseCandidateList{} }),
+			func() *v1alpha1.LeaseCandidateList { return &v1alpha1.LeaseCandidateList{} },
+			gentype.PrefersProtobuf[*v1alpha1.LeaseCandidate](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -64,6 +64,8 @@ func newLeases(c *CoordinationV1beta1Client, namespace string) *leases {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.Lease { return &v1beta1.Lease{} },
-			func() *v1beta1.LeaseList { return &v1beta1.LeaseList{} }),
+			func() *v1beta1.LeaseList { return &v1beta1.LeaseList{} },
+			gentype.PrefersProtobuf[*v1beta1.Lease](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -64,6 +64,8 @@ func newComponentStatuses(c *CoreV1Client) *componentStatuses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.ComponentStatus { return &v1.ComponentStatus{} },
-			func() *v1.ComponentStatusList { return &v1.ComponentStatusList{} }),
+			func() *v1.ComponentStatusList { return &v1.ComponentStatusList{} },
+			gentype.PrefersProtobuf[*v1.ComponentStatus](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -64,6 +64,8 @@ func newConfigMaps(c *CoreV1Client, namespace string) *configMaps {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.ConfigMap { return &v1.ConfigMap{} },
-			func() *v1.ConfigMapList { return &v1.ConfigMapList{} }),
+			func() *v1.ConfigMapList { return &v1.ConfigMapList{} },
+			gentype.PrefersProtobuf[*v1.ConfigMap](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -64,6 +64,8 @@ func newEndpoints(c *CoreV1Client, namespace string) *endpoints {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Endpoints { return &v1.Endpoints{} },
-			func() *v1.EndpointsList { return &v1.EndpointsList{} }),
+			func() *v1.EndpointsList { return &v1.EndpointsList{} },
+			gentype.PrefersProtobuf[*v1.Endpoints](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -64,6 +64,8 @@ func newEvents(c *CoreV1Client, namespace string) *events {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Event { return &v1.Event{} },
-			func() *v1.EventList { return &v1.EventList{} }),
+			func() *v1.EventList { return &v1.EventList{} },
+			gentype.PrefersProtobuf[*v1.Event](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -64,6 +64,8 @@ func newLimitRanges(c *CoreV1Client, namespace string) *limitRanges {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.LimitRange { return &v1.LimitRange{} },
-			func() *v1.LimitRangeList { return &v1.LimitRangeList{} }),
+			func() *v1.LimitRangeList { return &v1.LimitRangeList{} },
+			gentype.PrefersProtobuf[*v1.LimitRange](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -67,6 +67,8 @@ func newNamespaces(c *CoreV1Client) *namespaces {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.Namespace { return &v1.Namespace{} },
-			func() *v1.NamespaceList { return &v1.NamespaceList{} }),
+			func() *v1.NamespaceList { return &v1.NamespaceList{} },
+			gentype.PrefersProtobuf[*v1.Namespace](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -68,6 +68,8 @@ func newNodes(c *CoreV1Client) *nodes {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.Node { return &v1.Node{} },
-			func() *v1.NodeList { return &v1.NodeList{} }),
+			func() *v1.NodeList { return &v1.NodeList{} },
+			gentype.PrefersProtobuf[*v1.Node](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -68,6 +68,8 @@ func newPersistentVolumes(c *CoreV1Client) *persistentVolumes {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.PersistentVolume { return &v1.PersistentVolume{} },
-			func() *v1.PersistentVolumeList { return &v1.PersistentVolumeList{} }),
+			func() *v1.PersistentVolumeList { return &v1.PersistentVolumeList{} },
+			gentype.PrefersProtobuf[*v1.PersistentVolume](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -68,6 +68,8 @@ func newPersistentVolumeClaims(c *CoreV1Client, namespace string) *persistentVol
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.PersistentVolumeClaim { return &v1.PersistentVolumeClaim{} },
-			func() *v1.PersistentVolumeClaimList { return &v1.PersistentVolumeClaimList{} }),
+			func() *v1.PersistentVolumeClaimList { return &v1.PersistentVolumeClaimList{} },
+			gentype.PrefersProtobuf[*v1.PersistentVolumeClaim](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -70,7 +70,9 @@ func newPods(c *CoreV1Client, namespace string) *pods {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Pod { return &v1.Pod{} },
-			func() *v1.PodList { return &v1.PodList{} }),
+			func() *v1.PodList { return &v1.PodList{} },
+			gentype.PrefersProtobuf[*v1.Pod](),
+		),
 	}
 }
 
@@ -78,6 +80,7 @@ func newPods(c *CoreV1Client, namespace string) *pods {
 func (c *pods) UpdateEphemeralContainers(ctx context.Context, podName string, pod *v1.Pod, opts metav1.UpdateOptions) (result *v1.Pod, err error) {
 	result = &v1.Pod{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("pods").
 		Name(podName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -64,6 +64,8 @@ func newPodTemplates(c *CoreV1Client, namespace string) *podTemplates {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.PodTemplate { return &v1.PodTemplate{} },
-			func() *v1.PodTemplateList { return &v1.PodTemplateList{} }),
+			func() *v1.PodTemplateList { return &v1.PodTemplateList{} },
+			gentype.PrefersProtobuf[*v1.PodTemplate](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -72,7 +72,9 @@ func newReplicationControllers(c *CoreV1Client, namespace string) *replicationCo
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.ReplicationController { return &v1.ReplicationController{} },
-			func() *v1.ReplicationControllerList { return &v1.ReplicationControllerList{} }),
+			func() *v1.ReplicationControllerList { return &v1.ReplicationControllerList{} },
+			gentype.PrefersProtobuf[*v1.ReplicationController](),
+		),
 	}
 }
 
@@ -80,6 +82,7 @@ func newReplicationControllers(c *CoreV1Client, namespace string) *replicationCo
 func (c *replicationControllers) GetScale(ctx context.Context, replicationControllerName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("replicationcontrollers").
 		Name(replicationControllerName).
@@ -94,6 +97,7 @@ func (c *replicationControllers) GetScale(ctx context.Context, replicationContro
 func (c *replicationControllers) UpdateScale(ctx context.Context, replicationControllerName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	result = &autoscalingv1.Scale{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("replicationcontrollers").
 		Name(replicationControllerName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -68,6 +68,8 @@ func newResourceQuotas(c *CoreV1Client, namespace string) *resourceQuotas {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.ResourceQuota { return &v1.ResourceQuota{} },
-			func() *v1.ResourceQuotaList { return &v1.ResourceQuotaList{} }),
+			func() *v1.ResourceQuotaList { return &v1.ResourceQuotaList{} },
+			gentype.PrefersProtobuf[*v1.ResourceQuota](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -64,6 +64,8 @@ func newSecrets(c *CoreV1Client, namespace string) *secrets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Secret { return &v1.Secret{} },
-			func() *v1.SecretList { return &v1.SecretList{} }),
+			func() *v1.SecretList { return &v1.SecretList{} },
+			gentype.PrefersProtobuf[*v1.Secret](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -67,6 +67,8 @@ func newServices(c *CoreV1Client, namespace string) *services {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Service { return &v1.Service{} },
-			func() *v1.ServiceList { return &v1.ServiceList{} }),
+			func() *v1.ServiceList { return &v1.ServiceList{} },
+			gentype.PrefersProtobuf[*v1.Service](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -67,7 +67,9 @@ func newServiceAccounts(c *CoreV1Client, namespace string) *serviceAccounts {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.ServiceAccount { return &v1.ServiceAccount{} },
-			func() *v1.ServiceAccountList { return &v1.ServiceAccountList{} }),
+			func() *v1.ServiceAccountList { return &v1.ServiceAccountList{} },
+			gentype.PrefersProtobuf[*v1.ServiceAccount](),
+		),
 	}
 }
 
@@ -75,6 +77,7 @@ func newServiceAccounts(c *CoreV1Client, namespace string) *serviceAccounts {
 func (c *serviceAccounts) CreateToken(ctx context.Context, serviceAccountName string, tokenRequest *authenticationv1.TokenRequest, opts metav1.CreateOptions) (result *authenticationv1.TokenRequest, err error) {
 	result = &authenticationv1.TokenRequest{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("serviceaccounts").
 		Name(serviceAccountName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
@@ -64,6 +64,8 @@ func newEndpointSlices(c *DiscoveryV1Client, namespace string) *endpointSlices {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.EndpointSlice { return &v1.EndpointSlice{} },
-			func() *v1.EndpointSliceList { return &v1.EndpointSliceList{} }),
+			func() *v1.EndpointSliceList { return &v1.EndpointSliceList{} },
+			gentype.PrefersProtobuf[*v1.EndpointSlice](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
@@ -64,6 +64,8 @@ func newEndpointSlices(c *DiscoveryV1beta1Client, namespace string) *endpointSli
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.EndpointSlice { return &v1beta1.EndpointSlice{} },
-			func() *v1beta1.EndpointSliceList { return &v1beta1.EndpointSliceList{} }),
+			func() *v1beta1.EndpointSliceList { return &v1beta1.EndpointSliceList{} },
+			gentype.PrefersProtobuf[*v1beta1.EndpointSlice](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/events/v1/event.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/events/v1/event.go
@@ -64,6 +64,8 @@ func newEvents(c *EventsV1Client, namespace string) *events {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Event { return &v1.Event{} },
-			func() *v1.EventList { return &v1.EventList{} }),
+			func() *v1.EventList { return &v1.EventList{} },
+			gentype.PrefersProtobuf[*v1.Event](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -64,6 +64,8 @@ func newEvents(c *EventsV1beta1Client, namespace string) *events {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.Event { return &v1beta1.Event{} },
-			func() *v1beta1.EventList { return &v1beta1.EventList{} }),
+			func() *v1beta1.EventList { return &v1beta1.EventList{} },
+			gentype.PrefersProtobuf[*v1beta1.Event](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -68,6 +68,8 @@ func newDaemonSets(c *ExtensionsV1beta1Client, namespace string) *daemonSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.DaemonSet { return &v1beta1.DaemonSet{} },
-			func() *v1beta1.DaemonSetList { return &v1beta1.DaemonSetList{} }),
+			func() *v1beta1.DaemonSetList { return &v1beta1.DaemonSetList{} },
+			gentype.PrefersProtobuf[*v1beta1.DaemonSet](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -74,7 +74,9 @@ func newDeployments(c *ExtensionsV1beta1Client, namespace string) *deployments {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.Deployment { return &v1beta1.Deployment{} },
-			func() *v1beta1.DeploymentList { return &v1beta1.DeploymentList{} }),
+			func() *v1beta1.DeploymentList { return &v1beta1.DeploymentList{} },
+			gentype.PrefersProtobuf[*v1beta1.Deployment](),
+		),
 	}
 }
 
@@ -82,6 +84,7 @@ func newDeployments(c *ExtensionsV1beta1Client, namespace string) *deployments {
 func (c *deployments) GetScale(ctx context.Context, deploymentName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
 	result = &v1beta1.Scale{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deployments").
 		Name(deploymentName).
@@ -96,6 +99,7 @@ func (c *deployments) GetScale(ctx context.Context, deploymentName string, optio
 func (c *deployments) UpdateScale(ctx context.Context, deploymentName string, scale *v1beta1.Scale, opts v1.UpdateOptions) (result *v1beta1.Scale, err error) {
 	result = &v1beta1.Scale{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deployments").
 		Name(deploymentName).
@@ -121,6 +125,7 @@ func (c *deployments) ApplyScale(ctx context.Context, deploymentName string, sca
 
 	result = &v1beta1.Scale{}
 	err = c.GetClient().Patch(types.ApplyPatchType).
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deployments").
 		Name(deploymentName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -68,6 +68,8 @@ func newIngresses(c *ExtensionsV1beta1Client, namespace string) *ingresses {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.Ingress { return &v1beta1.Ingress{} },
-			func() *v1beta1.IngressList { return &v1beta1.IngressList{} }),
+			func() *v1beta1.IngressList { return &v1beta1.IngressList{} },
+			gentype.PrefersProtobuf[*v1beta1.Ingress](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -64,6 +64,8 @@ func newNetworkPolicies(c *ExtensionsV1beta1Client, namespace string) *networkPo
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.NetworkPolicy { return &v1beta1.NetworkPolicy{} },
-			func() *v1beta1.NetworkPolicyList { return &v1beta1.NetworkPolicyList{} }),
+			func() *v1beta1.NetworkPolicyList { return &v1beta1.NetworkPolicyList{} },
+			gentype.PrefersProtobuf[*v1beta1.NetworkPolicy](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -74,7 +74,9 @@ func newReplicaSets(c *ExtensionsV1beta1Client, namespace string) *replicaSets {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.ReplicaSet { return &v1beta1.ReplicaSet{} },
-			func() *v1beta1.ReplicaSetList { return &v1beta1.ReplicaSetList{} }),
+			func() *v1beta1.ReplicaSetList { return &v1beta1.ReplicaSetList{} },
+			gentype.PrefersProtobuf[*v1beta1.ReplicaSet](),
+		),
 	}
 }
 
@@ -82,6 +84,7 @@ func newReplicaSets(c *ExtensionsV1beta1Client, namespace string) *replicaSets {
 func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
 	result = &v1beta1.Scale{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("replicasets").
 		Name(replicaSetName).
@@ -96,6 +99,7 @@ func (c *replicaSets) GetScale(ctx context.Context, replicaSetName string, optio
 func (c *replicaSets) UpdateScale(ctx context.Context, replicaSetName string, scale *v1beta1.Scale, opts v1.UpdateOptions) (result *v1beta1.Scale, err error) {
 	result = &v1beta1.Scale{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("replicasets").
 		Name(replicaSetName).
@@ -121,6 +125,7 @@ func (c *replicaSets) ApplyScale(ctx context.Context, replicaSetName string, sca
 
 	result = &v1beta1.Scale{}
 	err = c.GetClient().Patch(types.ApplyPatchType).
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("replicasets").
 		Name(replicaSetName).

--- a/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/flowschema.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/flowschema.go
@@ -68,6 +68,8 @@ func newFlowSchemas(c *FlowcontrolV1Client) *flowSchemas {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.FlowSchema { return &v1.FlowSchema{} },
-			func() *v1.FlowSchemaList { return &v1.FlowSchemaList{} }),
+			func() *v1.FlowSchemaList { return &v1.FlowSchemaList{} },
+			gentype.PrefersProtobuf[*v1.FlowSchema](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/prioritylevelconfiguration.go
@@ -68,6 +68,8 @@ func newPriorityLevelConfigurations(c *FlowcontrolV1Client) *priorityLevelConfig
 			scheme.ParameterCodec,
 			"",
 			func() *v1.PriorityLevelConfiguration { return &v1.PriorityLevelConfiguration{} },
-			func() *v1.PriorityLevelConfigurationList { return &v1.PriorityLevelConfigurationList{} }),
+			func() *v1.PriorityLevelConfigurationList { return &v1.PriorityLevelConfigurationList{} },
+			gentype.PrefersProtobuf[*v1.PriorityLevelConfiguration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
@@ -68,6 +68,8 @@ func newFlowSchemas(c *FlowcontrolV1beta1Client) *flowSchemas {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.FlowSchema { return &v1beta1.FlowSchema{} },
-			func() *v1beta1.FlowSchemaList { return &v1beta1.FlowSchemaList{} }),
+			func() *v1beta1.FlowSchemaList { return &v1beta1.FlowSchemaList{} },
+			gentype.PrefersProtobuf[*v1beta1.FlowSchema](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -68,6 +68,8 @@ func newPriorityLevelConfigurations(c *FlowcontrolV1beta1Client) *priorityLevelC
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.PriorityLevelConfiguration { return &v1beta1.PriorityLevelConfiguration{} },
-			func() *v1beta1.PriorityLevelConfigurationList { return &v1beta1.PriorityLevelConfigurationList{} }),
+			func() *v1beta1.PriorityLevelConfigurationList { return &v1beta1.PriorityLevelConfigurationList{} },
+			gentype.PrefersProtobuf[*v1beta1.PriorityLevelConfiguration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
@@ -68,6 +68,8 @@ func newFlowSchemas(c *FlowcontrolV1beta2Client) *flowSchemas {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta2.FlowSchema { return &v1beta2.FlowSchema{} },
-			func() *v1beta2.FlowSchemaList { return &v1beta2.FlowSchemaList{} }),
+			func() *v1beta2.FlowSchemaList { return &v1beta2.FlowSchemaList{} },
+			gentype.PrefersProtobuf[*v1beta2.FlowSchema](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -68,6 +68,8 @@ func newPriorityLevelConfigurations(c *FlowcontrolV1beta2Client) *priorityLevelC
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta2.PriorityLevelConfiguration { return &v1beta2.PriorityLevelConfiguration{} },
-			func() *v1beta2.PriorityLevelConfigurationList { return &v1beta2.PriorityLevelConfigurationList{} }),
+			func() *v1beta2.PriorityLevelConfigurationList { return &v1beta2.PriorityLevelConfigurationList{} },
+			gentype.PrefersProtobuf[*v1beta2.PriorityLevelConfiguration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/flowschema.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/flowschema.go
@@ -68,6 +68,8 @@ func newFlowSchemas(c *FlowcontrolV1beta3Client) *flowSchemas {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta3.FlowSchema { return &v1beta3.FlowSchema{} },
-			func() *v1beta3.FlowSchemaList { return &v1beta3.FlowSchemaList{} }),
+			func() *v1beta3.FlowSchemaList { return &v1beta3.FlowSchemaList{} },
+			gentype.PrefersProtobuf[*v1beta3.FlowSchema](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -68,6 +68,8 @@ func newPriorityLevelConfigurations(c *FlowcontrolV1beta3Client) *priorityLevelC
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta3.PriorityLevelConfiguration { return &v1beta3.PriorityLevelConfiguration{} },
-			func() *v1beta3.PriorityLevelConfigurationList { return &v1beta3.PriorityLevelConfigurationList{} }),
+			func() *v1beta3.PriorityLevelConfigurationList { return &v1beta3.PriorityLevelConfigurationList{} },
+			gentype.PrefersProtobuf[*v1beta3.PriorityLevelConfiguration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
@@ -68,6 +68,8 @@ func newIngresses(c *NetworkingV1Client, namespace string) *ingresses {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Ingress { return &v1.Ingress{} },
-			func() *v1.IngressList { return &v1.IngressList{} }),
+			func() *v1.IngressList { return &v1.IngressList{} },
+			gentype.PrefersProtobuf[*v1.Ingress](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
@@ -64,6 +64,8 @@ func newIngressClasses(c *NetworkingV1Client) *ingressClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.IngressClass { return &v1.IngressClass{} },
-			func() *v1.IngressClassList { return &v1.IngressClassList{} }),
+			func() *v1.IngressClassList { return &v1.IngressClassList{} },
+			gentype.PrefersProtobuf[*v1.IngressClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -64,6 +64,8 @@ func newNetworkPolicies(c *NetworkingV1Client, namespace string) *networkPolicie
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.NetworkPolicy { return &v1.NetworkPolicy{} },
-			func() *v1.NetworkPolicyList { return &v1.NetworkPolicyList{} }),
+			func() *v1.NetworkPolicyList { return &v1.NetworkPolicyList{} },
+			gentype.PrefersProtobuf[*v1.NetworkPolicy](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/ipaddress.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/ipaddress.go
@@ -64,6 +64,8 @@ func newIPAddresses(c *NetworkingV1alpha1Client) *iPAddresses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.IPAddress { return &v1alpha1.IPAddress{} },
-			func() *v1alpha1.IPAddressList { return &v1alpha1.IPAddressList{} }),
+			func() *v1alpha1.IPAddressList { return &v1alpha1.IPAddressList{} },
+			gentype.PrefersProtobuf[*v1alpha1.IPAddress](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/servicecidr.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/servicecidr.go
@@ -68,6 +68,8 @@ func newServiceCIDRs(c *NetworkingV1alpha1Client) *serviceCIDRs {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.ServiceCIDR { return &v1alpha1.ServiceCIDR{} },
-			func() *v1alpha1.ServiceCIDRList { return &v1alpha1.ServiceCIDRList{} }),
+			func() *v1alpha1.ServiceCIDRList { return &v1alpha1.ServiceCIDRList{} },
+			gentype.PrefersProtobuf[*v1alpha1.ServiceCIDR](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -68,6 +68,8 @@ func newIngresses(c *NetworkingV1beta1Client, namespace string) *ingresses {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.Ingress { return &v1beta1.Ingress{} },
-			func() *v1beta1.IngressList { return &v1beta1.IngressList{} }),
+			func() *v1beta1.IngressList { return &v1beta1.IngressList{} },
+			gentype.PrefersProtobuf[*v1beta1.Ingress](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
@@ -64,6 +64,8 @@ func newIngressClasses(c *NetworkingV1beta1Client) *ingressClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.IngressClass { return &v1beta1.IngressClass{} },
-			func() *v1beta1.IngressClassList { return &v1beta1.IngressClassList{} }),
+			func() *v1beta1.IngressClassList { return &v1beta1.IngressClassList{} },
+			gentype.PrefersProtobuf[*v1beta1.IngressClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ipaddress.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ipaddress.go
@@ -64,6 +64,8 @@ func newIPAddresses(c *NetworkingV1beta1Client) *iPAddresses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.IPAddress { return &v1beta1.IPAddress{} },
-			func() *v1beta1.IPAddressList { return &v1beta1.IPAddressList{} }),
+			func() *v1beta1.IPAddressList { return &v1beta1.IPAddressList{} },
+			gentype.PrefersProtobuf[*v1beta1.IPAddress](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/networking/v1beta1/servicecidr.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/networking/v1beta1/servicecidr.go
@@ -68,6 +68,8 @@ func newServiceCIDRs(c *NetworkingV1beta1Client) *serviceCIDRs {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.ServiceCIDR { return &v1beta1.ServiceCIDR{} },
-			func() *v1beta1.ServiceCIDRList { return &v1beta1.ServiceCIDRList{} }),
+			func() *v1beta1.ServiceCIDRList { return &v1beta1.ServiceCIDRList{} },
+			gentype.PrefersProtobuf[*v1beta1.ServiceCIDR](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
@@ -64,6 +64,8 @@ func newRuntimeClasses(c *NodeV1Client) *runtimeClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.RuntimeClass { return &v1.RuntimeClass{} },
-			func() *v1.RuntimeClassList { return &v1.RuntimeClassList{} }),
+			func() *v1.RuntimeClassList { return &v1.RuntimeClassList{} },
+			gentype.PrefersProtobuf[*v1.RuntimeClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -64,6 +64,8 @@ func newRuntimeClasses(c *NodeV1alpha1Client) *runtimeClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.RuntimeClass { return &v1alpha1.RuntimeClass{} },
-			func() *v1alpha1.RuntimeClassList { return &v1alpha1.RuntimeClassList{} }),
+			func() *v1alpha1.RuntimeClassList { return &v1alpha1.RuntimeClassList{} },
+			gentype.PrefersProtobuf[*v1alpha1.RuntimeClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -64,6 +64,8 @@ func newRuntimeClasses(c *NodeV1beta1Client) *runtimeClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.RuntimeClass { return &v1beta1.RuntimeClass{} },
-			func() *v1beta1.RuntimeClassList { return &v1beta1.RuntimeClassList{} }),
+			func() *v1beta1.RuntimeClassList { return &v1beta1.RuntimeClassList{} },
+			gentype.PrefersProtobuf[*v1beta1.RuntimeClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/policy/v1/eviction.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/policy/v1/eviction.go
@@ -48,6 +48,8 @@ func newEvictions(c *PolicyV1Client, namespace string) *evictions {
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1.Eviction { return &v1.Eviction{} }),
+			func() *v1.Eviction { return &v1.Eviction{} },
+			gentype.PrefersProtobuf[*v1.Eviction](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
@@ -68,6 +68,8 @@ func newPodDisruptionBudgets(c *PolicyV1Client, namespace string) *podDisruption
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.PodDisruptionBudget { return &v1.PodDisruptionBudget{} },
-			func() *v1.PodDisruptionBudgetList { return &v1.PodDisruptionBudgetList{} }),
+			func() *v1.PodDisruptionBudgetList { return &v1.PodDisruptionBudgetList{} },
+			gentype.PrefersProtobuf[*v1.PodDisruptionBudget](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction.go
@@ -48,6 +48,8 @@ func newEvictions(c *PolicyV1beta1Client, namespace string) *evictions {
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1beta1.Eviction { return &v1beta1.Eviction{} }),
+			func() *v1beta1.Eviction { return &v1beta1.Eviction{} },
+			gentype.PrefersProtobuf[*v1beta1.Eviction](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -68,6 +68,8 @@ func newPodDisruptionBudgets(c *PolicyV1beta1Client, namespace string) *podDisru
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.PodDisruptionBudget { return &v1beta1.PodDisruptionBudget{} },
-			func() *v1beta1.PodDisruptionBudgetList { return &v1beta1.PodDisruptionBudgetList{} }),
+			func() *v1beta1.PodDisruptionBudgetList { return &v1beta1.PodDisruptionBudgetList{} },
+			gentype.PrefersProtobuf[*v1beta1.PodDisruptionBudget](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -64,6 +64,8 @@ func newClusterRoles(c *RbacV1Client) *clusterRoles {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.ClusterRole { return &v1.ClusterRole{} },
-			func() *v1.ClusterRoleList { return &v1.ClusterRoleList{} }),
+			func() *v1.ClusterRoleList { return &v1.ClusterRoleList{} },
+			gentype.PrefersProtobuf[*v1.ClusterRole](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -64,6 +64,8 @@ func newClusterRoleBindings(c *RbacV1Client) *clusterRoleBindings {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.ClusterRoleBinding { return &v1.ClusterRoleBinding{} },
-			func() *v1.ClusterRoleBindingList { return &v1.ClusterRoleBindingList{} }),
+			func() *v1.ClusterRoleBindingList { return &v1.ClusterRoleBindingList{} },
+			gentype.PrefersProtobuf[*v1.ClusterRoleBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -64,6 +64,8 @@ func newRoles(c *RbacV1Client, namespace string) *roles {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.Role { return &v1.Role{} },
-			func() *v1.RoleList { return &v1.RoleList{} }),
+			func() *v1.RoleList { return &v1.RoleList{} },
+			gentype.PrefersProtobuf[*v1.Role](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -64,6 +64,8 @@ func newRoleBindings(c *RbacV1Client, namespace string) *roleBindings {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.RoleBinding { return &v1.RoleBinding{} },
-			func() *v1.RoleBindingList { return &v1.RoleBindingList{} }),
+			func() *v1.RoleBindingList { return &v1.RoleBindingList{} },
+			gentype.PrefersProtobuf[*v1.RoleBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -64,6 +64,8 @@ func newClusterRoles(c *RbacV1alpha1Client) *clusterRoles {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.ClusterRole { return &v1alpha1.ClusterRole{} },
-			func() *v1alpha1.ClusterRoleList { return &v1alpha1.ClusterRoleList{} }),
+			func() *v1alpha1.ClusterRoleList { return &v1alpha1.ClusterRoleList{} },
+			gentype.PrefersProtobuf[*v1alpha1.ClusterRole](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -64,6 +64,8 @@ func newClusterRoleBindings(c *RbacV1alpha1Client) *clusterRoleBindings {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.ClusterRoleBinding { return &v1alpha1.ClusterRoleBinding{} },
-			func() *v1alpha1.ClusterRoleBindingList { return &v1alpha1.ClusterRoleBindingList{} }),
+			func() *v1alpha1.ClusterRoleBindingList { return &v1alpha1.ClusterRoleBindingList{} },
+			gentype.PrefersProtobuf[*v1alpha1.ClusterRoleBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -64,6 +64,8 @@ func newRoles(c *RbacV1alpha1Client, namespace string) *roles {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1alpha1.Role { return &v1alpha1.Role{} },
-			func() *v1alpha1.RoleList { return &v1alpha1.RoleList{} }),
+			func() *v1alpha1.RoleList { return &v1alpha1.RoleList{} },
+			gentype.PrefersProtobuf[*v1alpha1.Role](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -64,6 +64,8 @@ func newRoleBindings(c *RbacV1alpha1Client, namespace string) *roleBindings {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1alpha1.RoleBinding { return &v1alpha1.RoleBinding{} },
-			func() *v1alpha1.RoleBindingList { return &v1alpha1.RoleBindingList{} }),
+			func() *v1alpha1.RoleBindingList { return &v1alpha1.RoleBindingList{} },
+			gentype.PrefersProtobuf[*v1alpha1.RoleBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -64,6 +64,8 @@ func newClusterRoles(c *RbacV1beta1Client) *clusterRoles {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.ClusterRole { return &v1beta1.ClusterRole{} },
-			func() *v1beta1.ClusterRoleList { return &v1beta1.ClusterRoleList{} }),
+			func() *v1beta1.ClusterRoleList { return &v1beta1.ClusterRoleList{} },
+			gentype.PrefersProtobuf[*v1beta1.ClusterRole](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -64,6 +64,8 @@ func newClusterRoleBindings(c *RbacV1beta1Client) *clusterRoleBindings {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.ClusterRoleBinding { return &v1beta1.ClusterRoleBinding{} },
-			func() *v1beta1.ClusterRoleBindingList { return &v1beta1.ClusterRoleBindingList{} }),
+			func() *v1beta1.ClusterRoleBindingList { return &v1beta1.ClusterRoleBindingList{} },
+			gentype.PrefersProtobuf[*v1beta1.ClusterRoleBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -64,6 +64,8 @@ func newRoles(c *RbacV1beta1Client, namespace string) *roles {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.Role { return &v1beta1.Role{} },
-			func() *v1beta1.RoleList { return &v1beta1.RoleList{} }),
+			func() *v1beta1.RoleList { return &v1beta1.RoleList{} },
+			gentype.PrefersProtobuf[*v1beta1.Role](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -64,6 +64,8 @@ func newRoleBindings(c *RbacV1beta1Client, namespace string) *roleBindings {
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.RoleBinding { return &v1beta1.RoleBinding{} },
-			func() *v1beta1.RoleBindingList { return &v1beta1.RoleBindingList{} }),
+			func() *v1beta1.RoleBindingList { return &v1beta1.RoleBindingList{} },
+			gentype.PrefersProtobuf[*v1beta1.RoleBinding](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/deviceclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/deviceclass.go
@@ -64,6 +64,8 @@ func newDeviceClasses(c *ResourceV1alpha3Client) *deviceClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha3.DeviceClass { return &v1alpha3.DeviceClass{} },
-			func() *v1alpha3.DeviceClassList { return &v1alpha3.DeviceClassList{} }),
+			func() *v1alpha3.DeviceClassList { return &v1alpha3.DeviceClassList{} },
+			gentype.PrefersProtobuf[*v1alpha3.DeviceClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/podschedulingcontext.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/podschedulingcontext.go
@@ -68,6 +68,8 @@ func newPodSchedulingContexts(c *ResourceV1alpha3Client, namespace string) *podS
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1alpha3.PodSchedulingContext { return &v1alpha3.PodSchedulingContext{} },
-			func() *v1alpha3.PodSchedulingContextList { return &v1alpha3.PodSchedulingContextList{} }),
+			func() *v1alpha3.PodSchedulingContextList { return &v1alpha3.PodSchedulingContextList{} },
+			gentype.PrefersProtobuf[*v1alpha3.PodSchedulingContext](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/resourceclaim.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/resourceclaim.go
@@ -68,6 +68,8 @@ func newResourceClaims(c *ResourceV1alpha3Client, namespace string) *resourceCla
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1alpha3.ResourceClaim { return &v1alpha3.ResourceClaim{} },
-			func() *v1alpha3.ResourceClaimList { return &v1alpha3.ResourceClaimList{} }),
+			func() *v1alpha3.ResourceClaimList { return &v1alpha3.ResourceClaimList{} },
+			gentype.PrefersProtobuf[*v1alpha3.ResourceClaim](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/resourceclaimtemplate.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/resourceclaimtemplate.go
@@ -64,6 +64,8 @@ func newResourceClaimTemplates(c *ResourceV1alpha3Client, namespace string) *res
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1alpha3.ResourceClaimTemplate { return &v1alpha3.ResourceClaimTemplate{} },
-			func() *v1alpha3.ResourceClaimTemplateList { return &v1alpha3.ResourceClaimTemplateList{} }),
+			func() *v1alpha3.ResourceClaimTemplateList { return &v1alpha3.ResourceClaimTemplateList{} },
+			gentype.PrefersProtobuf[*v1alpha3.ResourceClaimTemplate](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/resourceslice.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/resourceslice.go
@@ -64,6 +64,8 @@ func newResourceSlices(c *ResourceV1alpha3Client) *resourceSlices {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha3.ResourceSlice { return &v1alpha3.ResourceSlice{} },
-			func() *v1alpha3.ResourceSliceList { return &v1alpha3.ResourceSliceList{} }),
+			func() *v1alpha3.ResourceSliceList { return &v1alpha3.ResourceSliceList{} },
+			gentype.PrefersProtobuf[*v1alpha3.ResourceSlice](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -64,6 +64,8 @@ func newPriorityClasses(c *SchedulingV1Client) *priorityClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.PriorityClass { return &v1.PriorityClass{} },
-			func() *v1.PriorityClassList { return &v1.PriorityClassList{} }),
+			func() *v1.PriorityClassList { return &v1.PriorityClassList{} },
+			gentype.PrefersProtobuf[*v1.PriorityClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -64,6 +64,8 @@ func newPriorityClasses(c *SchedulingV1alpha1Client) *priorityClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.PriorityClass { return &v1alpha1.PriorityClass{} },
-			func() *v1alpha1.PriorityClassList { return &v1alpha1.PriorityClassList{} }),
+			func() *v1alpha1.PriorityClassList { return &v1alpha1.PriorityClassList{} },
+			gentype.PrefersProtobuf[*v1alpha1.PriorityClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -64,6 +64,8 @@ func newPriorityClasses(c *SchedulingV1beta1Client) *priorityClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.PriorityClass { return &v1beta1.PriorityClass{} },
-			func() *v1beta1.PriorityClassList { return &v1beta1.PriorityClassList{} }),
+			func() *v1beta1.PriorityClassList { return &v1beta1.PriorityClassList{} },
+			gentype.PrefersProtobuf[*v1beta1.PriorityClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
@@ -64,6 +64,8 @@ func newCSIDrivers(c *StorageV1Client) *cSIDrivers {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.CSIDriver { return &v1.CSIDriver{} },
-			func() *v1.CSIDriverList { return &v1.CSIDriverList{} }),
+			func() *v1.CSIDriverList { return &v1.CSIDriverList{} },
+			gentype.PrefersProtobuf[*v1.CSIDriver](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -64,6 +64,8 @@ func newCSINodes(c *StorageV1Client) *cSINodes {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.CSINode { return &v1.CSINode{} },
-			func() *v1.CSINodeList { return &v1.CSINodeList{} }),
+			func() *v1.CSINodeList { return &v1.CSINodeList{} },
+			gentype.PrefersProtobuf[*v1.CSINode](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/csistoragecapacity.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/csistoragecapacity.go
@@ -64,6 +64,8 @@ func newCSIStorageCapacities(c *StorageV1Client, namespace string) *cSIStorageCa
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1.CSIStorageCapacity { return &v1.CSIStorageCapacity{} },
-			func() *v1.CSIStorageCapacityList { return &v1.CSIStorageCapacityList{} }),
+			func() *v1.CSIStorageCapacityList { return &v1.CSIStorageCapacityList{} },
+			gentype.PrefersProtobuf[*v1.CSIStorageCapacity](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -64,6 +64,8 @@ func newStorageClasses(c *StorageV1Client) *storageClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.StorageClass { return &v1.StorageClass{} },
-			func() *v1.StorageClassList { return &v1.StorageClassList{} }),
+			func() *v1.StorageClassList { return &v1.StorageClassList{} },
+			gentype.PrefersProtobuf[*v1.StorageClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -68,6 +68,8 @@ func newVolumeAttachments(c *StorageV1Client) *volumeAttachments {
 			scheme.ParameterCodec,
 			"",
 			func() *v1.VolumeAttachment { return &v1.VolumeAttachment{} },
-			func() *v1.VolumeAttachmentList { return &v1.VolumeAttachmentList{} }),
+			func() *v1.VolumeAttachmentList { return &v1.VolumeAttachmentList{} },
+			gentype.PrefersProtobuf[*v1.VolumeAttachment](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
@@ -64,6 +64,8 @@ func newCSIStorageCapacities(c *StorageV1alpha1Client, namespace string) *cSISto
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1alpha1.CSIStorageCapacity { return &v1alpha1.CSIStorageCapacity{} },
-			func() *v1alpha1.CSIStorageCapacityList { return &v1alpha1.CSIStorageCapacityList{} }),
+			func() *v1alpha1.CSIStorageCapacityList { return &v1alpha1.CSIStorageCapacityList{} },
+			gentype.PrefersProtobuf[*v1alpha1.CSIStorageCapacity](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -68,6 +68,8 @@ func newVolumeAttachments(c *StorageV1alpha1Client) *volumeAttachments {
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.VolumeAttachment { return &v1alpha1.VolumeAttachment{} },
-			func() *v1alpha1.VolumeAttachmentList { return &v1alpha1.VolumeAttachmentList{} }),
+			func() *v1alpha1.VolumeAttachmentList { return &v1alpha1.VolumeAttachmentList{} },
+			gentype.PrefersProtobuf[*v1alpha1.VolumeAttachment](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattributesclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattributesclass.go
@@ -64,6 +64,8 @@ func newVolumeAttributesClasses(c *StorageV1alpha1Client) *volumeAttributesClass
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.VolumeAttributesClass { return &v1alpha1.VolumeAttributesClass{} },
-			func() *v1alpha1.VolumeAttributesClassList { return &v1alpha1.VolumeAttributesClassList{} }),
+			func() *v1alpha1.VolumeAttributesClassList { return &v1alpha1.VolumeAttributesClassList{} },
+			gentype.PrefersProtobuf[*v1alpha1.VolumeAttributesClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -64,6 +64,8 @@ func newCSIDrivers(c *StorageV1beta1Client) *cSIDrivers {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.CSIDriver { return &v1beta1.CSIDriver{} },
-			func() *v1beta1.CSIDriverList { return &v1beta1.CSIDriverList{} }),
+			func() *v1beta1.CSIDriverList { return &v1beta1.CSIDriverList{} },
+			gentype.PrefersProtobuf[*v1beta1.CSIDriver](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -64,6 +64,8 @@ func newCSINodes(c *StorageV1beta1Client) *cSINodes {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.CSINode { return &v1beta1.CSINode{} },
-			func() *v1beta1.CSINodeList { return &v1beta1.CSINodeList{} }),
+			func() *v1beta1.CSINodeList { return &v1beta1.CSINodeList{} },
+			gentype.PrefersProtobuf[*v1beta1.CSINode](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
@@ -64,6 +64,8 @@ func newCSIStorageCapacities(c *StorageV1beta1Client, namespace string) *cSIStor
 			scheme.ParameterCodec,
 			namespace,
 			func() *v1beta1.CSIStorageCapacity { return &v1beta1.CSIStorageCapacity{} },
-			func() *v1beta1.CSIStorageCapacityList { return &v1beta1.CSIStorageCapacityList{} }),
+			func() *v1beta1.CSIStorageCapacityList { return &v1beta1.CSIStorageCapacityList{} },
+			gentype.PrefersProtobuf[*v1beta1.CSIStorageCapacity](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -64,6 +64,8 @@ func newStorageClasses(c *StorageV1beta1Client) *storageClasses {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.StorageClass { return &v1beta1.StorageClass{} },
-			func() *v1beta1.StorageClassList { return &v1beta1.StorageClassList{} }),
+			func() *v1beta1.StorageClassList { return &v1beta1.StorageClassList{} },
+			gentype.PrefersProtobuf[*v1beta1.StorageClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -68,6 +68,8 @@ func newVolumeAttachments(c *StorageV1beta1Client) *volumeAttachments {
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.VolumeAttachment { return &v1beta1.VolumeAttachment{} },
-			func() *v1beta1.VolumeAttachmentList { return &v1beta1.VolumeAttachmentList{} }),
+			func() *v1beta1.VolumeAttachmentList { return &v1beta1.VolumeAttachmentList{} },
+			gentype.PrefersProtobuf[*v1beta1.VolumeAttachment](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattributesclass.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattributesclass.go
@@ -64,6 +64,8 @@ func newVolumeAttributesClasses(c *StorageV1beta1Client) *volumeAttributesClasse
 			scheme.ParameterCodec,
 			"",
 			func() *v1beta1.VolumeAttributesClass { return &v1beta1.VolumeAttributesClass{} },
-			func() *v1beta1.VolumeAttributesClassList { return &v1beta1.VolumeAttributesClassList{} }),
+			func() *v1beta1.VolumeAttributesClassList { return &v1beta1.VolumeAttributesClassList{} },
+			gentype.PrefersProtobuf[*v1beta1.VolumeAttributesClass](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/kubernetes/typed/storagemigration/v1alpha1/storageversionmigration.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/storagemigration/v1alpha1/storageversionmigration.go
@@ -68,6 +68,8 @@ func newStorageVersionMigrations(c *StoragemigrationV1alpha1Client) *storageVers
 			scheme.ParameterCodec,
 			"",
 			func() *v1alpha1.StorageVersionMigration { return &v1alpha1.StorageVersionMigration{} },
-			func() *v1alpha1.StorageVersionMigrationList { return &v1alpha1.StorageVersionMigrationList{} }),
+			func() *v1alpha1.StorageVersionMigrationList { return &v1alpha1.StorageVersionMigrationList{} },
+			gentype.PrefersProtobuf[*v1alpha1.StorageVersionMigration](),
+		),
 	}
 }

--- a/vendor/k8s.io/client-go/pkg/version/.gitattributes
+++ b/vendor/k8s.io/client-go/pkg/version/.gitattributes
@@ -1,0 +1,1 @@
+base.go export-subst

--- a/vendor/k8s.io/client-go/rest/client.go
+++ b/vendor/k8s.io/client-go/rest/client.go
@@ -105,10 +105,6 @@ type RESTClient struct {
 // NewRESTClient creates a new RESTClient. This client performs generic REST functions
 // such as Get, Put, Post, and Delete on specified paths.
 func NewRESTClient(baseURL *url.URL, versionedAPIPath string, config ClientContentConfig, rateLimiter flowcontrol.RateLimiter, client *http.Client) (*RESTClient, error) {
-	if len(config.ContentType) == 0 {
-		config.ContentType = "application/json"
-	}
-
 	base := *baseURL
 	if !strings.HasSuffix(base.Path, "/") {
 		base.Path += "/"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1184,7 +1184,7 @@ k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2
 k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1
 k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme
 k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1
-# k8s.io/client-go v0.31.1
+# k8s.io/client-go v0.31.1 => github.com/vrutkovs/client-go v0.0.0-20241029114452-7f4b7d7b258d
 ## explicit; go 1.22.0
 k8s.io/client-go/applyconfigurations
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
@@ -1633,3 +1633,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
+# k8s.io/client-go => github.com/vrutkovs/client-go v0.0.0-20241029114452-7f4b7d7b258d


### PR DESCRIPTION
Protobuf is more efficient comparing to JSON, but it cannot yet be used for custom types

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
