### PR TITLE
OCPBUGS-44003: fix(monitoring-plugin): disable emitting nginx version on error pages

### DIFF
--- a/assets/monitoring-plugin/config-map.yaml
+++ b/assets/monitoring-plugin/config-map.yaml
@@ -7,6 +7,7 @@ data:
       include            /etc/nginx/mime.types;
       default_type       application/octet-stream;
       keepalive_timeout  65;
+      server_tokens off;
       server {
         listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
         ssl_certificate     /var/cert/tls.crt;

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -23,6 +23,7 @@ function(params)
       include            /etc/nginx/mime.types;
       default_type       application/octet-stream;
       keepalive_timeout  65;
+      server_tokens off;
       server {
         listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
         ssl_certificate     %(tlsPath)s/tls.crt;


### PR DESCRIPTION
See http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
