### PR TITLE
OCPBUGS-44831: disable token automount for alertmanager-user-workload SA

### DIFF
--- a/assets/alertmanager-user-workload/alertmanager.yaml
+++ b/assets/alertmanager-user-workload/alertmanager.yaml
@@ -25,6 +25,7 @@ spec:
         namespaces:
         - openshift-user-workload-monitoring
         topologyKey: kubernetes.io/hostname
+  automountServiceAccountToken: true
   containers:
   - env:
     - name: HTTP_PROXY

--- a/assets/alertmanager-user-workload/service-account.yaml
+++ b/assets/alertmanager-user-workload/service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -18,12 +18,6 @@ function(params)
 
     trustedCaBundle: generateCertInjection.trustedCNOCaBundleCM(cfg.namespace, 'alertmanager-trusted-ca-bundle'),
 
-    serviceAccount+: {
-      // automountServiceAccountToken is set to true as kube-rbac-proxy sidecar
-      // requires connection to kubernetes API
-      automountServiceAccountToken: true,
-    },
-
     // Adding the serving certs annotation causes the serving certs controller
     // to generate a valid and signed serving certificate and put it in the
     // specified secret.
@@ -31,7 +25,6 @@ function(params)
     // The ClusterIP is explicitly set, as it signifies the
     // cluster-monitoring-operator, that when reconciling this service the
     // cluster IP needs to be retained.
-
     service+: {
       metadata+: {
         annotations: {
@@ -209,6 +202,7 @@ function(params)
         },
       },
       spec+: {
+        automountServiceAccountToken: true,
         securityContext: {
           fsGroup: 65534,
           runAsNonRoot: true,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
