### PR TITLE
OCPBUGS-35726: remove certificate hash annotation for monitoring-plugin

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2804,7 +2804,7 @@ func (f *Factory) MonitoringPlugin() (*consolev1.ConsolePlugin, error) {
 	return f.NewConsolePlugin(f.assets.MustNewAssetSlice(MonitoringPlugin))
 }
 
-func (f *Factory) MonitoringPluginDeployment(tlsSecret *v1.Secret) (*appsv1.Deployment, error) {
+func (f *Factory) MonitoringPluginDeployment() (*appsv1.Deployment, error) {
 	d, err := f.NewDeployment(f.assets.MustNewAssetSlice(MonitoringPluginDeployment))
 	if err != nil {
 		return nil, err
@@ -2822,11 +2822,6 @@ func (f *Factory) MonitoringPluginDeployment(tlsSecret *v1.Secret) (*appsv1.Depl
 	}
 
 	containers[idx].Image = f.config.Images.MonitoringPlugin
-
-	// Hash the TLS secret and propagate it as an annotation to the
-	// deployment's pods to trigger a new rollout when the TLS certificate/key
-	// are rotated.
-	d.Spec.Template.Annotations["monitoring.openshift.io/cert-hash"] = hashByteMap(tlsSecret.Data)
 
 	cfg := f.config.ClusterMonitoringConfiguration.MonitoringPluginConfig
 	if cfg == nil {

--- a/pkg/tasks/monitoring_plugin.go
+++ b/pkg/tasks/monitoring_plugin.go
@@ -20,7 +20,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
@@ -108,18 +107,7 @@ func (t *MonitoringPluginTask) Run(ctx context.Context) error {
 			return fmt.Errorf("reconciling Console Plugin Service failed: %w", err)
 		}
 
-		secret, err := t.client.WaitForSecretByNsName(
-			ctx,
-			types.NamespacedName{
-				Namespace: svc.Namespace,
-				Name:      svc.Annotations["service.beta.openshift.io/serving-cert-secret-name"],
-			},
-		)
-		if err != nil {
-			return err
-		}
-
-		d, err := t.factory.MonitoringPluginDeployment(secret)
+		d, err := t.factory.MonitoringPluginDeployment()
 		if err != nil {
 			return fmt.Errorf("initializing Console Plugin Deployment failed: %w", err)
 		}


### PR DESCRIPTION
With https://github.com/openshift/monitoring-plugin/pull/264, the monitoring plugin binary reloads the certificate and key files from disk automatically.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
