### PR TITLE
OCPBUGS-45179: Use explicit name label for logging telemetry metrics

### DIFF
--- a/Documentation/data-collection.md
+++ b/Documentation/data-collection.md
@@ -1020,27 +1020,27 @@ data:
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:log_forwarder_pipelines:sum number of logging pipelines in each namespace
-    - 'openshift_logging:log_forwarder_pipelines:sum'
+    - '{__name__="openshift_logging:log_forwarder_pipelines:sum"}'
     #
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:log_forwarders:sum number of ClusterLogForwarder instances in each namespace
-    - 'openshift_logging:log_forwarders:sum'
+    - '{__name__="openshift_logging:log_forwarders:sum"}'
     #
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:log_forwarder_input_type:sum number of inputs per namespace
-    - 'openshift_logging:log_forwarder_input_type:sum'
+    - '{__name__="openshift_logging:log_forwarder_input_type:sum"}'
     #
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:log_forwarder_output_type:sum number of outputs per namespace
-    - 'openshift_logging:log_forwarder_output_type:sum'
+    - '{__name__="openshift_logging:log_forwarder_output_type:sum"}'
     #
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:vector_component_received_bytes_total:rate5m total number of collected log bytes per namespace
-    - 'openshift_logging:vector_component_received_bytes_total:rate5m'
+    - '{__name__="openshift_logging:vector_component_received_bytes_total:rate5m"}'
     #
     # owners: (@openshift/sandboxed-containers-operator)
     #

--- a/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
@@ -1012,27 +1012,27 @@ data:
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:log_forwarder_pipelines:sum number of logging pipelines in each namespace
-    - 'openshift_logging:log_forwarder_pipelines:sum'
+    - '{__name__="openshift_logging:log_forwarder_pipelines:sum"}'
     #
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:log_forwarders:sum number of ClusterLogForwarder instances in each namespace
-    - 'openshift_logging:log_forwarders:sum'
+    - '{__name__="openshift_logging:log_forwarders:sum"}'
     #
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:log_forwarder_input_type:sum number of inputs per namespace
-    - 'openshift_logging:log_forwarder_input_type:sum'
+    - '{__name__="openshift_logging:log_forwarder_input_type:sum"}'
     #
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:log_forwarder_output_type:sum number of outputs per namespace
-    - 'openshift_logging:log_forwarder_output_type:sum'
+    - '{__name__="openshift_logging:log_forwarder_output_type:sum"}'
     #
     # owners: (@openshift/team-logging)
     #
     # openshift_logging:vector_component_received_bytes_total:rate5m total number of collected log bytes per namespace
-    - 'openshift_logging:vector_component_received_bytes_total:rate5m'
+    - '{__name__="openshift_logging:vector_component_received_bytes_total:rate5m"}'
     #
     # owners: (@openshift/sandboxed-containers-operator)
     #


### PR DESCRIPTION
Updates the metrics queries for the logging telemetry to explicitly use the `__name__` label.

See also #2526 (backport to 4.18) and #2528 (backport of original change to 4.17 including this fix).

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
