### PR TITLE
MGMT-19498: Adding accelerators configuration file to the node-exporter

### DIFF
--- a/assets/node-exporter/accelerators-collector-configmap.yaml
+++ b/assets/node-exporter/accelerators-collector-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  config.yaml: |-
+    - "models":
+      - "pciID": "0x20b5"
+        "pciName": "A100"
+      - "pciID": "0x2230"
+        "pciName": "RTX_A6000"
+      - "pciID": "0x2717"
+        "pciName": "RTX_4090"
+      - "pciID": "0x2235"
+        "pciName": "A40"
+      - "pciID": "0x1df5"
+        "pciName": "V100"
+      - "pciID": "0x20f1"
+        "pciName": "A100 40G"
+      - "pciID": "0x1ff2"
+        "pciName": "T400 4GB"
+      - "pciID": "0x1eb8"
+        "pciName": "Tesla T4"
+      "vendorID": "0x10de"
+      "vendorName": "NVIDIA"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: node-exporter-accelerators-collector-config
+  namespace: openshift-monitoring

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -79,6 +79,9 @@ spec:
         - mountPath: /var/node_exporter/textfile
           name: node-exporter-textfile
           readOnly: true
+        - mountPath: /var/node_exporter/accelerators_collector_config
+          name: node-exporter-accelerators-collector-config
+          readOnly: true
         workingDir: /var/node_exporter/textfile
       - args:
         - --secure-listen-address=[$(IP)]:9100
@@ -182,6 +185,12 @@ spec:
       - name: node-exporter-kube-rbac-proxy-config
         secret:
           secretName: node-exporter-kube-rbac-proxy-config
+      - configMap:
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: node-exporter-accelerators-collector-config
+        name: node-exporter-accelerators-collector-config
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -138,6 +138,7 @@ var (
 	NodeExporterMinimalServiceMonitor      = "node-exporter/minimal-service-monitor.yaml"
 	NodeExporterPrometheusRule             = "node-exporter/prometheus-rule.yaml"
 	NodeExporterKubeRbacProxySecret        = "node-exporter/kube-rbac-proxy-secret.yaml"
+	NodeExporterAcceleratorsConfigMap      = "node-exporter/accelerators-collector-configmap.yaml"
 
 	PrometheusK8sClusterRoleBinding               = "prometheus-k8s/cluster-role-binding.yaml"
 	PrometheusK8sRoleBindingConfig                = "prometheus-k8s/role-binding-config.yaml"
@@ -1031,6 +1032,10 @@ func (f *Factory) NodeExporterPrometheusRule() (*monv1.PrometheusRule, error) {
 
 func (f *Factory) NodeExporterRBACProxySecret() (*v1.Secret, error) {
 	return f.NewSecret(f.assets.MustNewAssetSlice(NodeExporterKubeRbacProxySecret))
+}
+
+func (f *Factory) NodeExporterAcceleratorsCollectorConfigMap() (*v1.ConfigMap, error) {
+	return f.NewConfigMap(f.assets.MustNewAssetSlice(NodeExporterAcceleratorsConfigMap))
 }
 
 func (f *Factory) PrometheusK8sClusterRoleBinding() (*rbacv1.ClusterRoleBinding, error) {

--- a/pkg/tasks/nodeexporter.go
+++ b/pkg/tasks/nodeexporter.go
@@ -94,6 +94,15 @@ func (t *NodeExporterTask) Run(ctx context.Context) error {
 		return fmt.Errorf("reconciling node-exporter Service failed: %w", err)
 	}
 
+	cm, err := t.factory.NodeExporterAcceleratorsCollectorConfigMap()
+	if err != nil {
+		return fmt.Errorf("initializing node-exporter accelerators collector ConfigMap failed: %w", err)
+	}
+	err = t.client.CreateOrUpdateConfigMap(ctx, cm)
+	if err != nil {
+		return fmt.Errorf("reconciling node-exporter accelerators collector ConfigMap failed: %w", err)
+	}
+
 	ds, err := t.factory.NodeExporterDaemonSet()
 	if err != nil {
 		return fmt.Errorf("initializing node-exporter DaemonSet failed: %w", err)


### PR DESCRIPTION
1) adding ConfigMap that contains the yaml structure describing
   monitored accelerators per vendor/model
2) mapping accelerators ConfigMap into the node-exporter pods 3) adding env variable that contains the exact path for the mapped
   ConfigMap

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
