### PR TITLE
MON-3866: create separate metrics client cert for metrics server

### DIFF
--- a/assets/cluster-monitoring-operator/metrics-server-client-certs.yaml
+++ b/assets/cluster-monitoring-operator/metrics-server-client-certs.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+  name: metrics-server-client-certs
+  namespace: openshift-monitoring
+type: Opaque

--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -46,8 +46,8 @@ spec:
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
         - --kubelet-certificate-authority=/etc/tls/kubelet-serving-ca-bundle/ca-bundle.crt
-        - --kubelet-client-certificate=/etc/tls/metrics-client-certs/tls.crt
-        - --kubelet-client-key=/etc/tls/metrics-client-certs/tls.key
+        - --kubelet-client-certificate=/etc/tls/metrics-server-client-certs/tls.crt
+        - --kubelet-client-key=/etc/tls/metrics-server-client-certs/tls.key
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
@@ -88,8 +88,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/tls/private
           name: secret-metrics-server-tls
-        - mountPath: /etc/tls/metrics-client-certs
-          name: secret-metrics-client-certs
+        - mountPath: /etc/tls/metrics-server-client-certs
+          name: secret-metrics-server-client-certs
         - mountPath: /etc/tls/kubelet-serving-ca-bundle
           name: configmap-kubelet-serving-ca-bundle
         - mountPath: /etc/audit
@@ -104,9 +104,9 @@ spec:
       serviceAccountName: metrics-server
       terminationGracePeriodSeconds: 170
       volumes:
-      - name: secret-metrics-client-certs
+      - name: secret-metrics-server-client-certs
         secret:
-          secretName: metrics-client-certs
+          secretName: metrics-server-client-certs
       - name: secret-metrics-server-tls
         secret:
           secretName: metrics-server-tls

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -80,6 +80,17 @@ function(params) {
     },
   },
 
+  metricsServerClientCerts: {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name: 'metrics-server-client-certs',
+      namespace: cfg.namespace,
+    },
+    type: 'Opaque',
+    data: {},
+  },
+
   metricsClientCerts: {
     apiVersion: 'v1',
     kind: 'Secret',

--- a/jsonnet/components/metrics-server.libsonnet
+++ b/jsonnet/components/metrics-server.libsonnet
@@ -197,8 +197,8 @@ function(params) {
                 '--kubelet-use-node-status-port',
                 '--metric-resolution=15s',
                 '--kubelet-certificate-authority=/etc/tls/kubelet-serving-ca-bundle/ca-bundle.crt',
-                '--kubelet-client-certificate=/etc/tls/metrics-client-certs/tls.crt',
-                '--kubelet-client-key=/etc/tls/metrics-client-certs/tls.key',
+                '--kubelet-client-certificate=/etc/tls/metrics-server-client-certs/tls.crt',
+                '--kubelet-client-key=/etc/tls/metrics-server-client-certs/tls.key',
                 '--tls-cert-file=/etc/tls/private/tls.crt',
                 '--tls-private-key-file=/etc/tls/private/tls.key',
                 '--tls-cipher-suites=' + cfg.tlsCipherSuites,
@@ -260,8 +260,8 @@ function(params) {
                   name: 'secret-metrics-server-tls',
                 },
                 {
-                  mountPath: '/etc/tls/metrics-client-certs',
-                  name: 'secret-metrics-client-certs',
+                  mountPath: '/etc/tls/metrics-server-client-certs',
+                  name: 'secret-metrics-server-client-certs',
                 },
                 {
                   mountPath: '/etc/tls/kubelet-serving-ca-bundle',
@@ -278,9 +278,9 @@ function(params) {
           terminationGracePeriodSeconds: 170,
           volumes: [
             {
-              name: 'secret-metrics-client-certs',
+              name: 'secret-metrics-server-client-certs',
               secret: {
-                secretName: 'metrics-client-certs',
+                secretName: 'metrics-server-client-certs',
               },
             },
             {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -242,6 +242,7 @@ var (
 	ClusterMonitoringGrpcTLSSecret                         = "cluster-monitoring-operator/grpc-tls-secret.yaml"
 	ClusterMonitoringOperatorPrometheusRule                = "cluster-monitoring-operator/prometheus-rule.yaml"
 	ClusterMonitoringMetricsClientCertsSecret              = "cluster-monitoring-operator/metrics-client-certs.yaml"
+	ClusterMonitoringMetricsServerClientCertsSecret        = "cluster-monitoring-operator/metrics-server-client-certs.yaml"
 	ClusterMonitoringFederateClientCertsSecret             = "cluster-monitoring-operator/federate-client-certs.yaml"
 	ClusterMonitoringMetricsClientCACM                     = "cluster-monitoring-operator/metrics-client-ca.yaml"
 
@@ -1889,7 +1890,7 @@ func (f *Factory) MetricsServerRoleBindingAuthReader() (*rbacv1.RoleBinding, err
 	return f.NewRoleBinding(f.assets.MustNewAssetSlice(MetricsServerRoleBindingAuthReader))
 }
 
-func (f *Factory) MetricsServerDeployment(apiAuthSecretName string, kubeletCABundle *v1.ConfigMap, servingCASecret, metricsClientCert *v1.Secret, requestheader map[string]string) (*appsv1.Deployment, error) {
+func (f *Factory) MetricsServerDeployment(apiAuthSecretName string, kubeletCABundle *v1.ConfigMap, servingCASecret, metricsServerClientCerts *v1.Secret, requestheader map[string]string) (*appsv1.Deployment, error) {
 	dep, err := f.NewDeployment(f.assets.MustNewAssetSlice(MetricsServerDeployment))
 	if err != nil {
 		return nil, err
@@ -1934,10 +1935,10 @@ func (f *Factory) MetricsServerDeployment(apiAuthSecretName string, kubeletCABun
 	// are rotated.
 	dep.Spec.Template.Annotations["monitoring.openshift.io/serving-ca-secret-hash"] = hashByteMap(servingCASecret.Data)
 
-	// Hash the metrics client cert and propagate it as an annotation to the
-	// deployment's pods to trigger a new rollout when the metrics client cert
+	// Hash the metrics server client cert and propagate it as an annotation to the
+	// deployment's pods to trigger a new rollout when the metrics server client cert
 	// is rotated.
-	dep.Spec.Template.Annotations["monitoring.openshift.io/metrics-client-cert-hash"] = hashByteMap(metricsClientCert.Data)
+	dep.Spec.Template.Annotations["monitoring.openshift.io/metrics-server-client-certs-hash"] = hashByteMap(metricsServerClientCerts.Data)
 
 	config := f.config.ClusterMonitoringConfiguration.MetricsServerConfig
 	if config == nil {
@@ -2017,12 +2018,8 @@ func (f *Factory) MetricsServerDeployment(apiAuthSecretName string, kubeletCABun
 	return dep, nil
 }
 
-func (f *Factory) MetricsServerSecret(tlsSecret *v1.Secret, apiAuthConfigmap *v1.ConfigMap) (*v1.Secret, error) {
+func (f *Factory) MetricsServerClientCASecret(apiAuthConfigmap *v1.ConfigMap) (*v1.Secret, error) {
 	data := make(map[string]string)
-
-	for k, v := range tlsSecret.Data {
-		data[k] = string(v)
-	}
 
 	for k, v := range apiAuthConfigmap.Data {
 		data[k] = v
@@ -2033,8 +2030,6 @@ func (f *Factory) MetricsServerSecret(tlsSecret *v1.Secret, apiAuthConfigmap *v1
 	var (
 		clientCA              = r.value("client-ca-file")
 		requestheaderClientCA = r.value("requestheader-client-ca-file")
-		tlsCA                 = r.value("tls.crt")
-		tlsKey                = r.value("tls.key")
 	)
 
 	if r.Error() != nil {
@@ -2042,7 +2037,7 @@ func (f *Factory) MetricsServerSecret(tlsSecret *v1.Secret, apiAuthConfigmap *v1
 	}
 
 	h := fnv.New64()
-	h.Write([]byte(clientCA + requestheaderClientCA + tlsCA + tlsKey))
+	h.Write([]byte(clientCA + requestheaderClientCA))
 	hash := strconv.FormatUint(h.Sum64(), 32)
 
 	return &v1.Secret{
@@ -2057,8 +2052,6 @@ func (f *Factory) MetricsServerSecret(tlsSecret *v1.Secret, apiAuthConfigmap *v1
 		Data: map[string][]byte{
 			"client-ca-file":               []byte(clientCA),
 			"requestheader-client-ca-file": []byte(requestheaderClientCA),
-			"tls.crt":                      []byte(tlsCA),
-			"tls.key":                      []byte(tlsKey),
 		},
 	}, nil
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2577,7 +2577,7 @@ metricsServer:
 	}
 	metricsClientSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "metrics-client-cert",
+			Name:      "metrics-server-client-certs",
 			Namespace: "openshift-monitoring",
 		},
 		Data: map[string][]byte{
@@ -2637,7 +2637,7 @@ metricsServer:
 
 	podAnnotations := d.Spec.Template.Annotations
 	require.Equal(t, "eplue2a9srfkb", podAnnotations["monitoring.openshift.io/kubelet-serving-ca-bundle-hash"])
-	require.Equal(t, "arprfan3mk728", podAnnotations["monitoring.openshift.io/metrics-client-cert-hash"])
+	require.Equal(t, "arprfan3mk728", podAnnotations["monitoring.openshift.io/metrics-server-client-certs-hash"])
 	require.Equal(t, "383c7cmidrae2", podAnnotations["monitoring.openshift.io/serving-ca-secret-hash"])
 }
 

--- a/pkg/manifests/tls.go
+++ b/pkg/manifests/tls.go
@@ -66,6 +66,19 @@ func (f *Factory) MetricsClientCerts() (*v1.Secret, error) {
 	return s, nil
 }
 
+func (f *Factory) MetricsServerClientCerts() (*v1.Secret, error) {
+	s, err := f.NewSecret(f.assets.MustNewAssetSlice(ClusterMonitoringMetricsServerClientCertsSecret))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Namespace = f.namespace
+	s.Data = make(map[string][]byte)
+	s.Annotations = make(map[string]string)
+
+	return s, nil
+}
+
 func (f *Factory) FederateClientCerts() (*v1.Secret, error) {
 	s, err := f.NewSecret(f.assets.MustNewAssetSlice(ClusterMonitoringFederateClientCertsSecret))
 	if err != nil {


### PR DESCRIPTION
reviving https://github.com/openshift/cluster-monitoring-operator/pull/2329

requires https://github.com/openshift/cluster-policy-controller/pull/148

- [x] test deleting the secret

---

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
