### PR TITLE
OCPBUGS-45895: Reconcile pre-existing Secrets

### DIFF
--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -111,7 +111,7 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return fmt.Errorf("initializing Alertmanager RBAC proxy Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
 	if err != nil {
 		return fmt.Errorf("creating Alertmanager RBAC proxy Secret failed: %w", err)
 	}
@@ -121,7 +121,7 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return fmt.Errorf("initializing Alertmanager RBAC proxy metric Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rsm)
+	err = t.client.CreateOrUpdateSecret(ctx, rsm)
 	if err != nil {
 		return fmt.Errorf("creating Alertmanager RBAC proxy metric Secret failed: %w", err)
 	}
@@ -173,7 +173,7 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return fmt.Errorf("initializing Alertmanager proxy web Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, ps)
+	err = t.client.CreateOrUpdateSecret(ctx, ps)
 	if err != nil {
 		return fmt.Errorf("creating Alertmanager proxy web Secret failed: %w", err)
 	}

--- a/pkg/tasks/alertmanager_user_workload.go
+++ b/pkg/tasks/alertmanager_user_workload.go
@@ -90,7 +90,7 @@ func (t *AlertmanagerUserWorkloadTask) create(ctx context.Context) error {
 		return fmt.Errorf("initializing Alertmanager User Workload RBAC proxy Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, s)
+	err = t.client.CreateOrUpdateSecret(ctx, s)
 	if err != nil {
 		return fmt.Errorf("creating Alertmanager User Workload RBAC proxy Secret failed: %w", err)
 	}
@@ -100,7 +100,7 @@ func (t *AlertmanagerUserWorkloadTask) create(ctx context.Context) error {
 		return fmt.Errorf("initializing Alertmanager User Workload RBAC proxy tenancy Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, s)
+	err = t.client.CreateOrUpdateSecret(ctx, s)
 	if err != nil {
 		return fmt.Errorf("creating Alertmanager User Workload RBAC proxy tenancy Secret failed: %w", err)
 	}
@@ -110,7 +110,7 @@ func (t *AlertmanagerUserWorkloadTask) create(ctx context.Context) error {
 		return fmt.Errorf("initializing Alertmanager User Workload RBAC proxy metric Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rsm)
+	err = t.client.CreateOrUpdateSecret(ctx, rsm)
 	if err != nil {
 		return fmt.Errorf("creating Alertmanager User Workload RBAC proxy metric Secret failed: %w", err)
 	}

--- a/pkg/tasks/kubestatemetrics.go
+++ b/pkg/tasks/kubestatemetrics.go
@@ -80,7 +80,7 @@ func (t *KubeStateMetricsTask) Run(ctx context.Context) error {
 		return fmt.Errorf("initializing kube-state-metrics RBAC proxy Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
 	if err != nil {
 		return fmt.Errorf("creating kube-state-metrics RBAC proxy Secret failed: %w", err)
 	}

--- a/pkg/tasks/nodeexporter.go
+++ b/pkg/tasks/nodeexporter.go
@@ -80,7 +80,7 @@ func (t *NodeExporterTask) Run(ctx context.Context) error {
 		return fmt.Errorf("intializing node-exporter rbac proxy secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, nes)
+	err = t.client.CreateOrUpdateSecret(ctx, nes)
 	if err != nil {
 		return fmt.Errorf("creating node-exporter rbac proxy secret failed: %w", err)
 	}

--- a/pkg/tasks/openshiftstatemetrics.go
+++ b/pkg/tasks/openshiftstatemetrics.go
@@ -90,7 +90,7 @@ func (t *OpenShiftStateMetricsTask) Run(ctx context.Context) error {
 		return fmt.Errorf("initializing openshift-state-metrics RBAC proxy Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
 	if err != nil {
 		return fmt.Errorf("creating openshift-state-metrics RBAC proxy Secret failed: %w", err)
 	}

--- a/pkg/tasks/prometheusoperator.go
+++ b/pkg/tasks/prometheusoperator.go
@@ -95,7 +95,7 @@ func (t *PrometheusOperatorTask) Run(ctx context.Context) error {
 		return fmt.Errorf("initializing Prometheus Operator RBAC proxy Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
 	if err != nil {
 		return fmt.Errorf("creating Prometheus Operator RBAC proxy Secret failed: %w", err)
 	}

--- a/pkg/tasks/thanos_querier.go
+++ b/pkg/tasks/thanos_querier.go
@@ -83,7 +83,7 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 		return fmt.Errorf("initializing Thanos Querier RBAC proxy Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
 	if err != nil {
 		return fmt.Errorf("creating Thanos Querier RBAC proxy Secret failed: %w", err)
 	}
@@ -93,7 +93,7 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 		return fmt.Errorf("initializing Thanos Querier RBAC proxy rules Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
 	if err != nil {
 		return fmt.Errorf("creating Thanos Querier RBAC proxy rules Secret failed: %w", err)
 	}
@@ -103,7 +103,7 @@ func (t *ThanosQuerierTask) Run(ctx context.Context) error {
 		return fmt.Errorf("initializing Thanos Querier RBAC proxy metrics Secret failed: %w", err)
 	}
 
-	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	err = t.client.CreateOrUpdateSecret(ctx, rs)
 	if err != nil {
 		return fmt.Errorf("creating Thanos Querier RBAC proxy metrics Secret failed: %w", err)
 	}

--- a/test/e2e/reconcile_objects_test.go
+++ b/test/e2e/reconcile_objects_test.go
@@ -14,6 +14,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 )
 
 // TestSecretsReconciliation tests whether the secrets created by the operator are reconciled correctly. These include:
@@ -53,14 +54,12 @@ func TestSecretsReconciliation(t *testing.T) {
 		},
 	}
 
-	restoreSecrets := func(secrets []types.NamespacedName) {
-		for _, secret := range secrets {
+	// Restore unsynced secrets to their original state after the test.
+	// Synced secrets don't need restoration since the operator reconciles those.
+	t.Cleanup(func() {
+		for _, secret := range unsyncedSecrets {
 			gotSecret, err := f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
-			if err != nil {
-				// Secret may have been rotated (e.g. hash-suffixed TLS secrets).
-				t.Logf("skipping restore of %s: %v", secret.String(), err)
-				continue
-			}
+			require.NoError(t, err)
 			data := gotSecret.Data
 			for k, v := range data {
 				if isSecretDataJSONEncoded(gotSecret) {
@@ -78,70 +77,70 @@ func TestSecretsReconciliation(t *testing.T) {
 			_, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Update(context.Background(), gotSecret, metav1.UpdateOptions{})
 			require.NoError(t, err)
 		}
-	}
+	})
 
-	var syncedSecrets []types.NamespacedName
 	// Fetch all secrets since we are responsible for the whole namespace.
+	var syncedSecrets []types.NamespacedName
 	secretsNS, err := f.KubeClient.CoreV1().Secrets(f.Ns).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-
 	secretsUWMNS, err := f.KubeClient.CoreV1().Secrets(f.UserWorkloadMonitoringNs).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 
 	for _, secret := range append(secretsNS.Items, secretsUWMNS.Items...) {
-		secretNamespacedName := types.NamespacedName{
+		nn := types.NamespacedName{
 			Name:      secret.Name,
 			Namespace: secret.Namespace,
 		}
-		if slices.Contains(unsyncedSecrets, secretNamespacedName) {
+		if slices.Contains(unsyncedSecrets, nn) {
 			continue
 		}
-		syncedSecrets = append(syncedSecrets, secretNamespacedName)
+		// Skip TLS secrets since they have hash suffixes and get rotated (replaced, not updated in-place).
+		if strings.Contains(secret.Name, "tls") {
+			continue
+		}
+		syncedSecrets = append(syncedSecrets, nn)
 	}
 	require.NotEmpty(t, syncedSecrets)
 
 	secrets := append(syncedSecrets, unsyncedSecrets...)
 
-	t.Cleanup(func() { restoreSecrets(secrets) })
-
 	// Update the aforementioned secrets' data.
-	var mutatedSecrets []types.NamespacedName
 	for _, secret := range secrets {
-		var gotSecret *v1.Secret
-		gotSecret, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
-		if err != nil {
-			// Secret may have been rotated (e.g. hash-suffixed TLS secrets).
-			t.Logf("skipping mutation of %s: %v", secret.String(), err)
-			continue
-		}
-		data := gotSecret.Data
-		for k, v := range data {
-			if isSecretDataJSONEncoded(gotSecret) {
-				var jsonData map[string]interface{}
-				err = json.Unmarshal(v, &jsonData)
-				require.NoError(t, err)
-				jsonData[t.Name()] = t.Name()
-				v, err = json.Marshal(jsonData)
-				require.NoError(t, err)
-				data[k] = v
-			} else {
-				data[k] = []byte(t.Name() + string(v))
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			gotSecret, err := f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
 			}
-			break
-		}
-
-		_, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Update(context.Background(), gotSecret, metav1.UpdateOptions{})
+			data := gotSecret.Data
+			for k, v := range data {
+				if isSecretDataJSONEncoded(gotSecret) {
+					var jsonData map[string]interface{}
+					if err := json.Unmarshal(v, &jsonData); err != nil {
+						return err
+					}
+					jsonData[t.Name()] = t.Name()
+					v, err = json.Marshal(jsonData)
+					if err != nil {
+						return err
+					}
+					data[k] = v
+				} else {
+					data[k] = []byte(t.Name() + string(v))
+				}
+				break
+			}
+			_, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Update(context.Background(), gotSecret, metav1.UpdateOptions{})
+			return err
+		})
 		require.NoError(t, err)
-		mutatedSecrets = append(mutatedSecrets, secret)
 	}
 
 	// Check for reconciliation of secrets.
-	for _, secret := range mutatedSecrets {
-		// Check if the secrets were reconciled as expected.
+	for _, secret := range secrets {
+		// Synced secrets should be reconciled, i.e., the test prefix must be removed.
 		if slices.Contains(syncedSecrets, secret) {
-			err = framework.Poll(10*time.Second, 5*time.Minute, func() error {
-				var updatedSecret *v1.Secret
-				updatedSecret, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+			err := framework.Poll(10*time.Second, 5*time.Minute, func() error {
+				updatedSecret, err := f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -152,7 +151,8 @@ func TestSecretsReconciliation(t *testing.T) {
 						if strings.HasPrefix(string(v), t.Name()) {
 							return fmt.Errorf("secret %s has unexpected data: %v", secret.String(), string(v))
 						}
-						// Don't return early. Since map iteration order is non-deterministic, the mutated entry may not be the first one visited here.
+						// Don't return early. Since map iteration order is non-deterministic,
+						// the mutated entry may not be the first one visited here.
 						continue
 					}
 
@@ -168,15 +168,13 @@ func TestSecretsReconciliation(t *testing.T) {
 
 				return nil
 			})
-
 			require.NoError(t, err)
 		}
 
-		// Check if the secrets were reconciled unexpectedly.
-		// Only one entry was mutated, so we verify at least one entry still carries the test prefix.
+		// Unsynced secrets should NOT be reconciled, i.e., the test prefix must still be present.
+		// Only one entry was mutated, so we verify at least one entry still carries it.
 		if slices.Contains(unsyncedSecrets, secret) {
-			var updatedSecret *v1.Secret
-			updatedSecret, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+			updatedSecret, err := f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 			data := updatedSecret.Data
 			found := false

--- a/test/e2e/reconcile_objects_test.go
+++ b/test/e2e/reconcile_objects_test.go
@@ -95,7 +95,11 @@ func TestSecretsReconciliation(t *testing.T) {
 			continue
 		}
 		// Skip TLS secrets since they are managed by the service-ca controller, not CMO.
+		// Skip hashed secrets since they are replaced (not updated in-place) on rotation.
 		if secret.Type == v1.SecretTypeTLS {
+			continue
+		}
+		if _, ok := secret.Labels["monitoring.openshift.io/hash"]; ok {
 			continue
 		}
 		syncedSecrets = append(syncedSecrets, nn)

--- a/test/e2e/reconcile_objects_test.go
+++ b/test/e2e/reconcile_objects_test.go
@@ -94,8 +94,8 @@ func TestSecretsReconciliation(t *testing.T) {
 		if slices.Contains(unsyncedSecrets, nn) {
 			continue
 		}
-		// Skip TLS secrets since they have hash suffixes and get rotated (replaced, not updated in-place).
-		if strings.Contains(secret.Name, "tls") {
+		// Skip TLS secrets since they are managed by the service-ca controller, not CMO.
+		if secret.Type == v1.SecretTypeTLS {
 			continue
 		}
 		syncedSecrets = append(syncedSecrets, nn)
@@ -167,7 +167,7 @@ func TestSecretsReconciliation(t *testing.T) {
 				for _, v := range data {
 					if !isSecretDataJSONEncoded(updatedSecret) {
 						if strings.HasPrefix(string(v), t.Name()) {
-							return fmt.Errorf("secret %s has unexpected data: %v", secret.String(), string(v))
+							return fmt.Errorf("secret %s still has the test prefix in its data", secret.String())
 						}
 						// Don't return early. Since map iteration order is non-deterministic,
 						// the mutated entry may not be the first one visited here.

--- a/test/e2e/reconcile_objects_test.go
+++ b/test/e2e/reconcile_objects_test.go
@@ -1,0 +1,204 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestSecretsReconciliation tests whether the secrets created by the operator are reconciled correctly. These include:
+// * unsynced secrets: secrets that are deployed by, but not synced by the operator, and,
+// * synced secrets: secrets that are deployed by, and should be synced by the operator.
+
+func TestSecretsReconciliation(t *testing.T) {
+	// Create assets under both scenarios for us to work with.
+	setupUserWorkloadAssetsWithTeardownHook(t, f)
+	userWorkloadConfigMap := f.BuildUserWorkloadConfigMap(t, `alertmanager:
+  enabled: true
+`)
+	f.MustCreateOrUpdateConfigMap(t, userWorkloadConfigMap)
+	defer f.MustDeleteConfigMap(t, userWorkloadConfigMap)
+
+	f.AssertStatefulSetExistsAndRolloutFunc("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
+	f.AssertServiceExistsFunc("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
+	f.AssertSecretExistsFunc("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
+
+	// List of secrets that should not be synced during operator's reconciliation.
+	unsyncedSecrets := []types.NamespacedName{
+		{
+			Name:      "alertmanager-main",
+			Namespace: f.Ns,
+		},
+		{
+			Name:      "alertmanager-user-workload",
+			Namespace: f.UserWorkloadMonitoringNs,
+		},
+		{
+			Name:      "thanos-ruler-user-workload-config",
+			Namespace: f.UserWorkloadMonitoringNs,
+		},
+		{
+			Name:      "thanos-ruler-user-workload-web-config",
+			Namespace: f.UserWorkloadMonitoringNs,
+		},
+	}
+
+	restoreSecrets := func(secrets []types.NamespacedName) {
+		for _, secret := range secrets {
+			gotSecret, err := f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+			if err != nil {
+				// Secret may have been rotated (e.g. hash-suffixed TLS secrets).
+				t.Logf("skipping restore of %s: %v", secret.String(), err)
+				continue
+			}
+			data := gotSecret.Data
+			for k, v := range data {
+				if isSecretDataJSONEncoded(gotSecret) {
+					var jsonData map[string]interface{}
+					err := json.Unmarshal(v, &jsonData)
+					require.NoErrorf(t, err, "failed to unmarshal JSON in %s", secret.String())
+					delete(jsonData, t.Name())
+					restored, err := json.Marshal(jsonData)
+					require.NoErrorf(t, err, "failed to marshal JSON in %s", secret.String())
+					data[k] = restored
+				} else {
+					data[k] = []byte(strings.TrimPrefix(string(v), t.Name()))
+				}
+			}
+			_, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Update(context.Background(), gotSecret, metav1.UpdateOptions{})
+			require.NoError(t, err)
+		}
+	}
+
+	var syncedSecrets []types.NamespacedName
+	// Fetch all secrets since we are responsible for the whole namespace.
+	secretsNS, err := f.KubeClient.CoreV1().Secrets(f.Ns).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	secretsUWMNS, err := f.KubeClient.CoreV1().Secrets(f.UserWorkloadMonitoringNs).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	for _, secret := range append(secretsNS.Items, secretsUWMNS.Items...) {
+		secretNamespacedName := types.NamespacedName{
+			Name:      secret.Name,
+			Namespace: secret.Namespace,
+		}
+		if slices.Contains(unsyncedSecrets, secretNamespacedName) {
+			continue
+		}
+		syncedSecrets = append(syncedSecrets, secretNamespacedName)
+	}
+	require.NotEmpty(t, syncedSecrets)
+
+	secrets := append(syncedSecrets, unsyncedSecrets...)
+
+	t.Cleanup(func() { restoreSecrets(secrets) })
+
+	// Update the aforementioned secrets' data.
+	var mutatedSecrets []types.NamespacedName
+	for _, secret := range secrets {
+		var gotSecret *v1.Secret
+		gotSecret, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+		if err != nil {
+			// Secret may have been rotated (e.g. hash-suffixed TLS secrets).
+			t.Logf("skipping mutation of %s: %v", secret.String(), err)
+			continue
+		}
+		data := gotSecret.Data
+		for k, v := range data {
+			if isSecretDataJSONEncoded(gotSecret) {
+				var jsonData map[string]interface{}
+				err = json.Unmarshal(v, &jsonData)
+				require.NoError(t, err)
+				jsonData[t.Name()] = t.Name()
+				v, err = json.Marshal(jsonData)
+				require.NoError(t, err)
+				data[k] = v
+			} else {
+				data[k] = []byte(t.Name() + string(v))
+			}
+			break
+		}
+
+		_, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Update(context.Background(), gotSecret, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		mutatedSecrets = append(mutatedSecrets, secret)
+	}
+
+	// Check for reconciliation of secrets.
+	for _, secret := range mutatedSecrets {
+		// Check if the secrets were reconciled as expected.
+		if slices.Contains(syncedSecrets, secret) {
+			err = framework.Poll(10*time.Second, 5*time.Minute, func() error {
+				var updatedSecret *v1.Secret
+				updatedSecret, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				data := updatedSecret.Data
+				for _, v := range data {
+					if !isSecretDataJSONEncoded(updatedSecret) {
+						if strings.HasPrefix(string(v), t.Name()) {
+							return fmt.Errorf("secret %s has unexpected data: %v", secret.String(), string(v))
+						}
+						// Don't return early. Since map iteration order is non-deterministic, the mutated entry may not be the first one visited here.
+						continue
+					}
+
+					var jsonData map[string]interface{}
+					err = json.Unmarshal(v, &jsonData)
+					if err != nil {
+						return fmt.Errorf("failed to unmarshal JSON data in secret %s: %v", secret.String(), err)
+					}
+					if _, ok := jsonData[t.Name()]; ok {
+						return fmt.Errorf("secret %s contains unexpected key %s", secret.String(), t.Name())
+					}
+				}
+
+				return nil
+			})
+
+			require.NoError(t, err)
+		}
+
+		// Check if the secrets were reconciled unexpectedly.
+		// Only one entry was mutated, so we verify at least one entry still carries the test prefix.
+		if slices.Contains(unsyncedSecrets, secret) {
+			var updatedSecret *v1.Secret
+			updatedSecret, err = f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(context.Background(), secret.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			data := updatedSecret.Data
+			found := false
+			for _, v := range data {
+				if isSecretDataJSONEncoded(updatedSecret) {
+					var jsonData map[string]interface{}
+					err := json.Unmarshal(v, &jsonData)
+					require.NoErrorf(t, err, "failed to unmarshal JSON in %s", secret.String())
+					if _, ok := jsonData[t.Name()]; ok {
+						found = true
+						break
+					}
+				} else if strings.HasPrefix(string(v), t.Name()) {
+					found = true
+					break
+				}
+			}
+			require.True(t, found, fmt.Sprintf("secret %s was unexpectedly reconciled", secret.String()))
+		}
+	}
+}
+
+func isSecretDataJSONEncoded(secret *v1.Secret) bool {
+	return secret.Type == v1.SecretTypeDockercfg || secret.Type == v1.SecretTypeDockerConfigJson
+}

--- a/test/e2e/reconcile_objects_test.go
+++ b/test/e2e/reconcile_objects_test.go
@@ -95,11 +95,18 @@ func TestSecretsReconciliation(t *testing.T) {
 			continue
 		}
 		// Skip TLS secrets since they are managed by the service-ca controller, not CMO.
-		// Skip hashed secrets since they are replaced (not updated in-place) on rotation.
 		if secret.Type == v1.SecretTypeTLS {
 			continue
 		}
+		// Skip hashed secrets since they are replaced (not updated in-place) on rotation.
 		if _, ok := secret.Labels["monitoring.openshift.io/hash"]; ok {
+			continue
+		}
+		// Skip dynamically-managed cert secrets. These use a read-modify-write
+		// pattern (load existing → maybe rotate → write back) rather than
+		// reconciling to a static desired state from an asset, so mutating
+		// non-CA keys won't be detected or corrected.
+		if _, hasCACert := secret.Data["ca.crt"]; hasCACert {
 			continue
 		}
 		syncedSecrets = append(syncedSecrets, nn)

--- a/test/e2e/reconcile_objects_test.go
+++ b/test/e2e/reconcile_objects_test.go
@@ -135,6 +135,24 @@ func TestSecretsReconciliation(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Trigger an operator reconciliation by annotating the cluster-monitoring-config
+	// ConfigMap. The operator's event handler only enqueues reconciliation for a
+	// specific set of ConfigMaps/Secrets, so mutating arbitrary secrets won't
+	// trigger a sync on its own.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := f.KubeClient.CoreV1().ConfigMaps(f.Ns).Get(context.Background(), framework.ClusterMonitorConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if cm.Annotations == nil {
+			cm.Annotations = map[string]string{}
+		}
+		cm.Annotations["monitoring.openshift.io/trigger-reconciliation"] = time.Now().Format(time.RFC3339)
+		_, err = f.KubeClient.CoreV1().ConfigMaps(f.Ns).Update(context.Background(), cm, metav1.UpdateOptions{})
+		return err
+	})
+	require.NoError(t, err)
+
 	// Check for reconciliation of secrets.
 	for _, secret := range secrets {
 		// Synced secrets should be reconciled, i.e., the test prefix must be removed.


### PR DESCRIPTION
Until now, CMO did not reconcile existing secrets, even if their data changed. This changes that behavior.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
