### PR TITLE
NO-JIRA: fix TestPrometheusRemoteWrite to align the image used for th…

### DIFF
--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -47,11 +47,11 @@ func (f Framework) MakePrometheusWithWebTLSRemoteReceive(name, tlsSecretName str
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Image:              image,
-				Replicas:           &replicas,
-				ServiceAccountName: "prometheus-k8s",
-				Secrets:            []string{tlsSecretName},
-				EnableFeatures:     []monitoringv1.EnableFeature{"remote-write-receiver"},
+				Image:                     image,
+				Replicas:                  &replicas,
+				ServiceAccountName:        "prometheus-k8s",
+				Secrets:                   []string{tlsSecretName},
+				EnableRemoteWriteReceiver: true,
 				Web: &monitoringv1.PrometheusWebSpec{
 					WebConfigFileFields: monitoringv1.WebConfigFileFields{
 						TLSConfig: &monitoringv1.WebTLSConfig{

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (f Framework) MakePrometheusWithWebTLSRemoteReceive(name, tlsSecretName string) *monitoringv1.Prometheus {
+func (f Framework) MakePrometheusWithWebTLSRemoteReceive(name, tlsSecretName string, image *string) *monitoringv1.Prometheus {
 	// This is not required in the Prometheus spec, but we inspect that value in
 	// WaitForPrometheus. Omitting it causes this code to derefence a nil.
 	replicas := int32(1)
@@ -47,6 +47,7 @@ func (f Framework) MakePrometheusWithWebTLSRemoteReceive(name, tlsSecretName str
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Image:              image,
 				Replicas:           &replicas,
 				ServiceAccountName: "prometheus-k8s",
 				Secrets:            []string{tlsSecretName},

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -123,7 +123,7 @@ type remoteWriteTest struct {
 func TestPrometheusRemoteWrite(t *testing.T) {
 	ctx := context.Background()
 
-	// Get the Prometheus image to use, use the same than k8s's.
+	// Use the same image than k8s' for the remote write target.
 	k8sProm, err := f.MonitoringClient.Prometheuses(f.Ns).Get(ctx, "k8s", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -123,6 +123,13 @@ type remoteWriteTest struct {
 func TestPrometheusRemoteWrite(t *testing.T) {
 	ctx := context.Background()
 
+	// Get the Prometheus image to use, use the same than k8s's.
+	k8sProm, err := f.MonitoringClient.Prometheuses(f.Ns).Get(ctx, "k8s", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	image := k8sProm.Spec.Image
+
 	name := "rwe2e"
 
 	// deploy a service for our remote write target
@@ -291,7 +298,7 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// deploy remote write target
-			prometheusReceiver := f.MakePrometheusWithWebTLSRemoteReceive(name, secName)
+			prometheusReceiver := f.MakePrometheusWithWebTLSRemoteReceive(name, secName, image)
 			if err := f.OperatorClient.CreateOrUpdatePrometheus(ctx, prometheusReceiver); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
…e remote write receiver with k8s'

instead of the operator's upstream default image

This broke once prometheus-operator's default image is a prom 3 see https://github.com/openshift/prometheus-operator/pull/321#issuecomment-2552954671: prometheus 3 no longer understand the `remote-write-receiver` feature flag.

also moved from the feature gate to the spec field as it'll be required for prom 3

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
