### PR TITLE
MON-4118: chore: use alertmanager v2 in tests as v1 is not longer supported in Prometheus 3

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -63,7 +63,7 @@ The `AdditionalAlertmanagerConfig` resource defines settings for how a component
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| apiVersion | string | Defines the API version of Alertmanager. Possible values are `v1` or `v2`. The default is `v2`. |
+| apiVersion | string | Defines the API version of Alertmanager. `v1` is no longer supported, `v2` is set as the default value. |
 | bearerToken | *[v1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretkeyselector-v1-core) | Defines the secret key reference containing the bearer token to use when authenticating to Alertmanager. |
 | pathPrefix | string | Defines the path prefix to add in front of the push endpoint path. |
 | scheme | string | Defines the URL scheme to use when communicating with Alertmanager instances. Possible values are `http` or `https`. The default value is `http`. |

--- a/Documentation/openshiftdocs/modules/additionalalertmanagerconfig.adoc
+++ b/Documentation/openshiftdocs/modules/additionalalertmanagerconfig.adoc
@@ -22,7 +22,7 @@ link:thanosrulerconfig.adoc[ThanosRulerConfig]
 [options="header"]
 |===
 | Property | Type | Description 
-|apiVersion|string|Defines the API version of Alertmanager. Possible values are `v1` or `v2`. The default is `v2`.
+|apiVersion|string|Defines the API version of Alertmanager. `v1` is no longer supported, `v2` is set as the default value.
 
 |bearerToken|*v1.SecretKeySelector|Defines the secret key reference containing the bearer token to use when authenticating to Alertmanager.
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -17,6 +17,7 @@ package manifests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -49,6 +50,8 @@ const (
 
 	configKey = "config.yaml"
 )
+
+var errAlertmanagerV1NotSupported = errors.New("alertmanager's apiVersion=v1 is no longer supported, v2 has been available since Alertmanager 0.16.0")
 
 type Config struct {
 	Images                               *Images `json:"-"`
@@ -196,6 +199,31 @@ func (u *UserWorkloadConfiguration) checkThanosRulerEvaluationInterval() error {
 	return nil
 }
 
+func (u *UserWorkloadConfiguration) checkAlertmanagerVersion() error {
+	if u.Prometheus != nil {
+		for _, amConfig := range u.Prometheus.AlertmanagerConfigs {
+			if alertmanagerV1(amConfig.APIVersion) {
+				return fmt.Errorf("%w: found in prometheus.additionalAlertmanagerConfigs", errAlertmanagerV1NotSupported)
+			}
+		}
+	}
+	if u.ThanosRuler != nil {
+		for _, amConfig := range u.ThanosRuler.AlertmanagersConfigs {
+			if alertmanagerV1(amConfig.APIVersion) {
+				return fmt.Errorf("%w: found in thanosRuler.additionalAlertmanagerConfigs", errAlertmanagerV1NotSupported)
+			}
+		}
+	}
+
+	return nil
+}
+
+func alertmanagerV1(version string) bool {
+	// Only meant to guide users by failing early in case v1 Alertmanager is still referenced,
+	// this is not meant to validate the apiVersion field.
+	return version == "v1"
+}
+
 func (u *UserWorkloadConfiguration) check() error {
 	if u == nil {
 		return nil
@@ -210,6 +238,12 @@ func (u *UserWorkloadConfiguration) check() error {
 	}
 
 	if err := u.checkThanosRulerEvaluationInterval(); err != nil {
+		return err
+	}
+
+	// TODO: remove after 4.19
+	// Only to assist with the migration to Prometheus 3; fail early if Alertmanager v1 is still in use.
+	if err := u.checkAlertmanagerVersion(); err != nil {
 		return err
 	}
 
@@ -526,6 +560,19 @@ func (c *Config) LoadEnforcedBodySizeLimit(pcr PodCapacityReader, ctx context.Co
 	return nil
 }
 
+func (c *Config) checkAlertmanagerVersion() error {
+	if c.ClusterMonitoringConfiguration == nil || c.ClusterMonitoringConfiguration.PrometheusK8sConfig == nil {
+		return nil
+	}
+
+	for _, amConfig := range c.ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
+		if alertmanagerV1(amConfig.APIVersion) {
+			return fmt.Errorf("%w: found in prometheusK8s.additionalAlertmanagerConfigs", errAlertmanagerV1NotSupported)
+		}
+	}
+	return nil
+}
+
 func (c *Config) Precheck() error {
 	if c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile != FullCollectionProfile && !c.CollectionProfilesFeatureGateEnabled {
 		return fmt.Errorf("%w: collectionProfiles is currently a TechPreview feature behind the \"MetricsCollectionProfiles\" feature-gate, to be able to use a profile different from the default (\"full\") please enable it first", ErrConfigValidation)
@@ -553,6 +600,13 @@ func (c *Config) Precheck() error {
 	}
 	// Prometheus-Adapter is replaced with Metrics Server by default from 4.16
 	metrics.DeprecatedConfig.WithLabelValues("openshift-monitoring/cluster-monitoring-config", "k8sPrometheusAdapter", "4.16").Set(d)
+
+	// TODO: remove after 4.19
+	// Only to assist with the migration to Prometheus 3; fail early if Alertmanager v1 is still in use.
+	if err := c.checkAlertmanagerVersion(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2013,7 +2013,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			name: "version, path and scheme override",
 			config: `prometheusK8s:
   additionalAlertmanagerConfigs:
-  - apiVersion: v1
+  - apiVersion: v2
     pathPrefix: /path
     scheme: ftp
     staticConfigs:
@@ -2022,7 +2022,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 `,
 			expected: `- scheme: ftp
   path_prefix: /path
-  api_version: v1
+  api_version: v2
   static_configs:
   - targets:
     - alertmanager1-remote.com
@@ -2301,7 +2301,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			name: "version, path and scheme override",
 			userWorkloadConfig: `thanosRuler:
   additionalAlertmanagerConfigs:
-  - apiVersion: v1
+  - apiVersion: v2
     pathPrefix: /path-prefix
     scheme: ftp
     staticConfigs:
@@ -2320,7 +2320,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
   - dnssrv+_web._tcp.alertmanager-operated.openshift-monitoring.svc
 - scheme: ftp
   path_prefix: /path-prefix
-  api_version: v1
+  api_version: v2
   static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -761,9 +761,8 @@ type MonitoringPluginConfig struct {
 // The `AdditionalAlertmanagerConfig` resource defines settings for how a
 // component communicates with additional Alertmanager instances.
 type AdditionalAlertmanagerConfig struct {
-	// Defines the API version of Alertmanager. Possible values are `v1` or
-	// `v2`.
-	// The default is `v2`.
+	// Defines the API version of Alertmanager.
+	// `v1` is no longer supported, `v2` is set as the default value.
 	APIVersion string `json:"apiVersion"`
 	// Defines the secret key reference containing the bearer token
 	// to use when authenticating to Alertmanager.

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -285,7 +285,7 @@ func TestUserWorkloadMonitoringWithAdditionalAlertmanagerConfigs(t *testing.T) {
   - scheme: https
     pathPrefix: /prefix
     timeout: "30s"
-    apiVersion: v1
+    apiVersion: v2
     tlsConfig:
       key:
         name: alertmanager-tls


### PR DESCRIPTION
    chore: adjust AdditionalAlertmanagerConfig.[*].APIVersion documentation as v1 is not longer suporter in Prom 3
    
    chore: add a config validation check in case v1 in still using in one of the three AdditionalAlertmanagerConfig (Platform
    Prom, UWM Prom and Thanos ruler), this is temp and just meant to guide users during the first 4.X upgrade that ships Prom 3

    MON-4118: chore: use alertmanager v2 in tests as v1 is not longer supported in Prometheus 3


---

This will be mentioned in the release notes and maybe we'll upgrade a "known risk/ a warning" for ->4.19 upgrades.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
