### PR TITLE
MON-4107: chore: add logs (at v=3 level) regarding the deactivation of components

### DIFF
--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
@@ -47,6 +48,7 @@ func (t *AlertmanagerTask) Run(ctx context.Context) error {
 		return t.create(ctx)
 	}
 
+	klog.V(3).Infof("Main alertmanager is disabled, existing related resources are to be destroyed.")
 	return t.destroy(ctx)
 }
 

--- a/pkg/tasks/alertmanager_user_workload.go
+++ b/pkg/tasks/alertmanager_user_workload.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
@@ -47,6 +48,7 @@ func (t *AlertmanagerUserWorkloadTask) Run(ctx context.Context) error {
 		return t.create(ctx)
 	}
 
+	klog.V(3).Infof("UWM alertmanager is disabled, existing related resources are to be destroyed.")
 	return t.destroy(ctx)
 }
 

--- a/pkg/tasks/prometheus_user_workload.go
+++ b/pkg/tasks/prometheus_user_workload.go
@@ -44,6 +44,7 @@ func (t *PrometheusUserWorkloadTask) Run(ctx context.Context) error {
 		return t.create(ctx)
 	}
 
+	klog.V(3).Infof("UWM prometheus is disabled (because UWM is disabled), existing related resources are to be destroyed.")
 	return t.destroy(ctx)
 }
 

--- a/pkg/tasks/prometheusoperator_user_workload.go
+++ b/pkg/tasks/prometheusoperator_user_workload.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/klog/v2"
+
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 )
@@ -41,6 +43,7 @@ func (t *PrometheusOperatorUserWorkloadTask) Run(ctx context.Context) error {
 		return t.create(ctx)
 	}
 
+	klog.V(3).Infof("UWM prometheus operator is disabled (because UWM is disabled), existing related resources are to be destroyed.")
 	return t.destroy(ctx)
 }
 

--- a/pkg/tasks/thanos_ruler_user_workload.go
+++ b/pkg/tasks/thanos_ruler_user_workload.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/klog/v2"
+
 	"github.com/openshift/cluster-monitoring-operator/pkg/client"
 	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 )
@@ -41,6 +43,7 @@ func (t *ThanosRulerUserWorkloadTask) Run(ctx context.Context) error {
 		return t.create(ctx)
 	}
 
+	klog.V(3).Infof("UWM thanos ruler is disabled (because UWM is disabled), existing related resources are to be destroyed.")
 	return t.destroy(ctx)
 }
 


### PR DESCRIPTION
This still requires CMO log level to be changed while debugging.




<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
