### PR TITLE
MON-4136: set up the PrometheusPossibleNarrowSelectors alert

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -30,6 +30,16 @@ spec:
       for: 15m
       labels:
         severity: warning
+    - alert: PrometheusPossibleNarrowSelectors
+      annotations:
+        description: Queries or/and relabel configs on Prometheus/Thanos {{$labels.namespace}}/{{$labels.pod}} could be too restrictive.
+        summary: |
+          Some queries or/and relabel configs with selectors on the values of the "le" label of classic histograms or/and the "quantile" label of summaries
+          may not take into account that values could also be floats, they may need to be adjusted. If assistance is needed, please let us know at https://issues.redhat.com/browse/MON-4129.
+      expr: increase(prometheus_narrow_selectors_count{job=~"prometheus-k8s|prometheus-user-workload|thanos-querier|thanos-ruler"}[5m]) > 0
+      for: 15m
+      labels:
+        severity: warning
   - name: openshift-kubernetes.rules
     rules:
     - expr: sum(rate(container_cpu_usage_seconds_total{container="",pod!=""}[5m])) BY (pod, namespace)

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -27,6 +27,21 @@ function(params) {
             severity: 'warning',
           },
         },
+        {
+          expr: 'increase(prometheus_narrow_selectors_count{job=~"prometheus-k8s|prometheus-user-workload|thanos-querier|thanos-ruler"}[5m]) > 0',
+          alert: 'PrometheusPossibleNarrowSelectors',
+          'for': '15m',
+          annotations: {
+            description: 'Queries or/and relabel configs on Prometheus/Thanos {{$labels.namespace}}/{{$labels.pod}} could be too restrictive.',
+            summary: |||
+              Some queries or/and relabel configs with selectors on the values of the "le" label of classic histograms or/and the "quantile" label of summaries
+              may not take into account that values could also be floats, they may need to be adjusted. If assistance is needed, please let us know at https://issues.redhat.com/browse/MON-4129.
+            |||,
+          },
+          labels: {
+            severity: 'warning',
+          },
+        },
       ],
     },
     {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
