### PR TITLE
MON-4043: Configuring external Alertmangers with proxy_url

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -70,6 +70,7 @@ The `AdditionalAlertmanagerConfig` resource defines settings for how a component
 | staticConfigs | []string | A list of statically configured Alertmanager endpoints in the form of `<hosts>:<port>`. |
 | timeout | *string | Defines the timeout value used when sending alerts. |
 | tlsConfig | [TLSConfig](#tlsconfig) | Defines the TLS settings to use for Alertmanager connections. |
+| proxyUrl | string | Defines proxy_url settings for Alertmanager |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/openshiftdocs/modules/additionalalertmanagerconfig.adoc
+++ b/Documentation/openshiftdocs/modules/additionalalertmanagerconfig.adoc
@@ -36,6 +36,8 @@ link:thanosrulerconfig.adoc[ThanosRulerConfig]
 
 |tlsConfig|link:tlsconfig.adoc[TLSConfig]|Defines the TLS settings to use for Alertmanager connections.
 
+|proxyUrl|string|Defines proxy_url settings for Alertmanager
+
 |===
 
 link:../index.adoc[Back to TOC]

--- a/pkg/manifests/amcfg.go
+++ b/pkg/manifests/amcfg.go
@@ -36,6 +36,7 @@ type amConfigPrometheus struct {
 	Authorization amConfigAuthorization   `yaml:"authorization,omitempty"`
 	TLSConfig     amConfigTLS             `yaml:"tls_config,omitempty"`
 	StaticConfigs []amConfigStaticConfigs `yaml:"static_configs,omitempty"`
+	ProxyURL      string                  `yaml:"proxyUrl,omitempty"`
 }
 
 type amConfigAuthorization struct {
@@ -68,6 +69,7 @@ func (a prometheusAdditionalAlertmanagerConfig) MarshalYAML() (interface{}, erro
 		PathPrefix: a.PathPrefix,
 		Timeout:    a.Timeout,
 		APIVersion: a.APIVersion,
+		ProxyURL:   a.ProxyURL,
 		TLSConfig: amConfigTLS{
 			CA:                 "",
 			Cert:               "",
@@ -126,6 +128,7 @@ type thanosAlertmanagerConfiguration struct {
 	APIVersion    string       `yaml:"api_version,omitempty"`
 	HTTPConfig    amHTTPConfig `yaml:"http_config,omitempty"`
 	StaticConfigs []string     `yaml:"static_configs,omitempty"`
+	ProxyURL      string       `yaml:"proxyUrl,omitempty"`
 }
 
 type amHTTPConfig struct {
@@ -142,6 +145,7 @@ func ConvertToThanosAlertmanagerConfiguration(ta []AdditionalAlertmanagerConfig)
 			PathPrefix: a.PathPrefix,
 			Timeout:    a.Timeout,
 			APIVersion: a.APIVersion,
+			ProxyURL:   a.ProxyURL,
 			HTTPConfig: amHTTPConfig{
 				BearerTokenFile: "",
 				TLSConfig: amConfigTLS{

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2010,6 +2010,27 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			mountedSecrets: []string{},
 		},
 		{
+			name: "proxy url",
+			config: `prometheusK8s:
+  additionalAlertmanagerConfigs:
+  - apiVersion: v2
+    scheme: https
+    proxyUrl: testproxy.com
+    staticConfigs:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+`,
+			expected: `- scheme: https
+  api_version: v2
+  static_configs:
+  - targets:
+    - alertmanager1-remote.com
+    - alertmanager1-remotex.com
+  proxyUrl: testproxy.com
+`,
+			mountedSecrets: []string{},
+		},
+		{
 			name: "version, path and scheme override",
 			config: `prometheusK8s:
   additionalAlertmanagerConfigs:
@@ -2479,6 +2500,21 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
   static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com
+`,
+		},
+		{
+			name: "proxyURL",
+			config: `alertmanagerMain:
+  enabled: false`,
+			userWorkloadConfig: `thanosRuler:
+  additionalAlertmanagerConfigs:
+  - apiVersion: v2
+    scheme: https
+    proxyUrl: testproxy.com`,
+			expected: `alertmanagers:
+- scheme: https
+  api_version: v2
+  proxyUrl: testproxy.com
 `,
 		},
 	}

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -780,6 +780,8 @@ type AdditionalAlertmanagerConfig struct {
 	Timeout *string `json:"timeout,omitempty"`
 	// Defines the TLS settings to use for Alertmanager connections.
 	TLSConfig TLSConfig `json:"tlsConfig,omitempty"`
+	// Defines proxy_url settings for Alertmanager
+	ProxyURL string `json:"proxyUrl,omitempty"`
 }
 
 // The `RemoteWriteSpec` resource defines the settings for remote write storage.


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
