### PR TITLE
OCPBUGS-48370: chore: rename default branch in various places

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -27,10 +27,10 @@ about: Create release checklist
 
 ## Cluster Monitoring Operator
 
-- [ ] update and pin jsonnet dependencies in [jsonnet/jsonnetfile.json](https://github.com/openshift/cluster-monitoring-operator/blob/master/jsonnet/jsonnetfile.json).
+- [ ] update and pin jsonnet dependencies in [jsonnet/jsonnetfile.json](https://github.com/openshift/cluster-monitoring-operator/blob/main/jsonnet/jsonnetfile.json).
   - example: https://github.com/openshift/cluster-monitoring-operator/blob/release-4.3/jsonnet/jsonnetfile.json
   - dependencies should be pinned to branches released in previous paragraph
   - ensure `jsonnet/version.json` file is tracking up-to-date component versions by running `make versions` and regenerating `assets/` if necessary
-- [ ] update golang dependencies in [go.mod](https://github.com/openshift/cluster-monitoring-operator/blob/master/go.mod) and [hack/tools/go.mod](https://github.com/openshift/cluster-monitoring-operator/blob/master/hack/tools/go.mod) files.
+- [ ] update golang dependencies in [go.mod](https://github.com/openshift/cluster-monitoring-operator/blob/main/go.mod) and [hack/tools/go.mod](https://github.com/openshift/cluster-monitoring-operator/blob/main/hack/tools/go.mod) files.
   - most important are dependencies on prometheus-operator and kubernetes components
   - update the tooling prometheus dependency to be in sync with the main one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you want to make changes to the actual code, please follow the [Coding Style]
 ## General workflow information
 These steps outline the general contribution workflow:
 
-* Create a topic branch from where you want to base your work (usually master).
+* Create a topic branch from where you want to base your work (usually main).
 * Make commits of logical units.
 * Make sure your commit messages are in the proper format (see [Format of the Commit Message](#format-of-the-commit-message))
 * Push your changes to a topic branch in your fork of the repository.

--- a/Documentation/sample-metrics.md
+++ b/Documentation/sample-metrics.md
@@ -1,7 +1,7 @@
 # Sample Metrics
 
 To understand what metrics are collected by the Telemeter service, we can replicate the request that the Telemeter client makes against a running OpenShift cluster's Prometheus service.
-The Telemeter client makes an HTTP GET request to Prometheus' `/federate` endpoint with the [metrics match rules](https://github.com/openshift/cluster-monitoring-operator/blob/master/Documentation/telemetry/telemeter_query) URL encoded as query parameters.
+The Telemeter client makes an HTTP GET request to Prometheus' `/federate` endpoint with the [metrics match rules](https://github.com/openshift/cluster-monitoring-operator/blob/main/Documentation/telemetry/telemeter_query) URL encoded as query parameters.
 
 To start, find the URL for the Prometheus service running in the OpenShift cluster:
 ```shell

--- a/hack/go/generate_versions.go
+++ b/hack/go/generate_versions.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	mainBranch          = "master"
+	mainBranch          = "main"
 	metricsServerRepo   = "openshift/kubernetes-metrics-server"
 	versionFile         = "../../jsonnet/versions.yaml"
 	versionNotFound     = "N/A"


### PR DESCRIPTION
Mainly for `make versions`

/hold
can be merged later

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
