### PR TITLE
fix(RBAC): Cluster Reader Permissions

### DIFF
--- a/assets/cluster-monitoring-operator/monitoring-rules-view-cluster-role.yaml
+++ b/assets/cluster-monitoring-operator/monitoring-rules-view-cluster-role.yaml
@@ -4,6 +4,10 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/part-of: openshift-monitoring
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: monitoring-rules-view
 rules:
 - apiGroups:

--- a/assets/cluster-monitoring-operator/monitoring-view-cluster-role.yaml
+++ b/assets/cluster-monitoring-operator/monitoring-view-cluster-role.yaml
@@ -8,19 +8,35 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: cluster-monitoring-view
+  name: monitoring-view
 rules:
 - apiGroups:
-  - ""
+  - monitoring.coreos.com
   resources:
-  - namespaces
+  - servicemonitors
+  - podmonitors
+  - probes
+  - alertmanagerconfigs
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - monitoring.coreos.com
-  resourceNames:
-  - k8s
   resources:
-  - prometheuses/api
+  - prometheuses
+  - alertmanagers
+  - thanosrulers
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.openshift.io
+  resources:
+  - alertingrules
+  - alertrelabelconfigs
+  verbs:
+  - get
+  - list
+  - watch

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -353,6 +353,12 @@ function(params) {
     kind: 'ClusterRole',
     metadata: {
       name: 'cluster-monitoring-view',
+      labels: {
+        'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+      },
     },
     rules: [
       {
@@ -364,7 +370,7 @@ function(params) {
         apiGroups: ['monitoring.coreos.com'],
         resources: ['prometheuses/api'],
         resourceNames: ['k8s'],
-        verbs: ['get', 'create', 'update'],
+        verbs: ['get'],
       },
     ],
   },
@@ -495,12 +501,50 @@ function(params) {
     }],
   },
 
+  monitoringViewClusterRole: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'ClusterRole',
+    metadata: {
+      name: 'monitoring-view',
+      labels: {
+        'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+      },
+    },
+    rules: [
+      {
+        apiGroups: ['monitoring.coreos.com'],
+        resources: ['servicemonitors', 'podmonitors', 'probes', 'alertmanagerconfigs'],
+        verbs: ['get', 'list', 'watch'],
+      },
+      {
+        apiGroups: ['monitoring.coreos.com'],
+        resources: ['prometheuses', 'alertmanagers', 'thanosrulers'],
+        verbs: ['get', 'list', 'watch'],
+      },
+      {
+        apiGroups: ['monitoring.openshift.io'],
+        resources: ['alertingrules', 'alertrelabelconfigs'],
+        verbs: ['get', 'list', 'watch'],
+      },
+    ],
+  },
+
   // This cluster role can be referenced in a RoleBinding object to provide read access to PrometheusRule objects for a project.
+  // This is required for viewing silences.
   monitoringRulesViewClusterRole: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
     metadata: {
       name: 'monitoring-rules-view',
+      labels: {
+        'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+      },
     },
     rules: [{
       apiGroups: ['monitoring.coreos.com'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -210,8 +210,6 @@ rules:
   - prometheuses/api
   verbs:
   - get
-  - create
-  - update
 - apiGroups:
   - ""
   resourceNames:

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -235,6 +235,7 @@ var (
 	ClusterMonitoringRulesEditClusterRole                  = "cluster-monitoring-operator/monitoring-rules-edit-cluster-role.yaml"
 	ClusterMonitoringRulesViewClusterRole                  = "cluster-monitoring-operator/monitoring-rules-view-cluster-role.yaml"
 	ClusterMonitoringEditClusterRole                       = "cluster-monitoring-operator/monitoring-edit-cluster-role.yaml"
+	ClusterMonitoringViewClusterRole                       = "cluster-monitoring-operator/monitoring-view-cluster-role.yaml"
 	ClusterMonitoringEditAlertingClusterRole               = "cluster-monitoring-operator/alerting-edit-cluster-role.yaml"
 	ClusterMonitoringEditUserWorkloadConfigRole            = "cluster-monitoring-operator/user-workload-config-edit-role.yaml"
 	ClusterMonitoringEditUserWorkloadAlertmanagerApiReader = "cluster-monitoring-operator/user-workload-alertmanager-api-reader.yaml"
@@ -2428,6 +2429,10 @@ func (f *Factory) ClusterMonitoringRulesViewClusterRole() (*rbacv1.ClusterRole, 
 
 func (f *Factory) ClusterMonitoringEditClusterRole() (*rbacv1.ClusterRole, error) {
 	return f.NewClusterRole(f.assets.MustNewAssetSlice(ClusterMonitoringEditClusterRole))
+}
+
+func (f *Factory) ClusterMonitoringViewClusterRole() (*rbacv1.ClusterRole, error) {
+	return f.NewClusterRole(f.assets.MustNewAssetSlice(ClusterMonitoringViewClusterRole))
 }
 
 func (f *Factory) ClusterMonitoringAlertingEditClusterRole() (*rbacv1.ClusterRole, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -534,6 +534,11 @@ func TestUnconfiguredManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, err = f.ClusterMonitoringViewClusterRole()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = f.ClusterMonitoringAlertingEditClusterRole()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/tasks/clustermonitoringoperator.go
+++ b/pkg/tasks/clustermonitoringoperator.go
@@ -52,6 +52,7 @@ func (t *ClusterMonitoringOperatorTask) Run(ctx context.Context) error {
 		"monitoring-rules-edit":            t.factory.ClusterMonitoringRulesEditClusterRole,
 		"monitoring-rules-view":            t.factory.ClusterMonitoringRulesViewClusterRole,
 		"monitoring-edit":                  t.factory.ClusterMonitoringEditClusterRole,
+		"monitoring-view":                  t.factory.ClusterMonitoringViewClusterRole,
 		"alert-routing-edit":               t.factory.ClusterMonitoringAlertingEditClusterRole,
 	} {
 		cr, err := crf()


### PR DESCRIPTION
Continuation of: https://github.com/openshift/cluster-monitoring-operator/pull/2273

## Viewing Metrics 
"assets/cluster-monitoring-operator/cluster-role-view.yaml" 
  - View Role has Non View Permissions?, Removed non view permissions. 
    -  This file "manifests/0000_50_cluster-monitoring-operator_02-role.yaml", has create/update defined twice, so a noop here.
       - If we don't want to potentially break customers using this view role in a non-view way, I can move this logic elsewhere.   
  - Added Aggregate Role  to Cluster-Reader
  
 ## Viewing Silences 
 assets/cluster-monitoring-operator/monitoring-rules-view-cluster-role.yaml
 - Added Aggregate Role to Cluster-Reader
 
 ## All other "monitoring.coreos.com" objects
Looking through the objects, I don't believe these contain any fields that could contain secrets, that also cannot be referenced as a proper secret. 
 
 ## Follow Up
A Follow Up PR for Aggregations for Namespace Scoped Users admin/edit to modify sm/probes/etc are missing.
If this should be included by default?
 ```
        'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
        'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
```        
Signed-off-by: Arthur <arthur@arthurvardevanyan.com>
