### PR TITLE
MON-4147: test: remove unnecessary UWM configuration in TestUserWorkloadMonitoringXXX

### DIFF
--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -349,9 +349,9 @@ func assertMetricsForMonitoringComponents(t *testing.T) {
 	} {
 		t.Run(service, func(t *testing.T) {
 			f.ThanosQuerierClient.WaitForQueryReturn(
-				// To avoid making the test wait for more than lookback-delta in case Prometheus
-				// wasn't able to write stale markers (because it was down), reduce the lookup period.
-				t, time.Minute, fmt.Sprintf(`count(last_over_time(up{service="%s",namespace="openshift-user-workload-monitoring"}[1m]) == 1)`, service),
+				// To avoid having to make the test run for more than lookback-delta in case Prometheus
+				// wasn't able to write stale markers (because it was down), reduce the lookup period and the timeout.
+				t, 3*time.Minute, fmt.Sprintf(`count(last_over_time(up{service="%s",namespace="openshift-user-workload-monitoring"}[1m]) == 1)`, service),
 				func(v float64) error {
 					if v == float64(expected) {
 						return nil

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -85,19 +85,6 @@ func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
 func TestUserWorkloadMonitoringMetrics(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
-	uwmCM := f.BuildUserWorkloadConfigMap(t,
-		`prometheus:
-  enforcedTargetLimit: 10
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 2Gi
-`,
-	)
-	f.MustCreateOrUpdateConfigMap(t, uwmCM)
-	defer f.MustDeleteConfigMap(t, uwmCM)
-
 	f.AssertStatefulSetExistsAndRollout("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
 	if err := deployUserApplication(f); err != nil {
 		t.Fatal(err)
@@ -145,13 +132,7 @@ func TestUserWorkloadMonitoringAlerting(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
 	uwmCM := f.BuildUserWorkloadConfigMap(t,
-		fmt.Sprintf(`prometheus:
-  enforcedTargetLimit: 10
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 2Gi
+		fmt.Sprintf(`
 namespacesWithoutLabelEnforcement:
 - %s
 `, notEnforcedNs),
@@ -217,19 +198,6 @@ userWorkload:
 func TestUserWorkloadMonitoringOptOut(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
-	uwmCM := f.BuildUserWorkloadConfigMap(t,
-		`prometheus:
-  enforcedTargetLimit: 10
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 2Gi
-`,
-	)
-	f.MustCreateOrUpdateConfigMap(t, uwmCM)
-	defer f.MustDeleteConfigMap(t, uwmCM)
-
 	f.AssertStatefulSetExistsAndRollout("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
 	if err := deployUserApplication(f); err != nil {
 		t.Fatal(err)
@@ -248,19 +216,6 @@ func TestUserWorkloadMonitoringOptOut(t *testing.T) {
 
 func TestUserWorkloadMonitoringGrpcSecrets(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
-
-	uwmCM := f.BuildUserWorkloadConfigMap(t,
-		`prometheus:
-  enforcedTargetLimit: 10
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 2Gi
-`,
-	)
-	f.MustCreateOrUpdateConfigMap(t, uwmCM)
-	defer f.MustDeleteConfigMap(t, uwmCM)
 
 	for _, scenario := range []struct {
 		name string


### PR DESCRIPTION
since those

scenarios are already tested in TestUserWorkloadMonitorPrometheusK8Config.

Additionally, these configurations may require UWM Prometheus Pods to restart during tests (with statefulset recreation as claim template is updated), as applying these configurations is asynchronous. This could disrupt the tests, make them harder to debug, and slow them down.

Also

test(TestUserWorkloadMonitoringMetrics): increase timeout to 3m as some Pods may require more that 1m to become ready and get scraped by Prometheus for the first time


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
