### PR TITLE
OCPBUGS-50837: Fix opentelemetry metrics to use regexp on label match

### DIFF
--- a/Documentation/data-collection.md
+++ b/Documentation/data-collection.md
@@ -856,37 +856,37 @@ data:
     # owners: (@tracing-team)
     #
     # Number of Tempo stacks with Jaeger UI enabled/disabled.
-    - '{__name__="enabled:tempo_operator_tempostack_jaeger_ui:sum",enabled="true|false"}'
+    - '{__name__="enabled:tempo_operator_tempostack_jaeger_ui:sum",enabled=~"true|false"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors using certain receiver types.
-    - '{__name__="type:opentelemetry_collector_receivers:sum",type="jaegerreceiver|hostmetricsreceiver|opencensusreceiver|prometheusreceiver|zipkinreceiver|kafkareceiver|filelogreceiver|journaldreceiver|k8seventsreceiver|kubeletstatsreceiver|k8sclusterreceiver|k8sobjectsreceiver"}'
+    - '{__name__="type:opentelemetry_collector_receivers:sum",type=~"jaegerreceiver|hostmetricsreceiver|opencensusreceiver|prometheusreceiver|zipkinreceiver|kafkareceiver|filelogreceiver|journaldreceiver|k8seventsreceiver|kubeletstatsreceiver|k8sclusterreceiver|k8sobjectsreceiver"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors used certain exporter type
-    - '{__name__="type:opentelemetry_collector_exporters:sum",type="debugexporter|loggingexporter|otlpexporter|otlphttpexporter|prometheusexporter|lokiexporter|kafkaexporter|awscloudwatchlogsexporter|loadbalancingexporter"}'
+    - '{__name__="type:opentelemetry_collector_exporters:sum",type=~"debugexporter|loggingexporter|otlpexporter|otlphttpexporter|prometheusexporter|lokiexporter|kafkaexporter|awscloudwatchlogsexporter|loadbalancingexporter"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors used certain processor type
-    - '{__name__="type:opentelemetry_collector_processors:sum",type="batchprocessor|memorylimiterprocessor|attributesprocessor|resourceprocessor|spanprocessor|k8sattributesprocessor|resourcedetectionprocessor|filterprocessor|routingprocessor|cumulativetodeltaprocessor|groupbyattrsprocessor"}'
+    - '{__name__="type:opentelemetry_collector_processors:sum",type=~"batchprocessor|memorylimiterprocessor|attributesprocessor|resourceprocessor|spanprocessor|k8sattributesprocessor|resourcedetectionprocessor|filterprocessor|routingprocessor|cumulativetodeltaprocessor|groupbyattrsprocessor"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors used certain extension type
-    - '{__name__="type:opentelemetry_collector_extensions:sum",type="zpagesextension|ballastextension|memorylimiterextension|jaegerremotesampling|healthcheckextension|pprofextension|oauth2clientauthextension|oidcauthextension|bearertokenauthextension|filestorage"}'
+    - '{__name__="type:opentelemetry_collector_extensions:sum",type=~"zpagesextension|ballastextension|memorylimiterextension|jaegerremotesampling|healthcheckextension|pprofextension|oauth2clientauthextension|oidcauthextension|bearertokenauthextension|filestorage"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors used certain connector type
-    - '{__name__="type:opentelemetry_collector_connectors:sum",type="spanmetricsconnector|forwardconnector"}'
+    - '{__name__="type:opentelemetry_collector_connectors:sum",type=~"spanmetricsconnector|forwardconnector"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors deployed using certain deployment type
-    - '{__name__="type:opentelemetry_collector_info:sum",type="deployment|daemonset|sidecar|statefulset"}'
+    - '{__name__="type:opentelemetry_collector_info:sum",type=~"deployment|daemonset|sidecar|statefulset"}'
     #
     # owners: (https://github.com/redhat-developer/application-services-metering-operator)
     #

--- a/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_04-config.yaml
@@ -848,37 +848,37 @@ data:
     # owners: (@tracing-team)
     #
     # Number of Tempo stacks with Jaeger UI enabled/disabled.
-    - '{__name__="enabled:tempo_operator_tempostack_jaeger_ui:sum",enabled="true|false"}'
+    - '{__name__="enabled:tempo_operator_tempostack_jaeger_ui:sum",enabled=~"true|false"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors using certain receiver types.
-    - '{__name__="type:opentelemetry_collector_receivers:sum",type="jaegerreceiver|hostmetricsreceiver|opencensusreceiver|prometheusreceiver|zipkinreceiver|kafkareceiver|filelogreceiver|journaldreceiver|k8seventsreceiver|kubeletstatsreceiver|k8sclusterreceiver|k8sobjectsreceiver"}'
+    - '{__name__="type:opentelemetry_collector_receivers:sum",type=~"jaegerreceiver|hostmetricsreceiver|opencensusreceiver|prometheusreceiver|zipkinreceiver|kafkareceiver|filelogreceiver|journaldreceiver|k8seventsreceiver|kubeletstatsreceiver|k8sclusterreceiver|k8sobjectsreceiver"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors used certain exporter type
-    - '{__name__="type:opentelemetry_collector_exporters:sum",type="debugexporter|loggingexporter|otlpexporter|otlphttpexporter|prometheusexporter|lokiexporter|kafkaexporter|awscloudwatchlogsexporter|loadbalancingexporter"}'
+    - '{__name__="type:opentelemetry_collector_exporters:sum",type=~"debugexporter|loggingexporter|otlpexporter|otlphttpexporter|prometheusexporter|lokiexporter|kafkaexporter|awscloudwatchlogsexporter|loadbalancingexporter"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors used certain processor type
-    - '{__name__="type:opentelemetry_collector_processors:sum",type="batchprocessor|memorylimiterprocessor|attributesprocessor|resourceprocessor|spanprocessor|k8sattributesprocessor|resourcedetectionprocessor|filterprocessor|routingprocessor|cumulativetodeltaprocessor|groupbyattrsprocessor"}'
+    - '{__name__="type:opentelemetry_collector_processors:sum",type=~"batchprocessor|memorylimiterprocessor|attributesprocessor|resourceprocessor|spanprocessor|k8sattributesprocessor|resourcedetectionprocessor|filterprocessor|routingprocessor|cumulativetodeltaprocessor|groupbyattrsprocessor"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors used certain extension type
-    - '{__name__="type:opentelemetry_collector_extensions:sum",type="zpagesextension|ballastextension|memorylimiterextension|jaegerremotesampling|healthcheckextension|pprofextension|oauth2clientauthextension|oidcauthextension|bearertokenauthextension|filestorage"}'
+    - '{__name__="type:opentelemetry_collector_extensions:sum",type=~"zpagesextension|ballastextension|memorylimiterextension|jaegerremotesampling|healthcheckextension|pprofextension|oauth2clientauthextension|oidcauthextension|bearertokenauthextension|filestorage"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors used certain connector type
-    - '{__name__="type:opentelemetry_collector_connectors:sum",type="spanmetricsconnector|forwardconnector"}'
+    - '{__name__="type:opentelemetry_collector_connectors:sum",type=~"spanmetricsconnector|forwardconnector"}'
     #
     # owners: (@tracing-team)
     #
     # Number of OpenTelemetry collectors deployed using certain deployment type
-    - '{__name__="type:opentelemetry_collector_info:sum",type="deployment|daemonset|sidecar|statefulset"}'
+    - '{__name__="type:opentelemetry_collector_info:sum",type=~"deployment|daemonset|sidecar|statefulset"}'
     #
     # owners: (https://github.com/redhat-developer/application-services-metering-operator)
     #


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
