### PR TITLE
WIP: MON-4150: Set fallbackScrapeProtocol for Prometheus v3

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -197,7 +197,8 @@ spec:
       openshift.io/cluster-monitoring: "true"
   ruleSelector: {}
   scrapeClasses:
-  - name: tls-client-certificate-auth
+  - fallbackScrapeProtocol: PrometheusText0.0.4
+    name: tls-client-certificate-auth
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -178,6 +178,7 @@ spec:
   - delayed-compaction
   enforcedNamespaceLabel: namespace
   externalLabels: {}
+  fallbackScrapeProtocol: PrometheusText0.0.4
   ignoreNamespaceSelectors: true
   image: quay.io/prometheus/prometheus:v2.55.1
   listenLocal: true

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -292,6 +292,7 @@ function(params)
       spec+: {
         // Enable experimental additional scrape metrics and delayed compaction features.
         enableFeatures+: ['extra-scrape-metrics', 'delayed-compaction'],
+        fallbackScrapeProtocol: 'PrometheusText0.0.4',
         overrideHonorTimestamps: true,
         overrideHonorLabels: true,
         ignoreNamespaceSelectors: true,

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -579,6 +579,7 @@ function(params)
               keyFile: '/etc/prometheus/secrets/metrics-client-certs/tls.key',
               insecureSkipVerify: false,
             },
+            fallbackScrapeProtocol: 'PrometheusText0.0.4',
           },
         ],
         volumes+: [


### PR DESCRIPTION
For Platform Prometheus using scrapeClass
For UWM Prometheus setting globally

Keeping it in draft and needs Prometheus v3 as well to work
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
