### PR TITLE
NO-JIRA: Bump prometheus-operator to 0.80.1

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -191,7 +191,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "56cc9eea5f8bffedbc4a77ae08555dd5f510ed76",
+      "version": "524131da7888af88091e30274c2507ea8b959017",
       "sum": "gi+knjdxs2T715iIQIntrimbHRgHnpM8IFBJDD1gYfs=",
       "name": "prometheus-operator-mixin"
     },
@@ -202,8 +202,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "56cc9eea5f8bffedbc4a77ae08555dd5f510ed76",
-      "sum": "SzECES1Sqax8WtD7faDXWEjFii0LLkcSkGqE5B3vlvQ="
+      "version": "4126d60d8a8ae99be866cdd0d15546a4d3e9fe8b",
+      "sum": "VF9CoB3hjwDGrxKONlX4OxW+k+9CkICWg+xbLb7dZ8A="
     },
     {
       "source": {

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.80.0
+    operator.prometheus.io/version: 0.80.1
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.80.0
+    operator.prometheus.io/version: 0.80.1
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.80.0
+    operator.prometheus.io/version: 0.80.1
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.80.0
+    operator.prometheus.io/version: 0.80.1
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.80.0
+    operator.prometheus.io/version: 0.80.1
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.80.0
+    operator.prometheus.io/version: 0.80.1
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.80.0
+    operator.prometheus.io/version: 0.80.1
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.80.0
+    operator.prometheus.io/version: 0.80.1
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
