### PR TITLE
NO-JIRA: chore: versions: kubeRbacProxy's primary branch isn't main yet

### DIFF
--- a/hack/go/generate_versions.go
+++ b/hack/go/generate_versions.go
@@ -83,8 +83,15 @@ func updateVersionFile(fileP string, components Components) error {
 	sort.Strings(keys)
 
 	for _, component := range keys {
-		knownVersion, _ := components.Versions[component]
-		newVersion, err := getVersion(components.Repos[component], mainBranch)
+		knownVersion := components.Versions[component]
+
+		// TODO: simplify once kubeRbacProxy's primary branch is main
+		branch := mainBranch
+		if component == "kubeRbacProxy" {
+			branch = "master"
+		}
+
+		newVersion, err := getVersion(components.Repos[component], branch)
 		if err != nil {
 			log.Fatalf("couldn't fetch the new version for %s: %v", component, err)
 		}


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
