### PR TITLE
OCPBUGS-52565: Bump prometheus-operator to 0.78.2

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -192,7 +192,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "3c35a6d7baf761cc2e4426d508528e913cc9aab2",
+      "version": "3afdfd506b63c71fabdf9dcda7fc81c945208098",
       "sum": "gi+knjdxs2T715iIQIntrimbHRgHnpM8IFBJDD1gYfs=",
       "name": "prometheus-operator-mixin"
     },
@@ -203,8 +203,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "40104e6b861f6794243d65a11ef5ba3bc356e121",
-      "sum": "rgCAJulmuWjMCgd17hyaw4CE/G52MnPZH8Bd6kLmnW4="
+      "version": "9efea40e09ee6d80627c40b0ef208af200ecd7d5",
+       "sum": "C4oz34hEILHHKOHgaI+XvZur0cKObfU+cYy30e5tApQ="
     },
     {
       "source": {

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.78.1
+    operator.prometheus.io/version: 0.78.2
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
@@ -738,6 +738,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -1641,6 +1647,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -2369,6 +2381,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -3083,6 +3101,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -3821,6 +3845,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -4654,6 +4684,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -5325,6 +5361,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -6088,6 +6130,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -6783,6 +6831,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -7438,6 +7492,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -8082,6 +8142,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -8787,6 +8853,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -9677,6 +9749,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -10559,6 +10637,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -11273,6 +11357,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -11981,6 +12071,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -12698,6 +12794,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -13503,6 +13605,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -14167,6 +14275,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -14916,6 +15030,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -15597,6 +15717,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -16243,6 +16369,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -16880,6 +17012,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$
@@ -17564,6 +17702,12 @@ spec:
 
                                   It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
                                 type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
                                 pattern: ^http(s)?://.+$

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.78.1
+    operator.prometheus.io/version: 0.78.2
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.78.1
+    operator.prometheus.io/version: 0.78.2
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.78.1
+    operator.prometheus.io/version: 0.78.2
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.78.1
+    operator.prometheus.io/version: 0.78.2
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.78.1
+    operator.prometheus.io/version: 0.78.2
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.78.1
+    operator.prometheus.io/version: 0.78.2
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.78.1
+    operator.prometheus.io/version: 0.78.2
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
