### PR TITLE
WIP: OCPBUGS-18282: Reject reserved labels used as external labels

### DIFF
--- a/pkg/client/status_reporter.go
+++ b/pkg/client/status_reporter.go
@@ -34,6 +34,8 @@ const (
 	StorageNotConfiguredReason                       = "PrometheusDataPersistenceNotConfigured"
 	UserAlermanagerConfigMisconfiguredMessage        = "Misconfigured Alertmanager:  Alertmanager for user-defined alerting is enabled in the openshift-monitoring/cluster-monitoring-config configmap by setting 'enableUserAlertmanagerConfig: true' field. This conflicts with a dedicated Alertmanager instance enabled in  openshift-user-workload-monitoring/user-workload-monitoring-config. Alertmanager enabled in openshift-user-workload-monitoring takes precedence over the one in openshift-monitoring, so please remove the 'enableUserAlertmanagerConfig' field in openshift-monitoring/cluster-monitoring-config."
 	UserAlermanagerConfigMisconfiguredReason         = "UserAlertmanagerMisconfigured"
+	CannotUseReservedExternalLabelsMessage           = "Reserved Labels cannot be as External Labels. `externalLabels` specified under `prometheusK8s` field in the `openshift-monitoring/cluster-monitoring-config` uses reserved labels `prometheus` or `prometheus_replica` which is not allowed, please remove these from externalLabels"
+	CannotUseReservedExternalLabelsReason            = "ReservedExternalLabelsConfigured"
 )
 
 // Status represents if the state being reported is known to be True, False, or Unknown.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -896,6 +896,9 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	} else if config.HasInconsistentAlertmanagerConfigurations() {
 		degradedConditionMessage = client.UserAlermanagerConfigMisconfiguredMessage
 		degradedConditionReason = client.UserAlermanagerConfigMisconfiguredReason
+	} else if config.HasPrometheusReservedExternalLabelsConfigured() {
+		degradedConditionMessage = client.CannotUseReservedExternalLabelsMessage
+		degradedConditionReason = client.CannotUseReservedExternalLabelsReason
 	}
 
 	klog.Info("Updating ClusterOperator status to done.")

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -186,6 +186,34 @@ prometheusK8s:
 				f.AssertOperatorConditionMessage(configv1.OperatorDegraded, "")
 			},
 		},
+		{
+			name: "default config with reserved external labels used",
+			config: `
+prometheusK8s:
+  externalLabels:
+    prometheus: "some-value"
+`,
+			assertion: func(t *testing.T) {
+				f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+				f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
+				f.AssertOperatorConditionReason(configv1.OperatorDegraded, client.CannotUseReservedExternalLabelsReason)
+				f.AssertOperatorConditionMessageContains(configv1.OperatorDegraded, client.CannotUseReservedExternalLabelsMessage)
+			},
+		},
+		{
+			name: "default config with no reserved external labels used",
+			config: `
+prometheusK8s:
+  externalLabels:
+    dc: "us-east-1"
+`,
+			assertion: func(t *testing.T) {
+				f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+				f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
+				f.AssertOperatorConditionReason(configv1.OperatorDegraded, "")
+				f.AssertOperatorConditionMessage(configv1.OperatorDegraded, "")
+			},
+		},
 	} {
 		f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, tc.config))
 


### PR DESCRIPTION

API documentation for `externalLabels` is like this

```
// The labels to add to any time series or alerts when communicating with
// external systems (federation, remote storage, Alertmanager).
// Labels defined by `spec.replicaExternalLabelName` and
// `spec.prometheusExternalLabelName` take precedence over this list.
```

We also [advise not to use reserved labels](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/monitoring/configuring-core-platform-monitoring#attaching-additional-labels-to-your-time-series-and-alerts_configuring-alerts-and-notifications
) `prometheus` or `prometheus_replica` as externalLabels, because they are reserved and will be overwritten. It was not overwritten due to bug in PO which is fixed in [upstream](https://github.com/prometheus-operator/prometheus-operator/pull/5888/files ).

This change is for CMO to reject it beforehand and report to user if they use reserved labels as externalLabels

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
