### PR TITLE
MON-4188: Add docs for proxy_url alertmanager

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -611,7 +611,7 @@ The `ThanosRulerConfig` resource defines configuration for the Thanos Ruler inst
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| additionalAlertmanagerConfigs | [][AdditionalAlertmanagerConfig](#additionalalertmanagerconfig) | Configures how the Thanos Ruler component communicates with additional Alertmanager instances. The default value is `nil`. |
+| additionalAlertmanagerConfigs | [][AdditionalAlertmanagerConfig](#additionalalertmanagerconfig) | Configures how the Thanos Ruler component communicates with additional Alertmanager instances. The Cluster Monitoring Operator reads the cluster-wide proxy settings and configures the appropriate proxy URL for the Alertmanager endpoints. All Alertmanager endpoints in this group are expected to use the same proxy URL. Endpoints that bypass the cluster proxy should be placed in a separate group. The default value is `nil`. |
 | evaluationInterval | string | Configures the default interval between Prometheus rule evaluations in case the `PrometheusRule` resource does not specify any value. The interval must be set between 5 seconds and 5 minutes. The value can be expressed in: seconds (for example `30s`.), minutes (for example `1m`.) or a mix of minutes and seconds (for example `1m30s`.). It applies to `PrometheusRule` resources without the `openshift.io/prometheus-rule-evaluation-scope=\"leaf-prometheus\"` label. The default value is `15s`. |
 | logLevel | string | Defines the log level setting for Thanos Ruler. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`. |
 | nodeSelector | map[string]string | Defines the nodes on which the Pods are scheduled. |

--- a/Documentation/openshiftdocs/modules/thanosrulerconfig.adoc
+++ b/Documentation/openshiftdocs/modules/thanosrulerconfig.adoc
@@ -18,7 +18,7 @@ Appears in: link:userworkloadconfiguration.adoc[UserWorkloadConfiguration]
 [options="header"]
 |===
 | Property | Type | Description 
-|additionalAlertmanagerConfigs|[]link:additionalalertmanagerconfig.adoc[AdditionalAlertmanagerConfig]|Configures how the Thanos Ruler component communicates with additional Alertmanager instances. The default value is `nil`.
+|additionalAlertmanagerConfigs|[]link:additionalalertmanagerconfig.adoc[AdditionalAlertmanagerConfig]|Configures how the Thanos Ruler component communicates with additional Alertmanager instances. The Cluster Monitoring Operator reads the cluster-wide proxy settings and configures the appropriate proxy URL for the Alertmanager endpoints. All Alertmanager endpoints in this group are expected to use the same proxy URL. Endpoints that bypass the cluster proxy should be placed in a separate group. The default value is `nil`.
 
 |evaluationInterval|string|Configures the default interval between Prometheus rule evaluations in case the `PrometheusRule` resource does not specify any value. The interval must be set between 5 seconds and 5 minutes. The value can be expressed in: seconds (for example `30s`.), minutes (for example `1m`.) or a mix of minutes and seconds (for example `1m30s`.). It applies to `PrometheusRule` resources without the `openshift.io/prometheus-rule-evaluation-scope=\"leaf-prometheus\"` label. The default value is `15s`.
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -703,9 +703,9 @@ type ThanosRulerConfig struct {
 	// Configures how the Thanos Ruler component communicates
 	// with additional Alertmanager instances.
 	// The Cluster Monitoring Operator reads the cluster-wide proxy settings and configures
-	// the appropriate Proxy URL for the Alertmanager endpoints.
-	// All Alertmanager endpoints in this group are expected to resolve to the same Proxy URL.
-	// If certain endpoints should bypass the cluster proxy, they should be placed in a separate group.
+	// the appropriate proxy URL for the Alertmanager endpoints.
+	// All Alertmanager endpoints in this group are expected to use the same proxy URL.
+	// Endpoints that bypass the cluster proxy should be placed in a separate group.
 	// The default value is `nil`.
 	AlertmanagersConfigs []AdditionalAlertmanagerConfig `json:"additionalAlertmanagerConfigs,omitempty"`
 	// Configures the default interval between Prometheus rule evaluations in case the `PrometheusRule` resource does not specify any value.

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -702,6 +702,10 @@ type PrometheusRestrictedConfig struct {
 type ThanosRulerConfig struct {
 	// Configures how the Thanos Ruler component communicates
 	// with additional Alertmanager instances.
+	// The Cluster Monitoring Operator reads the cluster-wide proxy settings and configures
+	// the appropriate Proxy URL for the Alertmanager endpoints.
+	// All Alertmanager endpoints in this group are expected to resolve to the same Proxy URL.
+	// If certain endpoints should bypass the cluster proxy, they should be placed in a separate group.
 	// The default value is `nil`.
 	AlertmanagersConfigs []AdditionalAlertmanagerConfig `json:"additionalAlertmanagerConfigs,omitempty"`
 	// Configures the default interval between Prometheus rule evaluations in case the `PrometheusRule` resource does not specify any value.


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
