### PR TITLE
OCPBUGS-54211: return rules from tenancy endpoint

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -168,6 +168,7 @@ spec:
         - --label=namespace
         - --enable-label-apis
         - --error-on-replace
+        - --rules-with-active-alerts
         image: quay.io/prometheuscommunity/prom-label-proxy:v0.11.0
         name: prom-label-proxy
         resources:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -514,6 +514,7 @@ function(params)
                   '--label=namespace',
                   '--enable-label-apis',
                   '--error-on-replace',
+                  '--rules-with-active-alerts',
                 ],
                 resources: {
                   requests: {


### PR DESCRIPTION
While investigating [OCPBUGS-54211](https://issues.redhat.com/browse/OCPBUGS-54211) I found two issues.

1. A frontend bug which didn't use silences from the selected namespace. Addressed in openshift/monitoring-plugin#374
2. No alert rules were returned from the tenancy endpoint for any namespace other than `openshift-monitoring`, even when the user had appropriate permissions.

When comparing the thanos-querier deployment in release-4.17 to the working one in release-4.18, I found that the `prom-label-proxy` image didn't use the `--rules-with-active-alerts` flag in release-4.17. Once the flag was enabled the thanos-querier deployment returns the appropriate alert rules when the tenancy endpoint is queried with appropriate permissions. 

---

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
