### PR TITLE
MON-4126: set fallbackScrapeProtocol: 'PrometheusText1.0.0' as default for all UWM Prometheus targets for backward compatibility with Prometheus v2 until a better migration process is available

### DIFF
--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -260,6 +260,10 @@ spec:
       operator: In
       values:
       - leaf-prometheus
+  scrapeClasses:
+  - default: true
+    fallbackScrapeProtocol: PrometheusText1.0.0
+    name: global-config
   scrapeConfigNamespaceSelector: null
   scrapeConfigSelector: null
   secrets:

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -581,6 +581,15 @@ function(params)
             ],
           },
         ],
+        // As we do not have control over the targets, this is meant to maintain the v2 behavior.
+        // We will discuss later whether and how we want to enable the v3 behavior.
+        scrapeClasses: [
+          {
+            name: 'global-config',
+            default: true,
+            fallbackScrapeProtocol: 'PrometheusText1.0.0',
+          },
+        ],
         volumes+: [
           {
             name: $.trustedCaBundle.metadata.name,

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1719,6 +1719,11 @@ func TestPrometheusUserWorkloadConfiguration(t *testing.T) {
 	if !volumeMountsConfigured(container.VolumeMounts, volumeName) {
 		t.Fatalf("trusted CA bundle volume mount for %s is not configured correctly", container.Name)
 	}
+
+	// The FallbackScrapeProtocol default scrape class is set as expected.
+	require.Len(t, p.Spec.ScrapeClasses, 1)
+	require.Equal(t, p.Spec.ScrapeClasses[0].Default, ptr.To(true))
+	require.Equal(t, p.Spec.ScrapeClasses[0].FallbackScrapeProtocol, ptr.To(monv1.PrometheusText1_0_0))
 }
 
 func TestPrometheusQueryLogFileConfig(t *testing.T) {


### PR DESCRIPTION


<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
