### PR TITLE
[release-4.18] OCPBUGS-56251: set upgradable false when alertmanager v1 is specified

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -52,7 +52,12 @@ const (
 	automaticBodySizeLimit = "automatic"
 
 	configKey = "config.yaml"
+
+	clusterMonitorConfigMapName      = "openshift-monitoring/cluster-monitoring-config"
+	userWorkloadMonitorConfigMapName = "openshift-user-workload-monitoring/user-workload-monitoring-config"
 )
+
+var errAlertmanagerV1NotSupported = errors.New("alertmanager's apiVersion=v1 is no longer supported, v2 has been available since Alertmanager 0.16.0")
 
 type InvalidConfigWarning struct {
 	ConfigMap string
@@ -209,6 +214,31 @@ func (u *UserWorkloadConfiguration) checkThanosRulerEvaluationInterval() error {
 	return nil
 }
 
+func (u *UserWorkloadConfiguration) checkAlertmanagerVersion() error {
+	if u.Prometheus != nil {
+		for _, amConfig := range u.Prometheus.AlertmanagerConfigs {
+			if alertmanagerV1(amConfig.APIVersion) {
+				return fmt.Errorf("%w: found in prometheus.additionalAlertmanagerConfigs", errAlertmanagerV1NotSupported)
+			}
+		}
+	}
+	if u.ThanosRuler != nil {
+		for _, amConfig := range u.ThanosRuler.AlertmanagersConfigs {
+			if alertmanagerV1(amConfig.APIVersion) {
+				return fmt.Errorf("%w: found in thanosRuler.additionalAlertmanagerConfigs", errAlertmanagerV1NotSupported)
+			}
+		}
+	}
+
+	return nil
+}
+
+func alertmanagerV1(version string) bool {
+	// Only meant to guide users by failing early in case v1 Alertmanager is still referenced,
+	// this is not meant to validate the apiVersion field.
+	return version == "v1"
+}
+
 func (u *UserWorkloadConfiguration) check() error {
 	if u == nil {
 		return nil
@@ -340,7 +370,7 @@ func newConfig(content []byte, collectionProfilesFeatureGateEnabled bool) (*Conf
 	wCmc := defaultClusterMonitoringConfiguration()
 	wErr := UnmarshalStrict(content, &wCmc)
 	if wErr != nil {
-		warning = &InvalidConfigWarning{ConfigMap: "openshift-monitoring/cluster-monitoring-config", Err: wErr}
+		warning = &InvalidConfigWarning{ConfigMap: clusterMonitorConfigMapName, Err: wErr}
 	}
 
 	cmc := defaultClusterMonitoringConfiguration()
@@ -351,6 +381,18 @@ func newConfig(content []byte, collectionProfilesFeatureGateEnabled bool) (*Conf
 
 	c.ClusterMonitoringConfiguration = &cmc
 	c.applyDefaults()
+
+	// Only to assist with the migration to Prometheus 3; fail early if Alertmanager v1 is still in use.
+	if wErr := c.checkAlertmanagerVersion(); wErr != nil {
+		if warning != nil {
+			wErr = errors.Join(warning.Err, wErr)
+		}
+		warning = &InvalidConfigWarning{
+			ConfigMap: clusterMonitorConfigMapName,
+			Err:       wErr,
+		}
+	}
+
 	c.UserWorkloadConfiguration = NewDefaultUserWorkloadMonitoringConfig()
 
 	return &c, warning, nil
@@ -588,6 +630,19 @@ func (c *Config) LoadEnforcedBodySizeLimit(pcr PodCapacityReader, ctx context.Co
 	return nil
 }
 
+func (c *Config) checkAlertmanagerVersion() error {
+	if c.ClusterMonitoringConfiguration == nil || c.ClusterMonitoringConfiguration.PrometheusK8sConfig == nil {
+		return nil
+	}
+
+	for _, amConfig := range c.ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
+		if alertmanagerV1(amConfig.APIVersion) {
+			return fmt.Errorf("%w: found in prometheusK8s.additionalAlertmanagerConfigs", errAlertmanagerV1NotSupported)
+		}
+	}
+	return nil
+}
+
 func (c *Config) Precheck() error {
 	if c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile != FullCollectionProfile && !c.CollectionProfilesFeatureGateEnabled {
 		return fmt.Errorf("%w: collectionProfiles is currently a TechPreview feature behind the \"MetricsCollectionProfiles\" feature-gate, to be able to use a profile different from the default (\"full\") please enable it first", ErrConfigValidation)
@@ -614,7 +669,7 @@ func (c *Config) Precheck() error {
 		d = 1
 	}
 	// Prometheus-Adapter is replaced with Metrics Server by default from 4.16
-	metrics.DeprecatedConfig.WithLabelValues("openshift-monitoring/cluster-monitoring-config", "k8sPrometheusAdapter", "4.16").Set(d)
+	metrics.DeprecatedConfig.WithLabelValues(clusterMonitorConfigMapName, "k8sPrometheusAdapter", "4.16").Set(d)
 	return nil
 }
 
@@ -692,7 +747,7 @@ func NewUserConfigFromString(content string) (*UserWorkloadConfiguration, *Inval
 	wErr := UnmarshalStrict([]byte(content), &wU)
 	if wErr != nil {
 		warning = &InvalidConfigWarning{
-			ConfigMap: "openshift-user-workload-monitoring/user-workload-monitoring-config",
+			ConfigMap: userWorkloadMonitorConfigMapName,
 			Err:       wErr,
 		}
 	}
@@ -707,6 +762,17 @@ func NewUserConfigFromString(content string) (*UserWorkloadConfiguration, *Inval
 
 	if err := u.check(); err != nil {
 		return nil, warning, err
+	}
+
+	// Only to assist with the migration to Prometheus 3; fail early if Alertmanager v1 is still in use.
+	if wErr := u.checkAlertmanagerVersion(); wErr != nil {
+		if warning != nil {
+			wErr = errors.Join(warning.Err, wErr)
+		}
+		warning = &InvalidConfigWarning{
+			ConfigMap: userWorkloadMonitorConfigMapName,
+			Err:       wErr,
+		}
 	}
 
 	return u, warning, nil

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1998,6 +1998,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		name           string
 		config         string
 		expected       string
+		shouldWarn     bool
 		mountedSecrets []string
 	}{
 		{
@@ -2040,6 +2041,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
     - alertmanager1-remote.com
     - alertmanager1-remotex.com
 `,
+			shouldWarn:     true,
 			mountedSecrets: []string{},
 		},
 		{
@@ -2182,7 +2184,12 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			require.Nil(t, warning)
+			if tt.shouldWarn {
+				require.NotNil(t, warning)
+			}
+			if !tt.shouldWarn {
+				require.Nil(t, warning)
+			}
 			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 
 			p, err := f.PrometheusK8s(
@@ -2229,6 +2236,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 		name               string
 		config             string
 		userWorkloadConfig string
+		shouldWarn         bool
 
 		expected string
 	}{
@@ -2321,6 +2329,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
     - alertmanager1-remote.com
     - alertmanager1-remotex.com
 `,
+			shouldWarn: true,
 			expected: `alertmanagers:
 - scheme: https
   api_version: v2
@@ -2508,7 +2517,14 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			require.Nil(t, warning)
+
+			if tt.shouldWarn {
+				require.NotNil(t, warning)
+			}
+
+			if !tt.shouldWarn {
+				require.Nil(t, warning)
+			}
 			c.UserWorkloadConfiguration = uwc
 
 			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})


### PR DESCRIPTION
Prometheus v3 no longer supports alertmanager v1

OCP 4.19 will fail early (InvalidConfigXXX) in case alertmanager apiVersion: v1 is still specified in one of the two configmaps.

To avoid that InvalidConfigXXX from triggering just after the 4.19 upgrade, we can make users bump their alertmanagers and only use apiVersion: v2 in the configmaps.

We can do that by making CMO set upgradable=false when it sees apiVersion: v1 in one of the configmaps and make sure clusters go through that 4.18.x before upgrading to 4.19.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
