### PR TITLE
OCPBUGS-33691: mixin: longer rate interval for Alertmanager[Cluster]FailedToSendAlerts

### DIFF
--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -48,9 +48,9 @@ spec:
         summary: An Alertmanager instance failed to send notifications.
       expr: |
         (
-          rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+          rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
         /
-          ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
         )
         > 0.01
       for: 5m
@@ -63,9 +63,9 @@ spec:
         summary: All Alertmanager instances in a cluster failed to send notifications to a critical integration.
       expr: |
         min by (namespace,service, integration) (
-          rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+          rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
         /
-          ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
         )
         > 0.01
       for: 5m

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -167,6 +167,28 @@ local patchedRules = [
         labels: {
           severity: 'warning',
         },
+        expr: |||
+          min by (namespace,service, integration) (
+            rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
+          /
+            ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload", integration=~`.*`}[15m])
+          )
+          > 0.01
+        |||,
+      },
+      {
+        alert: 'AlertmanagerFailedToSendAlerts',
+        labels: {
+          severity: 'warning',
+        },
+        expr: |||
+          (
+            rate(alertmanager_notifications_failed_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
+          /
+            ignoring (reason) group_left rate(alertmanager_notifications_total{job=~"alertmanager-main|alertmanager-user-workload"}[15m])
+          )
+          > 0.01
+        |||,
       },
       {
         alert: 'AlertmanagerConfigInconsistent',


### PR DESCRIPTION
This picks up https://github.com/prometheus/alertmanager/pull/4206/ so we don't have to wait.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
