### PR TITLE
MON-4242: chore(metrics-server): allow setting log verbosity

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -191,6 +191,7 @@ The `MetricsServerConfig` resource defines settings for the Metrics Server compo
 | audit | *Audit | Defines the audit configuration used by the Metrics Server instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`. |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) | Defines tolerations for the pods. |
+| verbosity | uint8 | Defines the verbosity of log messages for Metrics Server. Valid values are positive integers, values over 10 are usually unnecessary. The default value is `0`. |
 | resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core) | Defines resource requests and limits for the Metrics Server container. |
 | topologySpreadConstraints | []v1.TopologySpreadConstraint | Defines a pod's topology spread constraints. |
 

--- a/Documentation/openshiftdocs/modules/metricsserverconfig.adoc
+++ b/Documentation/openshiftdocs/modules/metricsserverconfig.adoc
@@ -24,6 +24,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
+|verbosity|uint8|Defines the verbosity of log messages for Metrics Server. Valid values are positive integers, values over 10 are usually unnecessary. The default value is `0`.
+
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the Metrics Server container.
 
 |topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -2020,6 +2020,12 @@ func (f *Factory) MetricsServerDeployment(apiAuthSecretName string, kubeletCABun
 		containers[idx].Resources = *config.Resources
 	}
 
+	if config.Verbosity != 0 {
+		containers[idx].Args = append(containers[idx].Args,
+			fmt.Sprintf("--v=%d", config.Verbosity),
+		)
+	}
+
 	if len(config.TopologySpreadConstraints) > 0 {
 		podSpec.TopologySpreadConstraints = config.TopologySpreadConstraints
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2630,6 +2630,7 @@ metricsServer:
     limits:
       cpu: 200m
       memory: 200Mi
+  verbosity: 3
   nodeSelector:
     node: linux
   tolerations:
@@ -2695,6 +2696,8 @@ metricsServer:
 			if !reflect.DeepEqual(container.Resources, *f.config.ClusterMonitoringConfiguration.MetricsServerConfig.Resources) {
 				t.Fatal("metrics-server resources are not configured correctly")
 			}
+
+			require.Contains(t, container.Args, "--v=3")
 		}
 	}
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -148,6 +148,10 @@ type MetricsServerConfig struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// Defines the verbosity of log messages for Metrics Server.
+	// Valid values are positive integers, values over 10 are usually unnecessary.
+	// The default value is `0`.
+	Verbosity uint8 `json:"verbosity,omitempty"`
 	// Defines resource requests and limits for the Metrics Server container.
 	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 	// Defines a pod's topology spread constraints.


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
