### PR TITLE
OCPBUGS-18282: provide more context in externalLabels unmarshalling error

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -765,7 +765,8 @@ func (lb *ExternalLabels) UnmarshalJSON(data []byte) error {
 	}
 	for _, r := range reservedPrometheusExternalLabels {
 		if _, ok := v[r]; ok {
-			return fmt.Errorf("reserved keys %v cannot be set as external labels", reservedPrometheusExternalLabels)
+			// We’re assuming that the field is called "externalLabels", that's all the context we can easily provide.
+			return fmt.Errorf("reserved key %q (one of %v) cannot be set in externalLabels", r, reservedPrometheusExternalLabels)
 		}
 	}
 	*lb = v

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -5274,7 +5274,7 @@ func TestPromConfigurationExternalLabels(t *testing.T) {
 					if tc.shouldFail {
 						require.Error(t, err)
 						// Ensure we’re testing what we intend.
-						require.ErrorContains(t, err, "cannot be set as external labels")
+						require.ErrorContains(t, err, "cannot be set in externalLabels")
 						return
 					}
 					require.NoError(t, err)


### PR DESCRIPTION


follow up to https://github.com/openshift/cluster-monitoring-operator/pull/2604

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
