### PR TITLE
OCPBUGS-58427: pkg/manifests: don't reset annotations for metrics client CA

### DIFF
--- a/pkg/manifests/tls.go
+++ b/pkg/manifests/tls.go
@@ -100,7 +100,6 @@ func (f *Factory) MetricsClientCACM(apiAuthConfigmap *v1.ConfigMap) (*v1.ConfigM
 
 	cm.Namespace = f.namespace
 	cm.Data = make(map[string]string)
-	cm.Annotations = make(map[string]string)
 
 	clientCA, ok := apiAuthConfigmap.Data["client-ca-file"]
 	if !ok {


### PR DESCRIPTION
Previously this configmap didn't have annotations set, so these were being reset to an empty map. Now it has ownership annotation, so reset to an empty map is erasing them

Follow-up for https://github.com/openshift/cluster-monitoring-operator/pull/2602

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
