### PR TITLE
MON-4255: Bump prometheus-operator to v0.83

### DIFF
--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -17,7 +17,7 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "release-0.81"
+      "version": "release-0.83"
     },
     {
       "source": {

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -191,7 +191,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "81634cc2c103d3f755932fd586bd63fd2c13d705",
+      "version": "6176050674d427a1cee23d17b6b0bf307d806e57",
       "sum": "gi+knjdxs2T715iIQIntrimbHRgHnpM8IFBJDD1gYfs=",
       "name": "prometheus-operator-mixin"
     },
@@ -202,8 +202,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "81634cc2c103d3f755932fd586bd63fd2c13d705",
-      "sum": "wAOdGxl8D660MfS7YW5Rhh+KObOJBr0F/OOImHSTMO8="
+      "version": "5cf2f5d37906d64b2259a262e319df4c74639e31",
+      "sum": "xzGiEUwaDtS7FdoiizjlOFbvhz7d8vrbKUAJML1ssXw="
     },
     {
       "source": {

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-config-custom-resource-definition.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.81.0
+    operator.prometheus.io/version: 0.83.0
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
@@ -270,6 +270,14 @@ spec:
                             - key
                             type: object
                             x-kubernetes-map-type: atomic
+                          avatarURL:
+                            description: The avatar url of the message sender.
+                            pattern: ^https?://.+$
+                            type: string
+                          content:
+                            description: The template of the content's body.
+                            minLength: 1
+                            type: string
                           httpConfig:
                             description: HTTP client configuration.
                             properties:
@@ -398,7 +406,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -490,7 +498,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -521,18 +529,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -669,7 +677,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -680,7 +688,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -729,14 +737,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -746,7 +754,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -876,7 +884,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -887,7 +895,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -907,6 +915,10 @@ spec:
                             type: boolean
                           title:
                             description: The template of the message's title.
+                            type: string
+                          username:
+                            description: The username of the message sender.
+                            minLength: 1
                             type: string
                         required:
                         - apiURL
@@ -1143,7 +1155,7 @@ spec:
                                 description: |-
                                   Maximum acceptable TLS version.
 
-                                  It requires Prometheus >= v2.41.0.
+                                  It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                 enum:
                                 - TLS10
                                 - TLS11
@@ -1154,7 +1166,7 @@ spec:
                                 description: |-
                                   Minimum acceptable TLS version.
 
-                                  It requires Prometheus >= v2.35.0.
+                                  It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                 enum:
                                 - TLS10
                                 - TLS11
@@ -1307,7 +1319,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -1399,7 +1411,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -1430,18 +1442,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -1578,7 +1590,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -1589,7 +1601,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -1638,14 +1650,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -1655,7 +1667,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -1785,7 +1797,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -1796,7 +1808,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -1846,6 +1858,680 @@ spec:
                             x-kubernetes-map-type: atomic
                         required:
                         - webhookUrl
+                        type: object
+                      type: array
+                    msteamsv2Configs:
+                      description: |-
+                        List of MSTeamsV2 configurations.
+                        It requires Alertmanager >= 0.28.0.
+                      items:
+                        description: |-
+                          MSTeamsV2Config configures notifications via Microsoft Teams using the new message format with adaptive cards as required by flows
+                          See https://prometheus.io/docs/alerting/latest/configuration/#msteamsv2_config
+                          It requires Alertmanager >= 0.28.0.
+                        properties:
+                          httpConfig:
+                            description: HTTP client configuration.
+                            properties:
+                              authorization:
+                                description: |-
+                                  Authorization header configuration for the client.
+                                  This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                properties:
+                                  credentials:
+                                    description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type:
+                                    description: |-
+                                      Defines the authentication type. The value is case-insensitive.
+
+                                      "Basic" is not a supported value.
+
+                                      Default: "Bearer"
+                                    type: string
+                                type: object
+                              basicAuth:
+                                description: |-
+                                  BasicAuth for the client.
+                                  This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                properties:
+                                  password:
+                                    description: |-
+                                      `password` specifies a key of a Secret containing the password for
+                                      authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  username:
+                                    description: |-
+                                      `username` specifies a key of a Secret containing the username for
+                                      authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              bearerTokenSecret:
+                                description: |-
+                                  The secret's key that contains the bearer token to be used by the client
+                                  for authentication.
+                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                  object and accessible by the Prometheus Operator.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              followRedirects:
+                                description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
+                                type: boolean
+                              noProxy:
+                                description: |-
+                                  `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                                  that should be excluded from proxying. IP and domain names can
+                                  contain port numbers.
+
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                type: string
+                              oauth2:
+                                description: OAuth2 client credentials used to fetch a token for the targets.
+                                properties:
+                                  clientId:
+                                    description: |-
+                                      `clientId` specifies a key of a Secret or ConfigMap containing the
+                                      OAuth2 client's ID.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  clientSecret:
+                                    description: |-
+                                      `clientSecret` specifies a key of a Secret containing the OAuth2
+                                      client's secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  endpointParams:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      `endpointParams` configures the HTTP parameters to append to the token
+                                      URL.
+                                    type: object
+                                  noProxy:
+                                    description: |-
+                                      `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                                      that should be excluded from proxying. IP and domain names can
+                                      contain port numbers.
+
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                    type: string
+                                  proxyConnectHeader:
+                                    additionalProperties:
+                                      items:
+                                        description: SecretKeySelector selects a key of a Secret.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    description: |-
+                                      ProxyConnectHeader optionally specifies headers to send to
+                                      proxies during CONNECT requests.
+
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  proxyFromEnvironment:
+                                    description: |-
+                                      Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                    type: boolean
+                                  proxyUrl:
+                                    description: '`proxyURL` defines the HTTP proxy server to use.'
+                                    pattern: ^(http|https|socks5)://.+$
+                                    type: string
+                                  scopes:
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlsConfig:
+                                    description: |-
+                                      TLS configuration to use when connecting to the OAuth2 server.
+                                      It requires Prometheus >= v2.43.0.
+                                    properties:
+                                      ca:
+                                        description: Certificate authority used when verifying server certificates.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secret:
+                                            description: Secret containing data to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      cert:
+                                        description: Client certificate to present when doing client-authentication.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secret:
+                                            description: Secret containing data to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      insecureSkipVerify:
+                                        description: Disable target certificate validation.
+                                        type: boolean
+                                      keySecret:
+                                        description: Secret containing the client key file for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      maxVersion:
+                                        description: |-
+                                          Maximum acceptable TLS version.
+
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                                        enum:
+                                        - TLS10
+                                        - TLS11
+                                        - TLS12
+                                        - TLS13
+                                        type: string
+                                      minVersion:
+                                        description: |-
+                                          Minimum acceptable TLS version.
+
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                                        enum:
+                                        - TLS10
+                                        - TLS11
+                                        - TLS12
+                                        - TLS13
+                                        type: string
+                                      serverName:
+                                        description: Used to verify the hostname for the targets.
+                                        type: string
+                                    type: object
+                                  tokenUrl:
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - clientId
+                                - clientSecret
+                                - tokenUrl
+                                type: object
+                              proxyConnectHeader:
+                                additionalProperties:
+                                  items:
+                                    description: SecretKeySelector selects a key of a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                description: |-
+                                  ProxyConnectHeader optionally specifies headers to send to
+                                  proxies during CONNECT requests.
+
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              proxyFromEnvironment:
+                                description: |-
+                                  Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
+                              proxyUrl:
+                                description: '`proxyURL` defines the HTTP proxy server to use.'
+                                pattern: ^(http|https|socks5)://.+$
+                                type: string
+                              tlsConfig:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Certificate authority used when verifying server certificates.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  cert:
+                                    description: Client certificate to present when doing client-authentication.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keySecret:
+                                    description: Secret containing the client key file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  maxVersion:
+                                    description: |-
+                                      Maximum acceptable TLS version.
+
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                                    enum:
+                                    - TLS10
+                                    - TLS11
+                                    - TLS12
+                                    - TLS13
+                                    type: string
+                                  minVersion:
+                                    description: |-
+                                      Minimum acceptable TLS version.
+
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                                    enum:
+                                    - TLS10
+                                    - TLS11
+                                    - TLS12
+                                    - TLS13
+                                    type: string
+                                  serverName:
+                                    description: Used to verify the hostname for the targets.
+                                    type: string
+                                type: object
+                            type: object
+                          sendResolved:
+                            description: Whether to notify about resolved alerts.
+                            type: boolean
+                          text:
+                            description: Message body template.
+                            minLength: 1
+                            type: string
+                          title:
+                            description: Message title template.
+                            minLength: 1
+                            type: string
+                          webhookURL:
+                            description: MSTeams incoming webhook URL.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       type: array
                     name:
@@ -2041,7 +2727,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -2133,7 +2819,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -2164,18 +2850,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -2312,7 +2998,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -2323,7 +3009,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -2372,14 +3058,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -2389,7 +3075,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -2519,7 +3205,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -2530,7 +3216,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -2761,7 +3447,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -2853,7 +3539,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -2884,18 +3570,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -3032,7 +3718,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -3043,7 +3729,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -3092,14 +3778,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -3109,7 +3795,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -3239,7 +3925,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -3250,7 +3936,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -3505,7 +4191,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -3597,7 +4283,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -3628,18 +4314,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -3776,7 +4462,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -3787,7 +4473,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -3836,14 +4522,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -3853,7 +4539,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -3983,7 +4669,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -3994,7 +4680,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -4344,7 +5030,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -4436,7 +5122,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -4467,18 +5153,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -4615,7 +5301,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -4626,7 +5312,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -4675,14 +5361,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -4692,7 +5378,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -4822,7 +5508,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -4833,7 +5519,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -5021,7 +5707,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -5113,7 +5799,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -5144,18 +5830,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -5292,7 +5978,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -5303,7 +5989,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -5352,14 +6038,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -5369,7 +6055,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -5499,7 +6185,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -5510,7 +6196,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -5790,7 +6476,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -5882,7 +6568,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -5913,18 +6599,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -6061,7 +6747,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -6072,7 +6758,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -6121,14 +6807,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -6138,7 +6824,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -6268,7 +6954,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -6279,7 +6965,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -6497,7 +7183,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -6589,7 +7275,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -6620,18 +7306,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -6768,7 +7454,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -6779,7 +7465,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -6828,14 +7514,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -6845,7 +7531,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -6975,7 +7661,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -6986,7 +7672,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -7158,7 +7844,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -7250,7 +7936,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -7281,18 +7967,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -7429,7 +8115,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -7440,7 +8126,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -7489,14 +8175,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -7506,7 +8192,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -7636,7 +8322,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -7647,7 +8333,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -7808,7 +8494,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -7900,7 +8586,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -7931,18 +8617,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -8079,7 +8765,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -8090,7 +8776,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -8139,14 +8825,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -8156,7 +8842,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -8286,7 +8972,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -8297,7 +8983,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -8317,6 +9003,13 @@ spec:
                           sendResolved:
                             description: Whether or not to notify about resolved alerts.
                             type: boolean
+                          timeout:
+                            description: |-
+                              The maximum time to wait for a webhook request to complete, before failing the
+                              request and allowing it to be retried.
+                              It requires Alertmanager >= v0.28.0.
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
                           url:
                             description: |-
                               The URL to send HTTP POST requests to. `urlSecret` takes precedence over
@@ -8519,7 +9212,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -8611,7 +9304,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -8642,18 +9335,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -8790,7 +9483,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -8801,7 +9494,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -8850,14 +9543,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -8867,7 +9560,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -8997,7 +9690,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -9008,7 +9701,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -9294,6 +9987,14 @@ spec:
                             - key
                             type: object
                             x-kubernetes-map-type: atomic
+                          avatarURL:
+                            description: The avatar url of the message sender.
+                            pattern: ^https?://.+$
+                            type: string
+                          content:
+                            description: The template of the content's body.
+                            minLength: 1
+                            type: string
                           httpConfig:
                             description: HTTP client configuration.
                             properties:
@@ -9415,7 +10116,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -9507,7 +10208,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -9538,18 +10239,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -9686,7 +10387,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -9697,7 +10398,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -9746,14 +10447,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -9763,7 +10464,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -9893,7 +10594,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -9904,7 +10605,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -9924,6 +10625,10 @@ spec:
                             type: boolean
                           title:
                             description: The template of the message's title.
+                            type: string
+                          username:
+                            description: The username of the message sender.
+                            minLength: 1
                             type: string
                         required:
                         - apiURL
@@ -10146,7 +10851,7 @@ spec:
                                 description: |-
                                   Maximum acceptable TLS version.
 
-                                  It requires Prometheus >= v2.41.0.
+                                  It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                 enum:
                                 - TLS10
                                 - TLS11
@@ -10157,7 +10862,7 @@ spec:
                                 description: |-
                                   Minimum acceptable TLS version.
 
-                                  It requires Prometheus >= v2.35.0.
+                                  It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                 enum:
                                 - TLS10
                                 - TLS11
@@ -10303,7 +11008,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -10395,7 +11100,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -10426,18 +11131,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -10574,7 +11279,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -10585,7 +11290,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -10634,14 +11339,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -10651,7 +11356,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -10781,7 +11486,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -10792,7 +11497,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -10842,6 +11547,673 @@ spec:
                             x-kubernetes-map-type: atomic
                         required:
                         - webhookUrl
+                        type: object
+                      type: array
+                    msteamsv2Configs:
+                      description: |-
+                        List of MSTeamsV2 configurations.
+                        It requires Alertmanager >= 0.28.0.
+                      items:
+                        description: |-
+                          MSTeamsV2Config configures notifications via Microsoft Teams using the new message format with adaptive cards as required by flows
+                          See https://prometheus.io/docs/alerting/latest/configuration/#msteamsv2_config
+                          It requires Alertmanager >= 0.28.0.
+                        properties:
+                          httpConfig:
+                            description: HTTP client configuration.
+                            properties:
+                              authorization:
+                                description: |-
+                                  Authorization header configuration for the client.
+                                  This is mutually exclusive with BasicAuth and is only available starting from Alertmanager v0.22+.
+                                properties:
+                                  credentials:
+                                    description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type:
+                                    description: |-
+                                      Defines the authentication type. The value is case-insensitive.
+
+                                      "Basic" is not a supported value.
+
+                                      Default: "Bearer"
+                                    type: string
+                                type: object
+                              basicAuth:
+                                description: |-
+                                  BasicAuth for the client.
+                                  This is mutually exclusive with Authorization. If both are defined, BasicAuth takes precedence.
+                                properties:
+                                  password:
+                                    description: |-
+                                      `password` specifies a key of a Secret containing the password for
+                                      authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  username:
+                                    description: |-
+                                      `username` specifies a key of a Secret containing the username for
+                                      authentication.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              bearerTokenSecret:
+                                description: |-
+                                  The secret's key that contains the bearer token to be used by the client
+                                  for authentication.
+                                  The secret needs to be in the same namespace as the AlertmanagerConfig
+                                  object and accessible by the Prometheus Operator.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    minLength: 1
+                                    type: string
+                                  name:
+                                    description: The name of the secret in the object's namespace to select from.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              followRedirects:
+                                description: FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
+                                type: boolean
+                              noProxy:
+                                description: |-
+                                  `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                                  that should be excluded from proxying. IP and domain names can
+                                  contain port numbers.
+
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                type: string
+                              oauth2:
+                                description: OAuth2 client credentials used to fetch a token for the targets.
+                                properties:
+                                  clientId:
+                                    description: |-
+                                      `clientId` specifies a key of a Secret or ConfigMap containing the
+                                      OAuth2 client's ID.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  clientSecret:
+                                    description: |-
+                                      `clientSecret` specifies a key of a Secret containing the OAuth2
+                                      client's secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  endpointParams:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      `endpointParams` configures the HTTP parameters to append to the token
+                                      URL.
+                                    type: object
+                                  noProxy:
+                                    description: |-
+                                      `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                                      that should be excluded from proxying. IP and domain names can
+                                      contain port numbers.
+
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                    type: string
+                                  proxyConnectHeader:
+                                    additionalProperties:
+                                      items:
+                                        description: SecretKeySelector selects a key of a Secret.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    description: |-
+                                      ProxyConnectHeader optionally specifies headers to send to
+                                      proxies during CONNECT requests.
+
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  proxyFromEnvironment:
+                                    description: |-
+                                      Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                    type: boolean
+                                  proxyUrl:
+                                    description: '`proxyURL` defines the HTTP proxy server to use.'
+                                    pattern: ^(http|https|socks5)://.+$
+                                    type: string
+                                  scopes:
+                                    description: '`scopes` defines the OAuth2 scopes used for the token request.'
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlsConfig:
+                                    description: |-
+                                      TLS configuration to use when connecting to the OAuth2 server.
+                                      It requires Prometheus >= v2.43.0.
+                                    properties:
+                                      ca:
+                                        description: Certificate authority used when verifying server certificates.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secret:
+                                            description: Secret containing data to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      cert:
+                                        description: Client certificate to present when doing client-authentication.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secret:
+                                            description: Secret containing data to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      insecureSkipVerify:
+                                        description: Disable target certificate validation.
+                                        type: boolean
+                                      keySecret:
+                                        description: Secret containing the client key file for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      maxVersion:
+                                        description: |-
+                                          Maximum acceptable TLS version.
+
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                                        enum:
+                                        - TLS10
+                                        - TLS11
+                                        - TLS12
+                                        - TLS13
+                                        type: string
+                                      minVersion:
+                                        description: |-
+                                          Minimum acceptable TLS version.
+
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                                        enum:
+                                        - TLS10
+                                        - TLS11
+                                        - TLS12
+                                        - TLS13
+                                        type: string
+                                      serverName:
+                                        description: Used to verify the hostname for the targets.
+                                        type: string
+                                    type: object
+                                  tokenUrl:
+                                    description: '`tokenURL` configures the URL to fetch the token from.'
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - clientId
+                                - clientSecret
+                                - tokenUrl
+                                type: object
+                              proxyConnectHeader:
+                                additionalProperties:
+                                  items:
+                                    description: SecretKeySelector selects a key of a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                description: |-
+                                  ProxyConnectHeader optionally specifies headers to send to
+                                  proxies during CONNECT requests.
+
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              proxyFromEnvironment:
+                                description: |-
+                                  Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                                type: boolean
+                              proxyURL:
+                                description: |-
+                                  Optional proxy URL.
+
+                                  If defined, this field takes precedence over `proxyUrl`.
+                                type: string
+                              proxyUrl:
+                                description: '`proxyURL` defines the HTTP proxy server to use.'
+                                pattern: ^(http|https|socks5)://.+$
+                                type: string
+                              tlsConfig:
+                                description: TLS configuration for the client.
+                                properties:
+                                  ca:
+                                    description: Certificate authority used when verifying server certificates.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  cert:
+                                    description: Client certificate to present when doing client-authentication.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secret:
+                                        description: Secret containing data to use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keySecret:
+                                    description: Secret containing the client key file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  maxVersion:
+                                    description: |-
+                                      Maximum acceptable TLS version.
+
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                                    enum:
+                                    - TLS10
+                                    - TLS11
+                                    - TLS12
+                                    - TLS13
+                                    type: string
+                                  minVersion:
+                                    description: |-
+                                      Minimum acceptable TLS version.
+
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                                    enum:
+                                    - TLS10
+                                    - TLS11
+                                    - TLS12
+                                    - TLS13
+                                    type: string
+                                  serverName:
+                                    description: Used to verify the hostname for the targets.
+                                    type: string
+                                type: object
+                            type: object
+                          sendResolved:
+                            description: Whether to notify about resolved alerts.
+                            type: boolean
+                          text:
+                            description: Message body template.
+                            minLength: 1
+                            type: string
+                          title:
+                            description: Message title template.
+                            minLength: 1
+                            type: string
+                          webhookURL:
+                            description: MSTeams incoming webhook URL.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       type: array
                     name:
@@ -11023,7 +12395,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -11115,7 +12487,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -11146,18 +12518,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -11294,7 +12666,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -11305,7 +12677,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -11354,14 +12726,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -11371,7 +12743,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -11501,7 +12873,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -11512,7 +12884,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -11737,7 +13109,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -11829,7 +13201,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -11860,18 +13232,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -12008,7 +13380,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -12019,7 +13391,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -12068,14 +13440,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -12085,7 +13457,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -12215,7 +13587,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -12226,7 +13598,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -12460,7 +13832,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -12552,7 +13924,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -12583,18 +13955,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -12731,7 +14103,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -12742,7 +14114,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -12791,14 +14163,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -12808,7 +14180,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -12938,7 +14310,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -12949,7 +14321,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -13271,7 +14643,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -13363,7 +14735,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -13394,18 +14766,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -13542,7 +14914,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -13553,7 +14925,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -13602,14 +14974,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -13619,7 +14991,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -13749,7 +15121,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -13760,7 +15132,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -13941,7 +15313,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -14033,7 +15405,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -14064,18 +15436,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -14212,7 +15584,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -14223,7 +15595,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -14272,14 +15644,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -14289,7 +15661,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -14419,7 +15791,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -14430,7 +15802,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -14696,7 +16068,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -14788,7 +16160,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -14819,18 +16191,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -14967,7 +16339,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -14978,7 +16350,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -15027,14 +16399,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -15044,7 +16416,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -15174,7 +16546,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -15185,7 +16557,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -15389,7 +16761,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -15481,7 +16853,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -15512,18 +16884,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -15660,7 +17032,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -15671,7 +17043,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -15720,14 +17092,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -15737,7 +17109,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -15867,7 +17239,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -15878,7 +17250,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -16041,7 +17413,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -16133,7 +17505,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -16164,18 +17536,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -16312,7 +17684,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -16323,7 +17695,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -16372,14 +17744,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -16389,7 +17761,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -16519,7 +17891,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -16530,7 +17902,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -16684,7 +18056,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -16776,7 +18148,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -16807,18 +18179,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -16955,7 +18327,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -16966,7 +18338,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -17015,14 +18387,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -17032,7 +18404,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -17162,7 +18534,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -17173,7 +18545,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -17193,6 +18565,13 @@ spec:
                           sendResolved:
                             description: Whether or not to notify about resolved alerts.
                             type: boolean
+                          timeout:
+                            description: |-
+                              The maximum time to wait for a webhook request to complete, before failing the
+                              request and allowing it to be retried.
+                              It requires Alertmanager >= v0.28.0.
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
                           url:
                             description: |-
                               The URL to send HTTP POST requests to. `urlSecret` takes precedence over
@@ -17374,7 +18753,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               oauth2:
                                 description: OAuth2 client credentials used to fetch a token for the targets.
@@ -17466,7 +18845,7 @@ spec:
                                       that should be excluded from proxying. IP and domain names can
                                       contain port numbers.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: string
                                   proxyConnectHeader:
                                     additionalProperties:
@@ -17497,18 +18876,18 @@ spec:
                                       ProxyConnectHeader optionally specifies headers to send to
                                       proxies during CONNECT requests.
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   proxyFromEnvironment:
                                     description: |-
                                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                     type: boolean
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                                    pattern: ^http(s)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -17645,7 +19024,7 @@ spec:
                                         description: |-
                                           Maximum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.41.0.
+                                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -17656,7 +19035,7 @@ spec:
                                         description: |-
                                           Minimum acceptable TLS version.
 
-                                          It requires Prometheus >= v2.35.0.
+                                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                         enum:
                                         - TLS10
                                         - TLS11
@@ -17705,14 +19084,14 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyURL:
                                 description: |-
@@ -17722,7 +19101,7 @@ spec:
                                 type: string
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -17852,7 +19231,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -17863,7 +19242,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11

--- a/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0alertmanager-custom-resource-definition.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.81.0
+    operator.prometheus.io/version: 0.83.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -84,6 +84,27 @@ spec:
               Specification of the desired behavior of the Alertmanager cluster. More info:
               https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              additionalArgs:
+                description: |-
+                  AdditionalArgs allows setting additional arguments for the 'Alertmanager' container.
+                  It is intended for e.g. activating hidden flags which are not supported by
+                  the dedicated configuration options yet. The arguments are passed as-is to the
+                  Alertmanager container which may cause issues if they are invalid or not supported
+                  by the given Alertmanager version.
+                items:
+                  description: Argument as part of the AdditionalArgs list.
+                  properties:
+                    name:
+                      description: Name of the argument, e.g. "scrape.discovery-reload-interval".
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Argument value, e.g. 30s. Can be empty for name-only arguments (e.g. --storage.tsdb.no-lockfile)
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               additionalPeers:
                 description: AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
                 items:
@@ -355,7 +376,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -370,7 +390,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -531,7 +550,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -546,7 +564,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -700,7 +717,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -715,7 +731,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -876,7 +891,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -891,7 +905,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -1218,7 +1231,7 @@ spec:
                               that should be excluded from proxying. IP and domain names can
                               contain port numbers.
 
-                              It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                              It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                             type: string
                           oauth2:
                             description: OAuth2 client credentials used to fetch a token for the targets.
@@ -1310,7 +1323,7 @@ spec:
                                   that should be excluded from proxying. IP and domain names can
                                   contain port numbers.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: string
                               proxyConnectHeader:
                                 additionalProperties:
@@ -1341,18 +1354,18 @@ spec:
                                   ProxyConnectHeader optionally specifies headers to send to
                                   proxies during CONNECT requests.
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: object
                                 x-kubernetes-map-type: atomic
                               proxyFromEnvironment:
                                 description: |-
                                   Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                                  It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                                 type: boolean
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                                pattern: ^http(s)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               scopes:
                                 description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -1489,7 +1502,7 @@ spec:
                                     description: |-
                                       Maximum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.41.0.
+                                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -1500,7 +1513,7 @@ spec:
                                     description: |-
                                       Minimum acceptable TLS version.
 
-                                      It requires Prometheus >= v2.35.0.
+                                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                     enum:
                                     - TLS10
                                     - TLS11
@@ -1549,18 +1562,18 @@ spec:
                               ProxyConnectHeader optionally specifies headers to send to
                               proxies during CONNECT requests.
 
-                              It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                              It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                             type: object
                             x-kubernetes-map-type: atomic
                           proxyFromEnvironment:
                             description: |-
                               Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                              It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                              It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                             type: boolean
                           proxyUrl:
                             description: '`proxyURL` defines the HTTP proxy server to use.'
-                            pattern: ^http(s)?://.+$
+                            pattern: ^(http|https|socks5)://.+$
                             type: string
                           tlsConfig:
                             description: TLS configuration for the client.
@@ -1690,7 +1703,7 @@ spec:
                                 description: |-
                                   Maximum acceptable TLS version.
 
-                                  It requires Prometheus >= v2.41.0.
+                                  It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                                 enum:
                                 - TLS10
                                 - TLS11
@@ -1701,7 +1714,7 @@ spec:
                                 description: |-
                                   Minimum acceptable TLS version.
 
-                                  It requires Prometheus >= v2.35.0.
+                                  It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                                 enum:
                                 - TLS10
                                 - TLS11
@@ -1867,6 +1880,156 @@ spec:
                             required:
                             - host
                             - port
+                            type: object
+                          tlsConfig:
+                            description: The default TLS configuration for SMTP receivers
+                            properties:
+                              ca:
+                                description: Certificate authority used when verifying server certificates.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secret:
+                                    description: Secret containing data to use for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              cert:
+                                description: Client certificate to present when doing client-authentication.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secret:
+                                    description: Secret containing data to use for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              insecureSkipVerify:
+                                description: Disable target certificate validation.
+                                type: boolean
+                              keySecret:
+                                description: Secret containing the client key file for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              maxVersion:
+                                description: |-
+                                  Maximum acceptable TLS version.
+
+                                  It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                                enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                                type: string
+                              minVersion:
+                                description: |-
+                                  Minimum acceptable TLS version.
+
+                                  It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                                enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                                type: string
+                              serverName:
+                                description: Used to verify the hostname for the targets.
+                                type: string
                             type: object
                         type: object
                     type: object
@@ -2096,7 +2259,7 @@ spec:
                         description: |-
                           Maximum acceptable TLS version.
 
-                          It requires Prometheus >= v2.41.0.
+                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -2107,7 +2270,7 @@ spec:
                         description: |-
                           Minimum acceptable TLS version.
 
-                          It requires Prometheus >= v2.35.0.
+                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -2510,7 +2673,7 @@ spec:
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -2530,7 +2693,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -2779,6 +2942,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -4024,7 +4193,7 @@ spec:
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -4044,7 +4213,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -4293,6 +4462,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -5233,6 +5408,25 @@ spec:
                   - name
                   type: object
                 type: array
+              limits:
+                description: Defines the limits command line flags when starting Alertmanager.
+                properties:
+                  maxPerSilenceBytes:
+                    description: |-
+                      The maximum size of an individual silence as stored on disk. This corresponds to the Alertmanager's
+                      `--silences.max-per-silence-bytes` flag.
+                      It requires Alertmanager >= v0.28.0.
+                    pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                    type: string
+                  maxSilences:
+                    description: |-
+                      The maximum number active and pending silences. This corresponds to the
+                      Alertmanager's `--silences.max-silences` flag.
+                      It requires Alertmanager >= v0.28.0.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
               listenLocal:
                 description: |-
                   ListenLocal makes the Alertmanager server listen on loopback, so that it
@@ -6319,6 +6513,16 @@ spec:
                   Version is ignored if Tag is set.
                   Deprecated: use 'image' instead. The image tag can be specified as part of the image URL.
                 type: string
+              terminationGracePeriodSeconds:
+                description: |-
+                  Optional duration in seconds the pod needs to terminate gracefully.
+                  Value must be non-negative integer. The value zero indicates stop immediately via
+                  the kill signal (no opportunity to shut down) which may lead to data corruption.
+
+                  Defaults to 120 seconds.
+                format: int64
+                minimum: 0
+                type: integer
               tolerations:
                 description: If specified, the pod's tolerations.
                 items:
@@ -6478,7 +6682,6 @@ spec:
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                         If this value is nil, the behavior is equivalent to the Honor policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     nodeTaintsPolicy:
                       description: |-
@@ -6489,7 +6692,6 @@ spec:
                         - Ignore: node taints are ignored. All nodes are included.
 
                         If this value is nil, the behavior is equivalent to the Ignore policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     topologyKey:
                       description: |-
@@ -7485,7 +7687,7 @@ spec:
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                         The volume will be mounted read-only (ro) and non-executable files (noexec).
-                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
                         pullPolicy:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0podmonitor-custom-resource-definition.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.81.0
+    operator.prometheus.io/version: 0.83.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -82,6 +82,11 @@ spec:
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  Whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  It requires Prometheus >= v3.0.0.
+                type: boolean
               fallbackScrapeProtocol:
                 description: |-
                   The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
@@ -513,7 +518,7 @@ spec:
                             that should be excluded from proxying. IP and domain names can
                             contain port numbers.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: string
                         proxyConnectHeader:
                           additionalProperties:
@@ -544,18 +549,18 @@ spec:
                             ProxyConnectHeader optionally specifies headers to send to
                             proxies during CONNECT requests.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: object
                           x-kubernetes-map-type: atomic
                         proxyFromEnvironment:
                           description: |-
                             Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: boolean
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to use.'
-                          pattern: ^http(s)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -692,7 +697,7 @@ spec:
                               description: |-
                                 Maximum acceptable TLS version.
 
-                                It requires Prometheus >= v2.41.0.
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -703,7 +708,7 @@ spec:
                               description: |-
                                 Minimum acceptable TLS version.
 
-                                It requires Prometheus >= v2.35.0.
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -1005,7 +1010,7 @@ spec:
                           description: |-
                             Maximum acceptable TLS version.
 
-                            It requires Prometheus >= v2.41.0.
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                           enum:
                           - TLS10
                           - TLS11
@@ -1016,7 +1021,7 @@ spec:
                           description: |-
                             Minimum acceptable TLS version.
 
-                            It requires Prometheus >= v2.35.0.
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                           enum:
                           - TLS10
                           - TLS11

--- a/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0probe-custom-resource-definition.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.81.0
+    operator.prometheus.io/version: 0.83.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -170,6 +170,11 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  Whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  It requires Prometheus >= v3.0.0.
+                type: boolean
               fallbackScrapeProtocol:
                 description: |-
                   The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
@@ -415,7 +420,7 @@ spec:
                       that should be excluded from proxying. IP and domain names can
                       contain port numbers.
 
-                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                     type: string
                   proxyConnectHeader:
                     additionalProperties:
@@ -446,18 +451,18 @@ spec:
                       ProxyConnectHeader optionally specifies headers to send to
                       proxies during CONNECT requests.
 
-                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                     type: object
                     x-kubernetes-map-type: atomic
                   proxyFromEnvironment:
                     description: |-
                       Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                      It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                     type: boolean
                   proxyUrl:
                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                    pattern: ^http(s)?://.+$
+                    pattern: ^(http|https|socks5)://.+$
                     type: string
                   scopes:
                     description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -594,7 +599,7 @@ spec:
                         description: |-
                           Maximum acceptable TLS version.
 
-                          It requires Prometheus >= v2.41.0.
+                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -605,7 +610,7 @@ spec:
                         description: |-
                           Minimum acceptable TLS version.
 
-                          It requires Prometheus >= v2.35.0.
+                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -1099,7 +1104,7 @@ spec:
                     description: |-
                       Maximum acceptable TLS version.
 
-                      It requires Prometheus >= v2.41.0.
+                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                     enum:
                     - TLS10
                     - TLS11
@@ -1110,7 +1115,7 @@ spec:
                     description: |-
                       Minimum acceptable TLS version.
 
-                      It requires Prometheus >= v2.35.0.
+                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                     enum:
                     - TLS10
                     - TLS11

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheus-custom-resource-definition.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.81.0
+    operator.prometheus.io/version: 0.83.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -483,7 +483,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -498,7 +497,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -659,7 +657,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -674,7 +671,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -828,7 +824,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -843,7 +838,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1004,7 +998,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -1019,7 +1012,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -1327,7 +1319,7 @@ spec:
                             that should be excluded from proxying. IP and domain names can
                             contain port numbers.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: string
                         pathPrefix:
                           description: Prefix for the HTTP path alerts are pushed to.
@@ -1367,18 +1359,18 @@ spec:
                             ProxyConnectHeader optionally specifies headers to send to
                             proxies during CONNECT requests.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: object
                           x-kubernetes-map-type: atomic
                         proxyFromEnvironment:
                           description: |-
                             Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: boolean
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to use.'
-                          pattern: ^http(s)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         relabelings:
                           description: Relabel configuration applied to the discovered Alertmanagers.
@@ -1675,7 +1667,7 @@ spec:
                               description: |-
                                 Maximum acceptable TLS version.
 
-                                It requires Prometheus >= v2.41.0.
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -1686,7 +1678,7 @@ spec:
                               description: |-
                                 Minimum acceptable TLS version.
 
-                                It requires Prometheus >= v2.35.0.
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -1974,7 +1966,7 @@ spec:
                         description: |-
                           Maximum acceptable TLS version.
 
-                          It requires Prometheus >= v2.41.0.
+                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -1985,7 +1977,7 @@ spec:
                         description: |-
                           Minimum acceptable TLS version.
 
-                          It requires Prometheus >= v2.35.0.
+                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -2215,7 +2207,7 @@ spec:
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -2235,7 +2227,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -2484,6 +2476,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -3424,6 +3422,13 @@ spec:
                   - name
                   type: object
                 type: array
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  Whether to convert all scraped classic histograms into a native
+                  histogram with custom buckets.
+
+                  It requires Prometheus >= v3.4.0.
+                type: boolean
               disableCompaction:
                 description: |-
                   When true, the Prometheus compaction is disabled.
@@ -3999,7 +4004,7 @@ spec:
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -4019,7 +4024,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -4268,6 +4273,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -5284,8 +5295,24 @@ spec:
                   enabling the StatefulSetMinReadySeconds feature gate.
                 format: int32
                 type: integer
+              nameEscapingScheme:
+                description: |-
+                  Specifies the character escaping scheme that will be requested when scraping
+                  for metric and label names that do not conform to the legacy Prometheus
+                  character set.
+
+                  It requires Prometheus >= v3.4.0.
+                enum:
+                - AllowUTF8
+                - Underscores
+                - Dots
+                - Values
+                type: string
               nameValidationScheme:
-                description: Specifies the validation scheme for metric and label names.
+                description: |-
+                  Specifies the validation scheme for metric and label names.
+
+                  It requires Prometheus >= v2.55.0.
                 enum:
                 - UTF8
                 - Legacy
@@ -5300,6 +5327,11 @@ spec:
                   Settings related to the OTLP receiver feature.
                   It requires Prometheus >= v2.55.0.
                 properties:
+                  convertHistogramsToNHCB:
+                    description: |-
+                      Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.
+                      It requires Prometheus >= v3.4.0.
+                    type: boolean
                   keepIdentifyingResourceAttributes:
                     description: |-
                       Enables adding `service.name`, `service.namespace` and `service.instance.id`
@@ -5323,6 +5355,7 @@ spec:
                     enum:
                     - NoUTF8EscapingWithSuffixes
                     - UnderscoreEscapingWithSuffixes
+                    - NoTranslation
                     type: string
                 type: object
               overrideHonorLabels:
@@ -5856,7 +5889,7 @@ spec:
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-                        It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     oauth2:
                       description: |-
@@ -5953,7 +5986,7 @@ spec:
                             that should be excluded from proxying. IP and domain names can
                             contain port numbers.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: string
                         proxyConnectHeader:
                           additionalProperties:
@@ -5984,18 +6017,18 @@ spec:
                             ProxyConnectHeader optionally specifies headers to send to
                             proxies during CONNECT requests.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: object
                           x-kubernetes-map-type: atomic
                         proxyFromEnvironment:
                           description: |-
                             Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: boolean
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to use.'
-                          pattern: ^http(s)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -6132,7 +6165,7 @@ spec:
                               description: |-
                                 Maximum acceptable TLS version.
 
-                                It requires Prometheus >= v2.41.0.
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -6143,7 +6176,7 @@ spec:
                               description: |-
                                 Minimum acceptable TLS version.
 
-                                It requires Prometheus >= v2.35.0.
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -6192,18 +6225,18 @@ spec:
                         ProxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-                        It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
                         Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                        It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^http(s)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     readRecent:
                       description: |-
@@ -6358,7 +6391,7 @@ spec:
                           description: |-
                             Maximum acceptable TLS version.
 
-                            It requires Prometheus >= v2.41.0.
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                           enum:
                           - TLS10
                           - TLS11
@@ -6369,7 +6402,7 @@ spec:
                           description: |-
                             Minimum acceptable TLS version.
 
-                            It requires Prometheus >= v2.35.0.
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                           enum:
                           - TLS10
                           - TLS11
@@ -6398,7 +6431,7 @@ spec:
                       description: |-
                         Authorization section for the URL.
 
-                        It requires Prometheus >= v2.26.0.
+                        It requires Prometheus >= v2.26.0 or Thanos >= v0.24.0.
 
                         Cannot be set at the same time as `sigv4`, `basicAuth`, `oauth2`, or `azureAd`.
                       properties:
@@ -6440,7 +6473,7 @@ spec:
                       description: |-
                         AzureAD for the URL.
 
-                        It requires Prometheus >= v2.45.0.
+                        It requires Prometheus >= v2.45.0 or Thanos >= v0.31.0.
 
                         Cannot be set at the same time as `authorization`, `basicAuth`, `oauth2`, or `sigv4`.
                       properties:
@@ -6467,7 +6500,7 @@ spec:
                             OAuth defines the oauth config that is being used to authenticate.
                             Cannot be set at the same time as `managedIdentity` or `sdk`.
 
-                            It requires Prometheus >= v2.48.0.
+                            It requires Prometheus >= v2.48.0 or Thanos >= v0.31.0.
                           properties:
                             clientId:
                               description: '`clientID` is the clientId of the Azure Active Directory application that is being used to authenticate.'
@@ -6511,7 +6544,7 @@ spec:
                             See https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication
                             Cannot be set at the same time as `oauth` or `managedIdentity`.
 
-                            It requires Prometheus >= 2.52.0.
+                            It requires Prometheus >= v2.52.0 or Thanos >= v0.36.0.
                           properties:
                             tenantId:
                               description: '`tenantId` is the tenant ID of the azure active directory application that is being used to authenticate.'
@@ -6594,7 +6627,7 @@ spec:
                       description: |-
                         Configure whether HTTP requests follow HTTP 3xx redirects.
 
-                        It requires Prometheus >= v2.26.0.
+                        It requires Prometheus >= v2.26.0 or Thanos >= v0.24.0.
                       type: boolean
                     headers:
                       additionalProperties:
@@ -6603,7 +6636,7 @@ spec:
                         Custom HTTP headers to be sent along with each remote write request.
                         Be aware that headers that are set by Prometheus itself can't be overwritten.
 
-                        It requires Prometheus >= v2.25.0.
+                        It requires Prometheus >= v2.25.0 or Thanos >= v0.24.0.
                       type: object
                     messageVersion:
                       description: |-
@@ -6618,7 +6651,7 @@ spec:
                         Before setting this field, consult with your remote storage provider
                         what message version it supports.
 
-                        It requires Prometheus >= v2.54.0.
+                        It requires Prometheus >= v2.54.0 or Thanos >= v0.37.0.
                       enum:
                       - V1.0
                       - V2.0
@@ -6626,6 +6659,14 @@ spec:
                     metadataConfig:
                       description: MetadataConfig configures the sending of series metadata to the remote storage.
                       properties:
+                        maxSamplesPerSend:
+                          description: |-
+                            MaxSamplesPerSend is the maximum number of metadata samples per send.
+
+                            It requires Prometheus >= v2.29.0.
+                          format: int32
+                          minimum: -1
+                          type: integer
                         send:
                           description: Defines whether metric metadata is sent to the remote storage or not.
                           type: boolean
@@ -6639,7 +6680,7 @@ spec:
                         The name of the remote write queue, it must be unique if specified. The
                         name is used in metrics and logging in order to differentiate queues.
 
-                        It requires Prometheus >= v2.15.0.
+                        It requires Prometheus >= v2.15.0 or Thanos >= 0.24.0.
                       type: string
                     noProxy:
                       description: |-
@@ -6647,13 +6688,13 @@ spec:
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-                        It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     oauth2:
                       description: |-
                         OAuth2 configuration for the URL.
 
-                        It requires Prometheus >= v2.27.0.
+                        It requires Prometheus >= v2.27.0 or Thanos >= v0.24.0.
 
                         Cannot be set at the same time as `sigv4`, `authorization`, `basicAuth`, or `azureAd`.
                       properties:
@@ -6744,7 +6785,7 @@ spec:
                             that should be excluded from proxying. IP and domain names can
                             contain port numbers.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: string
                         proxyConnectHeader:
                           additionalProperties:
@@ -6775,18 +6816,18 @@ spec:
                             ProxyConnectHeader optionally specifies headers to send to
                             proxies during CONNECT requests.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: object
                           x-kubernetes-map-type: atomic
                         proxyFromEnvironment:
                           description: |-
                             Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: boolean
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to use.'
-                          pattern: ^http(s)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -6923,7 +6964,7 @@ spec:
                               description: |-
                                 Maximum acceptable TLS version.
 
-                                It requires Prometheus >= v2.41.0.
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -6934,7 +6975,7 @@ spec:
                               description: |-
                                 Minimum acceptable TLS version.
 
-                                It requires Prometheus >= v2.35.0.
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -6983,18 +7024,18 @@ spec:
                         ProxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-                        It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
                         Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                        It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^http(s)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue parameters.
@@ -7038,7 +7079,7 @@ spec:
                         sampleAgeLimit:
                           description: |-
                             SampleAgeLimit drops samples older than the limit.
-                            It requires Prometheus >= v2.50.0.
+                            It requires Prometheus >= v2.50.0 or Thanos >= v0.32.0.
                           pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                           type: string
                       type: object
@@ -7059,7 +7100,7 @@ spec:
                         Note: The connection timeout applies to the entire resolution and connection process.
                               If disabled, the timeout is distributed across all connection attempts.
 
-                        It requires Prometheus >= v3.1.0.
+                        It requires Prometheus >= v3.1.0 or Thanos >= v0.38.0.
                       type: boolean
                     sendExemplars:
                       description: |-
@@ -7067,20 +7108,20 @@ spec:
                         exemplar-storage itself must be enabled using the `spec.enableFeatures`
                         option for exemplars to be scraped in the first place.
 
-                        It requires Prometheus >= v2.27.0.
+                        It requires Prometheus >= v2.27.0 or Thanos >= v0.24.0.
                       type: boolean
                     sendNativeHistograms:
                       description: |-
                         Enables sending of native histograms, also known as sparse histograms
                         over remote write.
 
-                        It requires Prometheus >= v2.40.0.
+                        It requires Prometheus >= v2.40.0 or Thanos >= v0.30.0.
                       type: boolean
                     sigv4:
                       description: |-
                         Sigv4 allows to configures AWS's Signature Verification 4 for the URL.
 
-                        It requires Prometheus >= v2.26.0.
+                        It requires Prometheus >= v2.26.0 or Thanos >= v0.24.0.
 
                         Cannot be set at the same time as `authorization`, `basicAuth`, `oauth2`, or `azureAd`.
                       properties:
@@ -7279,7 +7320,7 @@ spec:
                           description: |-
                             Maximum acceptable TLS version.
 
-                            It requires Prometheus >= v2.41.0.
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                           enum:
                           - TLS10
                           - TLS11
@@ -7290,7 +7331,7 @@ spec:
                           description: |-
                             Minimum acceptable TLS version.
 
-                            It requires Prometheus >= v2.35.0.
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                           enum:
                           - TLS10
                           - TLS11
@@ -8066,7 +8107,7 @@ spec:
                           description: |-
                             Maximum acceptable TLS version.
 
-                            It requires Prometheus >= v2.41.0.
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                           enum:
                           - TLS10
                           - TLS11
@@ -8077,7 +8118,7 @@ spec:
                           description: |-
                             Minimum acceptable TLS version.
 
-                            It requires Prometheus >= v2.35.0.
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                           enum:
                           - TLS10
                           - TLS11
@@ -8634,6 +8675,21 @@ spec:
                   however, the feature is not yet fully implemented in this PR. The limitation being:
                   * Retention duration is not settable, for now, shards are retained forever.
                 properties:
+                  retain:
+                    description: |-
+                      Defines the config for retention when the retention policy is set to `Retain`.
+                      This field is ineffective as of now.
+                    properties:
+                      retentionPeriod:
+                        description: |-
+                          Duration is a valid time duration that can be parsed by Prometheus model.ParseDuration() function.
+                          Supported units: y, w, d, h, m, s, ms
+                          Examples: `30s`, `1m`, `1h20m15s`, `15d`
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                    required:
+                    - retentionPeriod
+                    type: object
                   whenScaled:
                     description: |-
                       Defines the retention policy when the Prometheus shards are scaled down.
@@ -8670,6 +8726,10 @@ spec:
                   Users can define their own sharding implementation by setting the
                   `__tmp_hash` label during the target discovery with relabeling
                   configuration (either in the monitoring resources or via scrape class).
+
+                  You can also disable sharding on a specific target by setting the
+                  `__tmp_disable_sharding` label with relabeling configuration. When
+                  the label value isn't empty, all Prometheus shards will scrape the target.
                 format: int32
                 type: integer
               storage:
@@ -9311,6 +9371,16 @@ spec:
                   If you want to enforce a maximum limit for all scrape objects, refer to enforcedTargetLimit.
                 format: int64
                 type: integer
+              terminationGracePeriodSeconds:
+                description: |-
+                  Optional duration in seconds the pod needs to terminate gracefully.
+                  Value must be non-negative integer. The value zero indicates stop immediately via
+                  the kill signal (no opportunity to shut down) which may lead to data corruption.
+
+                  Defaults to 600 seconds.
+                format: int64
+                minimum: 0
+                type: integer
               thanos:
                 description: Defines the configuration of the optional Thanos sidecar.
                 properties:
@@ -9507,7 +9577,7 @@ spec:
                         description: |-
                           Maximum acceptable TLS version.
 
-                          It requires Prometheus >= v2.41.0.
+                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -9518,7 +9588,7 @@ spec:
                         description: |-
                           Minimum acceptable TLS version.
 
-                          It requires Prometheus >= v2.35.0.
+                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -9962,7 +10032,6 @@ spec:
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                         If this value is nil, the behavior is equivalent to the Honor policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     nodeTaintsPolicy:
                       description: |-
@@ -9973,7 +10042,6 @@ spec:
                         - Ignore: node taints are ignored. All nodes are included.
 
                         If this value is nil, the behavior is equivalent to the Ignore policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     topologyKey:
                       description: |-
@@ -10193,7 +10261,7 @@ spec:
                         description: |-
                           Maximum acceptable TLS version.
 
-                          It requires Prometheus >= v2.41.0.
+                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -10204,7 +10272,7 @@ spec:
                         description: |-
                           Minimum acceptable TLS version.
 
-                          It requires Prometheus >= v2.35.0.
+                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                         enum:
                         - TLS10
                         - TLS11
@@ -11199,7 +11267,7 @@ spec:
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                         The volume will be mounted read-only (ro) and non-executable files (noexec).
-                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
                         pullPolicy:

--- a/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0prometheusrule-custom-resource-definition.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.81.0
+    operator.prometheus.io/version: 0.83.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0servicemonitor-custom-resource-definition.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.81.0
+    operator.prometheus.io/version: 0.83.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -84,6 +84,11 @@ spec:
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  Whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  It requires Prometheus >= v3.0.0.
+                type: boolean
               endpoints:
                 description: |-
                   List of endpoints part of this ServiceMonitor.
@@ -437,7 +442,7 @@ spec:
                             that should be excluded from proxying. IP and domain names can
                             contain port numbers.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: string
                         proxyConnectHeader:
                           additionalProperties:
@@ -468,18 +473,18 @@ spec:
                             ProxyConnectHeader optionally specifies headers to send to
                             proxies during CONNECT requests.
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: object
                           x-kubernetes-map-type: atomic
                         proxyFromEnvironment:
                           description: |-
                             Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: boolean
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to use.'
-                          pattern: ^http(s)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for the token request.'
@@ -616,7 +621,7 @@ spec:
                               description: |-
                                 Maximum acceptable TLS version.
 
-                                It requires Prometheus >= v2.41.0.
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -627,7 +632,7 @@ spec:
                               description: |-
                                 Minimum acceptable TLS version.
 
-                                It requires Prometheus >= v2.35.0.
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                               enum:
                               - TLS10
                               - TLS11
@@ -930,7 +935,7 @@ spec:
                           description: |-
                             Maximum acceptable TLS version.
 
-                            It requires Prometheus >= v2.41.0.
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                           enum:
                           - TLS10
                           - TLS11
@@ -941,7 +946,7 @@ spec:
                           description: |-
                             Minimum acceptable TLS version.
 
-                            It requires Prometheus >= v2.35.0.
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                           enum:
                           - TLS10
                           - TLS11

--- a/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_00_0thanosruler-custom-resource-definition.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    operator.prometheus.io/version: 0.81.0
+    operator.prometheus.io/version: 0.83.0
   labels:
     app.kubernetes.io/managed-by: cluster-version-operator
     app.kubernetes.io/part-of: openshift-monitoring
@@ -374,7 +374,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -389,7 +388,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -550,7 +548,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -565,7 +562,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -719,7 +715,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -734,7 +729,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -895,7 +889,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -910,7 +903,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -1251,7 +1243,7 @@ spec:
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -1271,7 +1263,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -1520,6 +1512,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -2711,7 +2709,7 @@ spec:
                     description: |-
                       Maximum acceptable TLS version.
 
-                      It requires Prometheus >= v2.41.0.
+                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                     enum:
                     - TLS10
                     - TLS11
@@ -2722,7 +2720,7 @@ spec:
                     description: |-
                       Minimum acceptable TLS version.
 
-                      It requires Prometheus >= v2.35.0.
+                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                     enum:
                     - TLS10
                     - TLS11
@@ -2954,7 +2952,7 @@ spec:
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -2974,7 +2972,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -3223,6 +3221,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -4362,6 +4366,1026 @@ spec:
                 items:
                   type: string
                 type: array
+              remoteWrite:
+                description: |-
+                  Defines the list of remote write configurations.
+
+                  When the list isn't empty, the ruler is configured with stateless mode.
+
+                  It requires Thanos >= 0.24.0.
+                items:
+                  description: |-
+                    RemoteWriteSpec defines the configuration to write samples from Prometheus
+                    to a remote endpoint.
+                  properties:
+                    authorization:
+                      description: |-
+                        Authorization section for the URL.
+
+                        It requires Prometheus >= v2.26.0 or Thanos >= v0.24.0.
+
+                        Cannot be set at the same time as `sigv4`, `basicAuth`, `oauth2`, or `azureAd`.
+                      properties:
+                        credentials:
+                          description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        credentialsFile:
+                          description: File to read a secret from, mutually exclusive with `credentials`.
+                          type: string
+                        type:
+                          description: |-
+                            Defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    azureAd:
+                      description: |-
+                        AzureAD for the URL.
+
+                        It requires Prometheus >= v2.45.0 or Thanos >= v0.31.0.
+
+                        Cannot be set at the same time as `authorization`, `basicAuth`, `oauth2`, or `sigv4`.
+                      properties:
+                        cloud:
+                          description: The Azure Cloud. Options are 'AzurePublic', 'AzureChina', or 'AzureGovernment'.
+                          enum:
+                          - AzureChina
+                          - AzureGovernment
+                          - AzurePublic
+                          type: string
+                        managedIdentity:
+                          description: |-
+                            ManagedIdentity defines the Azure User-assigned Managed identity.
+                            Cannot be set at the same time as `oauth` or `sdk`.
+                          properties:
+                            clientId:
+                              description: The client id
+                              type: string
+                          required:
+                          - clientId
+                          type: object
+                        oauth:
+                          description: |-
+                            OAuth defines the oauth config that is being used to authenticate.
+                            Cannot be set at the same time as `managedIdentity` or `sdk`.
+
+                            It requires Prometheus >= v2.48.0 or Thanos >= v0.31.0.
+                          properties:
+                            clientId:
+                              description: '`clientID` is the clientId of the Azure Active Directory application that is being used to authenticate.'
+                              minLength: 1
+                              type: string
+                            clientSecret:
+                              description: '`clientSecret` specifies a key of a Secret containing the client secret of the Azure Active Directory application that is being used to authenticate.'
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            tenantId:
+                              description: '`tenantId` is the tenant ID of the Azure Active Directory application that is being used to authenticate.'
+                              minLength: 1
+                              pattern: ^[0-9a-zA-Z-.]+$
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecret
+                          - tenantId
+                          type: object
+                        sdk:
+                          description: |-
+                            SDK defines the Azure SDK config that is being used to authenticate.
+                            See https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication
+                            Cannot be set at the same time as `oauth` or `managedIdentity`.
+
+                            It requires Prometheus >= v2.52.0 or Thanos >= v0.36.0.
+                          properties:
+                            tenantId:
+                              description: '`tenantId` is the tenant ID of the azure active directory application that is being used to authenticate.'
+                              pattern: ^[0-9a-zA-Z-.]+$
+                              type: string
+                          type: object
+                      type: object
+                    basicAuth:
+                      description: |-
+                        BasicAuth configuration for the URL.
+
+                        Cannot be set at the same time as `sigv4`, `authorization`, `oauth2`, or `azureAd`.
+                      properties:
+                        password:
+                          description: |-
+                            `password` specifies a key of a Secret containing the password for
+                            authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: |-
+                            `username` specifies a key of a Secret containing the username for
+                            authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    bearerToken:
+                      description: |-
+                        *Warning: this field shouldn't be used because the token value appears
+                        in clear-text. Prefer using `authorization`.*
+
+                        Deprecated: this will be removed in a future release.
+                      type: string
+                    bearerTokenFile:
+                      description: |-
+                        File from which to read bearer token for the URL.
+
+                        Deprecated: this will be removed in a future release. Prefer using `authorization`.
+                      type: string
+                    enableHTTP2:
+                      description: Whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description: |-
+                        Configure whether HTTP requests follow HTTP 3xx redirects.
+
+                        It requires Prometheus >= v2.26.0 or Thanos >= v0.24.0.
+                      type: boolean
+                    headers:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Custom HTTP headers to be sent along with each remote write request.
+                        Be aware that headers that are set by Prometheus itself can't be overwritten.
+
+                        It requires Prometheus >= v2.25.0 or Thanos >= v0.24.0.
+                      type: object
+                    messageVersion:
+                      description: |-
+                        The Remote Write message's version to use when writing to the endpoint.
+
+                        `Version1.0` corresponds to the `prometheus.WriteRequest` protobuf message introduced in Remote Write 1.0.
+                        `Version2.0` corresponds to the `io.prometheus.write.v2.Request` protobuf message introduced in Remote Write 2.0.
+
+                        When `Version2.0` is selected, Prometheus will automatically be
+                        configured to append the metadata of scraped metrics to the WAL.
+
+                        Before setting this field, consult with your remote storage provider
+                        what message version it supports.
+
+                        It requires Prometheus >= v2.54.0 or Thanos >= v0.37.0.
+                      enum:
+                      - V1.0
+                      - V2.0
+                      type: string
+                    metadataConfig:
+                      description: MetadataConfig configures the sending of series metadata to the remote storage.
+                      properties:
+                        maxSamplesPerSend:
+                          description: |-
+                            MaxSamplesPerSend is the maximum number of metadata samples per send.
+
+                            It requires Prometheus >= v2.29.0.
+                          format: int32
+                          minimum: -1
+                          type: integer
+                        send:
+                          description: Defines whether metric metadata is sent to the remote storage or not.
+                          type: boolean
+                        sendInterval:
+                          description: Defines how frequently metric metadata is sent to the remote storage.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                          type: string
+                      type: object
+                    name:
+                      description: |-
+                        The name of the remote write queue, it must be unique if specified. The
+                        name is used in metrics and logging in order to differentiate queues.
+
+                        It requires Prometheus >= v2.15.0 or Thanos >= 0.24.0.
+                      type: string
+                    noProxy:
+                      description: |-
+                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description: |-
+                        OAuth2 configuration for the URL.
+
+                        It requires Prometheus >= v2.27.0 or Thanos >= v0.24.0.
+
+                        Cannot be set at the same time as `sigv4`, `authorization`, `basicAuth`, or `azureAd`.
+                      properties:
+                        clientId:
+                          description: |-
+                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            `endpointParams` configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            ProxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: '`proxyURL` defines the HTTP proxy server to use.'
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description: '`scopes` defines the OAuth2 scopes used for the token request.'
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description: Certificate authority used when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description: Secret containing data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description: Client certificate to present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description: Secret containing data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description: Secret containing the client key file for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                Maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                Minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                              type: string
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description: '`tokenURL` configures the URL to fetch the token from.'
+                          minLength: 1
+                          type: string
+                      required:
+                      - clientId
+                      - clientSecret
+                      - tokenUrl
+                      type: object
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        ProxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    queueConfig:
+                      description: QueueConfig allows tuning of the remote write queue parameters.
+                      properties:
+                        batchSendDeadline:
+                          description: BatchSendDeadline is the maximum time a sample will wait in buffer.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                          type: string
+                        capacity:
+                          description: |-
+                            Capacity is the number of samples to buffer per shard before we start
+                            dropping them.
+                          type: integer
+                        maxBackoff:
+                          description: MaxBackoff is the maximum retry delay.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                          type: string
+                        maxRetries:
+                          description: MaxRetries is the maximum number of times to retry a batch on recoverable errors.
+                          type: integer
+                        maxSamplesPerSend:
+                          description: MaxSamplesPerSend is the maximum number of samples per send.
+                          type: integer
+                        maxShards:
+                          description: MaxShards is the maximum number of shards, i.e. amount of concurrency.
+                          type: integer
+                        minBackoff:
+                          description: MinBackoff is the initial retry delay. Gets doubled for every retry.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                          type: string
+                        minShards:
+                          description: MinShards is the minimum number of shards, i.e. amount of concurrency.
+                          type: integer
+                        retryOnRateLimit:
+                          description: |-
+                            Retry upon receiving a 429 status code from the remote-write storage.
+
+                            This is an *experimental feature*, it may change in any upcoming release
+                            in a breaking way.
+                          type: boolean
+                        sampleAgeLimit:
+                          description: |-
+                            SampleAgeLimit drops samples older than the limit.
+                            It requires Prometheus >= v2.50.0 or Thanos >= v0.32.0.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                          type: string
+                      type: object
+                    remoteTimeout:
+                      description: Timeout for requests to the remote write endpoint.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    roundRobinDNS:
+                      description: |-
+                        When enabled:
+                            - The remote-write mechanism will resolve the hostname via DNS.
+                            - It will randomly select one of the resolved IP addresses and connect to it.
+
+                        When disabled (default behavior):
+                            - The Go standard library will handle hostname resolution.
+                            - It will attempt connections to each resolved IP address sequentially.
+
+                        Note: The connection timeout applies to the entire resolution and connection process.
+                              If disabled, the timeout is distributed across all connection attempts.
+
+                        It requires Prometheus >= v3.1.0 or Thanos >= v0.38.0.
+                      type: boolean
+                    sendExemplars:
+                      description: |-
+                        Enables sending of exemplars over remote write. Note that
+                        exemplar-storage itself must be enabled using the `spec.enableFeatures`
+                        option for exemplars to be scraped in the first place.
+
+                        It requires Prometheus >= v2.27.0 or Thanos >= v0.24.0.
+                      type: boolean
+                    sendNativeHistograms:
+                      description: |-
+                        Enables sending of native histograms, also known as sparse histograms
+                        over remote write.
+
+                        It requires Prometheus >= v2.40.0 or Thanos >= v0.30.0.
+                      type: boolean
+                    sigv4:
+                      description: |-
+                        Sigv4 allows to configures AWS's Signature Verification 4 for the URL.
+
+                        It requires Prometheus >= v2.26.0 or Thanos >= v0.24.0.
+
+                        Cannot be set at the same time as `authorization`, `basicAuth`, `oauth2`, or `azureAd`.
+                      properties:
+                        accessKey:
+                          description: |-
+                            AccessKey is the AWS API key. If not specified, the environment variable
+                            `AWS_ACCESS_KEY_ID` is used.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        profile:
+                          description: Profile is the named AWS profile used to authenticate.
+                          type: string
+                        region:
+                          description: Region is the AWS region. If blank, the region from the default credentials chain used.
+                          type: string
+                        roleArn:
+                          description: RoleArn is the named AWS profile used to authenticate.
+                          type: string
+                        secretKey:
+                          description: |-
+                            SecretKey is the AWS API secret. If not specified, the environment
+                            variable `AWS_SECRET_ACCESS_KEY` is used.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    tlsConfig:
+                      description: TLS Config to use for the URL.
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        caFile:
+                          description: Path to the CA cert in the Prometheus container to use for the targets.
+                          type: string
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        certFile:
+                          description: Path to the client cert file in the Prometheus container for the targets.
+                          type: string
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keyFile:
+                          description: Path to the client key file in the Prometheus container for the targets.
+                          type: string
+                        keySecret:
+                          description: Secret containing the client key file for the targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            Maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            Minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
+                    url:
+                      description: The URL of the endpoint to send samples to.
+                      minLength: 1
+                      type: string
+                    writeRelabelConfigs:
+                      description: The list of remote write relabel configurations.
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              Action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              Modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: Regular expression against which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              Replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: Separator is the string between concatenated SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              The source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name which may only contain ASCII
+                                letters, numbers, as well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              Label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - url
+                  type: object
+                type: array
               replicas:
                 description: Number of thanos ruler instances to deploy.
                 format: int32
@@ -4430,8 +5454,12 @@ spec:
               retention:
                 default: 24h
                 description: |-
-                  Time duration ThanosRuler shall retain data for. Default is '24h',
-                  and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).
+                  Time duration ThanosRuler shall retain data for. Default is '24h', and
+                  must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds
+                  seconds minutes hours days weeks years).
+
+                  The field has no effect when remote-write is configured since the Ruler
+                  operates in stateless mode.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               routePrefix:
@@ -5400,6 +6428,16 @@ spec:
                         type: object
                     type: object
                 type: object
+              terminationGracePeriodSeconds:
+                description: |-
+                  Optional duration in seconds the pod needs to terminate gracefully.
+                  Value must be non-negative integer. The value zero indicates stop immediately via
+                  the kill signal (no opportunity to shut down) which may lead to data corruption.
+
+                  Defaults to 120 seconds.
+                format: int64
+                minimum: 0
+                type: integer
               tolerations:
                 description: If specified, the pod's tolerations.
                 items:
@@ -5559,7 +6597,6 @@ spec:
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                         If this value is nil, the behavior is equivalent to the Honor policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     nodeTaintsPolicy:
                       description: |-
@@ -5570,7 +6607,6 @@ spec:
                         - Ignore: node taints are ignored. All nodes are included.
 
                         If this value is nil, the behavior is equivalent to the Ignore policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     topologyKey:
                       description: |-
@@ -6610,7 +7646,7 @@ spec:
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                         The volume will be mounted read-only (ro) and non-executable files (noexec).
-                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
                         pullPolicy:


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x ] No user facing changes, so no entry in CHANGELOG was needed.
