### PR TITLE
OCPBUGS-58475: Enforce secure TLS settings in CMO

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1634,9 +1634,8 @@ func (f *Factory) setupPrometheusRemoteWriteProxy(p *monv1.Prometheus) {
 
 func (f *Factory) PrometheusK8sAdditionalAlertManagerConfigsSecret() (*v1.Secret, error) {
 	amConfigs := f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs
-	prometheusAmConfigs := PrometheusAdditionalAlertmanagerConfigs(amConfigs)
 
-	config, err := yaml2.Marshal(prometheusAmConfigs)
+	config, err := f.MarshalPrometheusAdditionalAlertmanagerConfigs(amConfigs)
 	if err != nil {
 		return nil, err
 	}
@@ -1654,8 +1653,8 @@ func (f *Factory) PrometheusK8sAdditionalAlertManagerConfigsSecret() (*v1.Secret
 
 func (f *Factory) PrometheusUserWorkloadAdditionalAlertManagerConfigsSecret() (*v1.Secret, error) {
 	amConfigs := f.config.AdditionalAlertmanagerConfigsForPrometheusUserWorkload()
-	prometheusAmConfigs := PrometheusAdditionalAlertmanagerConfigs(amConfigs)
-	config, err := yaml2.Marshal(prometheusAmConfigs)
+
+	config, err := f.MarshalPrometheusAdditionalAlertmanagerConfigs(amConfigs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2058,6 +2058,20 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
   api_version: v2
   authorization:
     credentials_file: /etc/prometheus/secrets/alertmanager1-bearer-token/token
+  tls_config:
+    min_version: VersionTLS12
+    cipher_suites:
+    - TLS_AES_128_GCM_SHA256
+    - TLS_AES_256_GCM_SHA384
+    - TLS_CHACHA20_POLY1305_SHA256
+    - ECDHE-ECDSA-AES128-GCM-SHA256
+    - ECDHE-RSA-AES128-GCM-SHA256
+    - ECDHE-ECDSA-AES256-GCM-SHA384
+    - ECDHE-RSA-AES256-GCM-SHA384
+    - ECDHE-ECDSA-CHACHA20-POLY1305
+    - ECDHE-RSA-CHACHA20-POLY1305
+    - DHE-RSA-AES128-GCM-SHA256
+    - DHE-RSA-AES256-GCM-SHA384
   static_configs:
   - targets:
     - alertmanager1-remote.com
@@ -2353,6 +2367,21 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
 - scheme: https
   path_prefix: /path-prefix
   api_version: v2
+  http_config:
+    tls_config:
+      min_version: VersionTLS12
+      cipher_suites:
+      - TLS_AES_128_GCM_SHA256
+      - TLS_AES_256_GCM_SHA384
+      - TLS_CHACHA20_POLY1305_SHA256
+      - ECDHE-ECDSA-AES128-GCM-SHA256
+      - ECDHE-RSA-AES128-GCM-SHA256
+      - ECDHE-ECDSA-AES256-GCM-SHA384
+      - ECDHE-RSA-AES256-GCM-SHA384
+      - ECDHE-ECDSA-CHACHA20-POLY1305
+      - ECDHE-RSA-CHACHA20-POLY1305
+      - DHE-RSA-AES128-GCM-SHA256
+      - DHE-RSA-AES256-GCM-SHA384
   static_configs:
   - alertmanager1-remote.com
   - alertmanager1-remotex.com


### PR DESCRIPTION
This commit enforces secure TLS settings in order to eliminate insecure
cipher warnings in cluster-monitoring-operator logs. It changes
Alertmanager configurations used by Prometheus and Thanos.

- Set `min_version: TLS1.2` and explicitly define secure `cipher_suites`
- Applied to all additional Alertmanager configs
- Updated tests accordingly

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
