### PR TITLE
feat: Support OpenShift-specific topologies

### DIFF
--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -40,6 +40,12 @@ import (
 type fakeInfrastructureReader struct {
 	highlyAvailableInfrastructure bool
 	hostedControlPlane            bool
+	singleNodeControlPlane        bool
+	twoNodeControlPlane           bool
+}
+
+func (f *fakeInfrastructureReader) HighlyAvailableControlPlane() bool {
+	return !f.singleNodeControlPlane && !f.twoNodeControlPlane
 }
 
 func (f *fakeInfrastructureReader) HighlyAvailableInfrastructure() bool {
@@ -50,8 +56,21 @@ func (f *fakeInfrastructureReader) HostedControlPlane() bool {
 	return f.hostedControlPlane
 }
 
+func (f *fakeInfrastructureReader) TwoNodeControlPlane() bool {
+	return f.twoNodeControlPlane
+}
+
+func (f *fakeInfrastructureReader) SingleNodeControlPlane() bool {
+	return f.singleNodeControlPlane
+}
+
 func defaultInfrastructureReader() InfrastructureReader {
-	return &fakeInfrastructureReader{highlyAvailableInfrastructure: true, hostedControlPlane: false}
+	return &fakeInfrastructureReader{
+		highlyAvailableInfrastructure: true,
+		hostedControlPlane:            false,
+		singleNodeControlPlane:        false,
+		twoNodeControlPlane:           false,
+	}
 }
 
 type fakeProxyReader struct {


### PR DESCRIPTION
The `kubernetes-resource` rule group upstream, based on customer requirements, partially supports HA and non-HA (SNO/TNX) topologies at the moment, and we may want to dis/allow certain groups based on topologies in the future as they evolve.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

***

This is most likely for demonstration purposes for now and not needed for [OCPBUGS-34568](OCPBUGS-34568) since we support the requested alerts in non-HA scenario (and hence SNO/TNX) upstream: https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/1010.

