### PR TITLE
OCPBUGS-57215: operator: increase wait time till degraded to max 4 times 5m

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -871,7 +871,7 @@ func (o *Operator) reportFailed(ctx context.Context, report runReport) {
 	// Rate limit to avoid unnecessary status updates for temporary or transient errors that may resolve themselves within a few attempts.
 	// Ensure you have thoroughly considered all implications before adjusting the threshold.
 	// See: https://issues.redhat.com/browse/OCPBUGS-23745
-	maxAttempts := 3
+	maxAttempts := 4
 	if o.failedReconcileAttempts < maxAttempts {
 		klog.Infof("%d reconciliation(s) failed, %d more attempt(s) will be made before reporting failures.", o.failedReconcileAttempts, maxAttempts-o.failedReconcileAttempts)
 		return


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-57215

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
