### PR TITLE
MON-4163: Allow whitelisting KSM metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.20
 
 - [#2595](https://github.com/openshift/cluster-monitoring-operator/pull/2595) Multi-tenant support for KSM's CRS feature-set downstream.
+- [#2625](https://github.com/openshift/cluster-monitoring-operator/pull/2625) Support lookarounds in KSM's deny-list and white-list `kube_namespace_created`.
 
 ## 4.18
 

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]
         - |
           --metric-denylist=
-          ^kube_.+_created$,
+          ^kube_(?=namespace).*_created$,
           ^kube_.+_metadata_resource_version$,
           ^kube_replicaset_metadata_generation$,
           ^kube_replicaset_status_observed_generation$,

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -10,6 +10,7 @@ local alertmanager = import './components/alertmanager.libsonnet';
 local alertmanagerUserWorkload = import './components/alertmanager-user-workload.libsonnet';
 local dashboards = import './components/dashboards.libsonnet';
 local kubeStateMetrics = import './components/kube-state-metrics.libsonnet';
+local ksmLite = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet';
 local controlPlane = import './components/control-plane.libsonnet';
 local nodeExporter = import './components/node-exporter.libsonnet';
 local metricsServer = import './components/metrics-server.libsonnet';
@@ -432,7 +433,23 @@ local inCluster =
     openshiftStateMetrics: openshiftStateMetrics($.values.openshiftStateMetrics),
   } +
   (import './utils/anti-affinity.libsonnet') +
-  (import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet') +
+  (ksmLite {
+    ksmConfig: {
+        ksmDenyList: [
+            '^kube_(?=namespace).*_created$',
+            '^kube_.+_metadata_resource_version$',
+            '^kube_replicaset_metadata_generation$',
+            '^kube_replicaset_status_observed_generation$',
+            '^kube_pod_restart_policy$',
+            '^kube_pod_init_container_status_terminated$',
+            '^kube_pod_init_container_status_running$',
+            '^kube_pod_container_status_terminated$',
+            '^kube_pod_container_status_running$',
+            '^kube_pod_completion_time$',
+            '^kube_pod_status_scheduled$',
+        ],
+    },
+  }) +
   (import './utils/ibm-cloud-managed-profile.libsonnet') +
   (import './components/metrics-server-audit.libsonnet') +
   {};  // Including empty object to simplify adding and removing imports during development


### PR DESCRIPTION
Whitelist `kube_namespace_created`, but block others as earlier. This is possible owing to the recent lookarounds support merged in KSM [1].

[1]: https://github.com/kubernetes/kube-state-metrics/pull/2616

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [X] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.

***

Blocked by https://github.com/prometheus-operator/kube-prometheus/pull/2684.