### PR TITLE
MON-4371: chore(prometheus): enable use-uncached-io feature flag

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -168,6 +168,7 @@ spec:
       name: prometheus-trusted-ca-bundle
   enableFeatures:
   - delayed-compaction
+  - use-uncached-io
   externalLabels: {}
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091
   image: quay.io/prometheus/prometheus:v3.5.0

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -183,6 +183,7 @@ spec:
   enableFeatures:
   - extra-scrape-metrics
   - delayed-compaction
+  - use-uncached-io
   enforcedNamespaceLabel: namespace
   externalLabels: {}
   ignoreNamespaceSelectors: true

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -290,8 +290,9 @@ function(params)
         },
       },
       spec+: {
-        // Enable experimental additional scrape metrics and delayed compaction features.
-        enableFeatures+: ['extra-scrape-metrics', 'delayed-compaction'],
+        // Enable some experimental features.
+        // More at https://prometheus.io/docs/prometheus/latest/feature_flags/
+        enableFeatures+: ['extra-scrape-metrics', 'delayed-compaction', 'use-uncached-io'],
         overrideHonorTimestamps: true,
         overrideHonorLabels: true,
         ignoreNamespaceSelectors: true,

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -325,8 +325,9 @@ function(params)
         },
       },
       spec+: {
-        // Enable experimental delayed compaction feature.
-        enableFeatures+: ['delayed-compaction'],
+        // Enable some experimental features.
+        // More at https://prometheus.io/docs/prometheus/latest/feature_flags/
+        enableFeatures+: ['delayed-compaction', 'use-uncached-io'],
         alerting+: {
           alertmanagers:
             std.map(

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -284,7 +284,7 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 					expectMatchingRequests(podName, containerName, mem, cpu),
 					// Set by default.
 					expectContainerArg("--scrape.timestamp-tolerance=15ms", containerName),
-					expectContainerArg("--enable-feature=delayed-compaction", containerName),
+					expectContainerArg("--enable-feature=delayed-compaction,use-uncached-io", containerName),
 					// Set via the config above.
 					expectContainerArg("--log.level=debug", containerName),
 					expectContainerArg("--storage.tsdb.retention.time=10h", containerName),
@@ -641,8 +641,8 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
 				[]framework.PodAssertion{
 					expectCatchAllToleration(),
 					expectMatchingRequests(podName, containerName, mem, cpu),
-					// Set by default.
-					expectContainerArg("--enable-feature=extra-scrape-metrics,delayed-compaction,exemplar-storage", containerName),
+					// exemplar-storage is set dynamically, so it will likely appear at the end.
+					expectContainerArg("--enable-feature=extra-scrape-metrics,delayed-compaction,use-uncached-io,exemplar-storage", containerName),
 					// Set via the config above.
 					expectContainerArg("--log.level=debug", containerName),
 					expectContainerArg("--storage.tsdb.retention.time=10h", containerName),


### PR DESCRIPTION
chore: enable use-uncached-io (using direct I/O for now) feature flag to prevent bad
decisions based on page cache.

to learn more about it https://github.com/prometheus/proposals/blob/main/proposals/0045-direct-io.md

Introduced in https://github.com/prometheus/prometheus/pull/15365

from upstream benchmark

<img width="2489" height="621" alt="Screenshot 2025-09-15 at 11 42 19" src="https://github.com/user-attachments/assets/eccb5c6b-d70c-4274-83f4-f4d2db94eab4" />

for the same written data, cache is bypassed (where direct i/o is used) as expected, `container_memory_usage_bytes` reflects that as expected.

---

The first version of the PR ran the presubmit and payload tests with `storage.tsdb.min-block-duration=5m` to speed up compaction and trigger the feature flag more frequently. No regressions were identified.

---

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
