### PR TITLE
NO-JIRA: Use label matchers for Rules API in prom-label-proxy

### DIFF
--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -167,6 +167,7 @@ spec:
         - --enable-label-apis
         - --error-on-replace
         - --rules-with-active-alerts
+        - --enable-label-matchers-for-rules-api
         image: quay.io/prometheuscommunity/prom-label-proxy:v0.12.0
         name: prom-label-proxy
         resources:

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -513,6 +513,7 @@ function(params)
                   '--enable-label-apis',
                   '--error-on-replace',
                   '--rules-with-active-alerts',
+                  '--enable-label-matchers-for-rules-api',
                 ],
                 resources: {
                   requests: {


### PR DESCRIPTION
There's no user visible change but it should bring performance and resource usage improvements in setups with large number of rules since the data is filtered at the source (Prometheus and Thanos) rather than by the proxy.

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.
