### PR TITLE
OCPBUGS-60221: remove `managed_cluster` from reserved external labels

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -54,7 +54,7 @@ const (
 )
 
 var errAlertmanagerV1NotSupported = errors.New("alertmanager's apiVersion=v1 is no longer supported, v2 has been available since Alertmanager 0.16.0")
-var reservedPrometheusExternalLabels = []string{"prometheus", "prometheus_replica", "cluster", "managed_cluster"}
+var reservedPrometheusExternalLabels = []string{"prometheus", "prometheus_replica", "cluster"}
 
 type Config struct {
 	Images                               *Images `json:"-"`

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -5285,7 +5285,7 @@ func TestPromConfigurationExternalLabels(t *testing.T) {
 					name: "one rempty reserved",
 					template: `%s:
   externalLabels:
-    managed_cluster:
+    cluster:
     bar: foo
 `,
 					shouldFail: true,


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
