### PR TITLE
NO-JIRA: chore: drop check for AlertmanagerV1

### DIFF
--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -278,85 +278,6 @@ thanosRuler:
 	}
 }
 
-// TestNewUserConfigFromStringUnsupportedAlertmanagerVersion is a temp test
-// TODO: remove after 4.19
-// Only to assist with the migration to Prometheus 3; fail early if Alertmanager v1 is still in use.
-func TestNewUserConfigFromStringUnsupportedAlertmanagerVersion(t *testing.T) {
-	tcs := []struct {
-		name         string
-		configString func() string
-		shouldFail   bool
-	}{
-		{
-			name: "unsupported alertmanager version in thanosRuler.additionalAlertmanagerConfigs",
-			configString: func() string {
-				return `
-thanosRuler:
-  additionalAlertmanagerConfigs:
-    - apiVersion: v1`
-			},
-			shouldFail: true,
-		},
-		{
-			name: "unsupported alertmanager version in prometheus.additionalAlertmanagerConfigs",
-			configString: func() string {
-				return `
-prometheus:
-  additionalAlertmanagerConfigs:
-    - apiVersion: v1`
-			},
-			shouldFail: true,
-		},
-		{
-			name: "supported alertmanager version in thanosRuler.additionalAlertmanagerConfigs",
-			configString: func() string {
-				return `
-thanosRuler:
-  additionalAlertmanagerConfigs:
-    - apiVersion: v2`
-			},
-		},
-		{
-			name: "supported alertmanager version in prometheus.additionalAlertmanagerConfigs",
-			configString: func() string {
-				return `
-prometheus:
-  additionalAlertmanagerConfigs:
-    - apiVersion: v2`
-			},
-		},
-		{
-			name: "default alertmanager version in thanosRuler.additionalAlertmanagerConfigs",
-			configString: func() string {
-				return `
-thanosRuler:
-  additionalAlertmanagerConfigs:
-    - scheme: foo`
-			},
-		},
-		{
-			name: "default alertmanager version in prometheus.additionalAlertmanagerConfigs",
-			configString: func() string {
-				return `
-prometheus:
-  additionalAlertmanagerConfigs:
-    - scheme: foo`
-			},
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewUserConfigFromString(tc.configString())
-			if tc.shouldFail {
-				require.ErrorIs(t, err, errAlertmanagerV1NotSupported)
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
-}
-
 func TestTelemeterClientConfig(t *testing.T) {
 	truev, falsev := true, false
 
@@ -835,51 +756,6 @@ func TestDeprecatedConfig(t *testing.T) {
 			err = c.Precheck()
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedMetricValue, prom_testutil.ToFloat64(metrics.DeprecatedConfig))
-		})
-	}
-}
-
-// TestUnsupportedAlertmanagerVersion is a temp test
-// TODO: remove after 4.19
-// Only to assist with the migration to Prometheus 3; fail early if Alertmanager v1 is still in use.
-func TestUnsupportedAlertmanagerVersion(t *testing.T) {
-	for _, tc := range []struct {
-		name       string
-		config     string
-		shouldFail bool
-	}{
-		{
-			name: "using unsupported Alertmanager v1 API",
-			config: `prometheusK8s:
-  additionalAlertmanagerConfigs:
-    - apiVersion: v1
-  `,
-			shouldFail: true,
-		},
-		{
-			name: "using supported Alertmanager v2 API",
-			config: `prometheusK8s:
-  additionalAlertmanagerConfigs:
-    - apiVersion: v2
-  `,
-		},
-		{
-			name: "using default value",
-			config: `prometheusK8s:
-  additionalAlertmanagerConfigs:
-    - scheme: foo
-  `,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			c, err := NewConfigFromString(tc.config, true)
-			require.NoError(t, err)
-			err = c.Precheck()
-			if tc.shouldFail {
-				require.ErrorIs(t, err, errAlertmanagerV1NotSupported)
-			} else {
-				require.NoError(t, err)
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
