### PR TITLE
MON-4343: Cleanup deprecate pa config

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -55,6 +55,15 @@ const (
 
 var reservedPrometheusExternalLabels = []string{"prometheus", "prometheus_replica", "cluster"}
 
+type InvalidConfigWarning struct {
+	ConfigMap string
+	Err       error
+}
+
+func (e *InvalidConfigWarning) Warning() string {
+	return fmt.Sprintf("configuration in the %q ConfigMap is invalid and should be fixed: %s", e.ConfigMap, e.Err)
+}
+
 type Config struct {
 	Images                               *Images `json:"-"`
 	RemoteWrite                          bool    `json:"-"`
@@ -328,6 +337,7 @@ func UnmarshalStrict(data []byte, v interface{}) error {
 
 func newConfig(content []byte, collectionProfilesFeatureGateEnabled bool) (*Config, error) {
 	c := Config{CollectionProfilesFeatureGateEnabled: collectionProfilesFeatureGateEnabled}
+
 	cmc := defaultClusterMonitoringConfiguration()
 	err := UnmarshalStrict(content, &cmc)
 	if err != nil {
@@ -673,6 +683,7 @@ func NewUserConfigFromString(content string) (*UserWorkloadConfiguration, error)
 	if content == "" {
 		return NewDefaultUserWorkloadMonitoringConfig(), nil
 	}
+
 	u := &UserWorkloadConfiguration{}
 	err := UnmarshalStrict([]byte(content), &u)
 	if err != nil {

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -719,7 +719,7 @@ func TestCollectionProfilePreCheck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := NewConfigFromString(tc.config, true)
 			require.NoError(t, err)
-			err = c.Precheck()
+			_, err = c.Precheck()
 			if err != nil && tc.expectedError {
 				return
 			}
@@ -734,6 +734,7 @@ func TestDeprecatedConfig(t *testing.T) {
 		name                string
 		config              string
 		expectedMetricValue float64
+		warning             string
 	}{
 		{
 			name: "setting a field in k8sPrometheusAdapter",
@@ -744,6 +745,7 @@ func TestDeprecatedConfig(t *testing.T) {
       memory: 20Mi
   `,
 			expectedMetricValue: 1,
+			warning:             "configuration in the \"openshift-monitoring/cluster-monitoring-config\" ConfigMap is invalid and should be fixed: k8sPrometheusAdapter is deprecated and usage should be removed, use metricsServer instead",
 		},
 		{
 			name: "k8sPrometheusAdapter nil",
@@ -760,7 +762,10 @@ func TestDeprecatedConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := NewConfigFromString(tc.config, true)
 			require.NoError(t, err)
-			err = c.Precheck()
+			warning, err := c.Precheck()
+			if tc.warning != "" {
+				require.Equal(t, tc.warning, warning.Warning())
+			}
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedMetricValue, prom_testutil.ToFloat64(metrics.DeprecatedConfig))
 		})

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -200,6 +200,13 @@ func TestNewUserConfigFromString(t *testing.T) {
 			err: "error unmarshaling: unknown field \"prometheusOperator.nodeselector\"",
 		},
 		{
+			name: "json string with field of wrong case",
+			configString: func() string {
+				return `{"prometheusoperator": {}}`
+			},
+			err: "error unmarshaling: unknown field \"prometheusoperator\"",
+		},
+		{
 			name: "json string with duplicated field",
 			// users should be aware of this as unmarshalling would only take one part into account.
 			configString: func() string {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -4251,6 +4251,7 @@ func TestTelemeterClientSecret(t *testing.T) {
 
 func TestThanosRulerConfiguration(t *testing.T) {
 	c, err := NewConfigFromString(``, false)
+	require.NoError(t, err)
 	uwc, err := NewUserConfigFromString(`thanosRuler:
   evaluationInterval: 20s
   resources:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -995,7 +995,10 @@ func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, [
 		return nil, warnings, err
 	}
 
-	err = c.Precheck()
+	warning, err := c.Precheck()
+	if warning != nil {
+		warnings = append(warnings, warning.Warning())
+	}
 	if err != nil {
 		return nil, warnings, err
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -750,16 +750,30 @@ func newUWMTaskSpec(targetName string, task tasks.Task) *tasks.TaskSpec {
 	return tasks.NewTaskSpec(UWMTaskPrefix+targetName, task)
 }
 
-func (o *Operator) sync(ctx context.Context, key string) error {
-	config, err := o.Config(ctx, key)
+func (o *Operator) setUpgradeable(ctx context.Context, status configv1.ConditionStatus, message, reason string) {
+	err := o.client.StatusReporter().SetUpgradeable(ctx, status, message, reason)
 	if err != nil {
-		reason := "InvalidConfiguration"
+		klog.Errorf("error occurred while setting Upgradeable status: %v", err)
+	}
+}
+
+func (o *Operator) sync(ctx context.Context, key string) error {
+	config, warnings, err := o.Config(ctx, key)
+
+	reason := "InvalidConfiguration"
+	if warnings != nil {
+		o.setUpgradeable(ctx, configv1.ConditionFalse, strings.Join(warnings, ". "), reason)
+	} else {
+		o.setUpgradeable(ctx, configv1.ConditionTrue, "", "")
+	}
+	if err != nil {
 		if errors.Is(err, ErrUserWorkloadInvalidConfiguration) {
 			reason = "UserWorkloadInvalidConfiguration"
 		}
 		o.reportFailed(ctx, newRunReportForError(reason, err))
 		return err
 	}
+
 	config.SetImages(o.images)
 	config.SetTelemetryMatches(o.telemetryMatches)
 	config.SetRemoteWrite(o.remoteWrite)
@@ -853,12 +867,6 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	err = o.client.StatusReporter().SetRollOutDone(ctx, degradedConditionMessage, degradedConditionReason)
 	if err != nil {
 		klog.Errorf("error occurred while setting status to done: %v", err)
-	}
-
-	// CMO always reports Upgradeable=True.
-	err = o.client.StatusReporter().SetUpgradeable(ctx, configv1.ConditionTrue, "", "")
-	if err != nil {
-		klog.Errorf("error occurred while setting Upgradeable status: %v", err)
 	}
 
 	return nil
@@ -979,15 +987,17 @@ func (o *Operator) loadConfig(key string) (*manifests.Config, error) {
 	return manifests.NewConfigFromConfigMap(cmap, o.CollectionProfilesEnabled)
 }
 
-func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, error) {
+func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, []string, error) {
+	var warnings []string
+
 	c, err := o.loadConfig(key)
 	if err != nil {
-		return nil, err
+		return nil, warnings, err
 	}
 
 	err = c.Precheck()
 	if err != nil {
-		return nil, err
+		return nil, warnings, err
 	}
 
 	// Only use User Workload Monitoring ConfigMap from user ns and populate if
@@ -997,7 +1007,7 @@ func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, e
 	if *c.ClusterMonitoringConfiguration.UserWorkloadEnabled {
 		c.UserWorkloadConfiguration, err = o.loadUserWorkloadConfig(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %w", ErrUserWorkloadInvalidConfiguration, err)
+			return nil, warnings, fmt.Errorf("%w: %w", ErrUserWorkloadInvalidConfiguration, err)
 		}
 	}
 
@@ -1025,7 +1035,7 @@ func (o *Operator) Config(ctx context.Context, key string) (*manifests.Config, e
 			klog.Warningf("Error loading token from API. Proceeding without it: %v", err)
 		}
 	}
-	return c, nil
+	return c, warnings, nil
 }
 
 // storageNotConfiguredMessage returns the message to be set if a pvc has not

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -904,12 +904,14 @@ k8sPrometheusAdapter:
     profile: Request`
 	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, data))
 	checkMetricValue(1)
+	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse)(t)
 
 	// The metric should be reset to 0.
 	data = `
 k8sPrometheusAdapter:`
 	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, data))
 	checkMetricValue(0)
+	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
 }
 
 // checks that the toleration is present

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -71,6 +71,9 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 	t.Log("asserting that CMO goes degraded after an invalid configuration is pushed")
 	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionTrue)(t)
 	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionFalse)(t)
+	// operator should stay upgradeable even when a malformed config was
+	// rejected
+	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
 	f.AssertOperatorConditionReason(configv1.OperatorDegraded, "InvalidConfiguration")
 	f.AssertOperatorConditionReason(configv1.OperatorAvailable, "InvalidConfiguration")
 	// Check that the previous setup hasn't been reverted
@@ -81,6 +84,9 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 	t.Log("asserting that CMO goes back healthy after the configuration is fixed")
 	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
 	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
+	f.AssertOperatorConditionReason(configv1.OperatorUpgradeable, "")(t)
+	f.AssertOperatorConditionMessage(configv1.OperatorUpgradeable, "")(t)
 }
 
 func TestClusterMonitoringStatus(t *testing.T) {

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -48,7 +48,6 @@ type scenario struct {
 }
 
 func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
-	// Deploy an invalid UWM config
 	uwmCM := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      framework.UserWorkloadMonitorConfigMapName,
@@ -58,7 +57,7 @@ func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
 			},
 		},
 		Data: map[string]string{
-			"config.yaml": `invalid config`,
+			"config.yaml": `cannot be deserialized`,
 		},
 	}
 	err := f.OperatorClient.CreateOrUpdateConfigMap(ctx, uwmCM)
@@ -76,10 +75,23 @@ func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
 	f.MustCreateOrUpdateConfigMap(t, cm)
 	defer f.MustDeleteConfigMap(t, cm)
 
+	t.Log("invalid UWM configuration with malformed YAML/JSON")
 	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionTrue)(t)
 	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionFalse)(t)
+	// operator should stay upgradeable even when a malformed config was
+	// rejected
+	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
 	f.AssertOperatorConditionReason(configv1.OperatorDegraded, "UserWorkloadInvalidConfiguration")
 	f.AssertOperatorConditionReason(configv1.OperatorAvailable, "UserWorkloadInvalidConfiguration")
+
+	t.Log("restoring the initial configurations")
+	uwmCM.Data["config.yaml"] = ``
+	f.MustCreateOrUpdateConfigMap(t, uwmCM)
+	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
+	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
+	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
+	f.AssertOperatorConditionReason(configv1.OperatorUpgradeable, "")(t)
+	f.AssertOperatorConditionMessage(configv1.OperatorUpgradeable, "")(t)
 }
 
 func TestUserWorkloadMonitoringMetrics(t *testing.T) {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
