### PR TITLE
OCPBUGS-61113: add flag `--watch-referenced-objects-in-all-namespaces` to prometheus-operator

### DIFF
--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.85.0
         - --kubelet-endpoints=true
         - --kubelet-endpointslice=false
+        - --watch-referenced-objects-in-all-namespaces=true
         - --prometheus-instance-namespaces=openshift-monitoring
         - --thanos-ruler-instance-namespaces=openshift-monitoring
         - --alertmanager-instance-namespaces=openshift-monitoring

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -70,6 +70,7 @@ function(params)
                     // without requiring client TLS authentication.
                     c {
                       args+: [
+                        '--watch-referenced-objects-in-all-namespaces=true',
                         '--prometheus-instance-namespaces=' + params.namespace,
                         '--thanos-ruler-instance-namespaces=' + params.namespace,
                         '--alertmanager-instance-namespaces=' + params.namespace,


### PR DESCRIPTION

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
