### PR TITLE
OCPBUGS-61135: Revert "MON-4343: Cleanup deprecate pa config"

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -55,17 +55,6 @@ const (
 
 var reservedPrometheusExternalLabels = []string{"prometheus", "prometheus_replica", "cluster"}
 
-type InvalidConfigWarning struct {
-	ConfigMap string
-	Err       error
-}
-
-func (e *InvalidConfigWarning) Warning() string {
-	return fmt.Sprintf("configuration in the %q ConfigMap is invalid and should be fixed: %s", e.ConfigMap, e.Err)
-}
-
-var errPrometheusAdapterDeprecated = errors.New("k8sPrometheusAdapter is deprecated and usage should be removed, use metricsServer instead")
-
 type Config struct {
 	Images                               *Images `json:"-"`
 	RemoteWrite                          bool    `json:"-"`
@@ -339,7 +328,6 @@ func UnmarshalStrict(data []byte, v interface{}) error {
 
 func newConfig(content []byte, collectionProfilesFeatureGateEnabled bool) (*Config, error) {
 	c := Config{CollectionProfilesFeatureGateEnabled: collectionProfilesFeatureGateEnabled}
-
 	cmc := defaultClusterMonitoringConfiguration()
 	err := UnmarshalStrict(content, &cmc)
 	if err != nil {
@@ -586,9 +574,9 @@ func (c *Config) LoadEnforcedBodySizeLimit(pcr PodCapacityReader, ctx context.Co
 	return nil
 }
 
-func (c *Config) Precheck() (*InvalidConfigWarning, error) {
+func (c *Config) Precheck() error {
 	if c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile != FullCollectionProfile && !c.CollectionProfilesFeatureGateEnabled {
-		return nil, fmt.Errorf("%w: collectionProfiles is currently a TechPreview feature behind the \"MetricsCollectionProfiles\" feature-gate, to be able to use a profile different from the default (\"full\") please enable it first", ErrConfigValidation)
+		return fmt.Errorf("%w: collectionProfiles is currently a TechPreview feature behind the \"MetricsCollectionProfiles\" feature-gate, to be able to use a profile different from the default (\"full\") please enable it first", ErrConfigValidation)
 	}
 
 	// Validate the configured collection profile iff tech preview is enabled, even if the default profile is set.
@@ -601,22 +589,20 @@ func (c *Config) Precheck() (*InvalidConfigWarning, error) {
 			metrics.CollectionProfile.WithLabelValues(string(profile)).Set(v)
 		}
 		if !slices.Contains(SupportedCollectionProfiles, c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile) {
-			return nil, fmt.Errorf(`%q is not supported, supported collection profiles are: %q: %w`, c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile, SupportedCollectionProfiles.String(), ErrConfigValidation)
+			return fmt.Errorf(`%q is not supported, supported collection profiles are: %q: %w`, c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile, SupportedCollectionProfiles.String(), ErrConfigValidation)
 		}
 	}
 
 	// Highlight deprecated config fields.
 	var d float64
-	var warn *InvalidConfigWarning
 	if c.ClusterMonitoringConfiguration.K8sPrometheusAdapter != nil {
 		klog.Infof("k8sPrometheusAdapter is a deprecated config use metricsServer instead")
 		d = 1
-		warn = &InvalidConfigWarning{ConfigMap: "openshift-monitoring/cluster-monitoring-config", Err: errPrometheusAdapterDeprecated}
 	}
 	// Prometheus-Adapter is replaced with Metrics Server by default from 4.16
 	metrics.DeprecatedConfig.WithLabelValues("openshift-monitoring/cluster-monitoring-config", "k8sPrometheusAdapter", "4.16").Set(d)
 
-	return warn, nil
+	return nil
 }
 
 func calculateBodySizeLimit(podCapacity int) string {
@@ -687,7 +673,6 @@ func NewUserConfigFromString(content string) (*UserWorkloadConfiguration, error)
 	if content == "" {
 		return NewDefaultUserWorkloadMonitoringConfig(), nil
 	}
-
 	u := &UserWorkloadConfiguration{}
 	err := UnmarshalStrict([]byte(content), &u)
 	if err != nil {

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -200,13 +200,6 @@ func TestNewUserConfigFromString(t *testing.T) {
 			err: "error unmarshaling: unknown field \"prometheusOperator.nodeselector\"",
 		},
 		{
-			name: "json string with field of wrong case",
-			configString: func() string {
-				return `{"prometheusoperator": {}}`
-			},
-			err: "error unmarshaling: unknown field \"prometheusoperator\"",
-		},
-		{
 			name: "json string with duplicated field",
 			// users should be aware of this as unmarshalling would only take one part into account.
 			configString: func() string {
@@ -719,7 +712,7 @@ func TestCollectionProfilePreCheck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := NewConfigFromString(tc.config, true)
 			require.NoError(t, err)
-			_, err = c.Precheck()
+			err = c.Precheck()
 			if err != nil && tc.expectedError {
 				return
 			}
@@ -734,7 +727,6 @@ func TestDeprecatedConfig(t *testing.T) {
 		name                string
 		config              string
 		expectedMetricValue float64
-		warning             string
 	}{
 		{
 			name: "setting a field in k8sPrometheusAdapter",
@@ -745,7 +737,6 @@ func TestDeprecatedConfig(t *testing.T) {
       memory: 20Mi
   `,
 			expectedMetricValue: 1,
-			warning:             "configuration in the \"openshift-monitoring/cluster-monitoring-config\" ConfigMap is invalid and should be fixed: k8sPrometheusAdapter is deprecated and usage should be removed, use metricsServer instead",
 		},
 		{
 			name: "k8sPrometheusAdapter nil",
@@ -762,10 +753,7 @@ func TestDeprecatedConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := NewConfigFromString(tc.config, true)
 			require.NoError(t, err)
-			warning, err := c.Precheck()
-			if tc.warning != "" {
-				require.Equal(t, tc.warning, warning.Warning())
-			}
+			err = c.Precheck()
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedMetricValue, prom_testutil.ToFloat64(metrics.DeprecatedConfig))
 		})

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -4251,7 +4251,6 @@ func TestTelemeterClientSecret(t *testing.T) {
 
 func TestThanosRulerConfiguration(t *testing.T) {
 	c, err := NewConfigFromString(``, false)
-	require.NoError(t, err)
 	uwc, err := NewUserConfigFromString(`thanosRuler:
   evaluationInterval: 20s
   resources:

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -71,9 +71,6 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 	t.Log("asserting that CMO goes degraded after an invalid configuration is pushed")
 	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionTrue)(t)
 	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionFalse)(t)
-	// operator should stay upgradeable even when a malformed config was
-	// rejected
-	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
 	f.AssertOperatorConditionReason(configv1.OperatorDegraded, "InvalidConfiguration")
 	f.AssertOperatorConditionReason(configv1.OperatorAvailable, "InvalidConfiguration")
 	// Check that the previous setup hasn't been reverted
@@ -84,9 +81,6 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 	t.Log("asserting that CMO goes back healthy after the configuration is fixed")
 	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
 	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
-	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
-	f.AssertOperatorConditionReason(configv1.OperatorUpgradeable, "")(t)
-	f.AssertOperatorConditionMessage(configv1.OperatorUpgradeable, "")(t)
 }
 
 func TestClusterMonitoringStatus(t *testing.T) {
@@ -904,14 +898,12 @@ k8sPrometheusAdapter:
     profile: Request`
 	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, data))
 	checkMetricValue(1)
-	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse)(t)
 
 	// The metric should be reset to 0.
 	data = `
 k8sPrometheusAdapter:`
 	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, data))
 	checkMetricValue(0)
-	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
 }
 
 // checks that the toleration is present

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -48,6 +48,7 @@ type scenario struct {
 }
 
 func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
+	// Deploy an invalid UWM config
 	uwmCM := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      framework.UserWorkloadMonitorConfigMapName,
@@ -57,7 +58,7 @@ func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
 			},
 		},
 		Data: map[string]string{
-			"config.yaml": `cannot be deserialized`,
+			"config.yaml": `invalid config`,
 		},
 	}
 	err := f.OperatorClient.CreateOrUpdateConfigMap(ctx, uwmCM)
@@ -75,23 +76,10 @@ func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
 	f.MustCreateOrUpdateConfigMap(t, cm)
 	defer f.MustDeleteConfigMap(t, cm)
 
-	t.Log("invalid UWM configuration with malformed YAML/JSON")
 	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionTrue)(t)
 	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionFalse)(t)
-	// operator should stay upgradeable even when a malformed config was
-	// rejected
-	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
 	f.AssertOperatorConditionReason(configv1.OperatorDegraded, "UserWorkloadInvalidConfiguration")
 	f.AssertOperatorConditionReason(configv1.OperatorAvailable, "UserWorkloadInvalidConfiguration")
-
-	t.Log("restoring the initial configurations")
-	uwmCM.Data["config.yaml"] = ``
-	f.MustCreateOrUpdateConfigMap(t, uwmCM)
-	f.AssertOperatorCondition(configv1.OperatorDegraded, configv1.ConditionFalse)(t)
-	f.AssertOperatorCondition(configv1.OperatorAvailable, configv1.ConditionTrue)(t)
-	f.AssertOperatorCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue)(t)
-	f.AssertOperatorConditionReason(configv1.OperatorUpgradeable, "")(t)
-	f.AssertOperatorConditionMessage(configv1.OperatorUpgradeable, "")(t)
 }
 
 func TestUserWorkloadMonitoringMetrics(t *testing.T) {


### PR DESCRIPTION
Reverts openshift/cluster-monitoring-operator#2651

See https://issues.redhat.com/browse/OCPBUGS-61135