### PR TITLE
chore(jsonnet): use prometheus_remote_storage_queue_highest_timestamp_in_seconds in PrometheusRemoteWriteBehind

### DIFF
--- a/assets/prometheus-k8s/prometheus-rule.yaml
+++ b/assets/prometheus-k8s/prometheus-rule.yaml
@@ -166,11 +166,12 @@ spec:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write is {{ printf "%.1f" $value }}s behind for {{ $labels.remote_name}}:{{ $labels.url }}.
         summary: Prometheus remote write is behind.
       expr: |
+        # Use the metric added in https://github.com/openshift/prometheus/pull/262 and related PRs.
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         (
-          max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
-        - ignoring(remote_name, url) group_right
+          max_over_time(prometheus_remote_storage_queue_highest_timestamp_seconds{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+        -
           max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
         )
         > 120

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -431,6 +431,17 @@ local patchedRules = [
         labels: {
           severity: 'info',
         },
+        expr: |||
+          # Use the metric added in https://github.com/openshift/prometheus/pull/262 and related PRs.
+          # Without max_over_time, failed scrapes could create false negatives, see
+          # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+          (
+            max_over_time(prometheus_remote_storage_queue_highest_timestamp_seconds{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+          -
+            max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job=~"prometheus-k8s|prometheus-user-workload"}[5m])
+          )
+          > 120
+        |||,
       },
     ],
   },


### PR DESCRIPTION
This metric was introduced in https://github.com/openshift/prometheus/pull/262 and related PRs.

Dashboard expressions are not changed, since updating them may be more complex. Fixing the alert is more important and we can always revisit that if it causes confusion.

On main, dashboards will be adjusted later once the jsonnet dependencies are updated.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
