### PR TITLE
OCPBUGS-60751: Fix Prometheus UI redirect for port-forward access

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -200,6 +200,7 @@ spec:
     requests:
       cpu: 70m
       memory: 1Gi
+  routePrefix: /
   ruleNamespaceSelector:
     matchLabels:
       openshift.io/cluster-monitoring: "true"

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -374,6 +374,7 @@ function(params)
           'metrics-client-certs',
         ],
         externalURL: 'https://prometheus-k8s.openshift-monitoring.svc:9091',
+        routePrefix: '/',
         configMaps: ['serving-certs-ca-bundle', 'kubelet-serving-ca-bundle', 'metrics-client-ca'],
         probeNamespaceSelector: cfg.namespaceSelector,
         podMonitorNamespaceSelector: cfg.namespaceSelector,

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1337,7 +1337,10 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, telemetrySecret *v1.Secret) 
 
 	p.Spec.Image = &f.config.Images.Prometheus
 
-	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "monitoring")
+	// Set external URL without the /monitoring path to fix redirect behavior.
+	// This ensures that when accessing via port-forward, redirects go to /query instead of /monitoring/query.
+	// See: https://issues.redhat.com/browse/OCPBUGS-60751
+	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1484,6 +1487,10 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, telemetrySecret *v1.Secret) 
 	if f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.EnforcedBodySizeLimit != "" {
 		p.Spec.EnforcedBodySizeLimit = monv1.ByteSize(f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.EnforcedBodySizeLimit)
 	}
+
+	// Always set routePrefix to "/" to ensure correct redirect behavior.
+	// See: https://issues.redhat.com/browse/OCPBUGS-60751
+	p.Spec.RoutePrefix = "/"
 
 	return p, nil
 }
@@ -1690,7 +1697,10 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 
 	p.Spec.Image = &f.config.Images.Prometheus
 
-	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "monitoring")
+	// Set external URL without the /monitoring path to fix redirect behavior.
+	// This ensures that when accessing via port-forward, redirects go to /query instead of /monitoring/query.
+	// See: https://issues.redhat.com/browse/OCPBUGS-60751
+	alertGeneratorURL, err := makeConsoleURL(f.consoleConfig, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1822,6 +1832,10 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 	}
 
 	p.Spec.ExcludedFromEnforcement = f.excludedFromEnforcement()
+
+	// Always set routePrefix to "/" to ensure correct redirect behavior.
+	// See: https://issues.redhat.com/browse/OCPBUGS-60751
+	p.Spec.RoutePrefix = "/"
 
 	return p, nil
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1640,7 +1640,7 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
 		t.Fatal("Prometheus query log is not configured correctly")
 	}
 
-	expectedExternalURL := "https://console-openshift-console.apps.foo.devcluster.openshift.com/monitoring"
+	expectedExternalURL := "https://console-openshift-console.apps.foo.devcluster.openshift.com"
 	if p.Spec.ExternalURL != expectedExternalURL {
 		t.Fatalf("Prometheus external URL is not configured correctly, expected %s, but got %s", expectedExternalURL, p.Spec.ExternalURL)
 	}


### PR DESCRIPTION
When accessing Prometheus via port-forward, the UI incorrectly redirects
to /monitoring/query instead of /query, causing a 404 error.

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
