### PR TITLE
OCPBUGS-15430: Remove KubeAPIDown alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Note: This CHANGELOG is only for the monitoring team to track all monitoring related changes. Please see OpenShift release notes for official changes.
 
+## 4.21
+
+- [#2665](https://github.com/openshift/cluster-monitoring-operator/pull/2665) Remove KubeAPIDown alert
+
 ## 4.20
 
 - [#2595](https://github.com/openshift/cluster-monitoring-operator/pull/2595) Multi-tenant support for KSM's CRS feature-set downstream.

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -352,16 +352,6 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: KubeAPIDown
-      annotations:
-        description: KubeAPI has disappeared from Prometheus target discovery.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeAPIDown.md
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="apiserver"} == 1)
-      for: 15m
-      labels:
-        severity: critical
     - alert: KubeAPITerminatedRequests
       annotations:
         description: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -71,6 +71,14 @@ local excludedRules = [
       // actionable because the cluster admin has no way to
       // prevent a client from using an expird certificate.
       { alert: 'KubeClientCertificateExpiration' },
+      // KubeAPIDown alert fires only when either all kube-apiserver instances
+      // are down or connection to Prometheus is down. From the use perspective
+      // accessing the Console is a common scenario. Thus, when API is down
+      // the console/Prometheus can not be accessed. Thus, this alert is not
+      // observed unless an external observer is installed. There are also
+      // other alerts like KubeAPIErrorBudgetBurn that are expected to trigger
+      // before the API is down.
+      { alert: 'KubeAPIDown' },
     ],
   },
   {


### PR DESCRIPTION
KubeAPIDown alert fires only when either all kube-apiserver instances are down or connection to Prometheus is down. From the use perspective accessing the Console is a common scenario. Thus, when API is down the console/Prometheus can not be accessed. Thus, this alert is not observed unless an external observer is installed. There are also other alerts like KubeAPIErrorBudgetBurn that are expected to trigger before the API is down.

* [x] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
