### PR TITLE
WIP: fix(prometheus): use legacy validation and escaping schemes until fully utf8 support

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -174,6 +174,8 @@ spec:
   image: quay.io/prometheus/prometheus:v3.5.0
   listenLocal: true
   maximumStartupDurationSeconds: 3600
+  nameEscapingScheme: Underscores
+  nameValidationScheme: Legacy
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -189,6 +189,8 @@ spec:
   ignoreNamespaceSelectors: true
   image: quay.io/prometheus/prometheus:v3.5.0
   listenLocal: true
+  nameEscapingScheme: Underscores
+  nameValidationScheme: Legacy
   nodeSelector:
     kubernetes.io/os: linux
   overrideHonorLabels: true

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -378,6 +378,9 @@ function(params)
             value: '15ms',
           },
         ],
+        // Prometheus should use legacy validation and escaping schemes until fully utf8 support.
+        nameEscapingScheme: 'Underscores',
+        nameValidationScheme: 'Legacy',
         containers: [
           {
             name: 'kube-rbac-proxy-federate',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -402,6 +402,9 @@ function(params)
         // failures when the WAL replay takes a long time.
         // See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
         maximumStartupDurationSeconds: 3600,
+        // Prometheus should use legacy validation and escaping schemes until fully utf8 support.
+        nameEscapingScheme: 'Underscores',
+        nameValidationScheme: 'Legacy',
         containers: [
           {
             name: 'kube-rbac-proxy-web',


### PR DESCRIPTION
This doesn't guarantee utf8 is disabled everywhere, promtool e.g. will continue using utf8.

This only concerns scraping. 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
