### PR TITLE
NO-ISSUE: chore: remove mentions of prometheus Adapter

### DIFF
--- a/assets/cluster-monitoring-operator/cluster-role-aggregated-metrics-reader.yaml
+++ b/assets/cluster-monitoring-operator/cluster-role-aggregated-metrics-reader.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/component: metrics-server
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: cluster-monitoring-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/cluster-monitoring-operator/cluster-role-pod-metrics-reader.yaml
+++ b/assets/cluster-monitoring-operator/cluster-role-pod-metrics-reader.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/component: metrics-server
     app.kubernetes.io/managed-by: cluster-monitoring-operator
     app.kubernetes.io/name: cluster-monitoring-operator
     app.kubernetes.io/part-of: openshift-monitoring

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -36,7 +36,7 @@ function(params) {
         'rbac.authorization.k8s.io/aggregate-to-view': 'true',
         'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
         'app.kubernetes.io/name': cfg.name,
-        'app.kubernetes.io/component': 'metrics-adapter',
+        'app.kubernetes.io/component': 'metrics-server',
       },
     },
     rules: [{
@@ -410,7 +410,7 @@ function(params) {
       name: 'pod-metrics-reader',
       labels: cfg.commonLabels {
         'app.kubernetes.io/name': cfg.name,
-        'app.kubernetes.io/component': 'metrics-adapter',
+        'app.kubernetes.io/component': 'metrics-server',
       },
     },
     rules: [{

--- a/jsonnet/utils/anti-affinity.libsonnet
+++ b/jsonnet/utils/anti-affinity.libsonnet
@@ -8,8 +8,5 @@ addon {
     prometheus+: {
       podAntiAffinity: 'hard',
     },
-    prometheusAdapter+: {
-      podAntiAffinity: 'hard',
-    },
   },
 }

--- a/jsonnet/versions.yaml
+++ b/jsonnet/versions.yaml
@@ -22,6 +22,5 @@ versions:
     nodeExporter: 1.9.1
     promLabelProxy: 0.12.1
     prometheus: 3.5.0
-    prometheusAdapter: 0.12.0
     prometheusOperator: 0.85.0
     thanos: 0.39.2


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.
