### PR TITLE
chore: remove image locations in assets

### DIFF
--- a/assets/admission-webhook/deployment.yaml
+++ b/assets/admission-webhook/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - --web.key-file=/etc/tls/private/tls.key
         - --web.tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --web.tls-min-version=VersionTLS12
-        image: quay.io/prometheus-operator/admission-webhook:v0.85.0
+        image: ""
         livenessProbe:
           httpGet:
             path: /healthz

--- a/assets/alertmanager-user-workload/alertmanager.yaml
+++ b/assets/alertmanager-user-workload/alertmanager.yaml
@@ -34,6 +34,7 @@ spec:
       value: ""
     - name: NO_PROXY
       value: ""
+    image: ""
     name: alertmanager
     terminationMessagePolicy: FallbackToLogsOnError
   - args:
@@ -43,7 +44,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --config-file=/etc/kube-rbac-proxy/config.yaml
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: alertmanager-proxy
     ports:
     - containerPort: 9095
@@ -72,7 +73,7 @@ spec:
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: tenancy-proxy
     ports:
     - containerPort: 9092
@@ -101,7 +102,7 @@ spec:
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --allow-paths=/metrics
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-metric
     ports:
     - containerPort: 9097
@@ -131,7 +132,7 @@ spec:
     - --upstream=http://127.0.0.1:9093
     - --label=namespace
     - --error-on-replace
-    image: quay.io/prometheuscommunity/prom-label-proxy:v0.12.1
+    image: ""
     name: prom-label-proxy
     resources:
       requests:
@@ -143,7 +144,7 @@ spec:
         drop:
         - ALL
     terminationMessagePolicy: FallbackToLogsOnError
-  image: quay.io/prometheus/alertmanager:v0.28.1
+  image: ""
   listenLocal: true
   nodeSelector:
     kubernetes.io/os: linux

--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -34,6 +34,7 @@ spec:
       value: ""
     - name: NO_PROXY
       value: ""
+    image: ""
     name: alertmanager
     terminationMessagePolicy: FallbackToLogsOnError
   - args:
@@ -44,7 +45,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --ignore-paths=/-/healthy,/-/ready
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-web
     ports:
     - containerPort: 9095
@@ -68,7 +69,7 @@ spec:
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy
     ports:
     - containerPort: 9092
@@ -92,7 +93,7 @@ spec:
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --allow-paths=/metrics
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-metric
     ports:
     - containerPort: 9097
@@ -117,14 +118,14 @@ spec:
     - --upstream=http://127.0.0.1:9093
     - --label=namespace
     - --error-on-replace
-    image: quay.io/prometheuscommunity/prom-label-proxy:v0.12.1
+    image: ""
     name: prom-label-proxy
     resources:
       requests:
         cpu: 1m
         memory: 20Mi
     terminationMessagePolicy: FallbackToLogsOnError
-  image: quay.io/prometheus/alertmanager:v0.28.1
+  image: ""
   listenLocal: true
   nodeSelector:
     kubernetes.io/os: linux

--- a/assets/kube-state-metrics/deployment.yaml
+++ b/assets/kube-state-metrics/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           ^kube_pod_container_status_running$,
           ^kube_pod_completion_time$,
           ^kube_pod_status_scheduled$
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
+        image: ""
         name: kube-state-metrics
         resources:
           requests:
@@ -80,7 +80,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -109,7 +109,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443

--- a/assets/metrics-server/deployment.yaml
+++ b/assets/metrics-server/deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - --shutdown-send-retry-after=true
         - --shutdown-delay-duration=150s
         - --disable-http2-serving=true
-        image: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+        image: ""
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/assets/monitoring-plugin/deployment.yaml
+++ b/assets/monitoring-plugin/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - -key=/var/cert/tls.key
         command:
         - /opt/app-root/plugin-backend
-        image: quay.io/openshift/origin-monitoring-plugin:1.0.0
+        image: ""
         imagePullPolicy: IfNotPresent
         name: monitoring-plugin
         ports:

--- a/assets/node-exporter/daemonset.yaml
+++ b/assets/node-exporter/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
         env:
         - name: DBUS_SYSTEM_BUS_ADDRESS
           value: unix:path=/host/root/var/run/dbus/system_bus_socket
-        image: quay.io/prometheus/node-exporter:v1.9.1
+        image: ""
         name: node-exporter
         resources:
           requests:
@@ -96,7 +96,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100
@@ -138,7 +138,7 @@ spec:
         env:
         - name: TMPDIR
           value: /tmp
-        image: quay.io/prometheus/node-exporter:v1.9.1
+        image: ""
         name: init-textfile
         resources:
           requests:

--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --config-file=/etc/kube-rbac-policy/config.yaml
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -62,7 +62,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --config-file=/etc/kube-rbac-policy/config.yaml
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443
@@ -87,7 +87,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: quay.io/openshift/origin-openshift-state-metrics:latest
+        image: ""
         name: openshift-state-metrics
         resources:
           requests:

--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -56,7 +56,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
     - --ignore-paths=/-/healthy,/-/ready
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-web
     ports:
     - containerPort: 9091
@@ -85,7 +85,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy
     ports:
     - containerPort: 9092
@@ -117,7 +117,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-thanos
     ports:
     - containerPort: 10903
@@ -145,6 +145,7 @@ spec:
     - --grpc-server-tls-cert=/etc/tls/grpc/server.crt
     - --grpc-server-tls-key=/etc/tls/grpc/server.key
     - --grpc-server-tls-client-ca=/etc/tls/grpc/ca.crt
+    image: ""
     name: thanos-sidecar
     resources:
       requests:
@@ -161,6 +162,7 @@ spec:
       value: ""
     - name: NO_PROXY
       value: ""
+    image: ""
     name: prometheus
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
@@ -171,7 +173,7 @@ spec:
   - use-uncached-io
   externalLabels: {}
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091
-  image: quay.io/prometheus/prometheus:v3.5.0
+  image: ""
   listenLocal: true
   maximumStartupDurationSeconds: 3600
   nodeSelector:
@@ -229,7 +231,7 @@ spec:
       openshift.io/cluster-monitoring: "true"
   serviceMonitorSelector: {}
   thanos:
-    image: quay.io/thanos/thanos:v0.39.2
+    image: ""
     resources:
       requests:
         cpu: 1m

--- a/assets/prometheus-operator-user-workload/deployment.yaml
+++ b/assets/prometheus-operator-user-workload/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: GOGC
           value: "30"
-        image: quay.io/prometheus-operator/prometheus-operator:v0.85.0
+        image: ""
         name: prometheus-operator
         ports: []
         resources:
@@ -69,7 +69,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --config-file=/etc/kube-rbac-policy/config.yaml
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/prometheus-operator/deployment.yaml
+++ b/assets/prometheus-operator/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         env:
         - name: GOGC
           value: "30"
-        image: quay.io/prometheus-operator/prometheus-operator:v0.85.0
+        image: ""
         name: prometheus-operator
         ports: []
         resources:
@@ -71,7 +71,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --config-file=/etc/kube-rbac-policy/config.yaml
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -54,7 +54,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-federate
     ports:
     - containerPort: 9092
@@ -86,7 +86,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-metrics
     ports:
     - containerPort: 9091
@@ -123,7 +123,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-thanos
     ports:
     - containerPort: 10903
@@ -154,6 +154,7 @@ spec:
     - --grpc-server-tls-cert=/etc/tls/grpc/server.crt
     - --grpc-server-tls-key=/etc/tls/grpc/server.key
     - --grpc-server-tls-client-ca=/etc/tls/grpc/ca.crt
+    image: ""
     name: thanos-sidecar
     resources:
       requests:
@@ -175,6 +176,7 @@ spec:
       value: ""
     - name: NO_PROXY
       value: ""
+    image: ""
     name: prometheus
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
@@ -187,7 +189,7 @@ spec:
   enforcedNamespaceLabel: namespace
   externalLabels: {}
   ignoreNamespaceSelectors: true
-  image: quay.io/prometheus/prometheus:v3.5.0
+  image: ""
   listenLocal: true
   nodeSelector:
     kubernetes.io/os: linux
@@ -296,7 +298,7 @@ spec:
       values:
       - "false"
   thanos:
-    image: quay.io/thanos/thanos:v0.39.2
+    image: ""
     resources:
       requests:
         cpu: 1m

--- a/assets/telemeter-client/deployment.yaml
+++ b/assets/telemeter-client/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           value: ""
         - name: NO_PROXY
           value: ""
-        image: quay.io/openshift/origin-telemeter:v4.0
+        image: ""
         name: telemeter-client
         ports:
         - containerPort: 8080
@@ -77,7 +77,7 @@ spec:
       - args:
         - --reload-url=http://localhost:8080/-/reload
         - --watched-dir=/etc/serving-certs-ca-bundle
-        image: quay.io/openshift/origin-configmap-reload:v3.11
+        image: ""
         name: reload
         resources:
           requests:
@@ -96,7 +96,7 @@ spec:
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --config-file=/etc/kube-rbac-policy/config.yaml
         - --client-ca-file=/etc/tls/client/client-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/assets/thanos-querier/deployment.yaml
+++ b/assets/thanos-querier/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: quay.io/thanos/thanos:v0.39.2
+        image: ""
         imagePullPolicy: IfNotPresent
         name: thanos-query
         ports:
@@ -96,7 +96,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --ignore-paths=/-/healthy,/-/ready
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         livenessProbe:
           failureThreshold: 4
           httpGet:
@@ -140,7 +140,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --allow-paths=/api/v1/query,/api/v1/query_range,/api/v1/labels,/api/v1/label/*/values,/api/v1/series
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy
         ports:
         - containerPort: 9092
@@ -168,7 +168,7 @@ spec:
         - --error-on-replace
         - --rules-with-active-alerts
         - --enable-label-matchers-for-rules-api
-        image: quay.io/prometheuscommunity/prom-label-proxy:v0.12.1
+        image: ""
         name: prom-label-proxy
         resources:
           requests:
@@ -188,7 +188,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --allow-paths=/api/v1/rules,/api/v1/alerts
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy-rules
         ports:
         - containerPort: 9093
@@ -217,7 +217,7 @@ spec:
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --client-ca-file=/etc/tls/client/client-ca.crt
         - --allow-paths=/metrics
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: ""
         name: kube-rbac-proxy-metrics
         ports:
         - containerPort: 9094

--- a/assets/thanos-ruler/thanos-ruler.yaml
+++ b/assets/thanos-ruler/thanos-ruler.yaml
@@ -24,7 +24,8 @@ spec:
     key: alertmanagers.yaml
     name: thanos-ruler-alertmanagers-config
   containers:
-  - name: thanos-ruler
+  - image: ""
+    name: thanos-ruler
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -44,7 +45,7 @@ spec:
     - --config-file=/etc/kube-rbac-proxy/config.yaml
     - --tls-cert-file=/etc/tls/private/tls.crt
     - --tls-private-key-file=/etc/tls/private/tls.key
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-web
     ports:
     - containerPort: 9091
@@ -74,7 +75,7 @@ spec:
     - --tls-private-key-file=/etc/tls/private/tls.key
     - --client-ca-file=/etc/tls/client/client-ca.crt
     - --allow-paths=/metrics
-    image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+    image: ""
     name: kube-rbac-proxy-metrics
     ports:
     - containerPort: 9092
@@ -102,7 +103,7 @@ spec:
     caFile: /etc/tls/grpc/ca.crt
     certFile: /etc/tls/grpc/server.crt
     keyFile: /etc/tls/grpc/server.key
-  image: quay.io/thanos/thanos:v0.39.2
+  image: ""
   listenLocal: true
   podMetadata:
     annotations:

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -2,6 +2,7 @@ local removeLimits = (import './utils/remove-limits.libsonnet').removeLimits;
 local addAnnotations = (import './utils/add-annotations.libsonnet').addAnnotations;
 local addLabels = (import './utils/add-labels.libsonnet').addLabels;
 local sanitizeAlertRules = (import './utils/sanitize-rules.libsonnet').sanitizeAlertRules;
+local removeImageLocations = (import './utils/remove-images.libsonnet').removeImageLocations;
 local removeNetworkPolicy = (import './utils/remove-network-policy.libsonnet').removeNetworkPolicy;
 local configureAuthenticationForMonitors = (import './utils/configure-authentication-for-monitors.libsonnet').configureAuthenticationForMonitors;
 local setTerminationMessagePolicy = (import './utils/set-terminationMessagePolicy.libsonnet').setTerminationMessagePolicy;
@@ -512,32 +513,34 @@ setTerminationMessagePolicy(
     commonConfig.commonLabels,
     addAnnotations(
       sanitizeAlertRules(
-        removeLimits(
-          removeNetworkPolicy(
-            // Enforce mTLS authentication + disable usage of bearer token for all service/pod monitors.
-            // See https://issues.redhat.com/browse/OCPBUGS-4184 for details.
-            configureAuthenticationForMonitors(
-              { ['alertmanager/' + name]: inCluster.alertmanager[name] for name in std.objectFields(inCluster.alertmanager) } +
-              { ['alertmanager-user-workload/' + name]: userWorkload.alertmanager[name] for name in std.objectFields(userWorkload.alertmanager) } +
-              { ['cluster-monitoring-operator/' + name]: inCluster.clusterMonitoringOperator[name] for name in std.objectFields(inCluster.clusterMonitoringOperator) } +
-              { ['dashboards/' + name]: inCluster.dashboards[name] for name in std.objectFields(inCluster.dashboards) } +
-              { ['kube-state-metrics/' + name]: inCluster.kubeStateMetrics[name] for name in std.objectFields(inCluster.kubeStateMetrics) } +
-              { ['node-exporter/' + name]: inCluster.nodeExporter[name] for name in std.objectFields(inCluster.nodeExporter) } +
-              { ['openshift-state-metrics/' + name]: inCluster.openshiftStateMetrics[name] for name in std.objectFields(inCluster.openshiftStateMetrics) } +
-              { ['prometheus-k8s/' + name]: inCluster.prometheus[name] for name in std.objectFields(inCluster.prometheus) } +
-              { ['admission-webhook/' + name]: inCluster.admissionWebhook[name] for name in std.objectFields(inCluster.admissionWebhook) } +
-              { ['prometheus-operator/' + name]: inCluster.prometheusOperator[name] for name in std.objectFields(inCluster.prometheusOperator) } +
-              { ['prometheus-operator-user-workload/' + name]: userWorkload.prometheusOperator[name] for name in std.objectFields(userWorkload.prometheusOperator) } +
-              { ['prometheus-user-workload/' + name]: userWorkload.prometheus[name] for name in std.objectFields(userWorkload.prometheus) } +
-              { ['metrics-server/' + name]: inCluster.metricsServer[name] for name in std.objectFields(inCluster.metricsServer) } +
-              // needs to be removed once remote-write is allowed for sending telemetry
-              { ['telemeter-client/' + name]: inCluster.telemeterClient[name] for name in std.objectFields(inCluster.telemeterClient) } +
-              { ['monitoring-plugin/' + name]: inCluster.monitoringPlugin[name] for name in std.objectFields(inCluster.monitoringPlugin) } +
-              { ['thanos-querier/' + name]: inCluster.thanosQuerier[name] for name in std.objectFields(inCluster.thanosQuerier) } +
-              { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
-              { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
-              { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } +
-              {}
+        removeImageLocations(
+          removeLimits(
+            removeNetworkPolicy(
+              // Enforce mTLS authentication + disable usage of bearer token for all service/pod monitors.
+              // See https://issues.redhat.com/browse/OCPBUGS-4184 for details.
+              configureAuthenticationForMonitors(
+                { ['alertmanager/' + name]: inCluster.alertmanager[name] for name in std.objectFields(inCluster.alertmanager) } +
+                { ['alertmanager-user-workload/' + name]: userWorkload.alertmanager[name] for name in std.objectFields(userWorkload.alertmanager) } +
+                { ['cluster-monitoring-operator/' + name]: inCluster.clusterMonitoringOperator[name] for name in std.objectFields(inCluster.clusterMonitoringOperator) } +
+                { ['dashboards/' + name]: inCluster.dashboards[name] for name in std.objectFields(inCluster.dashboards) } +
+                { ['kube-state-metrics/' + name]: inCluster.kubeStateMetrics[name] for name in std.objectFields(inCluster.kubeStateMetrics) } +
+                { ['node-exporter/' + name]: inCluster.nodeExporter[name] for name in std.objectFields(inCluster.nodeExporter) } +
+                { ['openshift-state-metrics/' + name]: inCluster.openshiftStateMetrics[name] for name in std.objectFields(inCluster.openshiftStateMetrics) } +
+                { ['prometheus-k8s/' + name]: inCluster.prometheus[name] for name in std.objectFields(inCluster.prometheus) } +
+                { ['admission-webhook/' + name]: inCluster.admissionWebhook[name] for name in std.objectFields(inCluster.admissionWebhook) } +
+                { ['prometheus-operator/' + name]: inCluster.prometheusOperator[name] for name in std.objectFields(inCluster.prometheusOperator) } +
+                { ['prometheus-operator-user-workload/' + name]: userWorkload.prometheusOperator[name] for name in std.objectFields(userWorkload.prometheusOperator) } +
+                { ['prometheus-user-workload/' + name]: userWorkload.prometheus[name] for name in std.objectFields(userWorkload.prometheus) } +
+                { ['metrics-server/' + name]: inCluster.metricsServer[name] for name in std.objectFields(inCluster.metricsServer) } +
+                // needs to be removed once remote-write is allowed for sending telemetry
+                { ['telemeter-client/' + name]: inCluster.telemeterClient[name] for name in std.objectFields(inCluster.telemeterClient) } +
+                { ['monitoring-plugin/' + name]: inCluster.monitoringPlugin[name] for name in std.objectFields(inCluster.monitoringPlugin) } +
+                { ['thanos-querier/' + name]: inCluster.thanosQuerier[name] for name in std.objectFields(inCluster.thanosQuerier) } +
+                { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
+                { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
+                { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } +
+                {}
+              )
             )
           )
         )

--- a/jsonnet/utils/remove-images.libsonnet
+++ b/jsonnet/utils/remove-images.libsonnet
@@ -1,0 +1,44 @@
+{
+  removeImageLocations(o): {
+    local removeImageLocation(o) = o {
+      [if std.setMember(o.kind, std.set(['DaemonSet', 'Deployment'])) && o.metadata.name != 'cluster-monitoring-operator' then 'spec']+: {
+        template+: {
+          spec+: {
+            containers: [
+              c {
+                image: '',
+              }
+              for c in super.containers
+            ],
+            [if std.objectHas(o.spec.template.spec, 'initContainers') then 'initContainers']: [
+              c {
+                image: '',
+              }
+              for c in super.initContainers
+            ],
+          },
+        },
+      },
+      [if std.setMember(o.kind, std.set(['Prometheus', 'Alertmanager', 'ThanosRuler'])) then 'spec']+: {
+        image: '',
+        [if std.objectHas(o.spec, 'thanos') then 'thanos']+: {
+          image: '',
+        },
+        containers: [
+          c {
+            image: '',
+          }
+          for c in super.containers
+        ],
+        [if std.objectHas(o.spec, 'initContainers') then 'initContainers']: [
+          c {
+            image: '',
+          }
+          for c in super.initContainers
+        ],
+      },
+    },
+    [k]: removeImageLocation(o[k])
+    for k in std.objectFields(o)
+  },
+}


### PR DESCRIPTION
The image locations should be injected by CMO from the information provided by CVO. By removing the default values in the static manifests, end-to-end tests should catch bugs in CMO forgetting to pass the expected image locations.

Follow-up of #2681 

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
