### PR TITLE
[WIP] MON-4380: Add optional monitoring logic

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1748,6 +1748,11 @@ func (c *Client) HasConsoleCapability(ctx context.Context) (bool, error) {
 	return c.HasClusterCapability(ctx, configv1.ClusterVersionCapabilityConsole)
 }
 
+func (c *Client) HasOptionalMonitoringCapability(_ context.Context) (bool, error) {
+	//return c.HasClusterCapability(ctx, configv1.ClusterVersionCapabilityOptionalMonitoring)
+	return false, nil
+}
+
 // CreateOrUpdateConsolePlugin function uses retries because API requests related to the ConsolePlugin resource
 // may depend on the availability of a conversion container. This container is part of the console-operator Pod, which is not duplicated.
 // If this pod is down (due to restarts for upgrades or other reasons), transient failures will be reported.

--- a/pkg/tasks/clustermonitoringoperator_optionalmonitoring.go
+++ b/pkg/tasks/clustermonitoringoperator_optionalmonitoring.go
@@ -1,0 +1,126 @@
+// Copyright 2018 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+)
+
+type ClusterMonitoringOperatorOptionalMonitoringTask struct {
+	client  *client.Client
+	factory *manifests.Factory
+	config  *manifests.Config
+}
+
+func NewClusterMonitoringOperatorOptionalMonitoringTask(
+	client *client.Client,
+	factory *manifests.Factory,
+	config *manifests.Config,
+) *ClusterMonitoringOperatorOptionalMonitoringTask {
+	return &ClusterMonitoringOperatorOptionalMonitoringTask{
+		client:  client,
+		factory: factory,
+		config:  config,
+	}
+}
+
+func (t *ClusterMonitoringOperatorOptionalMonitoringTask) Run(ctx context.Context) error {
+	crfs := map[string]func() (*rbacv1.ClusterRole, error){
+		"cluster-monitoring-view":          t.factory.ClusterMonitoringClusterRoleView,
+		"system:aggregated-metrics-reader": t.factory.ClusterMonitoringClusterRoleAggregatedMetricsReader,
+		"pod-metrics-reader":               t.factory.ClusterMonitoringClusterRolePodMetricsReader,
+		"monitoring-rules-edit":            t.factory.ClusterMonitoringRulesEditClusterRole,
+		"monitoring-rules-view":            t.factory.ClusterMonitoringRulesViewClusterRole,
+		"monitoring-edit":                  t.factory.ClusterMonitoringEditClusterRole,
+	}
+	for name, crf := range crfs {
+		cr, err := crf()
+		if err != nil {
+			return fmt.Errorf("initializing %s ClusterRole failed: %w", name, err)
+		}
+
+		err = t.client.CreateOrUpdateClusterRole(ctx, cr)
+		if err != nil {
+			return fmt.Errorf("reconciling %s ClusterRole failed: %w", name, err)
+		}
+	}
+
+	clarr, err := t.factory.ClusterMonitoringApiReaderRole()
+	if err != nil {
+		return fmt.Errorf("initializing ClusterMonitoringApiReader Role failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateRole(ctx, clarr)
+	if err != nil {
+		return fmt.Errorf("reconciling ClusterMonitoringApiReader Role failed: %w", err)
+	}
+
+	pr, err := t.factory.ClusterMonitoringOperatorPrometheusRule()
+	if err != nil {
+		return fmt.Errorf("initializing cluster-monitoring-operator rules PrometheusRule failed: %w", err)
+	}
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
+	if err != nil {
+		return fmt.Errorf("reconciling cluster-monitoring-operator rules PrometheusRule failed: %w", err)
+	}
+
+	smcmo, err := t.factory.ClusterMonitoringOperatorServiceMonitor()
+	if err != nil {
+		return fmt.Errorf("initializing Cluster Monitoring Operator ServiceMonitor failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smcmo)
+	if err != nil {
+		return fmt.Errorf("reconciling Cluster Monitoring Operator ServiceMonitor failed: %w", err)
+	}
+
+	s, err := t.factory.GRPCSecret()
+	if err != nil {
+		return fmt.Errorf("error initializing Cluster Monitoring Operator GRPC TLS secret: %w", err)
+	}
+
+	loaded, err := t.client.GetSecret(ctx, s.Namespace, s.Name)
+	switch {
+	case apierrors.IsNotFound(err):
+		// No secret was found, proceed with the default empty secret from manifests.
+		klog.V(5).Info("creating new Cluster Monitoring Operator GRPC TLS secret")
+	case err == nil:
+		// Secret was found, use that.
+		s = loaded
+		klog.V(5).Info("found existing Cluster Monitoring Operator GRPC TLS secret")
+	default:
+		return fmt.Errorf("error reading Cluster Monitoring Operator GRPC TLS secret: %w", err)
+	}
+
+	err = manifests.RotateGRPCSecret(s)
+	if err != nil {
+		return fmt.Errorf("error rotating Cluster Monitoring Operator GRPC TLS secret: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateSecret(ctx, s)
+	if err != nil {
+		return fmt.Errorf("error creating Cluster Monitoring Operator GRPC TLS secret: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/tasks/prometheusoperator_optionalmonitoring.go
+++ b/pkg/tasks/prometheusoperator_optionalmonitoring.go
@@ -1,0 +1,184 @@
+// Copyright 2018 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/cluster-monitoring-operator/pkg/client"
+	"github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+)
+
+type PrometheusOperatorOptionalMonitoringTask struct {
+	client  *client.Client
+	factory *manifests.Factory
+}
+
+func NewPrometheusOperatorOptionalMonitoringTask(client *client.Client, factory *manifests.Factory) *PrometheusOperatorOptionalMonitoringTask {
+	return &PrometheusOperatorOptionalMonitoringTask{
+		client:  client,
+		factory: factory,
+	}
+}
+
+func (t *PrometheusOperatorOptionalMonitoringTask) Run(ctx context.Context) error {
+	sa, err := t.factory.PrometheusOperatorServiceAccount()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator ServiceAccount failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator ServiceAccount failed: %w", err)
+	}
+
+	cr, err := t.factory.PrometheusOperatorClusterRole()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator ClusterRole failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateClusterRole(ctx, cr)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator ClusterRole failed: %w", err)
+	}
+
+	crb, err := t.factory.PrometheusOperatorClusterRoleBinding()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator ClusterRoleBinding failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateClusterRoleBinding(ctx, crb)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator ClusterRoleBinding failed: %w", err)
+	}
+
+	err = t.runAdmissionWebhook(ctx)
+	if err != nil {
+		return err
+	}
+
+	svc, err := t.factory.PrometheusOperatorService()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator Service failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateService(ctx, svc)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator Service failed: %w", err)
+	}
+
+	rs, err := t.factory.PrometheusOperatorRBACProxySecret()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator RBAC proxy Secret failed: %w", err)
+	}
+
+	err = t.client.CreateIfNotExistSecret(ctx, rs)
+	if err != nil {
+		return fmt.Errorf("creating Prometheus Operator RBAC proxy Secret failed: %w", err)
+	}
+
+	d, err := t.factory.PrometheusOperatorDeployment()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator Deployment failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateDeployment(ctx, d)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator Deployment failed: %w", err)
+	}
+
+	err = t.client.AssurePrometheusOperatorCRsExist(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for Prometheus Operator CRs to become available failed: %w", err)
+	}
+
+	pr, err := t.factory.PrometheusOperatorPrometheusRule()
+	if err != nil {
+		return fmt.Errorf("initializing prometheus-operator rules PrometheusRule failed: %w", err)
+	}
+	err = t.client.CreateOrUpdatePrometheusRule(ctx, pr)
+	if err != nil {
+		return fmt.Errorf("reconciling prometheus-operator rules PrometheusRule failed: %w", err)
+	}
+
+	smpo, err := t.factory.PrometheusOperatorServiceMonitor()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator ServiceMonitor failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateServiceMonitor(ctx, smpo)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator ServiceMonitor failed: %w", err)
+	}
+	return nil
+}
+
+func (t *PrometheusOperatorOptionalMonitoringTask) runAdmissionWebhook(ctx context.Context) error {
+	// Deploy manifests for the admission webhook service.
+	sa, err := t.factory.PrometheusOperatorAdmissionWebhookServiceAccount()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator Admission Webhook ServiceAccount failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateServiceAccount(ctx, sa)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator Admission Webhook ServiceAccount failed: %w", err)
+	}
+
+	svc, err := t.factory.PrometheusOperatorAdmissionWebhookService()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator Admission Webhook Service failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateService(ctx, svc)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator Admission Webhook Service failed: %w", err)
+	}
+
+	pdb, err := t.factory.PrometheusOperatorAdmissionWebhookPodDisruptionBudget()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator Admission Webhook PodDisruptionBudget failed: %w", err)
+	}
+
+	if pdb != nil {
+		err = t.client.CreateOrUpdatePodDisruptionBudget(ctx, pdb)
+		if err != nil {
+			return fmt.Errorf("reconciling Prometheus Operator Admission Webhook PodDisruptionBudget failed: %w", err)
+		}
+	}
+
+	d, err := t.factory.PrometheusOperatorAdmissionWebhookDeployment()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Operator Admission Webhook Deployment failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateDeployment(ctx, d)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Operator Admission Webhook Deployment failed: %w", err)
+	}
+
+	w, err := t.factory.PrometheusRuleValidatingWebhook()
+	if err != nil {
+		return fmt.Errorf("initializing Prometheus Rule Validating Webhook failed: %w", err)
+	}
+
+	err = t.client.CreateOrUpdateValidatingWebhookConfiguration(ctx, w)
+	if err != nil {
+		return fmt.Errorf("reconciling Prometheus Rule Validating Webhook failed: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Optional components include:
* Alertmanager
* AlertmanagerUWM
* ClusterMonitoringOperatorDeps (partially, for AM)
* MonitoringPlugin
* PromtheusOperator (partially, for AM)
* PromtheusOperatorUWM
* ThanosRuler

<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
