### PR TITLE
NO-ISSUE: set openshift-state-metrics as default container

### DIFF
--- a/assets/openshift-state-metrics/deployment.yaml
+++ b/assets/openshift-state-metrics/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: openshift-state-metrics
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:

--- a/jsonnet/components/openshift-state-metrics.libsonnet
+++ b/jsonnet/components/openshift-state-metrics.libsonnet
@@ -34,6 +34,7 @@ function(params) {
           } + cfg.commonLabels,
           annotations+: {
             'openshift.io/required-scc': 'restricted-v2',
+            'kubectl.kubernetes.io/default-container': 'openshift-state-metrics',
           },
         },
         spec+: {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [x] No user facing changes, so no entry in CHANGELOG was needed.

As we use `kubectl logs -n openshift-monitoring openshift-state-metrics-xxx`,we see the default container logs is `kube-rbac-proxy-main`, like :
```
Defaulted container "kube-rbac-proxy-main" out of: kube-rbac-proxy-main, kube-rbac-proxy-self, openshift-state-metrics
I0824 20:06:46.135475       1 kube-rbac-proxy.go:530] Reading config file: /etc/kube-rbac-policy/config.yaml
I0824 20:06:46.137801       1 kube-rbac-proxy.go:233] Valid token audiences: 
I0824 20:06:46.138411       1 kube-rbac-proxy.go:347] Reading certificate files
I0824 20:06:46.138657       1 dynamic_cafile_content.go:157] "Starting controller" name="client-ca::/etc/tls/client/client-ca.crt"
I0824 20:06:46.139062       1 kube-rbac-proxy.go:395] Starting TCP socket on :8443
I0824 20:06:46.139651       1 kube-rbac-proxy.go:402] Listening securely on :8443
```

But most of the time we just care about the container `openshift-state-metrics` logs , not the`kube-rbac-proxy-main`