### PR TITLE
OCPBUGS-85115, MON-4420: Gateway API telemetry

### DIFF
--- a/assets/kube-state-metrics/cluster-role.yaml
+++ b/assets/kube-state-metrics/cluster-role.yaml
@@ -143,3 +143,11 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  verbs:
+  - list
+  - watch

--- a/assets/kube-state-metrics/custom-resource-state-configmap.yaml
+++ b/assets/kube-state-metrics/custom-resource-state-configmap.yaml
@@ -507,14 +507,6 @@ data:
                 "gateway_class":
                 - "metadata"
                 - "name"
-                "namespace":
-                - "metadata"
-                - "namespace"
-                "reason":
-                - "status"
-                - "conditions"
-                - "[type=Accepted]"
-                - "reason"
             "type": "Info"
           "help": "Information about GatewayClasses"
           "name": "gateway_class"
@@ -540,11 +532,6 @@ data:
                 - "conditions"
                 - "[type=Programmed]"
                 - "status"
-                "reason":
-                - "status"
-                - "conditions"
-                - "[type=Programmed]"
-                - "reason"
             "type": "Info"
           "help": "Information about Gateways"
           "name": "gateway"

--- a/assets/kube-state-metrics/custom-resource-state-configmap.yaml
+++ b/assets/kube-state-metrics/custom-resource-state-configmap.yaml
@@ -501,7 +501,7 @@ data:
                 - "conditions"
                 - "[type=Accepted]"
                 - "status"
-                "controller_name":
+                "controller":
                 - "spec"
                 - "controllerName"
                 "gateway_class":
@@ -509,7 +509,7 @@ data:
                 - "name"
             "type": "Info"
           "help": "Information about GatewayClasses"
-          "name": "gateway_class"
+          "name": "gateway_class_info"
       - "groupVersionKind":
           "group": "gateway.networking.k8s.io"
           "kind": "Gateway"
@@ -521,7 +521,7 @@ data:
                 "gateway":
                 - "metadata"
                 - "name"
-                "gateway_class_name":
+                "gateway_class":
                 - "spec"
                 - "gatewayClassName"
                 "namespace":
@@ -534,7 +534,7 @@ data:
                 - "status"
             "type": "Info"
           "help": "Information about Gateways"
-          "name": "gateway"
+          "name": "gateway_info"
 kind: ConfigMap
 metadata:
   labels:

--- a/assets/kube-state-metrics/custom-resource-state-configmap.yaml
+++ b/assets/kube-state-metrics/custom-resource-state-configmap.yaml
@@ -488,6 +488,66 @@ data:
             - "metadata"
             - "name"
           "name": "verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed_memory"
+      - "groupVersionKind":
+          "group": "gateway.networking.k8s.io"
+          "kind": "GatewayClass"
+          "version": "v1"
+        "metrics":
+        - "each":
+            "info":
+              "labelsFromPath":
+                "accepted":
+                - "status"
+                - "conditions"
+                - "[type=Accepted]"
+                - "status"
+                "controller_name":
+                - "spec"
+                - "controllerName"
+                "gateway_class":
+                - "metadata"
+                - "name"
+                "namespace":
+                - "metadata"
+                - "namespace"
+                "reason":
+                - "status"
+                - "conditions"
+                - "[type=Accepted]"
+                - "reason"
+            "type": "Info"
+          "help": "Information about GatewayClasses"
+          "name": "gateway_class"
+      - "groupVersionKind":
+          "group": "gateway.networking.k8s.io"
+          "kind": "Gateway"
+          "version": "v1"
+        "metrics":
+        - "each":
+            "info":
+              "labelsFromPath":
+                "gateway":
+                - "metadata"
+                - "name"
+                "gateway_class_name":
+                - "spec"
+                - "gatewayClassName"
+                "namespace":
+                - "metadata"
+                - "namespace"
+                "programmed":
+                - "status"
+                - "conditions"
+                - "[type=Programmed]"
+                - "status"
+                "reason":
+                - "status"
+                - "conditions"
+                - "[type=Programmed]"
+                - "reason"
+            "type": "Info"
+          "help": "Information about Gateways"
+          "name": "gateway"
 kind: ConfigMap
 metadata:
   labels:

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -54,6 +54,11 @@ function(params)
           resources: ['verticalpodautoscalers'],
           verbs: ['list', 'watch'],
         },
+        {
+          apiGroups: ['gateway.networking.k8s.io'],
+          resources: ['gatewayclasses', 'gateways'],
+          verbs: ['list', 'watch'],
+        },
       ],
     },
 

--- a/jsonnet/utils/kube-state-metrics-custom-resource-state.libsonnet
+++ b/jsonnet/utils/kube-state-metrics-custom-resource-state.libsonnet
@@ -93,14 +93,12 @@ local gatewayClassMetrics = [
       type: 'Info',
       info: {
         labelsFromPath: {
-          namespace: ['metadata', 'namespace'],
           gateway_class: ['metadata', 'name'],
           controller_name: ['spec', 'controllerName'],
           accepted: ['status', 'conditions', '[type=Accepted]', 'status'],
-          reason: ['status', 'conditions', '[type=Accepted]', 'reason']
-        }
-      }
-    }
+        },
+      },
+    },
   },
 ];
 
@@ -116,10 +114,9 @@ local gatewayMetrics = [
           gateway: ['metadata', 'name'],
           gateway_class_name: ['spec', 'gatewayClassName'],
           programmed: ['status', 'conditions', '[type=Programmed]', 'status'],
-          reason: ['status', 'conditions', '[type=Programmed]', 'reason']
-        }
-      }
-    }
+        },
+      },
+    },
   },
 ];
 

--- a/jsonnet/utils/kube-state-metrics-custom-resource-state.libsonnet
+++ b/jsonnet/utils/kube-state-metrics-custom-resource-state.libsonnet
@@ -87,14 +87,14 @@ local vpaMetrics = [
 
 local gatewayClassMetrics = [
   {
-    name: 'gateway_class',
+    name: 'gateway_class_info',
     help: 'Information about GatewayClasses',
     each: {
       type: 'Info',
       info: {
         labelsFromPath: {
           gateway_class: ['metadata', 'name'],
-          controller_name: ['spec', 'controllerName'],
+          controller: ['spec', 'controllerName'],
           accepted: ['status', 'conditions', '[type=Accepted]', 'status'],
         },
       },
@@ -104,7 +104,7 @@ local gatewayClassMetrics = [
 
 local gatewayMetrics = [
   {
-    name: 'gateway',
+    name: 'gateway_info',
     help: 'Information about Gateways',
     each: {
       type: 'Info',
@@ -112,7 +112,7 @@ local gatewayMetrics = [
         labelsFromPath: {
           namespace: ['metadata', 'namespace'],
           gateway: ['metadata', 'name'],
-          gateway_class_name: ['spec', 'gatewayClassName'],
+          gateway_class: ['spec', 'gatewayClassName'],
           programmed: ['status', 'conditions', '[type=Programmed]', 'status'],
         },
       },

--- a/jsonnet/utils/kube-state-metrics-custom-resource-state.libsonnet
+++ b/jsonnet/utils/kube-state-metrics-custom-resource-state.libsonnet
@@ -85,6 +85,44 @@ local vpaMetrics = [
   vpaMetric('verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed_memory', 'Minimum memory resources the VerticalPodAutoscaler can set for containers matching the name.', 'gauge'),
 ];
 
+local gatewayClassMetrics = [
+  {
+    name: 'gateway_class',
+    help: 'Information about GatewayClasses',
+    each: {
+      type: 'Info',
+      info: {
+        labelsFromPath: {
+          namespace: ['metadata', 'namespace'],
+          gateway_class: ['metadata', 'name'],
+          controller_name: ['spec', 'controllerName'],
+          accepted: ['status', 'conditions', '[type=Accepted]', 'status'],
+          reason: ['status', 'conditions', '[type=Accepted]', 'reason']
+        }
+      }
+    }
+  },
+];
+
+local gatewayMetrics = [
+  {
+    name: 'gateway',
+    help: 'Information about Gateways',
+    each: {
+      type: 'Info',
+      info: {
+        labelsFromPath: {
+          namespace: ['metadata', 'namespace'],
+          gateway: ['metadata', 'name'],
+          gateway_class_name: ['spec', 'gatewayClassName'],
+          programmed: ['status', 'conditions', '[type=Programmed]', 'status'],
+          reason: ['status', 'conditions', '[type=Programmed]', 'reason']
+        }
+      }
+    }
+  },
+];
+
 local crsConfig = {
   kind: 'CustomResourceStateMetrics',
   spec: {
@@ -96,6 +134,22 @@ local crsConfig = {
           kind: 'VerticalPodAutoscaler',
         },
         metrics: vpaMetrics,
+      },
+      {
+        groupVersionKind: {
+          group: 'gateway.networking.k8s.io',
+          version: 'v1',
+          kind: 'GatewayClass',
+        },
+        metrics: gatewayClassMetrics,
+      },
+      {
+        groupVersionKind: {
+          group: 'gateway.networking.k8s.io',
+          version: 'v1',
+          kind: 'Gateway',
+        },
+        metrics: gatewayMetrics,
       },
     ],
   },

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -375,6 +375,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [X] No user facing changes, so no entry in CHANGELOG was needed.


This PR adds the following changes required for Gateway API telemetry collection:
* Enables the collection of Gateway API resources (Gateway Class and Gateway) using kube-state-metrics from `openshift-monitoring` namespace
* Adds a PrometheusRule on the same namespace (as the collection comes from ksm) to aggregate the metrics and reduce labels.
