### PR TITLE
MON-4532: Introduce `telemetry`-specific monitors only

### DIFF
--- a/assets/alertmanager/telemetry-service-monitor.yaml
+++ b/assets/alertmanager/telemetry-service-monitor.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 0.29.0
+    monitoring.openshift.io/collection-profile: telemetry
+  name: alertmanager-main-telemetry
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: ""
+    interval: 30s
+    metricRelabelings:
+    - action: keep
+      regex: (alertmanager_integrations)
+      sourceLabels:
+      - __name__
+    port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: false
+      serverName: alertmanager-main.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: openshift-monitoring
+  serviceDiscoveryRole: EndpointSlice

--- a/assets/cluster-monitoring-operator/telemetry-service-monitor.yaml
+++ b/assets/cluster-monitoring-operator/telemetry-service-monitor.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+    monitoring.openshift.io/collection-profile: telemetry
+  name: cluster-monitoring-operator-telemetry
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: ""
+    metricRelabelings:
+    - action: keep
+      regex: (cluster_monitoring_operator_collection_profile)
+      sourceLabels:
+      - __name__
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: false
+      serverName: cluster-monitoring-operator.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-monitoring-operator

--- a/assets/control-plane/telemetry-service-monitor-kubelet.yaml
+++ b/assets/control-plane/telemetry-service-monitor-kubelet.yaml
@@ -1,0 +1,119 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: kubernetes
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: kubelet
+    app.kubernetes.io/part-of: openshift-monitoring
+    k8s-app: kubelet
+    monitoring.openshift.io/collection-profile: telemetry
+  name: kubelet-telemetry
+  namespace: openshift-monitoring
+spec:
+  attachMetadata:
+    node: true
+  endpoints:
+  - bearerTokenFile: ""
+    honorLabels: true
+    interval: 30s
+    metricRelabelings:
+    - action: keep
+      regex: (apiserver_current_inflight_requests|apiserver_request_total|apiserver_storage_objects|container_cpu_usage_seconds_total|container_memory_working_set_bytes|kubelet_containers_per_pod_count_sum|kubelet_volume_stats_used_bytes|pv_collector_total_pv_count|selinux_warning_controller_selinux_volume_conflict|volume_manager_selinux_pod_context_mismatch_errors_total|volume_manager_selinux_pod_context_mismatch_warnings_total|volume_manager_selinux_volume_context_mismatch_errors_total|volume_manager_selinux_volume_context_mismatch_warnings_total|volume_manager_selinux_volumes_admitted_total)
+      sourceLabels:
+      - __name__
+    port: https-metrics
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    scrapeTimeout: 30s
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
+      insecureSkipVerify: false
+  - bearerTokenFile: ""
+    honorLabels: true
+    honorTimestamps: true
+    interval: 30s
+    metricRelabelings:
+    - action: labeldrop
+      regex: __tmp_keep_metric
+    - action: keep
+      regex: (apiserver_current_inflight_requests|apiserver_request_total|apiserver_storage_objects|container_cpu_usage_seconds_total|container_memory_working_set_bytes|kubelet_containers_per_pod_count_sum|kubelet_volume_stats_used_bytes|pv_collector_total_pv_count|selinux_warning_controller_selinux_volume_conflict|volume_manager_selinux_pod_context_mismatch_errors_total|volume_manager_selinux_pod_context_mismatch_warnings_total|volume_manager_selinux_volume_context_mismatch_errors_total|volume_manager_selinux_volume_context_mismatch_warnings_total|volume_manager_selinux_volumes_admitted_total)
+      sourceLabels:
+      - __name__
+    path: /metrics/cadvisor
+    port: https-metrics
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    scrapeTimeout: 30s
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
+      insecureSkipVerify: false
+    trackTimestampsStaleness: true
+  - bearerTokenFile: ""
+    honorLabels: true
+    interval: 30s
+    metricRelabelings:
+    - action: keep
+      regex: (apiserver_current_inflight_requests|apiserver_request_total|apiserver_storage_objects|container_cpu_usage_seconds_total|container_memory_working_set_bytes|kubelet_containers_per_pod_count_sum|kubelet_volume_stats_used_bytes|pv_collector_total_pv_count|selinux_warning_controller_selinux_volume_conflict|volume_manager_selinux_pod_context_mismatch_errors_total|volume_manager_selinux_pod_context_mismatch_warnings_total|volume_manager_selinux_volume_context_mismatch_errors_total|volume_manager_selinux_volume_context_mismatch_warnings_total|volume_manager_selinux_volumes_admitted_total)
+      sourceLabels:
+      - __name__
+    path: /metrics/probes
+    port: https-metrics
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    scrapeTimeout: 30s
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
+      insecureSkipVerify: false
+  - bearerTokenFile: ""
+    interval: 30s
+    metricRelabelings:
+    - action: keep
+      regex: (apiserver_current_inflight_requests|apiserver_request_total|apiserver_storage_objects|container_cpu_usage_seconds_total|container_memory_working_set_bytes|kubelet_containers_per_pod_count_sum|kubelet_volume_stats_used_bytes|pv_collector_total_pv_count|selinux_warning_controller_selinux_volume_conflict|volume_manager_selinux_pod_context_mismatch_errors_total|volume_manager_selinux_pod_context_mismatch_warnings_total|volume_manager_selinux_volume_context_mismatch_errors_total|volume_manager_selinux_volume_context_mismatch_warnings_total|volume_manager_selinux_volumes_admitted_total)
+      sourceLabels:
+      - __name__
+    port: https-metrics
+    relabelings:
+    - action: keep
+      regex: (linux|)
+      sourceLabels:
+      - __meta_kubernetes_node_label_kubernetes_io_os
+    - action: replace
+      regex: (.+)(?::\d+)
+      replacement: $1:9637
+      sourceLabels:
+      - __address__
+      targetLabel: __address__
+    - action: replace
+      replacement: crio
+      sourceLabels:
+      - endpoint
+      targetLabel: endpoint
+    - action: replace
+      replacement: crio
+      targetLabel: job
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/kubelet-serving-ca-bundle/ca-bundle.crt
+      insecureSkipVerify: false
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  scrapeClass: tls-client-certificate-auth
+  selector:
+    matchLabels:
+      k8s-app: kubelet
+  serviceDiscoveryRole: EndpointSlice

--- a/assets/kube-state-metrics/telemetry-service-monitor.yaml
+++ b/assets/kube-state-metrics/telemetry-service-monitor.yaml
@@ -1,0 +1,53 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 2.18.0
+    monitoring.openshift.io/collection-profile: telemetry
+  name: kube-state-metrics-telemetry
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: ""
+    honorLabels: true
+    interval: 1m
+    metricRelabelings:
+    - action: labeldrop
+      regex: instance
+    - action: keep
+      regex: (kube_node_labels|kube_node_spec_unschedulable|kube_node_status_capacity|kube_node_status_condition|kube_persistentvolume_info|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_resource_requests|kube_pod_info|kube_pod_labels|kube_pod_restart_policy|kube_pod_status_phase|kube_running_pod_ready|kube_storageclass_info)
+      sourceLabels:
+      - __name__
+    port: https-main
+    relabelings:
+    - action: labeldrop
+      regex: pod
+    scheme: https
+    scrapeTimeout: 1m
+    tlsConfig:
+      insecureSkipVerify: false
+      serverName: kube-state-metrics.openshift-monitoring.svc
+  - bearerTokenFile: ""
+    interval: 1m
+    metricRelabelings:
+    - action: keep
+      regex: (kube_node_labels|kube_node_spec_unschedulable|kube_node_status_capacity|kube_node_status_condition|kube_persistentvolume_info|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_resource_requests|kube_pod_info|kube_pod_labels|kube_pod_restart_policy|kube_pod_status_phase|kube_running_pod_ready|kube_storageclass_info)
+      sourceLabels:
+      - __name__
+    port: https-self
+    scheme: https
+    scrapeTimeout: 1m
+    tlsConfig:
+      insecureSkipVerify: false
+      serverName: kube-state-metrics.openshift-monitoring.svc
+  jobLabel: app.kubernetes.io/name
+  scrapeClass: tls-client-certificate-auth
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/node-exporter/telemetry-service-monitor.yaml
+++ b/assets/node-exporter/telemetry-service-monitor.yaml
@@ -1,0 +1,40 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 1.10.2
+    monitoring.openshift.io/collection-profile: telemetry
+  name: node-exporter-telemetry
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: ""
+    interval: 15s
+    metricRelabelings:
+    - action: keep
+      regex: (node_accelerator_card_info|node_cpu_info|node_cpu_seconds_total|node_memory_MemAvailable_bytes|node_memory_MemTotal_bytes|virt_platform)
+      sourceLabels:
+      - __name__
+    port: https
+    relabelings:
+    - action: replace
+      regex: (.*)
+      replacement: $1
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: instance
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: false
+      serverName: node-exporter.openshift-monitoring.svc
+  jobLabel: app.kubernetes.io/name
+  scrapeClass: tls-client-certificate-auth
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: node-exporter
+      app.kubernetes.io/part-of: openshift-monitoring

--- a/assets/openshift-state-metrics/telemetry-service-monitor.yaml
+++ b/assets/openshift-state-metrics/telemetry-service-monitor.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+    k8s-app: openshift-state-metrics
+    monitoring.openshift.io/collection-profile: telemetry
+  name: openshift-state-metrics-telemetry
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: ""
+    honorLabels: true
+    interval: 2m
+    metricRelabelings:
+    - action: keep
+      regex: (openshift_build_status_phase_total|openshift_route_info)
+      sourceLabels:
+      - __name__
+    port: https-main
+    scheme: https
+    scrapeTimeout: 2m
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      insecureSkipVerify: false
+      serverName: openshift-state-metrics.openshift-monitoring.svc
+  - bearerTokenFile: ""
+    interval: 2m
+    metricRelabelings:
+    - action: keep
+      regex: (openshift_build_status_phase_total|openshift_route_info)
+      sourceLabels:
+      - __name__
+    port: https-self
+    scheme: https
+    scrapeTimeout: 2m
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      insecureSkipVerify: false
+      serverName: openshift-state-metrics.openshift-monitoring.svc
+  jobLabel: k8s-app
+  scrapeClass: tls-client-certificate-auth
+  selector:
+    matchLabels:
+      k8s-app: openshift-state-metrics

--- a/assets/prometheus-k8s/telemetry-service-monitor.yaml
+++ b/assets/prometheus-k8s/telemetry-service-monitor.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: openshift-monitoring
+    app.kubernetes.io/version: 3.7.3
+    monitoring.openshift.io/collection-profile: telemetry
+  name: prometheus-k8s-telemetry
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: ""
+    interval: 30s
+    metricRelabelings:
+    - action: keep
+      regex: (ALERTS|prometheus_tsdb_head_samples_appended_total|prometheus_tsdb_head_series|scrape_samples_post_metric_relabeling|scrape_series_added|up)
+      sourceLabels:
+      - __name__
+    port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: false
+      serverName: prometheus-k8s.openshift-monitoring.svc
+  scrapeClass: tls-client-certificate-auth
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: openshift-monitoring
+  serviceDiscoveryRole: EndpointSlice

--- a/assets/telemeter-client/telemetry-service-monitor.yaml
+++ b/assets/telemeter-client/telemetry-service-monitor.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/part-of: openshift-monitoring
+    k8s-app: telemeter-client
+    monitoring.openshift.io/collection-profile: telemetry
+  name: telemeter-client-telemetry
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: ""
+    interval: 30s
+    metricRelabelings:
+    - action: keep
+      regex: (federate_filtered_samples|federate_samples)
+      sourceLabels:
+      - __name__
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: false
+      serverName: telemeter-client.openshift-monitoring.svc
+  jobLabel: k8s-app
+  scrapeClass: tls-client-certificate-auth
+  selector:
+    matchLabels:
+      k8s-app: telemeter-client

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -3,6 +3,7 @@ local alertmanager = import 'github.com/prometheus-operator/kube-prometheus/json
 // local krp = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet';
 local generateCertInjection = import '../utils/generate-certificate-injection.libsonnet';
 local generateSecret = import '../utils/generate-secret.libsonnet';
+local generateServiceMonitor = import '../utils/generate-service-monitors.libsonnet';
 local withDescription = (import '../utils/add-annotations.libsonnet').withDescription;
 local testFilePlaceholder = (import '../utils/add-annotations.libsonnet').testFilePlaceholder;
 local requiredRoles = (import '../utils/add-annotations.libsonnet').requiredRoles;
@@ -228,6 +229,8 @@ function(params)
         ],
       },
     },
+
+    telemetryServiceMonitor: generateServiceMonitor.telemetry(self.serviceMonitor, 'alertmanager_integrations'),
 
     alertmanager+: {
       metadata+: {

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -1,5 +1,6 @@
 local metrics = import 'github.com/openshift/telemeter/jsonnet/telemeter/metrics.jsonnet';
 
+local generateServiceMonitor = import '../utils/generate-service-monitors.libsonnet';
 local cmoRules = import './../rules.libsonnet';
 local kubePrometheus = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/components/mixin/custom.libsonnet';
 
@@ -158,6 +159,8 @@ function(params) {
       ],
     },
   },
+
+  telemetryServiceMonitor: generateServiceMonitor.telemetry(self.serviceMonitor, 'cluster_monitoring_operator_collection_profile'),
 
   // This is the base for the cluster-monitoring-operator ClusterRole. It will
   // be extended with the rules from all other ClusterRoles in main.jsonnet.

--- a/jsonnet/components/control-plane.libsonnet
+++ b/jsonnet/components/control-plane.libsonnet
@@ -168,6 +168,26 @@ function(params)
                                            ])
     ),
 
+    telemetryServiceMonitorKubelet: generateServiceMonitor.telemetry(
+      self.serviceMonitorKubelet, std.join('|',
+                                           [
+                                             'apiserver_current_inflight_requests',
+                                             'apiserver_request_total',
+                                             'apiserver_storage_objects',
+                                             'container_cpu_usage_seconds_total',
+                                             'container_memory_working_set_bytes',
+                                             'kubelet_containers_per_pod_count_sum',
+                                             'kubelet_volume_stats_used_bytes',
+                                             'pv_collector_total_pv_count',
+                                             'selinux_warning_controller_selinux_volume_conflict',
+                                             'volume_manager_selinux_pod_context_mismatch_errors_total',
+                                             'volume_manager_selinux_pod_context_mismatch_warnings_total',
+                                             'volume_manager_selinux_volume_context_mismatch_errors_total',
+                                             'volume_manager_selinux_volume_context_mismatch_warnings_total',
+                                             'volume_manager_selinux_volumes_admitted_total',
+                                           ])
+    ),
+
     // This avoids creating service monitors which are already managed by the respective operators.
     serviceMonitorApiserver:: {},
     serviceMonitorKubeScheduler:: {},

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -176,6 +176,26 @@ function(params)
                                     ])
     ),
 
+    telemetryServiceMonitor: generateServiceMonitor.telemetry(
+      self.serviceMonitor, std.join('|',
+                                    [
+                                      'kube_node_labels',
+                                      'kube_node_spec_unschedulable',
+                                      'kube_node_status_capacity',
+                                      'kube_node_status_condition',
+                                      'kube_persistentvolume_info',
+                                      'kube_persistentvolumeclaim_info',
+                                      'kube_persistentvolumeclaim_resource_requests_storage_bytes',
+                                      'kube_pod_container_resource_requests',
+                                      'kube_pod_info',
+                                      'kube_pod_labels',
+                                      'kube_pod_restart_policy',
+                                      'kube_pod_status_phase',
+                                      'kube_running_pod_ready',
+                                      'kube_storageclass_info',
+                                    ])
+    ),
+
     kubeRbacProxySecret: generateSecret.staticAuthSecret(cfg.namespace, cfg.commonLabels, 'kube-state-metrics-kube-rbac-proxy-config'),
 
     // This removes the upstream addon-resizer and all resource requests and

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -224,6 +224,18 @@ function(params)
                                      ])
     ),
 
+    telemetryServiceMonitor: generateServiceMonitor.telemetry(
+      super.serviceMonitor, std.join('|',
+                                     [
+                                       'node_accelerator_card_info',
+                                       'node_cpu_info',
+                                       'node_cpu_seconds_total',
+                                       'node_memory_MemAvailable_bytes',
+                                       'node_memory_MemTotal_bytes',
+                                       'virt_platform',
+                                     ])
+    ),
+
     securityContextConstraints: {
       allowHostDirVolumePlugin: true,
       allowHostNetwork: true,

--- a/jsonnet/components/openshift-state-metrics.libsonnet
+++ b/jsonnet/components/openshift-state-metrics.libsonnet
@@ -1,4 +1,5 @@
 local generateSecret = import '../utils/generate-secret.libsonnet';
+local generateServiceMonitor = import '../utils/generate-service-monitors.libsonnet';
 local withDescription = (import '../utils/add-annotations.libsonnet').withDescription;
 
 function(params) {
@@ -97,6 +98,13 @@ function(params) {
     },
   },
   serviceMonitor: osm.openshiftStateMetrics.serviceMonitor,
+  telemetryServiceMonitor: generateServiceMonitor.telemetry(
+    self.serviceMonitor, std.join('|',
+                                  [
+                                    'openshift_build_status_phase_total',
+                                    'openshift_route_info',
+                                  ])
+  ),
   networkPolicyDownstream: {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'NetworkPolicy',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -2,6 +2,7 @@ local metrics = import 'github.com/openshift/telemeter/jsonnet/telemeter/metrics
 
 local generateCertInjection = import '../utils/generate-certificate-injection.libsonnet';
 local generateSecret = import '../utils/generate-secret.libsonnet';
+local generateServiceMonitor = import '../utils/generate-service-monitors.libsonnet';
 local prometheus = import 'github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus/components/prometheus.libsonnet';
 local withDescription = (import '../utils/add-annotations.libsonnet').withDescription;
 local requiredClusterRoles = (import '../utils/add-annotations.libsonnet').requiredClusterRoles;
@@ -296,6 +297,18 @@ function(params)
         ],
       },
     },
+
+    telemetryServiceMonitor: generateServiceMonitor.telemetry(
+      self.serviceMonitor, std.join('|',
+                                    [
+                                      'ALERTS',
+                                      'prometheus_tsdb_head_samples_appended_total',
+                                      'prometheus_tsdb_head_series',
+                                      'scrape_samples_post_metric_relabeling',
+                                      'scrape_series_added',
+                                      'up',
+                                    ])
+    ),
 
     serviceThanosSidecar+: {
       metadata+: {

--- a/jsonnet/components/telemeter-client.libsonnet
+++ b/jsonnet/components/telemeter-client.libsonnet
@@ -1,5 +1,6 @@
 local generateCertInjection = import '../utils/generate-certificate-injection.libsonnet';
 local generateSecret = import '../utils/generate-secret.libsonnet';
+local generateServiceMonitor = import '../utils/generate-service-monitors.libsonnet';
 local withDescription = (import '../utils/add-annotations.libsonnet').withDescription;
 
 function(params) {
@@ -43,6 +44,13 @@ function(params) {
       ],
     },
   },
+  telemetryServiceMonitor: generateServiceMonitor.telemetry(
+    self.serviceMonitor, std.join('|',
+                                  [
+                                    'federate_filtered_samples',
+                                    'federate_samples',
+                                  ])
+  ),
   secret: tc.telemeterClient.secret,
   servingCertsCABundle: tc.telemeterClient.servingCertsCABundle,
   kubeRbacProxySecret: generateSecret.staticAuthSecret(cfg.namespace, cfg.commonLabels, 'telemeter-client-kube-rbac-proxy-config'),

--- a/jsonnet/utils/configure-authentication-for-monitors.libsonnet
+++ b/jsonnet/utils/configure-authentication-for-monitors.libsonnet
@@ -25,7 +25,13 @@
                                                'prometheus-' + o.metadata.labels['app.kubernetes.io/instance'] + '-' + o.metadata.name
                                              else
                                                if std.objectHas(o.metadata.labels, 'monitoring.openshift.io/collection-profile') then
-                                                 std.rstripChars(o.metadata.name, '-' + o.metadata.labels['monitoring.openshift.io/collection-profile'])
+                                                 local suffix = '-' + o.metadata.labels['monitoring.openshift.io/collection-profile'];
+                                                 local suffixLen = std.length(suffix);
+                                                 local nameLen = std.length(o.metadata.name);
+                                                 if std.endsWith(o.metadata.name, suffix) then
+                                                   std.substr(o.metadata.name, 0, nameLen - suffixLen)
+                                                 else
+                                                   o.metadata.name
                                                else
                                                  o.metadata.name,
                                              o.metadata.namespace,

--- a/jsonnet/utils/generate-service-monitors.libsonnet
+++ b/jsonnet/utils/generate-service-monitors.libsonnet
@@ -1,14 +1,13 @@
 {
-  local minimalLabel = {
-    'monitoring.openshift.io/collection-profile': 'minimal',
-  },
-  // 1. Add the prefix minimal to the ServiceMonitor name
-  // 2. Add the minimal label "monitoring.openshift.io/collection-profile: minimal"
+  // 1. Add the profile prefix to the ServiceMonitor name
+  // 2. Add the profile label "monitoring.openshift.io/collection-profile: <profile>"
   // 3. Add a metricRelabelings with action keep and regex equal to metrics
-  local minimal(sm, metrics) = sm {
+  local run(sm, metrics, profile) = sm {
     metadata+: {
-      name+: '-minimal',
-      labels+: minimalLabel,
+      name+: '-' + profile,
+      labels+: {
+        'monitoring.openshift.io/collection-profile': profile,
+      },
     },
     spec+: {
       endpoints: std.map(
@@ -39,5 +38,6 @@
     },
   },
 
-  minimal(sm, metrics): minimal(removeDrop(sm), metrics),
+  minimal(sm, metrics): run(removeDrop(sm), metrics, 'minimal'),
+  telemetry(sm, metrics): run(removeDrop(sm), metrics, 'telemetry'),
 }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -82,21 +82,22 @@ const (
 )
 
 var (
-	AlertmanagerConfig                = "alertmanager/secret.yaml"
-	AlertmanagerService               = "alertmanager/service.yaml"
-	AlertmanagerMain                  = "alertmanager/alertmanager.yaml"
-	AlertmanagerServiceAccount        = "alertmanager/service-account.yaml"
-	AlertmanagerClusterRoleBinding    = "alertmanager/cluster-role-binding.yaml"
-	AlertmanagerClusterRole           = "alertmanager/cluster-role.yaml"
-	AlertmanagerRBACProxySecret       = "alertmanager/kube-rbac-proxy-secret.yaml"
-	AlertmanagerRBACProxyMetricSecret = "alertmanager/kube-rbac-proxy-metric-secret.yaml"
-	AlertmanagerRBACProxyWebSecret    = "alertmanager/kube-rbac-proxy-web-secret.yaml"
-	AlertmanagerRoute                 = "alertmanager/route.yaml"
-	AlertmanagerServiceMonitor        = "alertmanager/service-monitor.yaml"
-	AlertmanagerTrustedCABundle       = "alertmanager/trusted-ca-bundle.yaml"
-	AlertmanagerPrometheusRule        = "alertmanager/prometheus-rule.yaml"
-	AlertmanagerPodDisruptionBudget   = "alertmanager/pod-disruption-budget.yaml"
-	AlertmanagerNetworkPolicy         = "alertmanager/network-policy-downstream.yaml"
+	AlertmanagerConfig                  = "alertmanager/secret.yaml"
+	AlertmanagerService                 = "alertmanager/service.yaml"
+	AlertmanagerMain                    = "alertmanager/alertmanager.yaml"
+	AlertmanagerServiceAccount          = "alertmanager/service-account.yaml"
+	AlertmanagerClusterRoleBinding      = "alertmanager/cluster-role-binding.yaml"
+	AlertmanagerClusterRole             = "alertmanager/cluster-role.yaml"
+	AlertmanagerRBACProxySecret         = "alertmanager/kube-rbac-proxy-secret.yaml"
+	AlertmanagerRBACProxyMetricSecret   = "alertmanager/kube-rbac-proxy-metric-secret.yaml"
+	AlertmanagerRBACProxyWebSecret      = "alertmanager/kube-rbac-proxy-web-secret.yaml"
+	AlertmanagerRoute                   = "alertmanager/route.yaml"
+	AlertmanagerServiceMonitor          = "alertmanager/service-monitor.yaml"
+	AlertmanagerTrustedCABundle         = "alertmanager/trusted-ca-bundle.yaml"
+	AlertmanagerPrometheusRule          = "alertmanager/prometheus-rule.yaml"
+	AlertmanagerPodDisruptionBudget     = "alertmanager/pod-disruption-budget.yaml"
+	AlertmanagerNetworkPolicy           = "alertmanager/network-policy-downstream.yaml"
+	AlertmanagerTelemetryServiceMonitor = "alertmanager/telemetry-service-monitor.yaml"
 
 	AlertmanagerUserWorkloadSecret                 = "alertmanager-user-workload/secret.yaml"
 	AlertmanagerUserWorkloadService                = "alertmanager-user-workload/service.yaml"
@@ -112,26 +113,28 @@ var (
 	AlertmanagerUserWorkloadServiceMonitor         = "alertmanager-user-workload/service-monitor.yaml"
 	AlertmanagerUserWorkloadNetworkPolicy          = "alertmanager-user-workload/network-policy-downstream.yaml"
 
-	KubeStateMetricsClusterRoleBinding    = "kube-state-metrics/cluster-role-binding.yaml"
-	KubeStateMetricsClusterRole           = "kube-state-metrics/cluster-role.yaml"
-	KubeStateMetricsDeployment            = "kube-state-metrics/deployment.yaml"
-	KubeStateMetricsServiceAccount        = "kube-state-metrics/service-account.yaml"
-	KubeStateMetricsService               = "kube-state-metrics/service.yaml"
-	KubeStateMetricsServiceMonitor        = "kube-state-metrics/service-monitor.yaml"
-	KubeStateMetricsMinimalServiceMonitor = "kube-state-metrics/minimal-service-monitor.yaml"
-	KubeStateMetricsPrometheusRule        = "kube-state-metrics/prometheus-rule.yaml"
-	KubeStateMetricsKubeRbacProxySecret   = "kube-state-metrics/kube-rbac-proxy-secret.yaml"
-	KubeStateMetricsCRSConfig             = "kube-state-metrics/custom-resource-state-configmap.yaml"
-	KubeStateMetricsNetworkPolicy         = "kube-state-metrics/network-policy-downstream.yaml"
+	KubeStateMetricsClusterRoleBinding      = "kube-state-metrics/cluster-role-binding.yaml"
+	KubeStateMetricsClusterRole             = "kube-state-metrics/cluster-role.yaml"
+	KubeStateMetricsDeployment              = "kube-state-metrics/deployment.yaml"
+	KubeStateMetricsServiceAccount          = "kube-state-metrics/service-account.yaml"
+	KubeStateMetricsService                 = "kube-state-metrics/service.yaml"
+	KubeStateMetricsServiceMonitor          = "kube-state-metrics/service-monitor.yaml"
+	KubeStateMetricsMinimalServiceMonitor   = "kube-state-metrics/minimal-service-monitor.yaml"
+	KubeStateMetricsTelemetryServiceMonitor = "kube-state-metrics/telemetry-service-monitor.yaml"
+	KubeStateMetricsPrometheusRule          = "kube-state-metrics/prometheus-rule.yaml"
+	KubeStateMetricsKubeRbacProxySecret     = "kube-state-metrics/kube-rbac-proxy-secret.yaml"
+	KubeStateMetricsCRSConfig               = "kube-state-metrics/custom-resource-state-configmap.yaml"
+	KubeStateMetricsNetworkPolicy           = "kube-state-metrics/network-policy-downstream.yaml"
 
-	OpenShiftStateMetricsClusterRoleBinding  = "openshift-state-metrics/cluster-role-binding.yaml"
-	OpenShiftStateMetricsClusterRole         = "openshift-state-metrics/cluster-role.yaml"
-	OpenShiftStateMetricsDeployment          = "openshift-state-metrics/deployment.yaml"
-	OpenShiftStateMetricsServiceAccount      = "openshift-state-metrics/service-account.yaml"
-	OpenShiftStateMetricsService             = "openshift-state-metrics/service.yaml"
-	OpenShiftStateMetricsServiceMonitor      = "openshift-state-metrics/service-monitor.yaml"
-	OpenShiftStateMetricsKubeRbacProxySecret = "openshift-state-metrics/kube-rbac-proxy-secret.yaml"
-	OpenShiftStateMetricsNetworkPolicy       = "openshift-state-metrics/network-policy-downstream.yaml"
+	OpenShiftStateMetricsClusterRoleBinding      = "openshift-state-metrics/cluster-role-binding.yaml"
+	OpenShiftStateMetricsClusterRole             = "openshift-state-metrics/cluster-role.yaml"
+	OpenShiftStateMetricsDeployment              = "openshift-state-metrics/deployment.yaml"
+	OpenShiftStateMetricsServiceAccount          = "openshift-state-metrics/service-account.yaml"
+	OpenShiftStateMetricsService                 = "openshift-state-metrics/service.yaml"
+	OpenShiftStateMetricsServiceMonitor          = "openshift-state-metrics/service-monitor.yaml"
+	OpenShiftStateMetricsTelemetryServiceMonitor = "openshift-state-metrics/telemetry-service-monitor.yaml"
+	OpenShiftStateMetricsKubeRbacProxySecret     = "openshift-state-metrics/kube-rbac-proxy-secret.yaml"
+	OpenShiftStateMetricsNetworkPolicy           = "openshift-state-metrics/network-policy-downstream.yaml"
 
 	NodeExporterDaemonSet                  = "node-exporter/daemonset.yaml"
 	NodeExporterService                    = "node-exporter/service.yaml"
@@ -141,38 +144,40 @@ var (
 	NodeExporterSecurityContextConstraints = "node-exporter/security-context-constraints.yaml"
 	NodeExporterServiceMonitor             = "node-exporter/service-monitor.yaml"
 	NodeExporterMinimalServiceMonitor      = "node-exporter/minimal-service-monitor.yaml"
+	NodeExporterTelemetryServiceMonitor    = "node-exporter/telemetry-service-monitor.yaml"
 	NodeExporterPrometheusRule             = "node-exporter/prometheus-rule.yaml"
 	NodeExporterKubeRbacProxySecret        = "node-exporter/kube-rbac-proxy-secret.yaml"
 	NodeExporterAcceleratorsConfigMap      = "node-exporter/accelerators-collector-configmap.yaml"
 
-	PrometheusK8sClusterRoleBinding               = "prometheus-k8s/cluster-role-binding.yaml"
-	PrometheusK8sRoleBindingConfig                = "prometheus-k8s/role-binding-config.yaml"
-	PrometheusK8sRoleBindingList                  = "prometheus-k8s/role-binding-specific-namespaces.yaml"
-	PrometheusK8sClusterRole                      = "prometheus-k8s/cluster-role.yaml"
-	PrometheusK8sRoleConfig                       = "prometheus-k8s/role-config.yaml"
-	PrometheusK8sRoleList                         = "prometheus-k8s/role-specific-namespaces.yaml"
-	PrometheusK8sPrometheusRule                   = "prometheus-k8s/prometheus-rule.yaml"
-	PrometheusK8sThanosSidecarPrometheusRule      = "prometheus-k8s/prometheus-rule-thanos-sidecar.yaml"
-	PrometheusK8sServiceAccount                   = "prometheus-k8s/service-account.yaml"
-	PrometheusK8s                                 = "prometheus-k8s/prometheus.yaml"
-	PrometheusK8sPrometheusServiceMonitor         = "prometheus-k8s/service-monitor.yaml"
-	PrometheusK8sService                          = "prometheus-k8s/service.yaml"
-	PrometheusK8sServiceThanosSidecar             = "prometheus-k8s/service-thanos-sidecar.yaml"
-	PrometheusK8sRBACProxyWebSecret               = "prometheus-k8s/kube-rbac-proxy-web-secret.yaml"
-	PrometheusRBACProxySecret                     = "prometheus-k8s/kube-rbac-proxy-secret.yaml"
-	PrometheusUserWorkloadRBACProxyMetricsSecret  = "prometheus-user-workload/kube-rbac-proxy-metrics-secret.yaml"
-	PrometheusUserWorkloadRBACProxyFederateSecret = "prometheus-user-workload/kube-rbac-proxy-federate-secret.yaml"
-	PrometheusK8sAPIRoute                         = "prometheus-k8s/api-route.yaml"
-	PrometheusK8sFederateRoute                    = "prometheus-k8s/federate-route.yaml"
-	PrometheusK8sServingCertsCABundle             = "prometheus-k8s/serving-certs-ca-bundle.yaml"
-	PrometheusK8sKubeletServingCABundle           = "prometheus-k8s/kubelet-serving-ca-bundle.yaml"
-	PrometheusK8sGrpcTLSSecret                    = "prometheus-k8s/grpc-tls-secret.yaml"
-	PrometheusK8sTrustedCABundle                  = "prometheus-k8s/trusted-ca-bundle.yaml"
-	PrometheusK8sThanosSidecarServiceMonitor      = "prometheus-k8s/service-monitor-thanos-sidecar.yaml"
-	PrometheusK8sTAlertmanagerRoleBinding         = "prometheus-k8s/alertmanager-role-binding.yaml"
-	PrometheusK8sPodDisruptionBudget              = "prometheus-k8s/pod-disruption-budget.yaml"
-	PrometheusK8sTelemetry                        = "prometheus-k8s/telemetry-secret.yaml"
-	PrometheusK8sNetworkPolicy                    = "prometheus-k8s/network-policy-downstream.yaml"
+	PrometheusK8sClusterRoleBinding                = "prometheus-k8s/cluster-role-binding.yaml"
+	PrometheusK8sRoleBindingConfig                 = "prometheus-k8s/role-binding-config.yaml"
+	PrometheusK8sRoleBindingList                   = "prometheus-k8s/role-binding-specific-namespaces.yaml"
+	PrometheusK8sClusterRole                       = "prometheus-k8s/cluster-role.yaml"
+	PrometheusK8sRoleConfig                        = "prometheus-k8s/role-config.yaml"
+	PrometheusK8sRoleList                          = "prometheus-k8s/role-specific-namespaces.yaml"
+	PrometheusK8sPrometheusRule                    = "prometheus-k8s/prometheus-rule.yaml"
+	PrometheusK8sThanosSidecarPrometheusRule       = "prometheus-k8s/prometheus-rule-thanos-sidecar.yaml"
+	PrometheusK8sServiceAccount                    = "prometheus-k8s/service-account.yaml"
+	PrometheusK8s                                  = "prometheus-k8s/prometheus.yaml"
+	PrometheusK8sPrometheusServiceMonitor          = "prometheus-k8s/service-monitor.yaml"
+	PrometheusK8sPrometheusTelemetryServiceMonitor = "prometheus-k8s/telemetry-service-monitor.yaml"
+	PrometheusK8sService                           = "prometheus-k8s/service.yaml"
+	PrometheusK8sServiceThanosSidecar              = "prometheus-k8s/service-thanos-sidecar.yaml"
+	PrometheusK8sRBACProxyWebSecret                = "prometheus-k8s/kube-rbac-proxy-web-secret.yaml"
+	PrometheusRBACProxySecret                      = "prometheus-k8s/kube-rbac-proxy-secret.yaml"
+	PrometheusUserWorkloadRBACProxyMetricsSecret   = "prometheus-user-workload/kube-rbac-proxy-metrics-secret.yaml"
+	PrometheusUserWorkloadRBACProxyFederateSecret  = "prometheus-user-workload/kube-rbac-proxy-federate-secret.yaml"
+	PrometheusK8sAPIRoute                          = "prometheus-k8s/api-route.yaml"
+	PrometheusK8sFederateRoute                     = "prometheus-k8s/federate-route.yaml"
+	PrometheusK8sServingCertsCABundle              = "prometheus-k8s/serving-certs-ca-bundle.yaml"
+	PrometheusK8sKubeletServingCABundle            = "prometheus-k8s/kubelet-serving-ca-bundle.yaml"
+	PrometheusK8sGrpcTLSSecret                     = "prometheus-k8s/grpc-tls-secret.yaml"
+	PrometheusK8sTrustedCABundle                   = "prometheus-k8s/trusted-ca-bundle.yaml"
+	PrometheusK8sThanosSidecarServiceMonitor       = "prometheus-k8s/service-monitor-thanos-sidecar.yaml"
+	PrometheusK8sTAlertmanagerRoleBinding          = "prometheus-k8s/alertmanager-role-binding.yaml"
+	PrometheusK8sPodDisruptionBudget               = "prometheus-k8s/pod-disruption-budget.yaml"
+	PrometheusK8sTelemetry                         = "prometheus-k8s/telemetry-secret.yaml"
+	PrometheusK8sNetworkPolicy                     = "prometheus-k8s/network-policy-downstream.yaml"
 
 	PrometheusUserWorkloadServingCertsCABundle                = "prometheus-user-workload/serving-certs-ca-bundle.yaml"
 	PrometheusUserWorkloadTrustedCABundle                     = "prometheus-user-workload/trusted-ca-bundle.yaml"
@@ -236,6 +241,7 @@ var (
 	PrometheusOperatorUserWorkloadKubeRbacProxySecret = "prometheus-operator-user-workload/kube-rbac-proxy-secret.yaml"
 	PrometheusOperatorUserWorkloadNetworkPolicy       = "prometheus-operator-user-workload/network-policy-downstream.yaml"
 
+	ClusterMonitoringOperatorTelemetryServiceMonitor       = "cluster-monitoring-operator/telemetry-service-monitor.yaml"
 	ClusterMonitoringOperatorServiceMonitor                = "cluster-monitoring-operator/service-monitor.yaml"
 	ClusterMonitoringClusterRoleView                       = "cluster-monitoring-operator/cluster-role-view.yaml"
 	ClusterMonitoringClusterRoleAggregatedMetricsReader    = "cluster-monitoring-operator/cluster-role-aggregated-metrics-reader.yaml"
@@ -258,18 +264,19 @@ var (
 	ClusterMonitoringMetricsClientCACM                     = "cluster-monitoring-operator/metrics-client-ca.yaml"
 	ClusterMonitoringDenyAllTraffic                        = "cluster-monitoring-operator/network-policy-default-deny.yaml"
 
-	TelemeterClientClusterRole            = "telemeter-client/cluster-role.yaml"
-	TelemeterClientClusterRoleBinding     = "telemeter-client/cluster-role-binding.yaml"
-	TelemeterClientClusterRoleBindingView = "telemeter-client/cluster-role-binding-view.yaml"
-	TelemeterClientDeployment             = "telemeter-client/deployment.yaml"
-	TelemeterClientSecret                 = "telemeter-client/secret.yaml"
-	TelemeterClientService                = "telemeter-client/service.yaml"
-	TelemeterClientServiceAccount         = "telemeter-client/service-account.yaml"
-	TelemeterClientServiceMonitor         = "telemeter-client/service-monitor.yaml"
-	TelemeterClientServingCertsCABundle   = "telemeter-client/serving-certs-ca-bundle.yaml"
-	TelemeterClientKubeRbacProxySecret    = "telemeter-client/kube-rbac-proxy-secret.yaml"
-	TelemeterClientPrometheusRule         = "telemeter-client/prometheus-rule.yaml"
-	TelemeterClientNetworkPolicy          = "telemeter-client/network-policy-downstream.yaml"
+	TelemeterClientClusterRole             = "telemeter-client/cluster-role.yaml"
+	TelemeterClientClusterRoleBinding      = "telemeter-client/cluster-role-binding.yaml"
+	TelemeterClientClusterRoleBindingView  = "telemeter-client/cluster-role-binding-view.yaml"
+	TelemeterClientDeployment              = "telemeter-client/deployment.yaml"
+	TelemeterClientSecret                  = "telemeter-client/secret.yaml"
+	TelemeterClientService                 = "telemeter-client/service.yaml"
+	TelemeterClientServiceAccount          = "telemeter-client/service-account.yaml"
+	TelemeterClientServiceMonitor          = "telemeter-client/service-monitor.yaml"
+	TelemeterClientTelemetryServiceMonitor = "telemeter-client/telemetry-service-monitor.yaml"
+	TelemeterClientServingCertsCABundle    = "telemeter-client/serving-certs-ca-bundle.yaml"
+	TelemeterClientKubeRbacProxySecret     = "telemeter-client/kube-rbac-proxy-secret.yaml"
+	TelemeterClientPrometheusRule          = "telemeter-client/prometheus-rule.yaml"
+	TelemeterClientNetworkPolicy           = "telemeter-client/network-policy-downstream.yaml"
 
 	ThanosQuerierDeployment             = "thanos-querier/deployment.yaml"
 	ThanosQuerierPodDisruptionBudget    = "thanos-querier/pod-disruption-budget.yaml"
@@ -308,9 +315,10 @@ var (
 
 	TelemeterTrustedCABundle = "telemeter-client/trusted-ca-bundle.yaml"
 
-	ControlPlanePrometheusRule               = "control-plane/prometheus-rule.yaml"
-	ControlPlaneKubeletServiceMonitor        = "control-plane/service-monitor-kubelet.yaml"
-	ControlPlaneKubeletMinimalServiceMonitor = "control-plane/minimal-service-monitor-kubelet.yaml"
+	ControlPlanePrometheusRule                 = "control-plane/prometheus-rule.yaml"
+	ControlPlaneKubeletServiceMonitor          = "control-plane/service-monitor-kubelet.yaml"
+	ControlPlaneKubeletMinimalServiceMonitor   = "control-plane/minimal-service-monitor-kubelet.yaml"
+	ControlPlaneKubeletTelemetryServiceMonitor = "control-plane/telemetry-service-monitor-kubelet.yaml"
 
 	MonitoringPlugin                    = "monitoring-plugin/console-plugin.yaml"
 	MonitoringPluginDeployment          = "monitoring-plugin/deployment.yaml"
@@ -436,8 +444,20 @@ func (f *Factory) AlertmanagerUserWorkloadClusterRole() (*rbacv1.ClusterRole, er
 	return f.NewClusterRole(f.assets.MustNewAssetSlice(AlertmanagerUserWorkloadClusterRole))
 }
 
+func (f *Factory) AlertmanagerServiceMonitors() ([]*monv1.ServiceMonitor, error) {
+	return serviceMonitors(
+		f.AlertmanagerServiceMonitor,
+		nil,
+		f.AlertmanagerTelemetryServiceMonitor,
+	)
+}
+
 func (f *Factory) AlertmanagerServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(AlertmanagerServiceMonitor))
+}
+
+func (f *Factory) AlertmanagerTelemetryServiceMonitor() (*monv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(AlertmanagerTelemetryServiceMonitor))
 }
 
 func (f *Factory) AlertmanagerUserWorkloadServiceMonitor() (*monv1.ServiceMonitor, error) {
@@ -762,7 +782,11 @@ func (f *Factory) KubeStateMetricsClusterRole() (*rbacv1.ClusterRole, error) {
 }
 
 func (f *Factory) KubeStateMetricsServiceMonitors() ([]*monv1.ServiceMonitor, error) {
-	return serviceMonitors(f.config.CollectionProfilesFeatureGateEnabled, f.KubeStateMetricsServiceMonitor, f.KubeStateMetricsMinimalServiceMonitor)
+	return serviceMonitors(
+		f.KubeStateMetricsServiceMonitor,
+		f.KubeStateMetricsMinimalServiceMonitor,
+		f.KubeStateMetricsTelemetryServiceMonitor,
+	)
 }
 
 func (f *Factory) KubeStateMetricsServiceMonitor() (*monv1.ServiceMonitor, error) {
@@ -771,6 +795,10 @@ func (f *Factory) KubeStateMetricsServiceMonitor() (*monv1.ServiceMonitor, error
 
 func (f *Factory) KubeStateMetricsMinimalServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(KubeStateMetricsMinimalServiceMonitor))
+}
+
+func (f *Factory) KubeStateMetricsTelemetryServiceMonitor() (*monv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(KubeStateMetricsTelemetryServiceMonitor))
 }
 
 func (f *Factory) KubeStateMetricsDeployment() (*appsv1.Deployment, error) {
@@ -838,8 +866,20 @@ func (f *Factory) OpenShiftStateMetricsClusterRole() (*rbacv1.ClusterRole, error
 	return f.NewClusterRole(f.assets.MustNewAssetSlice(OpenShiftStateMetricsClusterRole))
 }
 
+func (f *Factory) OpenShiftStateMetricsServiceMonitors() ([]*monv1.ServiceMonitor, error) {
+	return serviceMonitors(
+		f.OpenShiftStateMetricsServiceMonitor,
+		nil,
+		f.OpenShiftStateMetricsTelemetryServiceMonitor,
+	)
+}
+
 func (f *Factory) OpenShiftStateMetricsServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(OpenShiftStateMetricsServiceMonitor))
+}
+
+func (f *Factory) OpenShiftStateMetricsTelemetryServiceMonitor() (*monv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(OpenShiftStateMetricsTelemetryServiceMonitor))
 }
 
 func (f *Factory) OpenShiftStateMetricsDeployment() (*appsv1.Deployment, error) {
@@ -894,7 +934,11 @@ func (f *Factory) OpenShiftStateMetricsNetworkPolicy() (*networkingv1.NetworkPol
 }
 
 func (f *Factory) NodeExporterServiceMonitors() ([]*monv1.ServiceMonitor, error) {
-	return serviceMonitors(f.config.CollectionProfilesFeatureGateEnabled, f.NodeExporterServiceMonitor, f.NodeExporterMinimalServiceMonitor)
+	return serviceMonitors(
+		f.NodeExporterServiceMonitor,
+		f.NodeExporterMinimalServiceMonitor,
+		f.NodeExporterTelemetryServiceMonitor,
+	)
 }
 
 func (f *Factory) NodeExporterServiceMonitor() (*monv1.ServiceMonitor, error) {
@@ -1009,6 +1053,10 @@ func regexListToArg(list []string) (string, error) {
 
 func (f *Factory) NodeExporterMinimalServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(NodeExporterMinimalServiceMonitor))
+}
+
+func (f *Factory) NodeExporterTelemetryServiceMonitor() (*monv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(NodeExporterTelemetryServiceMonitor))
 }
 
 func (f *Factory) NodeExporterDaemonSet() (*appsv1.DaemonSet, error) {
@@ -1902,8 +1950,20 @@ func (f *Factory) excludedFromEnforcement() []monv1.ObjectReference {
 	return refs
 }
 
+func (f *Factory) PrometheusK8sPrometheusServiceMonitors() ([]*monv1.ServiceMonitor, error) {
+	return serviceMonitors(
+		f.PrometheusK8sPrometheusServiceMonitor,
+		nil,
+		f.PrometheusK8sPrometheusTelemetryServiceMonitor,
+	)
+}
+
 func (f *Factory) PrometheusK8sPrometheusServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(PrometheusK8sPrometheusServiceMonitor))
+}
+
+func (f *Factory) PrometheusK8sPrometheusTelemetryServiceMonitor() (*monv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(PrometheusK8sPrometheusTelemetryServiceMonitor))
 }
 
 func (f *Factory) PrometheusUserWorkloadPrometheusServiceMonitor() (*monv1.ServiceMonitor, error) {
@@ -2541,8 +2601,20 @@ func (f *Factory) ClusterMonitoringApiReaderRole() (*rbacv1.Role, error) {
 	return f.NewRole(f.assets.MustNewAssetSlice(ClusterMonitoringApiReaderRole))
 }
 
+func (f *Factory) ClusterMonitoringOperatorServiceMonitors() ([]*monv1.ServiceMonitor, error) {
+	return serviceMonitors(
+		f.ClusterMonitoringOperatorServiceMonitor,
+		nil,
+		f.ClusterMonitoringOperatorTelemetryServiceMonitor,
+	)
+}
+
 func (f *Factory) ClusterMonitoringOperatorServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(ClusterMonitoringOperatorServiceMonitor))
+}
+
+func (f *Factory) ClusterMonitoringOperatorTelemetryServiceMonitor() (*monv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(ClusterMonitoringOperatorTelemetryServiceMonitor))
 }
 
 func (f *Factory) ClusterMonitoringOperatorPrometheusRule() (*monv1.PrometheusRule, error) {
@@ -2569,7 +2641,11 @@ func (f *Factory) ControlPlanePrometheusRule() (*monv1.PrometheusRule, error) {
 }
 
 func (f *Factory) ControlPlaneKubeletServiceMonitors() ([]*monv1.ServiceMonitor, error) {
-	return serviceMonitors(f.config.CollectionProfilesFeatureGateEnabled, f.ControlPlaneKubeletServiceMonitor, f.ControlPlaneKubeletMinimalServiceMonitor)
+	return serviceMonitors(
+		f.ControlPlaneKubeletServiceMonitor,
+		f.ControlPlaneKubeletMinimalServiceMonitor,
+		f.ControlPlaneKubeletTelemetryServiceMonitor,
+	)
 }
 
 func (f *Factory) ControlPlaneKubeletServiceMonitor() (*monv1.ServiceMonitor, error) {
@@ -2578,6 +2654,10 @@ func (f *Factory) ControlPlaneKubeletServiceMonitor() (*monv1.ServiceMonitor, er
 
 func (f *Factory) ControlPlaneKubeletMinimalServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(ControlPlaneKubeletMinimalServiceMonitor))
+}
+
+func (f *Factory) ControlPlaneKubeletTelemetryServiceMonitor() (*monv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(ControlPlaneKubeletTelemetryServiceMonitor))
 }
 
 func IsMissingPortInAddressError(err error) bool {
@@ -3077,9 +3157,21 @@ func (f *Factory) TelemeterClientClusterRoleBindingView() (*rbacv1.ClusterRoleBi
 	return f.NewClusterRoleBinding(f.assets.MustNewAssetSlice(TelemeterClientClusterRoleBindingView))
 }
 
+func (f *Factory) TelemeterClientServiceMonitors() ([]*monv1.ServiceMonitor, error) {
+	return serviceMonitors(
+		f.TelemeterClientServiceMonitor,
+		nil,
+		f.TelemeterClientTelemetryServiceMonitor,
+	)
+}
+
 // TelemeterClientServiceMonitor generates a new ServiceMonitor for Telemeter client.
 func (f *Factory) TelemeterClientServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(TelemeterClientServiceMonitor))
+}
+
+func (f *Factory) TelemeterClientTelemetryServiceMonitor() (*monv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(TelemeterClientTelemetryServiceMonitor))
 }
 
 func (f *Factory) TelemeterClientKubeRbacProxySecret() (*v1.Secret, error) {
@@ -3494,19 +3586,33 @@ func makeConsoleURL(c *configv1.Console, path string) (string, error) {
 	return "", nil
 }
 
-func serviceMonitors(appendMinimal bool, fullServiceMonitor, minimalServiceMonitor func() (*monv1.ServiceMonitor, error)) ([]*monv1.ServiceMonitor, error) {
-	sMonitor, err := fullServiceMonitor()
-	if err != nil {
-		return nil, err
+func serviceMonitors(fullServiceMonitor, minimalServiceMonitor, telemetryServiceMonitor func() (*monv1.ServiceMonitor, error)) ([]*monv1.ServiceMonitor, error) {
+	var sms []*monv1.ServiceMonitor
+
+	if fullServiceMonitor != nil {
+		sMonitor, err := fullServiceMonitor()
+		if err != nil {
+			return nil, err
+		}
+		sms = append(sms, sMonitor)
 	}
-	sMonitorMinimal, err := minimalServiceMonitor()
-	if err != nil {
-		return nil, err
-	}
-	sms := []*monv1.ServiceMonitor{sMonitor}
-	if appendMinimal {
+
+	if minimalServiceMonitor != nil {
+		sMonitorMinimal, err := minimalServiceMonitor()
+		if err != nil {
+			return nil, err
+		}
 		sms = append(sms, sMonitorMinimal)
 	}
+
+	if telemetryServiceMonitor != nil {
+		sMonitorTelemetry, err := telemetryServiceMonitor()
+		if err != nil {
+			return nil, err
+		}
+		sms = append(sms, sMonitorTelemetry)
+	}
+
 	return sms, nil
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1838,7 +1838,7 @@ func TestPrometheusCollectionProfile(t *testing.T) {
 					{
 						Key:      "monitoring.openshift.io/collection-profile",
 						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"minimal"},
+						Values:   []string{"minimal", "telemetry"},
 					},
 				},
 			},
@@ -1851,7 +1851,20 @@ func TestPrometheusCollectionProfile(t *testing.T) {
 					{
 						Key:      "monitoring.openshift.io/collection-profile",
 						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"full"},
+						Values:   []string{"full", "telemetry"},
+					},
+				},
+			},
+		},
+		{
+			name:              "telemetry_collection_profile",
+			collectionProfile: "telemetry",
+			expectedLabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "monitoring.openshift.io/collection-profile",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"full", "minimal"},
 					},
 				},
 			},
@@ -2664,7 +2677,7 @@ metricsServer:
   - effect: PreferNoSchedule
     operator: Exists`
 
-	c, err := NewConfigFromString(config, true)
+	c, err := NewConfigFromString(config, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2762,7 +2775,7 @@ metricsServer:
 }
 
 func TestMetricsServerReadinessProbe(t *testing.T) {
-	c, err := NewConfigFromString("", true)
+	c, err := NewConfigFromString("", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -24,11 +24,16 @@ type CollectionProfiles []CollectionProfile
 type ExternalLabels map[string]string
 
 const (
-	FullCollectionProfile    = "full"
-	MinimalCollectionProfile = "minimal"
+	FullCollectionProfile      = "full"
+	MinimalCollectionProfile   = "minimal"
+	TelemetryCollectionProfile = "telemetry"
 )
 
-var SupportedCollectionProfiles = CollectionProfiles{FullCollectionProfile, MinimalCollectionProfile}
+var SupportedCollectionProfiles = CollectionProfiles{
+	FullCollectionProfile,
+	MinimalCollectionProfile,
+	TelemetryCollectionProfile,
+}
 
 // The `ClusterMonitoringConfiguration` resource defines settings that
 // customize the default platform monitoring stack through the

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -223,14 +223,16 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return fmt.Errorf("reconciling alertmanager rules PrometheusRule failed: %w", err)
 	}
 
-	smam, err := t.factory.AlertmanagerServiceMonitor()
+	smams, err := t.factory.AlertmanagerServiceMonitors()
 	if err != nil {
 		return fmt.Errorf("initializing Alertmanager ServiceMonitor failed: %w", err)
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(ctx, smam)
-	if err != nil {
-		return fmt.Errorf("reconciling Alertmanager ServiceMonitor failed: %w", err)
+	for _, smam := range smams {
+		err = t.client.CreateOrUpdateServiceMonitor(ctx, smam)
+		if err != nil {
+			return fmt.Errorf("reconciling Alertmanager ServiceMonitor failed: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/tasks/clustermonitoringoperator.go
+++ b/pkg/tasks/clustermonitoringoperator.go
@@ -140,14 +140,16 @@ func (t *ClusterMonitoringOperatorTask) Run(ctx context.Context) error {
 		return fmt.Errorf("reconciling cluster-monitoring-operator rules PrometheusRule failed: %w", err)
 	}
 
-	smcmo, err := t.factory.ClusterMonitoringOperatorServiceMonitor()
+	smscmo, err := t.factory.ClusterMonitoringOperatorServiceMonitors()
 	if err != nil {
 		return fmt.Errorf("initializing Cluster Monitoring Operator ServiceMonitor failed: %w", err)
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(ctx, smcmo)
-	if err != nil {
-		return fmt.Errorf("reconciling Cluster Monitoring Operator ServiceMonitor failed: %w", err)
+	for _, smcmo := range smscmo {
+		err = t.client.CreateOrUpdateServiceMonitor(ctx, smcmo)
+		if err != nil {
+			return fmt.Errorf("reconciling Cluster Monitoring Operator ServiceMonitor failed: %w", err)
+		}
 	}
 
 	s, err := t.factory.GRPCSecret()

--- a/pkg/tasks/openshiftstatemetrics.go
+++ b/pkg/tasks/openshiftstatemetrics.go
@@ -105,14 +105,16 @@ func (t *OpenShiftStateMetricsTask) Run(ctx context.Context) error {
 		return fmt.Errorf("reconciling openshift-state-metrics Deployment failed: %w", err)
 	}
 
-	sm, err := t.factory.OpenShiftStateMetricsServiceMonitor()
+	sms, err := t.factory.OpenShiftStateMetricsServiceMonitors()
 	if err != nil {
 		return fmt.Errorf("initializing openshift-state-metrics ServiceMonitor failed: %w", err)
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(ctx, sm)
-	if err != nil {
-		return fmt.Errorf("reconciling openshift-state-metrics ServiceMonitor failed: %w", err)
+	for _, sm := range sms {
+		err = t.client.CreateOrUpdateServiceMonitor(ctx, sm)
+		if err != nil {
+			return fmt.Errorf("reconciling openshift-state-metrics ServiceMonitor failed: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -403,14 +403,16 @@ func (t *PrometheusTask) create(ctx context.Context) error {
 		}
 	}
 
-	smp, err := t.factory.PrometheusK8sPrometheusServiceMonitor()
+	smps, err := t.factory.PrometheusK8sPrometheusServiceMonitors()
 	if err != nil {
 		return fmt.Errorf("initializing Prometheus Prometheus ServiceMonitor failed: %w", err)
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(ctx, smp)
-	if err != nil {
-		return fmt.Errorf("reconciling Prometheus Prometheus ServiceMonitor failed: %w", err)
+	for _, smp := range smps {
+		err = t.client.CreateOrUpdateServiceMonitor(ctx, smp)
+		if err != nil {
+			return fmt.Errorf("reconciling Prometheus Prometheus ServiceMonitor failed: %w", err)
+		}
 	}
 
 	smt, err := t.factory.PrometheusK8sThanosSidecarServiceMonitor()

--- a/pkg/tasks/telemeter.go
+++ b/pkg/tasks/telemeter.go
@@ -187,14 +187,16 @@ func (t *TelemeterClientTask) create(ctx context.Context) error {
 		return fmt.Errorf("reconciling Telemeter client Prometheus Rule failed: %w", err)
 	}
 
-	sm, err := t.factory.TelemeterClientServiceMonitor()
+	sms, err := t.factory.TelemeterClientServiceMonitors()
 	if err != nil {
-		return fmt.Errorf("initializing Telemeter client ServiceMonitor failed: %w", err)
+		return fmt.Errorf("initializing Telemeter client ServiceMonitors failed: %w", err)
 	}
 
-	err = t.client.CreateOrUpdateServiceMonitor(ctx, sm)
-	if err != nil {
-		return fmt.Errorf("reconciling Telemeter client ServiceMonitor failed: %w", err)
+	for _, sm := range sms {
+		err = t.client.CreateOrUpdateServiceMonitor(ctx, sm)
+		if err != nil {
+			return fmt.Errorf("reconciling Telemeter client %q ServiceMonitor failed: %w", sm.GetName(), err)
+		}
 	}
 
 	netpol, err := t.factory.TelemeterClientNetworkPolicy()


### PR DESCRIPTION
Does not entail the dynamically generating the whitelist and updating the monitoring from that [1], as well as, the `minimal` monitors' revision [2].

[1]:https://github.com/openshift/cluster-monitoring-operator/pull/2694
[2]:https://github.com/openshift/cluster-monitoring-operator/pull/2814