### PR TITLE
OCPBUGS-83284: validate more CMO configmap fields

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -55,6 +56,21 @@ const (
 )
 
 var reservedPrometheusExternalLabels = []string{"prometheus", "prometheus_replica", "cluster"}
+
+var lowestIntervalLimit, highestIntervalLimit model.Duration
+
+func init() {
+	var err error
+	lowestIntervalLimit, err = model.ParseDuration("5s")
+	if err != nil {
+		panic(err)
+	}
+
+	highestIntervalLimit, err = model.ParseDuration("5m")
+	if err != nil {
+		panic(err)
+	}
+}
 
 type InvalidConfigWarning struct {
 	ConfigMap string
@@ -143,90 +159,41 @@ func (c Config) GetThanosRulerAlertmanagerConfigs() []AdditionalAlertmanagerConf
 	return alertmanagerConfigs
 }
 
-func scrapeIntervalLimits() (model.Duration, model.Duration) {
-	lowerLimit, _ := model.ParseDuration("5s")
-	upperLimit, _ := model.ParseDuration("5m")
-	return lowerLimit, upperLimit
-}
-
-func evaluationIntervalLimits() (model.Duration, model.Duration) {
-	lowerLimit, _ := model.ParseDuration("5s")
-	upperLimit, _ := model.ParseDuration("5m")
-	return lowerLimit, upperLimit
-}
-
-func (u *UserWorkloadConfiguration) checkScrapeInterval() error {
-	if u.Prometheus == nil || u.Prometheus.ScrapeInterval == "" {
+func checkIntervalValue(interval string) error {
+	if interval == "" {
 		return nil
 	}
 
-	scrapeInterval, err := model.ParseDuration(u.Prometheus.ScrapeInterval)
-
+	d, err := model.ParseDuration(interval)
 	if err != nil {
-		return fmt.Errorf("invalid scrape interval value: %w", err)
+		return fmt.Errorf("invalid interval value: %w", err)
 	}
 
-	allowedLowerLimit, allowedUpperLimit := scrapeIntervalLimits()
-
-	if (scrapeInterval < allowedLowerLimit) || (scrapeInterval > allowedUpperLimit) {
-		return fmt.Errorf("Prometheus scrape interval value %q outside of the allowed range [%q, %q]", u.Prometheus.ScrapeInterval, allowedLowerLimit, allowedUpperLimit)
+	if (d < lowestIntervalLimit) || (d > highestIntervalLimit) {
+		return fmt.Errorf("interval value %q outside of the allowed range [%q, %q]", interval, lowestIntervalLimit, highestIntervalLimit)
 	}
 	return nil
 }
 
-func (u *UserWorkloadConfiguration) checkPrometheusEvaluationInterval() error {
-	if u.Prometheus == nil || u.Prometheus.EvaluationInterval == "" {
-		return nil
-	}
-
-	evaluationInterval, err := model.ParseDuration(u.Prometheus.EvaluationInterval)
-
-	if err != nil {
-		return fmt.Errorf("invalid evaluation interval value: %w", err)
-	}
-
-	allowedLowerLimit, allowedUpperLimit := evaluationIntervalLimits()
-
-	if (evaluationInterval < allowedLowerLimit) || (evaluationInterval > allowedUpperLimit) {
-		return fmt.Errorf("Prometheus evaluation interval value %q outside of the allowed range [%q, %q]", u.Prometheus.EvaluationInterval, allowedLowerLimit, allowedUpperLimit)
-	}
-	return nil
-}
-
-func (u *UserWorkloadConfiguration) checkThanosRulerEvaluationInterval() error {
-	if u.ThanosRuler == nil || u.ThanosRuler.EvaluationInterval == "" {
-		return nil
-	}
-
-	evaluationInterval, err := model.ParseDuration(u.ThanosRuler.EvaluationInterval)
-
-	if err != nil {
-		return fmt.Errorf("invalid evaluation interval value: %w", err)
-	}
-
-	allowedLowerLimit, allowedUpperLimit := evaluationIntervalLimits()
-
-	if (evaluationInterval < allowedLowerLimit) || (evaluationInterval > allowedUpperLimit) {
-		return fmt.Errorf("Thanos Ruler evaluation interval value %q outside of the allowed range [%q, %q]", u.ThanosRuler.EvaluationInterval, allowedLowerLimit, allowedUpperLimit)
-	}
-	return nil
-}
-
-func (u *UserWorkloadConfiguration) check() error {
+func (u *UserWorkloadConfiguration) validate() error {
 	if u == nil {
 		return nil
 	}
 
-	if err := u.checkScrapeInterval(); err != nil {
-		return err
+	if err := checkIntervalValue(u.Prometheus.ScrapeInterval); err != nil {
+		return fmt.Errorf("prometheus: scrape interval: %w", err)
 	}
 
-	if err := u.checkPrometheusEvaluationInterval(); err != nil {
-		return err
+	if err := checkIntervalValue(u.Prometheus.EvaluationInterval); err != nil {
+		return fmt.Errorf("prometheus: evaluation interval: %w", err)
 	}
 
-	if err := u.checkThanosRulerEvaluationInterval(); err != nil {
-		return err
+	if err := checkIntervalValue(u.ThanosRuler.EvaluationInterval); err != nil {
+		return fmt.Errorf("thanos ruler: evaluation interval: %w", err)
+	}
+
+	if err := validateQueryLogFile(u.Prometheus.QueryLogFile); err != nil {
+		return fmt.Errorf("prometheus: %w", err)
 	}
 
 	return nil
@@ -262,10 +229,10 @@ func (a AlertmanagerMainConfig) IsEnabled() bool {
 
 // Audit profile configurations
 type Audit struct {
-
-	// The Profile to set for audit logs. This currently matches the various
-	// audit log levels such as: "metadata, request, requestresponse, none".
-	// The default audit log level is "metadata"
+	// The Profile to set for audit logs. Supported values are
+	// "Metadata", "Request", "RequestResponse" or "None".
+	//
+	// The default audit log level is "Metadata".
 	//
 	// see: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy
 	// for more information about auditing and log levels.
@@ -352,12 +319,13 @@ func NewConfigFromStringAndClusterMonitoringResource(content string, cmr *config
 			},
 		},
 	}
+
 	err := UnmarshalStrict([]byte(content), &cmc)
 	if err != nil {
 		return nil, err
 	}
 
-	c := Config{
+	c := &Config{
 		ClusterMonitoringConfiguration: &cmc,
 		UserWorkloadConfiguration:      NewDefaultUserWorkloadMonitoringConfig(),
 	}
@@ -365,10 +333,16 @@ func NewConfigFromStringAndClusterMonitoringResource(content string, cmr *config
 
 	c.applyDefaults()
 
-	// Validate the configured collection profile.
+	if err := c.validate(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrConfigValidation, err)
+	}
+
+	return c, nil
+}
+
+func (c *Config) validate() error {
 	if !slices.Contains(SupportedCollectionProfiles, c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile) {
-		return nil, fmt.Errorf("%w: %q is not supported, supported collection profiles are [%s]",
-			ErrConfigValidation,
+		return fmt.Errorf("%q is not supported, supported collection profiles are [%s]",
 			c.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile,
 			strings.Join(SupportedCollectionProfiles.StringSlice(), ", "),
 		)
@@ -376,10 +350,52 @@ func NewConfigFromStringAndClusterMonitoringResource(content string, cmr *config
 
 	// Validate additional resource labels for KSM.
 	if err := validateAdditionalResourceLabels(c.ClusterMonitoringConfiguration.KubeStateMetricsConfig); err != nil {
-		return nil, err
+		return fmt.Errorf("kube-state-metrics: %w", err)
 	}
 
-	return &c, nil
+	// Refer to https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy
+	// for the valid log levels.
+	switch profile := c.ClusterMonitoringConfiguration.MetricsServerConfig.Audit.Profile; profile {
+	case auditv1.LevelNone,
+		auditv1.LevelMetadata,
+		auditv1.LevelRequest,
+		auditv1.LevelRequestResponse:
+	default:
+		return fmt.Errorf("metrics server: audit profile %q not supported", profile)
+	}
+
+	if err := validateQueryLogFile(c.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile); err != nil {
+		return fmt.Errorf("prometheus: %w", err)
+	}
+
+	return nil
+}
+
+// validateQueryLogFile validates the path of the Prometheus query log file.
+//
+// If not empty, the path should meet the following criteria:
+// - the path is either an absolute path or a simple filename (in which case, the directory is ".").
+// - the directory isn't the root directory.
+// - if the directory is /dev, the path can only be /dev/stdout, /dev/stderr or /dev/null.
+func validateQueryLogFile(path string) error {
+	if path == "" {
+		return nil
+	}
+
+	dirPath := filepath.Dir(path)
+	if !filepath.IsAbs(path) && dirPath != "." {
+		return errors.New("relative paths to query log file are not supported")
+	}
+
+	if dirPath == "/" {
+		return errors.New("query log file can't be stored on the root directory")
+	}
+
+	if dirPath == "/dev" && path != "/dev/stdout" && path != "/dev/stderr" && path != "/dev/null" {
+		return errors.New("query log file can't be stored on a new file on the dev directory")
+	}
+
+	return nil
 }
 
 var supportedResourceLabelsResources = []string{"jobs", "cronjobs"}
@@ -703,12 +719,15 @@ func (u *UserWorkloadConfiguration) applyDefaults() {
 	if u.PrometheusOperator == nil {
 		u.PrometheusOperator = &PrometheusOperatorConfig{}
 	}
+
 	if u.Prometheus == nil {
 		u.Prometheus = &PrometheusRestrictedConfig{}
 	}
+
 	if u.ThanosRuler == nil {
 		u.ThanosRuler = &ThanosRulerConfig{}
 	}
+
 	// If the user configured a retention for user-workload Prometheus but did not
 	// explicitly set a retention for Thanos Ruler, default Thanos Ruler retention
 	// to the same value as Prometheus. This keeps the effective retention aligned
@@ -716,6 +735,7 @@ func (u *UserWorkloadConfiguration) applyDefaults() {
 	if u.ThanosRuler.Retention == "" && u.Prometheus != nil && u.Prometheus.Retention != "" {
 		u.ThanosRuler.Retention = u.Prometheus.Retention
 	}
+
 	if u.Alertmanager == nil {
 		u.Alertmanager = &AlertmanagerUserWorkloadConfig{}
 	}
@@ -723,7 +743,8 @@ func (u *UserWorkloadConfiguration) applyDefaults() {
 
 func NewUserConfigFromString(content string) (*UserWorkloadConfiguration, error) {
 	if content == "" {
-		return NewDefaultUserWorkloadMonitoringConfig(), nil
+		// Consider an empty string to be equivalent to an empty map.
+		content = "{}"
 	}
 
 	u := &UserWorkloadConfiguration{}
@@ -734,8 +755,8 @@ func NewUserConfigFromString(content string) (*UserWorkloadConfiguration, error)
 
 	u.applyDefaults()
 
-	if err := u.check(); err != nil {
-		return nil, err
+	if err := u.validate(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrConfigValidation, err)
 	}
 
 	return u, nil
@@ -743,22 +764,25 @@ func NewUserConfigFromString(content string) (*UserWorkloadConfiguration, error)
 
 func NewUserWorkloadConfigFromConfigMap(c *v1.ConfigMap) (*UserWorkloadConfiguration, error) {
 	configContent, found := c.Data[configKey]
-
 	if !found {
 		klog.Warningf("the user workload monitoring configmap does not contain the %q key", configKey)
-		return NewDefaultUserWorkloadMonitoringConfig(), nil
 	}
 
 	uwc, err := NewUserConfigFromString(configContent)
 	if err != nil {
 		return nil, fmt.Errorf("the user workload monitoring configuration in %q could not be parsed: %w", configKey, err)
 	}
+
 	return uwc, nil
 }
 
 func NewDefaultUserWorkloadMonitoringConfig() *UserWorkloadConfiguration {
-	u := &UserWorkloadConfiguration{}
-	u.applyDefaults()
+	u, err := NewUserConfigFromString("{}")
+	if err != nil {
+		// Should never happen.
+		panic(err)
+	}
+
 	return u
 }
 

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -606,6 +606,7 @@ func TestScrapeIntervalUWM(t *testing.T) {
 			_, err := NewUserConfigFromString(tc.uwmconfig)
 			if tc.expectedError {
 				require.Error(t, err)
+				require.True(t, errors.Is(err, ErrConfigValidation))
 				return
 			}
 			require.NoError(t, err)
@@ -699,6 +700,7 @@ func TestEvaluationIntervalUWM(t *testing.T) {
 			_, err := NewUserConfigFromString(tc.uwmconfig)
 			if tc.expectedError {
 				require.Error(t, err)
+				require.True(t, errors.Is(err, ErrConfigValidation))
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -48,7 +48,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/utils/ptr"
 	k8syaml "sigs.k8s.io/yaml"
@@ -1444,13 +1443,9 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, telemetrySecret *v1.Secret) 
 		}
 	}
 
-	if err := f.setupQueryLogFile(p, f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile); err != nil {
-		return nil, err
-	}
+	f.setupQueryLogFile(p, f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile)
 
-	if err := setupProfilesToIgnore(p, f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile); err != nil {
-		return nil, err
-	}
+	setupProfilesToIgnore(p, f.config.ClusterMonitoringConfiguration.PrometheusK8sConfig.CollectionProfile)
 
 	clusterID := f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.ClusterID
 	if f.config.ClusterMonitoringConfiguration.TelemeterClientConfig.IsEnabled() && f.config.RemoteWrite {
@@ -1607,36 +1602,26 @@ func setupAlerting(p *monv1.Prometheus, svcName, svcNamespace string, enabled bo
 	p.Spec.Alerting.Alertmanagers = []monv1.AlertmanagerEndpoints{eps}
 }
 
-func (f *Factory) setupQueryLogFile(p *monv1.Prometheus, queryLogFile string) error {
+func (f *Factory) setupQueryLogFile(p *monv1.Prometheus, queryLogFile string) {
 	if queryLogFile == "" {
-		return nil
+		return
 	}
+
+	p.Spec.QueryLogFile = queryLogFile
 	dirPath := filepath.Dir(queryLogFile)
-	// queryLogFile is not an absolute path nor a simple filename
-	if !filepath.IsAbs(queryLogFile) && dirPath != "." {
-		return fmt.Errorf(`relative paths to query log file are not supported: %w`, ErrConfigValidation)
-	}
-	if dirPath == "/" {
-		return fmt.Errorf(`query log file can't be stored on the root directory: %w`, ErrConfigValidation)
-	}
 
 	// /prometheus is where Prometheus will store the TSDB, so it is
 	// already mounted inside the pod (either from a persistent volume claim or from an empty dir).
 	// When queryLogFile is a simple filename the prometheus-operator will take
 	// care of mounting an emptyDir under /var/log/prometheus
-	p.Spec.QueryLogFile = queryLogFile
 	if dirPath == "/prometheus" || dirPath == "." {
-		return nil
+		return
 	}
 
 	// It is not necesssary to mount a volume if the user configured
 	// the query log file to be one of the preexisting linux output streams.
 	if dirPath == "/dev" {
-		base := filepath.Base(p.Spec.QueryLogFile)
-		if base != "stdout" && base != "stderr" && base != "null" {
-			return fmt.Errorf(`query log file can't be stored on a new file on the dev directory: %w`, ErrConfigValidation)
-		}
-		return nil
+		return
 	}
 
 	p.Spec.Volumes = append(
@@ -1654,13 +1639,12 @@ func (f *Factory) setupQueryLogFile(p *monv1.Prometheus, queryLogFile string) er
 			Name:      "query-log",
 			MountPath: dirPath,
 		})
-	return nil
 }
 
 // setupProfilesToIgnore configures the label selectors of the Prometheus ("p")
 // to select any ServiceMonitor's or PodMonitor's that doesn't have the scrape
 // profile label or that matches the CollectionProfile ("cp").
-func setupProfilesToIgnore(p *monv1.Prometheus, cp CollectionProfile) error {
+func setupProfilesToIgnore(p *monv1.Prometheus, cp CollectionProfile) {
 	// Our goal is to configure Prometheus to select both the resources that
 	// either don't have the collection profile label or have the desired value.
 	// However, with label selectors we are not able to express OR conditions.
@@ -1688,8 +1672,6 @@ func setupProfilesToIgnore(p *monv1.Prometheus, cp CollectionProfile) error {
 	p.Spec.ServiceMonitorSelector = labelSelector
 	p.Spec.PodMonitorSelector = labelSelector
 	p.Spec.ProbeSelector = labelSelector
-
-	return nil
 }
 
 func (f *Factory) setupPrometheusRemoteWriteProxy(p *monv1.Prometheus) {
@@ -1852,9 +1834,7 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		p.Spec.Thanos.Image = &f.config.Images.Thanos
 	}
 
-	if err := f.setupQueryLogFile(p, f.config.UserWorkloadConfiguration.Prometheus.QueryLogFile); err != nil {
-		return nil, err
-	}
+	f.setupQueryLogFile(p, f.config.UserWorkloadConfiguration.Prometheus.QueryLogFile)
 
 	// Configure the TLS settings for the Thanos gRPC server.
 	grpcTLSVersion, err := convertTLSVersionToMonitoringV1(f.APIServerConfig.MinTLSVersion())
@@ -1939,22 +1919,6 @@ func (f *Factory) PrometheusK8sPrometheusServiceMonitor() (*monv1.ServiceMonitor
 
 func (f *Factory) PrometheusUserWorkloadPrometheusServiceMonitor() (*monv1.ServiceMonitor, error) {
 	return f.NewServiceMonitor(f.assets.MustNewAssetSlice(PrometheusUserWorkloadPrometheusServiceMonitor))
-}
-
-func validateAuditProfile(profile auditv1.Level) error {
-	// Refer: audit rules: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy
-	// for valid log levels
-
-	switch profile {
-	case auditv1.LevelNone,
-		auditv1.LevelMetadata,
-		auditv1.LevelRequest,
-		auditv1.LevelRequestResponse:
-		return nil
-	default:
-		// a wrong profile name is a Config validation Error
-		return fmt.Errorf("%w - adapter audit profile: %s", ErrConfigValidation, profile)
-	}
 }
 
 func (f *Factory) MetricsServerConfigMapAuditPolicy() (*v1.ConfigMap, error) {
@@ -2065,10 +2029,6 @@ func (f *Factory) MetricsServerDeployment(apiAuthSecretName string, kubeletCABun
 			MountPath: "/etc/client-ca-bundle",
 		},
 	)
-
-	if err := validateAuditProfile(config.Audit.Profile); err != nil {
-		return nil, err
-	}
 
 	profile := strings.ToLower(string(config.Audit.Profile))
 	containers[idx].Args = append(containers[idx].Args,

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1562,10 +1562,8 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
   - url: "https://test.remotewrite.com/api/write"
   queryLogFile: /tmp/test
 `)
+	require.NoError(t, err)
 
-	if err != nil {
-		t.Fatal(err)
-	}
 	c.SetImages(map[string]string{
 		"prometheus":       "docker.io/openshift/origin-prometheus:latest",
 		"kube-rbac-proxy":  "docker.io/openshift/origin-kube-rbac-proxy:latest",
@@ -1825,22 +1823,24 @@ func TestPrometheusQueryLogFileConfig(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := mustDefaultConfig()
-			c.ClusterMonitoringConfiguration.PrometheusK8sConfig.QueryLogFile = tc.queryLogFilePath
+			c, err := NewConfigFromString(
+				fmt.Sprintf(`prometheusK8s:
+    queryLogFile: %s`, tc.queryLogFilePath),
+			)
+
+			if tc.errExpected {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, ErrConfigValidation))
+				return
+			}
+			require.NoError(t, err)
+
 			f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
 			p, err := f.PrometheusK8s(
 				&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 				nil,
 			)
-			if err != nil {
-				if !tc.errExpected {
-					t.Fatalf("Expecting no error but got %v", err)
-				}
-				return
-			}
-			if tc.errExpected {
-				t.Fatalf("Expected query log file %s to give an error, but err is nil", tc.queryLogFilePath)
-			}
+			require.NoError(t, err)
 
 			if p.Spec.QueryLogFile != tc.expected {
 				t.Fatal("Prometheus query log is not configured correctly")
@@ -2932,9 +2932,9 @@ metricsServer:
 	for _, test := range tt {
 		t.Run(test.scenario, func(t *testing.T) {
 			c, err := NewConfigFromString(test.config)
-			if err != nil {
-				t.Logf("%s\n\n", test.config)
-				t.Fatal(err)
+			if test.err != nil {
+				require.True(t, errors.Is(err, ErrConfigValidation))
+				return
 			}
 			// When ConfigMap does not set metricsServer, the operator sets a default before building manifests.
 			// Simulate that for tests that expect default audit (metadata profile).
@@ -2984,18 +2984,11 @@ metricsServer:
 				"requestheader-username-headers":     "",
 			}
 			d, err := f.MetricsServerDeployment("foo", kubeletCABundle, servingCASecret, metricsClientSecret, apiAuthConfigMapData)
+			require.NoError(t, err)
 
-			if test.err != nil || err != nil {
-				// fail only if the error isn't what is expected
-				if !errors.Is(err, test.err) {
-					t.Fatalf("Expected error %q but got %q", test.err, err)
-				}
-				return
-			}
-
-			adapterArgs := d.Spec.Template.Spec.Containers[0].Args
+			args := d.Spec.Template.Spec.Containers[0].Args
 			auditArgs := []string{}
-			for _, arg := range adapterArgs {
+			for _, arg := range args {
 				if strings.HasPrefix(arg, "--audit-") {
 					auditArgs = append(auditArgs, arg)
 				}

--- a/test/monitoring/monitoring.go
+++ b/test/monitoring/monitoring.go
@@ -3078,10 +3078,9 @@ var _ = g.Describe("[sig-monitoring] Cluster_Observability parallel monitoring",
 		checkYamlconfig(oc, "openshift-monitoring", "deploy", "metrics-server", cmd, `"--audit-policy-file=/etc/audit/metadata-profile.yaml"`, true)
 
 		exutil.By("set invalid value for audit profile")
-		createResourceFromYaml(oc, "openshift-monitoring", invalid_value_audit_profile)
-
-		exutil.By("check failed log in CMO")
-		checkLogWithLabel(oc, "openshift-monitoring", "app.kubernetes.io/name=cluster-monitoring-operator", "cluster-monitoring-operator", `adapter audit profile: metadata`, true)
+		output, err := oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", invalid_value_audit_profile, "-n", "openshift-monitoring").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(output).To(o.ContainSubstring(`audit profile "metadata" not supported`))
 	})
 
 	// author: tagao@redhat.com


### PR DESCRIPTION
This commit moves some of the validations that were performed when reconciling the resources to the loading of the configuration files.