### PR TITLE
MON-4485: Use EndpointSlices SD for KSM

### DIFF
--- a/assets/kube-state-metrics/minimal-service-monitor.yaml
+++ b/assets/kube-state-metrics/minimal-service-monitor.yaml
@@ -51,3 +51,4 @@ spec:
       app.kubernetes.io/component: exporter
       app.kubernetes.io/name: kube-state-metrics
       app.kubernetes.io/part-of: openshift-monitoring
+  serviceDiscoveryRole: EndpointSlice

--- a/assets/kube-state-metrics/service-monitor.yaml
+++ b/assets/kube-state-metrics/service-monitor.yaml
@@ -42,3 +42,4 @@ spec:
       app.kubernetes.io/component: exporter
       app.kubernetes.io/name: kube-state-metrics
       app.kubernetes.io/part-of: openshift-monitoring
+  serviceDiscoveryRole: EndpointSlice

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -72,6 +72,7 @@ function(params)
         },
       },
       spec+: {
+        serviceDiscoveryRole: 'EndpointSlice',
         endpoints: [
           {
             honorLabels: true,


### PR DESCRIPTION
This is rebased over (and blocked by) [1] to pull in telemetry monitors. Please view the latest commit for changes specific to this PR. I'll rebase the changes here once more once [1] is in (if the set of commits pulled in from that change).

[1]:https://github.com/openshift/cluster-monitoring-operator/pull/2814