### PR TITLE
MON-4486: Use EndpointSlices SD for OSM

### DIFF
--- a/assets/openshift-state-metrics/minimal-service-monitor.yaml
+++ b/assets/openshift-state-metrics/minimal-service-monitor.yaml
@@ -34,3 +34,4 @@ spec:
   selector:
     matchLabels:
       k8s-app: openshift-state-metrics
+  serviceDiscoveryRole: EndpointSlice

--- a/assets/openshift-state-metrics/service-monitor.yaml
+++ b/assets/openshift-state-metrics/service-monitor.yaml
@@ -34,3 +34,4 @@ spec:
   selector:
     matchLabels:
       k8s-app: openshift-state-metrics
+  serviceDiscoveryRole: EndpointSlice

--- a/jsonnet/components/openshift-state-metrics.libsonnet
+++ b/jsonnet/components/openshift-state-metrics.libsonnet
@@ -103,6 +103,9 @@ function(params) {
         'monitoring.openshift.io/collection-profile': 'full',
       },
     },
+    spec+: {
+      serviceDiscoveryRole: 'EndpointSlice',
+    },
   },
   minimalServiceMonitor: generateServiceMonitor.serviceMonitorForMinimalProfile(self.serviceMonitor),
   networkPolicyDownstream: {


### PR DESCRIPTION
This is rebased over (and blocked by) [1] to pull in telemetry monitors. Please view the latest commit for changes specific to this PR. I'll rebase the changes here once more once [1] is in (if the set of commits pulled in from that change).

[1]:https://github.com/openshift/cluster-monitoring-operator/pull/2814