### PR TITLE
OCPBUGS-84215: Fix alertmanager SCC race condition during deployment

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -44,6 +44,7 @@ import (
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -1846,6 +1847,44 @@ func mergeMetadata(required *metav1.ObjectMeta, existing metav1.ObjectMeta) {
 
 	_ = mergo.Merge(&required.Annotations, existing.Annotations)
 	_ = mergo.Merge(&required.Labels, existing.Labels)
+}
+
+// WaitForSCCAccess waits for the specified serviceaccount to have access to use the specified SCC.
+// This prevents race conditions where workloads are created before RBAC propagates.
+func (c *Client) WaitForSCCAccess(ctx context.Context, serviceAccountName, namespace, sccName string) error {
+	var lastErr error
+	if err := Poll(ctx, func(ctx context.Context) (bool, error) {
+		sar := &authorizationv1.SubjectAccessReview{
+			Spec: authorizationv1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Namespace: namespace,
+					Verb:      "use",
+					Group:     "security.openshift.io",
+					Resource:  "securitycontextconstraints",
+					Name:      sccName,
+				},
+				User: fmt.Sprintf("system:serviceaccount:%s:%s", namespace, serviceAccountName),
+			},
+		}
+
+		result, err := c.kclient.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to create SubjectAccessReview: %w", err)
+			return false, nil
+		}
+
+		if !result.Status.Allowed {
+			lastErr = fmt.Errorf("serviceaccount %s/%s not yet allowed to use SCC %s: %s", namespace, serviceAccountName, sccName, result.Status.Reason)
+			return false, nil
+		}
+
+		klog.V(4).Infof("ServiceAccount %s/%s successfully granted access to SCC %s", namespace, serviceAccountName, sccName)
+		return true, nil
+	}, WithPollTimeout(2*time.Minute), WithLastError(&lastErr)); err != nil {
+		return fmt.Errorf("timeout waiting for serviceaccount %s/%s to get access to SCC %s: %w", namespace, serviceAccountName, sccName, err)
+	}
+
+	return nil
 }
 
 type jsonPatch struct {

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -168,6 +168,15 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return fmt.Errorf("reconciling Alertmanager ServiceAccount failed: %w", err)
 	}
 
+	// Wait for the alertmanager-main serviceaccount to have access to the nonroot SCC.
+	// This prevents race conditions where the StatefulSet tries to create pods before
+	// RBAC propagates to the kube-apiserver's authorizer cache.
+	klog.V(3).Info("Waiting for alertmanager-main serviceaccount to get access to nonroot SCC")
+	err = t.client.WaitForSCCAccess(ctx, "alertmanager-main", t.client.Namespace(), "nonroot")
+	if err != nil {
+		return fmt.Errorf("waiting for alertmanager serviceaccount SCC access failed: %w", err)
+	}
+
 	ps, err := t.factory.AlertmanagerRBACProxyWebSecret()
 	if err != nil {
 		return fmt.Errorf("initializing Alertmanager proxy web Secret failed: %w", err)


### PR DESCRIPTION
HI Team, 

PTAL on this PR. 

Add WaitForSCCAccess to prevent race condition where alertmanager-main StatefulSet creates pods before RBAC propagates to kube-apiserver.

Problem:
The cluster-monitoring-operator creates ClusterRole, ClusterRoleBinding, and ServiceAccount for alertmanager, then immediately creates the Alertmanager StatefulSet. The StatefulSet attempts to create pods before the kube-apiserver's RBAC authorizer cache has propagated the SCC access, resulting in pod creation failures with "unable to validate against any security context constraint: provider 'nonroot': Forbidden".

This causes the test "[sig-auth][Feature:SCC][Early] should not have pod creation failures during install" to fail when the SCC denials exceed the 5-second threshold (typically seeing 11 occurrences).

Solution:
- Add WaitForSCCAccess() method to pkg/client/client.go that uses SubjectAccessReview to verify the serviceaccount can "use" the SCC
- Call WaitForSCCAccess immediately after ServiceAccount creation and before creating any other resources
- Poll every 1 second with 2-minute timeout for RBAC to propagate
- Fail fast if RBAC doesn't propagate, avoiding creation of other resources

Changes:
- pkg/client/client.go: Add WaitForSCCAccess method with SubjectAccessReview
- pkg/tasks/alertmanager.go: Wait for alertmanager-main SA to get nonroot SCC access

This follows the same pattern used to fix OCPBUGS-77899 for the operator-controller-controller-manager component.
Failure logs: 
```
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31002-nightly-4.22-e2e-metal-ovn-two-node-fencing-serial-3of3/2047152852652003328
```