### PR TITLE
MON-4563: use AlwaysAllow UnhealthyPodEvictionPolicy option in PDBs

### DIFF
--- a/assets/admission-webhook/pod-disruption-budget.yaml
+++ b/assets/admission-webhook/pod-disruption-budget.yaml
@@ -14,3 +14,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: prometheus-operator-admission-webhook
       app.kubernetes.io/part-of: openshift-monitoring
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/alertmanager-user-workload/pod-disruption-budget.yaml
+++ b/assets/alertmanager-user-workload/pod-disruption-budget.yaml
@@ -18,3 +18,4 @@ spec:
       app.kubernetes.io/instance: user-workload
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: openshift-monitoring
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/alertmanager/pod-disruption-budget.yaml
+++ b/assets/alertmanager/pod-disruption-budget.yaml
@@ -18,3 +18,4 @@ spec:
       app.kubernetes.io/instance: main
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: openshift-monitoring
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/metrics-server/pod-disruption-budget.yaml
+++ b/assets/metrics-server/pod-disruption-budget.yaml
@@ -15,3 +15,4 @@ spec:
       app.kubernetes.io/component: metrics-server
       app.kubernetes.io/name: metrics-server
       app.kubernetes.io/part-of: openshift-monitoring
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/monitoring-plugin/pod-disruption-budget.yaml
+++ b/assets/monitoring-plugin/pod-disruption-budget.yaml
@@ -16,3 +16,4 @@ spec:
       app.kubernetes.io/managed-by: cluster-monitoring-operator
       app.kubernetes.io/name: monitoring-plugin
       app.kubernetes.io/part-of: openshift-monitoring
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/prometheus-k8s/pod-disruption-budget.yaml
+++ b/assets/prometheus-k8s/pod-disruption-budget.yaml
@@ -18,3 +18,4 @@ spec:
       app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/prometheus-user-workload/pod-disruption-budget.yaml
+++ b/assets/prometheus-user-workload/pod-disruption-budget.yaml
@@ -18,3 +18,4 @@ spec:
       app.kubernetes.io/instance: user-workload
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: openshift-monitoring
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/thanos-querier/pod-disruption-budget.yaml
+++ b/assets/thanos-querier/pod-disruption-budget.yaml
@@ -18,3 +18,4 @@ spec:
       app.kubernetes.io/instance: thanos-querier
       app.kubernetes.io/name: thanos-query
       app.kubernetes.io/part-of: openshift-monitoring
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/assets/thanos-ruler/pod-disruption-budget.yaml
+++ b/assets/thanos-ruler/pod-disruption-budget.yaml
@@ -13,3 +13,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: thanos-ruler
       thanos-ruler: user-workload
+  unhealthyPodEvictionPolicy: AlwaysAllow

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -6,6 +6,7 @@ local removeImageLocations = (import './utils/remove-images.libsonnet').removeIm
 local removeNetworkPolicy = (import './utils/remove-network-policy.libsonnet').removeNetworkPolicy;
 local configureAuthenticationForMonitors = (import './utils/configure-authentication-for-monitors.libsonnet').configureAuthenticationForMonitors;
 local setTerminationMessagePolicy = (import './utils/set-terminationMessagePolicy.libsonnet').setTerminationMessagePolicy;
+local setUnhealthyPodEvictionPolicy = (import './utils/set-unhealthyPodEvictionPolicy.libsonnet').setUnhealthyPodEvictionPolicy;
 
 local alertmanager = import './components/alertmanager.libsonnet';
 local alertmanagerUserWorkload = import './components/alertmanager-user-workload.libsonnet';
@@ -495,42 +496,44 @@ local userWorkload =
   {};  // Including empty object to simplify adding and removing imports during development
 
 // Manifestation
-setTerminationMessagePolicy(
-  addLabels(
-    commonConfig.commonLabels,
-    addAnnotations(
-      sanitizeAlertRules(
-        removeImageLocations(
-          removeLimits(
-            removeNetworkPolicy(
-              // Enforce mTLS authentication + disable usage of bearer token for all service/pod monitors.
-              // See https://issues.redhat.com/browse/OCPBUGS-4184 for details.
-              configureAuthenticationForMonitors(
-                { ['alertmanager/' + name]: inCluster.alertmanager[name] for name in std.objectFields(inCluster.alertmanager) } +
-                { ['alertmanager-user-workload/' + name]: userWorkload.alertmanager[name] for name in std.objectFields(userWorkload.alertmanager) } +
-                { ['cluster-monitoring-operator/' + name]: inCluster.clusterMonitoringOperator[name] for name in std.objectFields(inCluster.clusterMonitoringOperator) } +
-                { ['kube-state-metrics/' + name]: inCluster.kubeStateMetrics[name] for name in std.objectFields(inCluster.kubeStateMetrics) } +
-                { ['node-exporter/' + name]: inCluster.nodeExporter[name] for name in std.objectFields(inCluster.nodeExporter) } +
-                { ['openshift-state-metrics/' + name]: inCluster.openshiftStateMetrics[name] for name in std.objectFields(inCluster.openshiftStateMetrics) } +
-                { ['prometheus-k8s/' + name]: inCluster.prometheus[name] for name in std.objectFields(inCluster.prometheus) } +
-                { ['admission-webhook/' + name]: inCluster.admissionWebhook[name] for name in std.objectFields(inCluster.admissionWebhook) } +
-                { ['prometheus-operator/' + name]: inCluster.prometheusOperator[name] for name in std.objectFields(inCluster.prometheusOperator) } +
-                { ['prometheus-operator-user-workload/' + name]: userWorkload.prometheusOperator[name] for name in std.objectFields(userWorkload.prometheusOperator) } +
-                { ['prometheus-user-workload/' + name]: userWorkload.prometheus[name] for name in std.objectFields(userWorkload.prometheus) } +
-                { ['metrics-server/' + name]: inCluster.metricsServer[name] for name in std.objectFields(inCluster.metricsServer) } +
-                // needs to be removed once remote-write is allowed for sending telemetry
-                { ['telemeter-client/' + name]: inCluster.telemeterClient[name] for name in std.objectFields(inCluster.telemeterClient) } +
-                { ['monitoring-plugin/' + name]: inCluster.monitoringPlugin[name] for name in std.objectFields(inCluster.monitoringPlugin) } +
-                { ['thanos-querier/' + name]: inCluster.thanosQuerier[name] for name in std.objectFields(inCluster.thanosQuerier) } +
-                { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
-                { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
-                { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } +
-                {}
+setUnhealthyPodEvictionPolicy(
+  setTerminationMessagePolicy(
+    addLabels(
+      commonConfig.commonLabels,
+      addAnnotations(
+        sanitizeAlertRules(
+          removeImageLocations(
+            removeLimits(
+              removeNetworkPolicy(
+                // Enforce mTLS authentication + disable usage of bearer token for all service/pod monitors.
+                // See https://issues.redhat.com/browse/OCPBUGS-4184 for details.
+                configureAuthenticationForMonitors(
+                  { ['alertmanager/' + name]: inCluster.alertmanager[name] for name in std.objectFields(inCluster.alertmanager) } +
+                  { ['alertmanager-user-workload/' + name]: userWorkload.alertmanager[name] for name in std.objectFields(userWorkload.alertmanager) } +
+                  { ['cluster-monitoring-operator/' + name]: inCluster.clusterMonitoringOperator[name] for name in std.objectFields(inCluster.clusterMonitoringOperator) } +
+                  { ['kube-state-metrics/' + name]: inCluster.kubeStateMetrics[name] for name in std.objectFields(inCluster.kubeStateMetrics) } +
+                  { ['node-exporter/' + name]: inCluster.nodeExporter[name] for name in std.objectFields(inCluster.nodeExporter) } +
+                  { ['openshift-state-metrics/' + name]: inCluster.openshiftStateMetrics[name] for name in std.objectFields(inCluster.openshiftStateMetrics) } +
+                  { ['prometheus-k8s/' + name]: inCluster.prometheus[name] for name in std.objectFields(inCluster.prometheus) } +
+                  { ['admission-webhook/' + name]: inCluster.admissionWebhook[name] for name in std.objectFields(inCluster.admissionWebhook) } +
+                  { ['prometheus-operator/' + name]: inCluster.prometheusOperator[name] for name in std.objectFields(inCluster.prometheusOperator) } +
+                  { ['prometheus-operator-user-workload/' + name]: userWorkload.prometheusOperator[name] for name in std.objectFields(userWorkload.prometheusOperator) } +
+                  { ['prometheus-user-workload/' + name]: userWorkload.prometheus[name] for name in std.objectFields(userWorkload.prometheus) } +
+                  { ['metrics-server/' + name]: inCluster.metricsServer[name] for name in std.objectFields(inCluster.metricsServer) } +
+                  // needs to be removed once remote-write is allowed for sending telemetry
+                  { ['telemeter-client/' + name]: inCluster.telemeterClient[name] for name in std.objectFields(inCluster.telemeterClient) } +
+                  { ['monitoring-plugin/' + name]: inCluster.monitoringPlugin[name] for name in std.objectFields(inCluster.monitoringPlugin) } +
+                  { ['thanos-querier/' + name]: inCluster.thanosQuerier[name] for name in std.objectFields(inCluster.thanosQuerier) } +
+                  { ['thanos-ruler/' + name]: inCluster.thanosRuler[name] for name in std.objectFields(inCluster.thanosRuler) } +
+                  { ['control-plane/' + name]: inCluster.controlPlane[name] for name in std.objectFields(inCluster.controlPlane) } +
+                  { ['manifests/' + name]: inCluster.manifests[name] for name in std.objectFields(inCluster.manifests) } +
+                  {}
+                )
               )
             )
           )
         )
       )
-    )
-  ),
+    ),
+  )
 )

--- a/jsonnet/utils/set-unhealthyPodEvictionPolicy.libsonnet
+++ b/jsonnet/utils/set-unhealthyPodEvictionPolicy.libsonnet
@@ -2,7 +2,7 @@
   setUnhealthyPodEvictionPolicy(o): o {
     local addUnhealthyPodEvictionPolicy(o) = o {
       [if std.setMember(o.kind, std.set(['PodDisruptionBudget'])) then 'spec']+: {
-        unhealthyPodEvictionPolicy: 'AlwaysAllow'
+        unhealthyPodEvictionPolicy: 'AlwaysAllow',
       },
     },
     [k]: addUnhealthyPodEvictionPolicy(o[k])

--- a/jsonnet/utils/set-unhealthyPodEvictionPolicy.libsonnet
+++ b/jsonnet/utils/set-unhealthyPodEvictionPolicy.libsonnet
@@ -1,0 +1,11 @@
+{
+  setUnhealthyPodEvictionPolicy(o): o {
+    local addUnhealthyPodEvictionPolicy(o) = o {
+      [if std.setMember(o.kind, std.set(['PodDisruptionBudget'])) then 'spec']+: {
+        unhealthyPodEvictionPolicy: 'AlwaysAllow'
+      },
+    },
+    [k]: addUnhealthyPodEvictionPolicy(o[k])
+    for k in std.objectFields(o)
+  },
+}


### PR DESCRIPTION
Allow eviction of unhealthy (not ready) pods even if there are no disruptions
allowed on a PodDisruptionBudget. This can help to drain/maintain a node and
recover without a manual intervention when multiple instances of nodes or pods
are misbehaving.