### PR TITLE
MON-4520: follow up AlertManagerConfig and PrometheusOp PR changes

### DIFF
--- a/pkg/manifests/config_merge.go
+++ b/pkg/manifests/config_merge.go
@@ -208,8 +208,9 @@ func (c *Config) mergeAlertmanagerConfiguration(ac configv1alpha1.AlertmanagerCo
 	case configv1alpha1.AlertManagerDeployModeDisabled:
 		cfg.Enabled = ptr.To(false)
 	case configv1alpha1.AlertManagerDeployModeDefaultConfig:
-		// Deploy with platform defaults (Enabled is nil → true via IsEnabled).
+		cfg.Enabled = ptr.To(true)
 	case configv1alpha1.AlertManagerDeployModeCustomConfig:
+		cfg.Enabled = ptr.To(true)
 		mergeAlertmanagerCustomConfigFromCRD(cfg, ac.CustomConfig)
 	default:
 		return

--- a/test/e2e/cluster_monitoring_test.go
+++ b/test/e2e/cluster_monitoring_test.go
@@ -363,6 +363,156 @@ func TestClusterMonitorMetricsServerConfigMapAndCRD(t *testing.T) {
 	}
 }
 
+// TestClusterMonitoringPrometheusOperator tests PrometheusOperatorConfig via ClusterMonitoring CRD.
+func TestClusterMonitoringPrometheusOperator(t *testing.T) {
+	if !clusterMonitoringCRDAvailable {
+		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
+		return
+	}
+
+	baseCM := f.BuildCMOConfigMap(t, "{}")
+	f.MustCreateOrUpdateConfigMap(t, baseCM)
+	t.Cleanup(func() {
+		f.MustCreateOrUpdateConfigMap(t, baseCM)
+	})
+
+	t.Log("creating ClusterMonitoring resource with PrometheusOperatorConfig")
+	cm := &configv1alpha1.ClusterMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterMonitoringName,
+		},
+		Spec: configv1alpha1.ClusterMonitoringSpec{
+			PrometheusOperatorConfig: configv1alpha1.PrometheusOperatorConfig{
+				LogLevel: configv1alpha1.LogLevelDebug,
+				Resources: []configv1alpha1.ContainerResource{
+					{
+						Name:    "cpu",
+						Request: resource.MustParse("10m"),
+						Limit:   resource.MustParse("100m"),
+					},
+					{
+						Name:    "memory",
+						Request: resource.MustParse("100Mi"),
+						Limit:   resource.MustParse("200Mi"),
+					},
+				},
+				NodeSelector: map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+	}
+
+	f.MustCreateOrUpdateClusterMonitoring(t, cm)
+	t.Cleanup(func() {
+		cm.Spec.PrometheusOperatorConfig = configv1alpha1.PrometheusOperatorConfig{}
+		f.MustCreateOrUpdateClusterMonitoring(t, cm)
+	})
+
+	t.Logf("configured ClusterMonitoring resource: %s", cm.Name)
+
+	for _, test := range []scenario{
+		{
+			name:      "assert prometheus-operator deployment exists and rolled out",
+			assertion: f.AssertDeploymentExistsAndRolloutFunc("prometheus-operator", f.Ns),
+		},
+		{
+			name: "assert pod configuration is as expected",
+			assertion: f.AssertPodConfigurationFunc(
+				f.Ns,
+				"app.kubernetes.io/name=prometheus-operator,app.kubernetes.io/component=controller",
+				[]framework.PodAssertion{
+					expectContainerArg("--log-level=debug", "prometheus-operator"),
+					expectMatchingRequests("*", "prometheus-operator", "100Mi", "10m"),
+					expectMatchingLimits("*", "prometheus-operator", "200Mi", "100m"),
+					expectNodeSelector("kubernetes.io/os", "linux"),
+				},
+			),
+		},
+	} {
+		t.Run(test.name, test.assertion)
+	}
+}
+
+// TestClusterMonitorPrometheusOperatorConfigMapAndCRD verifies Phase 1 merge: when both ConfigMap and CR
+// specify prometheusOperator / prometheusOperatorConfig, the ConfigMap wins at the top level and CR values are ignored.
+func TestClusterMonitorPrometheusOperatorConfigMapAndCRD(t *testing.T) {
+	if !clusterMonitoringCRDAvailable {
+		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
+		return
+	}
+
+	t.Log("creating ConfigMap with baseline prometheusOperator configuration")
+	configMapData := `prometheusOperator:
+  nodeSelector:
+    test-precedence: "from-configmap"
+  resources:
+    requests:
+      cpu: "5m"
+      memory: "50Mi"
+`
+	cm := f.BuildCMOConfigMap(t, configMapData)
+	f.MustCreateOrUpdateConfigMap(t, cm)
+	t.Cleanup(func() {
+		f.MustDeleteConfigMap(t, cm)
+	})
+
+	t.Log("creating ClusterMonitoring CR with different prometheusOperator settings (must be ignored when ConfigMap defines prometheusOperator)")
+	crd := &configv1alpha1.ClusterMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterMonitoringName,
+		},
+		Spec: configv1alpha1.ClusterMonitoringSpec{
+			PrometheusOperatorConfig: configv1alpha1.PrometheusOperatorConfig{
+				LogLevel: configv1alpha1.LogLevelDebug,
+				NodeSelector: map[string]string{
+					"test-precedence": "from-crd",
+				},
+				Resources: []configv1alpha1.ContainerResource{
+					{
+						Name:    "cpu",
+						Request: resource.MustParse("10m"),
+						Limit:   resource.MustParse("100m"),
+					},
+					{
+						Name:    "memory",
+						Request: resource.MustParse("100Mi"),
+						Limit:   resource.MustParse("200Mi"),
+					},
+				},
+			},
+		},
+	}
+
+	f.MustCreateOrUpdateClusterMonitoring(t, crd)
+	t.Cleanup(func() {
+		crd.Spec.PrometheusOperatorConfig = configv1alpha1.PrometheusOperatorConfig{}
+		f.MustCreateOrUpdateClusterMonitoring(t, crd)
+	})
+
+	t.Logf("configured both ConfigMap and ClusterMonitoring CR for Phase 1 precedence (ConfigMap wins)")
+
+	for _, tc := range []scenario{
+		{
+			name:      "assert prometheus-operator deployment exists and rolled out",
+			assertion: f.AssertDeploymentExistsAndRolloutFunc("prometheus-operator", f.Ns),
+		},
+		{
+			name: "assert ConfigMap prometheusOperator is used; CR prometheusOperatorConfig is ignored",
+			assertion: f.AssertPodConfigurationFunc(
+				f.Ns,
+				"app.kubernetes.io/name=prometheus-operator,app.kubernetes.io/component=controller",
+				[]framework.PodAssertion{
+					expectMatchingRequests("*", "prometheus-operator", "50Mi", "5m"),
+					expectNodeSelector("test-precedence", "from-configmap"),
+				},
+			),
+		},
+	} {
+		t.Run(tc.name, tc.assertion)
+	}
+}
+
 // TestClusterMonitoringAlertmanager tests alertmanagerConfig via ClusterMonitoring CRD (CustomConfig).
 func TestClusterMonitoringAlertmanager(t *testing.T) {
 	if !clusterMonitoringCRDAvailable {


### PR DESCRIPTION
Changes:
- Set cfg.Enabled = ptr.To(true) explicitly for AlertManagerDeployModeDefaultConfig instead of relying on IsEnabled() treating nil as true.
- Add e2e tests for PrometheusOperator CRD configuration and Phase 1 ConfigMap-over-CRD precedence.

Made-with: Cursor