### PR TITLE
NO-ISSUE: chore(e2e): verify Prometheus Mantine UI is served on port 9090 and refactor ForwardPort helpers

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -85,7 +85,7 @@ func TestAlertmanagerTenancyAPI(t *testing.T) {
 
 			// The tenancy port (9092) is only exposed in-cluster, so we need to use
 			// port forwarding to access kube-rbac-proxy.
-			host, cleanUp, err := f.ForwardPort(t, tc.amNamespace, fmt.Sprintf("alertmanager-%s", tc.amName), 9092)
+			host, cleanUp, err := f.ForwardServicePort(t, tc.amNamespace, fmt.Sprintf("alertmanager-%s", tc.amName), 9092)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/e2e/alertmanager_user_workload_test.go
+++ b/test/e2e/alertmanager_user_workload_test.go
@@ -119,7 +119,7 @@ func assertUWMAlertsAccess(t *testing.T) {
 	err = framework.Poll(5*time.Second, time.Minute, func() error {
 		// The uwm alerts port (9095) is only exposed in-cluster, so we need to use
 		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardPort(t, f.UserWorkloadMonitoringNs, "alertmanager-user-workload", 9095)
+		host, cleanUp, err := f.ForwardServicePort(t, f.UserWorkloadMonitoringNs, "alertmanager-user-workload", 9095)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -790,7 +790,7 @@ func assertThanosRulerEvaluationInterval(evaluationInterval string) func(*testin
 // checkMonitorConsolePluginReachable makes sure that one of the pods at least can serve /plugin-manifest.json
 func checkMonitorConsolePluginReachable(t *testing.T, pluginName string) {
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
-		host, cleanUp, err := f.ForwardPort(t, f.Ns, pluginName, 9443)
+		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, pluginName, 9443)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -585,12 +585,28 @@ func (f *Framework) CreateRoleBindingFromRoleOtherNamespace(saNamespace, service
 	}, nil
 }
 
-func (f *Framework) ForwardPort(t *testing.T, ns, svc string, port int) (string, func(), error) {
+// ForwardServicePort sets up port forwarding to the given service and returns
+// the local host:port address, a cleanup function, and any error.
+func (f *Framework) ForwardServicePort(t *testing.T, ns, svc string, port int) (string, func(), error) {
+	t.Helper()
+	return f.forwardPort(t, ns, fmt.Sprintf("service/%s", svc), port)
+}
+
+// ForwardPodPort sets up port forwarding to the given pod and returns
+// the local host:port address, a cleanup function, and any error.
+func (f *Framework) ForwardPodPort(t *testing.T, ns, pod string, port int) (string, func(), error) {
+	t.Helper()
+	return f.forwardPort(t, ns, fmt.Sprintf("pod/%s", pod), port)
+}
+
+// forwardPort runs "oc port-forward" for the given target (e.g.
+// "service/name" or "pod/name") and returns the local address.
+func (f *Framework) forwardPort(t *testing.T, ns, target string, port int) (string, func(), error) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// Taken from github.com/openshift/origin/test/extended/etcd/etcd_test_runner.go
-	cmd := exec.CommandContext(ctx, "oc", "port-forward", fmt.Sprintf("service/%s", svc), fmt.Sprintf(":%d", port), "-n", ns, "--kubeconfig", f.KubeConfigPath)
+	cmd := exec.CommandContext(ctx, "oc", "port-forward", target, fmt.Sprintf(":%d", port), "-n", ns, "--kubeconfig", f.KubeConfigPath)
 
 	cleanUp := func() {
 		cancel()

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -17,16 +17,19 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	osConfigv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	_ "github.com/prometheus/prometheus/discovery/kubernetes" // required for promConfig.Load to parse kubernetes_sd_configs
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	osConfigv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 )
 
 func TestPrometheusMetrics(t *testing.T) {
@@ -386,4 +389,52 @@ func TestBodySizeLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestPrometheusWebUI verifies that the Prometheus Mantine web UI is reachable
+// via pod port-forwarding to port 9090. Even though it is not exposed through
+// the service, it is useful in some situations.
+func TestPrometheusWebUI(t *testing.T) {
+	t.Parallel()
+	host, cleanUp, err := f.ForwardPodPort(t, f.Ns, "prometheus-k8s-0", 9090)
+	require.NoError(t, err)
+	t.Cleanup(cleanUp)
+
+	err = framework.Poll(time.Second, 5*time.Minute, func() error {
+		// /query is a client-side route only defined in the Mantine UI code.
+		resp, err := http.Get(fmt.Sprintf("http://%s/query", host))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read /query response: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("/query: expected 200, got %d (%s)", resp.StatusCode, framework.ClampMax(b))
+		}
+
+		body := string(b)
+		// GLOBAL_READY is a JS global only defined in the Mantine UI template.
+		if !strings.Contains(body, "GLOBAL_READY") {
+			return fmt.Errorf("/query: missing Mantine UI marker GLOBAL_READY, got: %s", framework.ClampMax(b))
+		}
+
+		// Sanity check: an unknown path should 404 to confirm we're
+		// getting real responses from Prometheus, not a blanket 200.
+		resp, err = http.Get(fmt.Sprintf("http://%s/doesnotexist", host))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("/doesnotexist: expected 404, got %d", resp.StatusCode)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
 }

--- a/test/e2e/security_headers_test.go
+++ b/test/e2e/security_headers_test.go
@@ -26,7 +26,7 @@ import (
 func TestAlertmanagerPolicyHeaders(t *testing.T) {
 	// The tenancy port (9092) is only exposed in-cluster, so we need to use
 	// port forwarding to access kube-rbac-proxy.
-	host, cleanUp, err := f.ForwardPort(t, f.Ns, "alertmanager-main", 9092)
+	host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "alertmanager-main", 9092)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestAlertmanagerPolicyHeaders(t *testing.T) {
 }
 
 func TestPrometheusPolicyHeaders(t *testing.T) {
-	host, cleanUp, err := f.ForwardPort(t, f.Ns, "prometheus-k8s", 9091)
+	host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "prometheus-k8s", 9091)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -121,7 +121,7 @@ func createPrometheusRuleWithAlert(t *testing.T, namespace, name, alertName stri
 
 func verifyAlertmanagerReceivedAlerts(t *testing.T, namespace, svc string) {
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
-		host, cleanUp, err := f.ForwardPort(t, namespace, svc, 9093)
+		host, cleanUp, err := f.ForwardServicePort(t, namespace, svc, 9093)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -640,7 +640,7 @@ func assertTenancyForMetrics(t *testing.T) {
 			err = framework.Poll(5*time.Second, time.Minute, func() error {
 				// The tenancy port (9092) is only exposed in-cluster, so we need to use
 				// port forwarding to access kube-rbac-proxy.
-				host, cleanUp, err := f.ForwardPort(t, f.Ns, "thanos-querier", 9092)
+				host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -708,7 +708,7 @@ func assertTenancyForMetrics(t *testing.T) {
 		err = framework.Poll(5*time.Second, time.Minute, func() error {
 			// The tenancy port (9092) is only exposed in-cluster, so we need to use
 			// port forwarding to access kube-rbac-proxy.
-			host, cleanUp, err := f.ForwardPort(t, f.Ns, "thanos-querier", 9092)
+			host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -822,7 +822,7 @@ func assertTenancyForMetrics(t *testing.T) {
 			}()
 
 			// Forward the tenancy port.
-			host, cleanUp, err := f.ForwardPort(t, f.Ns, "thanos-querier", 9092)
+			host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -899,7 +899,7 @@ func assertTenancyForRulesAndAlerts(t *testing.T) {
 
 	// The tenancy port (9093) is only exposed in-cluster, so we need to use
 	// port forwarding to access kube-rbac-proxy.
-	host, cleanUp, err := f.ForwardPort(t, f.Ns, "thanos-querier", 9093)
+	host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9093)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1159,7 +1159,7 @@ func assertUWMFederateEndpoint(t *testing.T) {
 		}
 		// The federate port (9092) is only exposed in-cluster, so we need to use
 		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardPort(t, f.UserWorkloadMonitoringNs, "prometheus-user-workload", 9092)
+		host, cleanUp, err := f.ForwardServicePort(t, f.UserWorkloadMonitoringNs, "prometheus-user-workload", 9092)
 		if err != nil {
 			return err
 		}
@@ -1226,7 +1226,7 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 	err = framework.Poll(5*time.Second, time.Minute, func() error {
 		// The tenancy port (9092) is only exposed in-cluster, so we need to use
 		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardPort(t, f.Ns, "thanos-querier", 9092)
+		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
 		if err != nil {
 			return err
 		}
@@ -1280,7 +1280,7 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 	err = framework.Poll(5*time.Second, time.Minute, func() error {
 		// The tenancy port (9092) is only exposed in-cluster, so we need to use
 		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardPort(t, f.Ns, "thanos-querier", 9092)
+		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
 		if err != nil {
 			return err
 		}
@@ -1334,7 +1334,7 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 	err = framework.Poll(5*time.Second, time.Minute, func() error {
 		// The tenancy port (9092) is only exposed in-cluster, so we need to use
 		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardPort(t, f.Ns, "thanos-querier", 9092)
+		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This helps catch regressions in the web UI availability, e.g. after Prometheus upgrades done outside of syncbot.