### PR TITLE
MON-452 : merge ClusterMonitoring httpConfig into config

### DIFF
--- a/pkg/manifests/config_merge.go
+++ b/pkg/manifests/config_merge.go
@@ -39,6 +39,7 @@ func (c *Config) mergeClusterMonitoringCRD(clusterMonitoring *configv1alpha1.Clu
 	c.mergeMetricsServerConfiguration(clusterMonitoring.Spec.MetricsServerConfig)
 	c.mergePrometheusOperatorConfiguration(clusterMonitoring.Spec.PrometheusOperatorConfig)
 	c.mergeAlertmanagerConfiguration(clusterMonitoring.Spec.AlertmanagerConfig)
+	c.mergeClusterMonitoringHTTPConfig(clusterMonitoring.Spec.HTTPConfig)
 }
 
 // clusterMonitoringMetricsServerSpecEmpty reports whether the CR's
@@ -91,6 +92,22 @@ func clusterMonitoringPrometheusOperatorSpecEmpty(poc configv1alpha1.PrometheusO
 // alertmanagerConfig stanza contains no user intent.
 func clusterMonitoringAlertmanagerSpecEmpty(ac configv1alpha1.AlertmanagerConfig) bool {
 	return ac.DeploymentMode == ""
+}
+
+// clusterMonitoringHTTPConfigSpecEmpty reports whether the CR's httpConfig stanza
+// contains no user-set field. The API uses a value type, so omitted in the manifest
+// is always the zero struct in Go.
+func clusterMonitoringHTTPConfigSpecEmpty(hc configv1alpha1.ClusterMonitoringHTTPConfig) bool {
+	if hc.HTTPProxy != "" {
+		return false
+	}
+	if hc.HTTPSProxy != "" {
+		return false
+	}
+	if hc.NoProxy != "" {
+		return false
+	}
+	return true
 }
 
 func verbosityLevelToNumeric(level configv1alpha1.VerbosityLevel) uint8 {
@@ -215,6 +232,21 @@ func (c *Config) mergeAlertmanagerConfiguration(ac configv1alpha1.AlertmanagerCo
 		return
 	}
 	c.ClusterMonitoringConfiguration.AlertmanagerMainConfig = cfg
+}
+
+func (c *Config) mergeClusterMonitoringHTTPConfig(hc configv1alpha1.ClusterMonitoringHTTPConfig) {
+	// HTTP proxy (Phase 1): if the ConfigMap already has `http`, mergeClusterMonitoringHTTPConfig is a no-op.
+	if c.ClusterMonitoringConfiguration.HTTPConfig != nil {
+		return
+	}
+	if clusterMonitoringHTTPConfigSpecEmpty(hc) {
+		return
+	}
+	c.ClusterMonitoringConfiguration.HTTPConfig = &HTTPConfig{
+		HTTPProxy:  hc.HTTPProxy,
+		HTTPSProxy: hc.HTTPSProxy,
+		NoProxy:    hc.NoProxy,
+	}
 }
 
 func mergeAlertmanagerCustomConfigFromCRD(dst *AlertmanagerMainConfig, cc configv1alpha1.AlertmanagerCustomConfig) {

--- a/pkg/manifests/config_merge_test.go
+++ b/pkg/manifests/config_merge_test.go
@@ -108,6 +108,16 @@ func TestClusterMonitoringAlertmanagerSpecEmpty(t *testing.T) {
 	}))
 }
 
+func TestClusterMonitoringHTTPConfigSpecEmpty(t *testing.T) {
+	require.True(t, clusterMonitoringHTTPConfigSpecEmpty(configv1alpha1.ClusterMonitoringHTTPConfig{}))
+	require.False(t, clusterMonitoringHTTPConfigSpecEmpty(configv1alpha1.ClusterMonitoringHTTPConfig{
+		HTTPProxy: "http://proxy",
+	}))
+	require.False(t, clusterMonitoringHTTPConfigSpecEmpty(configv1alpha1.ClusterMonitoringHTTPConfig{
+		NoProxy: "localhost",
+	}))
+}
+
 func TestLogLevelCRDToManifest(t *testing.T) {
 	require.Equal(t, "debug", logLevelCRDToManifest(configv1alpha1.LogLevelDebug))
 	require.Equal(t, "", logLevelCRDToManifest(configv1alpha1.LogLevel("Unknown")))
@@ -233,5 +243,49 @@ func TestConfig_MergeClusterMonitoringCRD_AlertmanagerMainConfigPhase1(t *testin
 		require.NoError(t, err)
 		require.NotNil(t, c.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Enabled)
 		require.False(t, *c.ClusterMonitoringConfiguration.AlertmanagerMainConfig.Enabled)
+	})
+}
+
+func TestConfig_MergeClusterMonitoringCRD_HTTPConfigPhase1(t *testing.T) {
+	t.Run("CR applies when ConfigMap left HTTPConfig nil", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				UserDefined: configv1alpha1.UserDefinedMonitoring{
+					Mode: configv1alpha1.UserDefinedDisabled,
+				},
+				HTTPConfig: configv1alpha1.ClusterMonitoringHTTPConfig{
+					HTTPProxy:  "http://from-crd",
+					HTTPSProxy: "https://from-crd",
+					NoProxy:    "svc.cluster.local",
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{}", cm)
+		require.NoError(t, err)
+		require.NotNil(t, c.ClusterMonitoringConfiguration.HTTPConfig)
+		require.Equal(t, "http://from-crd", c.ClusterMonitoringConfiguration.HTTPConfig.HTTPProxy)
+		require.Equal(t, "https://from-crd", c.ClusterMonitoringConfiguration.HTTPConfig.HTTPSProxy)
+		require.Equal(t, "svc.cluster.local", c.ClusterMonitoringConfiguration.HTTPConfig.NoProxy)
+	})
+	t.Run("CR ignored when ConfigMap already set HTTPConfig", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				UserDefined: configv1alpha1.UserDefinedMonitoring{
+					Mode: configv1alpha1.UserDefinedDisabled,
+				},
+				HTTPConfig: configv1alpha1.ClusterMonitoringHTTPConfig{
+					HTTPProxy: "http://from-crd",
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource(`http:
+  httpProxy: http://from-configmap
+  httpsProxy: https://from-configmap
+  noProxy: from-configmap.example
+`, cm)
+		require.NoError(t, err)
+		require.Equal(t, "http://from-configmap", c.ClusterMonitoringConfiguration.HTTPConfig.HTTPProxy)
+		require.Equal(t, "https://from-configmap", c.ClusterMonitoringConfiguration.HTTPConfig.HTTPSProxy)
+		require.Equal(t, "from-configmap.example", c.ClusterMonitoringConfiguration.HTTPConfig.NoProxy)
 	})
 }

--- a/test/e2e/cluster_monitoring_test.go
+++ b/test/e2e/cluster_monitoring_test.go
@@ -515,6 +515,91 @@ func TestClusterMonitorAlertmanagerConfigMapAndCRD(t *testing.T) {
 	}
 }
 
+// TestClusterMonitorHTTPConfigMapAndCRD verifies Phase 1 merge: when both ConfigMap `http` and CR
+// `httpConfig` are set, the ConfigMap wins and CR proxy values are ignored.
+func TestClusterMonitorHTTPConfigMapAndCRD(t *testing.T) {
+	if !clusterMonitoringCRDAvailable {
+		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
+		return
+	}
+
+	t.Log("creating ConfigMap with baseline http proxy configuration")
+	configMapData := `http:
+  httpProxy: "http://proxy-from-configmap.openshift-monitoring-e2e.example:8080"
+  httpsProxy: "https://proxy-from-configmap.openshift-monitoring-e2e.example:8443"
+  noProxy: "from-configmap.example"
+`
+	cm := f.BuildCMOConfigMap(t, configMapData)
+	f.MustCreateOrUpdateConfigMap(t, cm)
+	t.Cleanup(func() {
+		f.MustDeleteConfigMap(t, cm)
+	})
+
+	t.Log("creating ClusterMonitoring CR with different httpConfig (must be ignored when ConfigMap defines http)")
+	crd := &configv1alpha1.ClusterMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterMonitoringName,
+		},
+		Spec: configv1alpha1.ClusterMonitoringSpec{
+			HTTPConfig: configv1alpha1.ClusterMonitoringHTTPConfig{
+				HTTPProxy:  "http://proxy-from-crd.openshift-monitoring-e2e.example:8080",
+				HTTPSProxy: "https://proxy-from-crd.openshift-monitoring-e2e.example:8443",
+				NoProxy:    "from-crd.example",
+			},
+		},
+	}
+
+	f.MustCreateOrUpdateClusterMonitoring(t, crd)
+	t.Cleanup(func() {
+		crd.Spec.HTTPConfig = configv1alpha1.ClusterMonitoringHTTPConfig{}
+		f.MustCreateOrUpdateClusterMonitoring(t, crd)
+	})
+
+	t.Logf("configured both ConfigMap and ClusterMonitoring CR for Phase 1 precedence (ConfigMap wins)")
+
+	for _, tc := range []scenario{
+		{
+			name:      "assert prometheus-k8s statefulset exists and rolled out",
+			assertion: f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns),
+		},
+		{
+			name: "assert ConfigMap http is used; CR httpConfig is ignored",
+			assertion: f.AssertPodConfigurationFunc(
+				f.Ns,
+				"app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s",
+				[]framework.PodAssertion{
+					expectContainerEnvVar("prometheus", "HTTP_PROXY", "http://proxy-from-configmap.openshift-monitoring-e2e.example:8080"),
+					expectContainerEnvVar("prometheus", "HTTPS_PROXY", "https://proxy-from-configmap.openshift-monitoring-e2e.example:8443"),
+					expectContainerEnvVar("prometheus", "NO_PROXY", "from-configmap.example"),
+				},
+			),
+		},
+	} {
+		t.Run(tc.name, tc.assertion)
+	}
+}
+
+func expectContainerEnvVar(containerName, name, value string) framework.PodAssertion {
+	return func(pod v1.Pod) error {
+		for _, c := range pod.Spec.Containers {
+			if c.Name != containerName {
+				continue
+			}
+			for _, e := range c.Env {
+				if e.Name != name {
+					continue
+				}
+				if e.Value != value {
+					return fmt.Errorf("container %s env %s: want %q got %q", containerName, name, value, e.Value)
+				}
+				return nil
+			}
+			return fmt.Errorf("container %s: env %s not found", containerName, name)
+		}
+		return fmt.Errorf("container %q not found in pod %s", containerName, pod.Name)
+	}
+}
+
 func expectMatchingLimits(podName, containerName, expectMem, expectCPU string) framework.PodAssertion {
 	return func(pod v1.Pod) error {
 		if podName != "*" && pod.Name != podName {

--- a/vendor/github.com/openshift/api/config/v1alpha1/types_cluster_monitoring.go
+++ b/vendor/github.com/openshift/api/config/v1alpha1/types_cluster_monitoring.go
@@ -142,6 +142,27 @@ type ClusterMonitoringSpec struct {
 	// When set, at least one field must be specified within thanosQuerierConfig.
 	// +optional
 	ThanosQuerierConfig ThanosQuerierConfig `json:"thanosQuerierConfig,omitempty,omitzero"`
+	// httpConfig configures HTTP proxy environment variables (httpProxy, httpsProxy, noProxy)
+	// for monitoring components that respect cluster monitoring proxy settings.
+	// httpConfig is optional. When omitted, the platform is left to choose a reasonable default.
+	// When the cluster-monitoring-config ConfigMap already defines an `http` stanza, that
+	// configuration takes precedence and this field is ignored (Phase 1 merge).
+	// +optional
+	HTTPConfig ClusterMonitoringHTTPConfig `json:"httpConfig,omitempty,omitzero"`
+}
+
+// ClusterMonitoringHTTPConfig defines HTTP, HTTPS, and no-proxy values for the monitoring stack.
+type ClusterMonitoringHTTPConfig struct {
+	// httpProxy defines the URL of the HTTP proxy to use for egress HTTP connections.
+	// +optional
+	HTTPProxy string `json:"httpProxy,omitempty"`
+	// httpsProxy defines the URL of the HTTPS proxy to use for egress HTTPS connections.
+	// +optional
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	// noProxy defines a comma-separated list of host names, host name suffixes, IP addresses,
+	// or CIDRs that should not use an HTTP or HTTPS proxy.
+	// +optional
+	NoProxy string `json:"noProxy,omitempty"`
 }
 
 // OpenShiftStateMetricsConfig provides configuration options for the openshift-state-metrics agent


### PR DESCRIPTION
Apply spec.httpConfig from the ClusterMonitoring CR when cluster-monitoring-config does not set the http stanza (Phase 1 precedence). Add openshift/api vendor types for httpConfig, unit tests, and e2e asserting ConfigMap wins over CR.