### PR TITLE
MON-4529: manifests: merge PrometheusOperatorAdmissionWebhookConfig from ClusterMonitoring CRD

### DIFF
--- a/pkg/manifests/config_merge.go
+++ b/pkg/manifests/config_merge.go
@@ -38,6 +38,7 @@ func (c *Config) mergeClusterMonitoringCRD(clusterMonitoring *configv1alpha1.Clu
 
 	c.mergeMetricsServerConfiguration(clusterMonitoring.Spec.MetricsServerConfig)
 	c.mergePrometheusOperatorConfiguration(clusterMonitoring.Spec.PrometheusOperatorConfig)
+	c.mergePrometheusOperatorAdmissionWebhookConfiguration(clusterMonitoring.Spec.PrometheusOperatorAdmissionWebhookConfig)
 	c.mergeAlertmanagerConfiguration(clusterMonitoring.Spec.AlertmanagerConfig)
 	c.mergeMonitoringPluginConfiguration(clusterMonitoring.Spec.MonitoringPluginConfig)
 }
@@ -92,6 +93,18 @@ func clusterMonitoringPrometheusOperatorSpecEmpty(poc configv1alpha1.PrometheusO
 // alertmanagerConfig stanza contains no user intent.
 func clusterMonitoringAlertmanagerSpecEmpty(ac configv1alpha1.AlertmanagerConfig) bool {
 	return ac.DeploymentMode == ""
+}
+
+// clusterMonitoringPrometheusOperatorAdmissionWebhookSpecEmpty reports whether the CR's
+// prometheusOperatorAdmissionWebhookConfig stanza contains no user-set field.
+func clusterMonitoringPrometheusOperatorAdmissionWebhookSpecEmpty(pawc configv1alpha1.PrometheusOperatorAdmissionWebhookConfig) bool {
+	if len(pawc.Resources) > 0 {
+		return false
+	}
+	if len(pawc.TopologySpreadConstraints) > 0 {
+		return false
+	}
+	return true
 }
 
 // clusterMonitoringMonitoringPluginSpecEmpty reports whether the CR's
@@ -214,6 +227,23 @@ func (c *Config) mergePrometheusOperatorConfiguration(poc configv1alpha1.Prometh
 	cfg.TopologySpreadConstraints = poc.TopologySpreadConstraints
 
 	c.ClusterMonitoringConfiguration.PrometheusOperatorConfig = cfg
+}
+
+func (c *Config) mergePrometheusOperatorAdmissionWebhookConfiguration(pawc configv1alpha1.PrometheusOperatorAdmissionWebhookConfig) {
+	if c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig != nil {
+		return
+	}
+	if clusterMonitoringPrometheusOperatorAdmissionWebhookSpecEmpty(pawc) {
+		return
+	}
+
+	cfg := &PrometheusOperatorAdmissionWebhookConfig{}
+	if res := containerResourcesFromCRD(pawc.Resources); res != nil {
+		cfg.Resources = res
+	}
+	cfg.TopologySpreadConstraints = pawc.TopologySpreadConstraints
+
+	c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig = cfg
 }
 
 func (c *Config) mergeMonitoringPluginConfiguration(mpc configv1alpha1.MonitoringPluginConfig) {

--- a/pkg/manifests/config_merge_test.go
+++ b/pkg/manifests/config_merge_test.go
@@ -125,6 +125,20 @@ func TestClusterMonitoringMonitoringPluginSpecEmpty(t *testing.T) {
 	}))
 }
 
+func TestClusterMonitoringPrometheusOperatorAdmissionWebhookSpecEmpty(t *testing.T) {
+	require.True(t, clusterMonitoringPrometheusOperatorAdmissionWebhookSpecEmpty(configv1alpha1.PrometheusOperatorAdmissionWebhookConfig{}))
+	require.False(t, clusterMonitoringPrometheusOperatorAdmissionWebhookSpecEmpty(configv1alpha1.PrometheusOperatorAdmissionWebhookConfig{
+		Resources: []configv1alpha1.ContainerResource{
+			{Name: "cpu", Request: resource.MustParse("10m")},
+		},
+	}))
+	require.False(t, clusterMonitoringPrometheusOperatorAdmissionWebhookSpecEmpty(configv1alpha1.PrometheusOperatorAdmissionWebhookConfig{
+		TopologySpreadConstraints: []v1.TopologySpreadConstraint{
+			{MaxSkew: 1, TopologyKey: "kubernetes.io/hostname"},
+		},
+	}))
+}
+
 func TestLogLevelCRDToManifest(t *testing.T) {
 	require.Equal(t, "debug", logLevelCRDToManifest(configv1alpha1.LogLevelDebug))
 	require.Equal(t, "", logLevelCRDToManifest(configv1alpha1.LogLevel("Unknown")))
@@ -271,6 +285,59 @@ func TestConfig_MergeClusterMonitoringCRD_MonitoringPluginConfigPhase1(t *testin
 		require.NotNil(t, c.ClusterMonitoringConfiguration.MonitoringPluginConfig.Resources)
 		require.Equal(t, resource.MustParse("100m"), c.ClusterMonitoringConfiguration.MonitoringPluginConfig.Resources.Requests[v1.ResourceCPU])
 		require.Equal(t, resource.MustParse("200m"), c.ClusterMonitoringConfiguration.MonitoringPluginConfig.Resources.Limits[v1.ResourceCPU])
+	})
+}
+
+func TestConfig_MergeClusterMonitoringCRD_PrometheusOperatorAdmissionWebhookConfigPhase1(t *testing.T) {
+	t.Run("CR applies when ConfigMap left PrometheusOperatorAdmissionWebhookConfig nil", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				PrometheusOperatorAdmissionWebhookConfig: configv1alpha1.PrometheusOperatorAdmissionWebhookConfig{
+					Resources: []configv1alpha1.ContainerResource{
+						{Name: "cpu", Request: resource.MustParse("10m")},
+					},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{}", cm)
+		require.NoError(t, err)
+		require.NotNil(t, c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig)
+		require.NotNil(t, c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources)
+		require.Equal(t, resource.MustParse("10m"), c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources.Requests[v1.ResourceCPU])
+	})
+	t.Run("CR ignored when ConfigMap already set PrometheusOperatorAdmissionWebhookConfig", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				PrometheusOperatorAdmissionWebhookConfig: configv1alpha1.PrometheusOperatorAdmissionWebhookConfig{
+					Resources: []configv1alpha1.ContainerResource{
+						{Name: "cpu", Request: resource.MustParse("999m")},
+					},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{prometheusOperatorAdmissionWebhook: {resources: {requests: {cpu: 5m}}}}", cm)
+		require.NoError(t, err)
+		require.Equal(t, resource.MustParse("5m"), c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources.Requests[v1.ResourceCPU])
+	})
+	t.Run("CR maps ContainerResource to Resources", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				PrometheusOperatorAdmissionWebhookConfig: configv1alpha1.PrometheusOperatorAdmissionWebhookConfig{
+					Resources: []configv1alpha1.ContainerResource{
+						{
+							Name:    "cpu",
+							Request: resource.MustParse("100m"),
+							Limit:   resource.MustParse("200m"),
+						},
+					},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{}", cm)
+		require.NoError(t, err)
+		require.NotNil(t, c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources)
+		require.Equal(t, resource.MustParse("100m"), c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources.Requests[v1.ResourceCPU])
+		require.Equal(t, resource.MustParse("200m"), c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources.Limits[v1.ResourceCPU])
 	})
 }
 


### PR DESCRIPTION
Apply Phase 1 CR merge when cluster-monitoring-config omits
prometheusOperatorAdmissionWebhook. Add empty-spec guard and unit
tests for CR resources mapping and ConfigMap-wins precedence.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>