### PR TITLE
MON-4526: manifests: merge ThanosQuerierConfig from ClusterMonitoring CRD

### DIFF
--- a/pkg/manifests/config_merge.go
+++ b/pkg/manifests/config_merge.go
@@ -42,6 +42,7 @@ func (c *Config) mergeClusterMonitoringCRD(clusterMonitoring *configv1alpha1.Clu
 	c.mergeAlertmanagerConfiguration(clusterMonitoring.Spec.AlertmanagerConfig)
 	c.mergeMonitoringPluginConfiguration(clusterMonitoring.Spec.MonitoringPluginConfig)
 	c.mergeTelemeterClientConfiguration(clusterMonitoring.Spec.TelemeterClientConfig)
+	c.mergeThanosQuerierConfiguration(clusterMonitoring.Spec.ThanosQuerierConfig)
 }
 
 // clusterMonitoringMetricsServerSpecEmpty reports whether the CR's
@@ -139,6 +140,24 @@ func clusterMonitoringTelemeterClientSpecEmpty(tcc configv1alpha1.TelemeterClien
 		return false
 	}
 	if len(tcc.TopologySpreadConstraints) > 0 {
+		return false
+	}
+	return true
+}
+
+// clusterMonitoringThanosQuerierSpecEmpty reports whether the CR's
+// thanosQuerierConfig stanza contains no user-set field.
+func clusterMonitoringThanosQuerierSpecEmpty(tqc configv1alpha1.ThanosQuerierConfig) bool {
+	if len(tqc.NodeSelector) > 0 {
+		return false
+	}
+	if len(tqc.Tolerations) > 0 {
+		return false
+	}
+	if len(tqc.Resources) > 0 {
+		return false
+	}
+	if len(tqc.TopologySpreadConstraints) > 0 {
 		return false
 	}
 	return true
@@ -299,6 +318,25 @@ func (c *Config) mergeTelemeterClientConfiguration(tcc configv1alpha1.TelemeterC
 	cfg.TopologySpreadConstraints = tcc.TopologySpreadConstraints
 
 	c.ClusterMonitoringConfiguration.TelemeterClientConfig = cfg
+}
+
+func (c *Config) mergeThanosQuerierConfiguration(tqc configv1alpha1.ThanosQuerierConfig) {
+	if c.ClusterMonitoringConfiguration.ThanosQuerierConfig != nil {
+		return
+	}
+	if clusterMonitoringThanosQuerierSpecEmpty(tqc) {
+		return
+	}
+
+	cfg := &ThanosQuerierConfig{}
+	cfg.NodeSelector = tqc.NodeSelector
+	cfg.Tolerations = tqc.Tolerations
+	if res := containerResourcesFromCRD(tqc.Resources); res != nil {
+		cfg.Resources = res
+	}
+	cfg.TopologySpreadConstraints = tqc.TopologySpreadConstraints
+
+	c.ClusterMonitoringConfiguration.ThanosQuerierConfig = cfg
 }
 
 func (c *Config) mergeAlertmanagerConfiguration(ac configv1alpha1.AlertmanagerConfig) {

--- a/pkg/manifests/config_merge_test.go
+++ b/pkg/manifests/config_merge_test.go
@@ -156,6 +156,23 @@ func TestClusterMonitoringTelemeterClientSpecEmpty(t *testing.T) {
 	}))
 }
 
+func TestClusterMonitoringThanosQuerierSpecEmpty(t *testing.T) {
+	require.True(t, clusterMonitoringThanosQuerierSpecEmpty(configv1alpha1.ThanosQuerierConfig{}))
+	require.False(t, clusterMonitoringThanosQuerierSpecEmpty(configv1alpha1.ThanosQuerierConfig{
+		NodeSelector: map[string]string{"k": "v"},
+	}))
+	require.False(t, clusterMonitoringThanosQuerierSpecEmpty(configv1alpha1.ThanosQuerierConfig{
+		Resources: []configv1alpha1.ContainerResource{
+			{Name: "cpu", Request: resource.MustParse("10m")},
+		},
+	}))
+	require.False(t, clusterMonitoringThanosQuerierSpecEmpty(configv1alpha1.ThanosQuerierConfig{
+		Tolerations: []v1.Toleration{
+			{Key: "key", Operator: v1.TolerationOpEqual, Value: "val"},
+		},
+	}))
+}
+
 func TestLogLevelCRDToManifest(t *testing.T) {
 	require.Equal(t, "debug", logLevelCRDToManifest(configv1alpha1.LogLevelDebug))
 	require.Equal(t, "", logLevelCRDToManifest(configv1alpha1.LogLevel("Unknown")))
@@ -403,6 +420,54 @@ func TestConfig_MergeClusterMonitoringCRD_TelemeterClientConfigPhase1(t *testing
 		require.NotNil(t, c.ClusterMonitoringConfiguration.TelemeterClientConfig.Resources)
 		require.Equal(t, resource.MustParse("100m"), c.ClusterMonitoringConfiguration.TelemeterClientConfig.Resources.Requests[v1.ResourceCPU])
 		require.Equal(t, resource.MustParse("200m"), c.ClusterMonitoringConfiguration.TelemeterClientConfig.Resources.Limits[v1.ResourceCPU])
+	})
+}
+
+func TestConfig_MergeClusterMonitoringCRD_ThanosQuerierConfigPhase1(t *testing.T) {
+	t.Run("CR applies when ConfigMap left ThanosQuerierConfig nil", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				ThanosQuerierConfig: configv1alpha1.ThanosQuerierConfig{
+					NodeSelector: map[string]string{"role": "infra"},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{}", cm)
+		require.NoError(t, err)
+		require.NotNil(t, c.ClusterMonitoringConfiguration.ThanosQuerierConfig)
+		require.Equal(t, map[string]string{"role": "infra"}, c.ClusterMonitoringConfiguration.ThanosQuerierConfig.NodeSelector)
+	})
+	t.Run("CR ignored when ConfigMap already set ThanosQuerierConfig", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				ThanosQuerierConfig: configv1alpha1.ThanosQuerierConfig{
+					NodeSelector: map[string]string{"from": "crd"},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{thanosQuerier: {nodeSelector: {from: configmap}}}", cm)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"from": "configmap"}, c.ClusterMonitoringConfiguration.ThanosQuerierConfig.NodeSelector)
+	})
+	t.Run("CR maps ContainerResource to Resources", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				ThanosQuerierConfig: configv1alpha1.ThanosQuerierConfig{
+					Resources: []configv1alpha1.ContainerResource{
+						{
+							Name:    "cpu",
+							Request: resource.MustParse("100m"),
+							Limit:   resource.MustParse("200m"),
+						},
+					},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{}", cm)
+		require.NoError(t, err)
+		require.NotNil(t, c.ClusterMonitoringConfiguration.ThanosQuerierConfig.Resources)
+		require.Equal(t, resource.MustParse("100m"), c.ClusterMonitoringConfiguration.ThanosQuerierConfig.Resources.Requests[v1.ResourceCPU])
+		require.Equal(t, resource.MustParse("200m"), c.ClusterMonitoringConfiguration.ThanosQuerierConfig.Resources.Limits[v1.ResourceCPU])
 	})
 }
 


### PR DESCRIPTION
Apply Phase 1 CR merge when cluster-monitoring-config omits
thanosQuerier. Map NodeSelector, Tolerations, Resources and
TopologySpreadConstraints from the CRD. Add empty-spec guard
and unit tests for CR resources mapping and ConfigMap-wins precedence.