### PR TITLE
OCPBUGS-85709: fix: use numeric ports in NetworkPolicies and add enforcement e2e test

### DIFF
--- a/assets/admission-webhook/network-policy-downstream.yaml
+++ b/assets/admission-webhook/network-policy-downstream.yaml
@@ -16,6 +16,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: prometheus-operator-admission-webhook
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/admission-webhook/network-policy-downstream.yaml
+++ b/assets/admission-webhook/network-policy-downstream.yaml
@@ -11,7 +11,7 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: https
+    - port: 8443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/alertmanager-user-workload/network-policy-downstream.yaml
+++ b/assets/alertmanager-user-workload/network-policy-downstream.yaml
@@ -24,6 +24,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/alertmanager-user-workload/network-policy-downstream.yaml
+++ b/assets/alertmanager-user-workload/network-policy-downstream.yaml
@@ -11,10 +11,16 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: tenancy
+    - port: 9092
       protocol: TCP
-    - port: metrics
+    - port: 9095
       protocol: TCP
+    - port: 9097
+      protocol: TCP
+    - port: 9094
+      protocol: TCP
+    - port: 9094
+      protocol: UDP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: alertmanager

--- a/assets/alertmanager/network-policy-downstream.yaml
+++ b/assets/alertmanager/network-policy-downstream.yaml
@@ -11,12 +11,16 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: tenancy
+    - port: 9092
       protocol: TCP
-    - port: web
+    - port: 9095
       protocol: TCP
-    - port: metrics
+    - port: 9097
       protocol: TCP
+    - port: 9094
+      protocol: TCP
+    - port: 9094
+      protocol: UDP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: alertmanager

--- a/assets/alertmanager/network-policy-downstream.yaml
+++ b/assets/alertmanager/network-policy-downstream.yaml
@@ -24,6 +24,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/kube-state-metrics/network-policy-downstream.yaml
+++ b/assets/kube-state-metrics/network-policy-downstream.yaml
@@ -18,6 +18,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/kube-state-metrics/network-policy-downstream.yaml
+++ b/assets/kube-state-metrics/network-policy-downstream.yaml
@@ -11,9 +11,9 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: https-main
+    - port: 8443
       protocol: TCP
-    - port: https-self
+    - port: 9443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/metrics-server/network-policy-downstream.yaml
+++ b/assets/metrics-server/network-policy-downstream.yaml
@@ -16,6 +16,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: metrics-server
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/metrics-server/network-policy-downstream.yaml
+++ b/assets/metrics-server/network-policy-downstream.yaml
@@ -11,7 +11,7 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: https
+    - port: 10250
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/monitoring-plugin/network-policy-downstream.yaml
+++ b/assets/monitoring-plugin/network-policy-downstream.yaml
@@ -16,6 +16,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: monitoring-plugin
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/monitoring-plugin/network-policy-downstream.yaml
+++ b/assets/monitoring-plugin/network-policy-downstream.yaml
@@ -11,7 +11,7 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: https
+    - port: 9443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/openshift-state-metrics/network-policy-downstream.yaml
+++ b/assets/openshift-state-metrics/network-policy-downstream.yaml
@@ -11,9 +11,9 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: https-main
+    - port: 8443
       protocol: TCP
-    - port: https-self
+    - port: 9443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/openshift-state-metrics/network-policy-downstream.yaml
+++ b/assets/openshift-state-metrics/network-policy-downstream.yaml
@@ -18,6 +18,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: openshift-state-metrics
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/prometheus-k8s/network-policy-downstream.yaml
+++ b/assets/prometheus-k8s/network-policy-downstream.yaml
@@ -11,7 +11,13 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: grpc
+    - port: 9091
+      protocol: TCP
+    - port: 9092
+      protocol: TCP
+    - port: 10901
+      protocol: TCP
+    - port: 10903
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/prometheus-k8s/network-policy-downstream.yaml
+++ b/assets/prometheus-k8s/network-policy-downstream.yaml
@@ -22,6 +22,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/prometheus-operator-user-workload/network-policy-downstream.yaml
+++ b/assets/prometheus-operator-user-workload/network-policy-downstream.yaml
@@ -16,6 +16,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/prometheus-operator-user-workload/network-policy-downstream.yaml
+++ b/assets/prometheus-operator-user-workload/network-policy-downstream.yaml
@@ -11,7 +11,7 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: https
+    - port: 8443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/prometheus-operator/network-policy-downstream.yaml
+++ b/assets/prometheus-operator/network-policy-downstream.yaml
@@ -16,6 +16,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/prometheus-operator/network-policy-downstream.yaml
+++ b/assets/prometheus-operator/network-policy-downstream.yaml
@@ -11,7 +11,7 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: https
+    - port: 8443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/prometheus-user-workload/network-policy-downstream.yaml
+++ b/assets/prometheus-user-workload/network-policy-downstream.yaml
@@ -11,7 +11,13 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: metrics
+    - port: 9091
+      protocol: TCP
+    - port: 9092
+      protocol: TCP
+    - port: 10901
+      protocol: TCP
+    - port: 10903
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/prometheus-user-workload/network-policy-downstream.yaml
+++ b/assets/prometheus-user-workload/network-policy-downstream.yaml
@@ -22,6 +22,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/telemeter-client/network-policy-downstream.yaml
+++ b/assets/telemeter-client/network-policy-downstream.yaml
@@ -16,6 +16,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: telemeter-client
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/telemeter-client/network-policy-downstream.yaml
+++ b/assets/telemeter-client/network-policy-downstream.yaml
@@ -11,7 +11,7 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: https
+    - port: 8443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/thanos-querier/network-policy-downstream.yaml
+++ b/assets/thanos-querier/network-policy-downstream.yaml
@@ -22,6 +22,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/assets/thanos-querier/network-policy-downstream.yaml
+++ b/assets/thanos-querier/network-policy-downstream.yaml
@@ -11,7 +11,13 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: tenancy
+    - port: 9091
+      protocol: TCP
+    - port: 9092
+      protocol: TCP
+    - port: 9093
+      protocol: TCP
+    - port: 9094
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/thanos-ruler/network-policy-downstream.yaml
+++ b/assets/thanos-ruler/network-policy-downstream.yaml
@@ -11,7 +11,11 @@ spec:
   - {}
   ingress:
   - ports:
-    - port: metrics
+    - port: 9091
+      protocol: TCP
+    - port: 9092
+      protocol: TCP
+    - port: 10901
       protocol: TCP
   podSelector:
     matchLabels:

--- a/assets/thanos-ruler/network-policy-downstream.yaml
+++ b/assets/thanos-ruler/network-policy-downstream.yaml
@@ -20,6 +20,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: thanos-ruler
+      app.kubernetes.io/part-of: openshift-monitoring
   policyTypes:
   - Ingress
   - Egress

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -190,9 +190,8 @@ function(params)
           {
             ports: [
               {
-                // allow apiserver reach to prometheus-operator-admission-webhook
-                // 8443(port name: https) port to validate customresourcedefinitions
-                port: 'https',
+                // Allow the kube-apiserver to reach the admission webhook.
+                port: 8443,
                 protocol: 'TCP',
               },
             ],

--- a/jsonnet/components/admission-webhook.libsonnet
+++ b/jsonnet/components/admission-webhook.libsonnet
@@ -180,6 +180,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'prometheus-operator-admission-webhook',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -439,16 +439,33 @@ function(params)
         ingress: [
           {
             ports: [
-              // allow access to the Alertmanager endpoints restricted to a given project,
-              // port number 9092(port name: tenancy)
               {
-                port: 'tenancy',
+                // Allow users to access namespace-scoped UWM Alertmanager API endpoints.
+                port: 9092,
                 protocol: 'TCP',
               },
-              // allow prometheus to scrape user workload alertmanager 9097(port name: metrics) port
               {
-                port: 'metrics',
+                // Allow Prometheus to push alerts to UWM Alertmanager and allow users
+                // to access the UWM Alertmanager UI/API via route.
+                port: 9095,
                 protocol: 'TCP',
+              },
+              {
+                // Allow Prometheus to scrape UWM Alertmanager's own /metrics endpoint
+                port: 9097,
+                protocol: 'TCP',
+              },
+              {
+                // Allow UWM Alertmanager replicas to communicate via the HA gossip mesh
+                // (injected by Prometheus Operator).
+                port: 9094,
+                protocol: 'TCP',
+              },
+              {
+                // Allow UWM Alertmanager replicas to communicate via the HA gossip mesh
+                // (injected by Prometheus Operator).
+                port: 9094,
+                protocol: 'UDP',
               },
             ],
           },

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -430,6 +430,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'alertmanager',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -478,20 +478,32 @@ function(params)
           {
             ports: [
               {
-                // allow access to the Alertmanager endpoints restricted to a given project,
-                // port number 9092(port name: tenancy)
-                port: 'tenancy',
+                // Allow users to access namespace-scoped Alertmanager API endpoints.
+                port: 9092,
                 protocol: 'TCP',
               },
               {
-                // allow prometheus to sent alerts to alertmanager, port number 9095(port name: web)
-                port: 'web',
+                // Allow Prometheus to push alerts to Alertmanager and allow users to
+                // access the Alertmanager UI/API via route.
+                port: 9095,
                 protocol: 'TCP',
               },
               {
-                // allow prometheus to scrape alertmanager endpoint, port number 9097(port name: metrics)
-                port: 'metrics',
+                // Allow Prometheus to scrape Alertmanager's own /metrics endpoint.
+                port: 9097,
                 protocol: 'TCP',
+              },
+              {
+                // Allow Alertmanager replicas to communicate via the HA gossip mesh
+                // (injected by Prometheus Operator).
+                port: 9094,
+                protocol: 'TCP',
+              },
+              {
+                // Allow Alertmanager replicas to communicate via the HA gossip mesh
+                // (injected by Prometheus Operator).
+                port: 9094,
+                protocol: 'UDP',
               },
             ],
           },

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -468,6 +468,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'alertmanager',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -333,14 +333,16 @@ function(params)
         ingress: [
           {
             ports: [
-              // allow prometheus to scrape kube-state-metrics endpoints,
-              // 8443(port name: https-main)/9443(port name: https-self) ports
               {
-                port: 'https-main',
+                // Allow Prometheus to scrape kube-state-metrics for Kubernetes object
+                // metrics.
+                port: 8443,
                 protocol: 'TCP',
               },
               {
-                port: 'https-self',
+                // Allow Prometheus to scrape kube-state-metrics process-level self
+                // metrics.
+                port: 9443,
                 protocol: 'TCP',
               },
             ],

--- a/jsonnet/components/kube-state-metrics.libsonnet
+++ b/jsonnet/components/kube-state-metrics.libsonnet
@@ -324,6 +324,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'kube-state-metrics',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/metrics-server.libsonnet
+++ b/jsonnet/components/metrics-server.libsonnet
@@ -414,10 +414,10 @@ function(params) {
       ingress: [
         {
           ports: [
-            // make Metrics API available and allow prometheus to scrape metrics-server endpoint,
-            // 10250(port name: https) port
             {
-              port: 'https',
+              // Allow kube-apiserver to reach the Metrics API and allow Prometheus
+              // to scrape metrics-server's /metrics endpoint.
+              port: 10250,
               protocol: 'TCP',
             },
           ],

--- a/jsonnet/components/metrics-server.libsonnet
+++ b/jsonnet/components/metrics-server.libsonnet
@@ -405,6 +405,7 @@ function(params) {
       podSelector: {
         matchLabels: {
           'app.kubernetes.io/name': 'metrics-server',
+          'app.kubernetes.io/part-of': 'openshift-monitoring',
         },
       },
       policyTypes: [

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -236,6 +236,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'monitoring-plugin',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -246,9 +246,9 @@ function(params)
           {
             ports: [
               {
-                // expose 9443(port name: https) port for admin web console to load monitoring-plugin,
-                // then Observe menu would show
-                port: 'https',
+                // Allow the console to load the monitoring dynamic
+                // plugin (serves plugin-manifest.json and assets).
+                port: 9443,
                 protocol: 'TCP',
               },
             ],

--- a/jsonnet/components/openshift-state-metrics.libsonnet
+++ b/jsonnet/components/openshift-state-metrics.libsonnet
@@ -108,6 +108,7 @@ function(params) {
       podSelector: {
         matchLabels: {
           'app.kubernetes.io/name': 'openshift-state-metrics',
+          'app.kubernetes.io/part-of': 'openshift-monitoring',
         },
       },
       policyTypes: [

--- a/jsonnet/components/openshift-state-metrics.libsonnet
+++ b/jsonnet/components/openshift-state-metrics.libsonnet
@@ -117,14 +117,16 @@ function(params) {
       ingress: [
         {
           ports: [
-            // allow prometheus to scrape openshift-state-metrics endpoints,
-            // 8443(port name: https-main)/9443(port name: https-self) ports
             {
-              port: 'https-main',
+              // Allow Prometheus to scrape openshift-state-metrics for OpenShift-specific
+              // object metrics.
+              port: 8443,
               protocol: 'TCP',
             },
             {
-              port: 'https-self',
+              // Allow Prometheus to scrape openshift-state-metrics process-level self
+              // metrics.
+              port: 9443,
               protocol: 'TCP',
             },
           ],

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -217,9 +217,9 @@ function(params)
         ingress: [
           {
             ports: [
-              // allow prometheus to scrape prometheus-operator endpoint, 8443(port name: https) port
               {
-                port: 'https',
+                // Allow Prometheus to scrape prometheus-operator's /metrics endpoint.
+                port: 8443,
                 protocol: 'TCP',
               },
             ],

--- a/jsonnet/components/prometheus-operator-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-operator-user-workload.libsonnet
@@ -208,6 +208,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'prometheus-operator',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -197,9 +197,9 @@ function(params)
         ingress: [
           {
             ports: [
-              // allow prometheus to scrape prometheus-operator endpoint, 8443(port name: https) port
               {
-                port: 'https',
+                // Allow Prometheus to scrape prometheus-operator's /metrics endpoint.
+                port: 8443,
                 protocol: 'TCP',
               },
             ],

--- a/jsonnet/components/prometheus-operator.libsonnet
+++ b/jsonnet/components/prometheus-operator.libsonnet
@@ -188,6 +188,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'prometheus-operator',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -602,6 +602,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'prometheus',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -611,9 +611,26 @@ function(params)
         ingress: [
           {
             ports: [
-              // allow prometheus to scrape user workload prometheus endpoint, 9091(port name: metrics) port
               {
-                port: 'metrics',
+                // Allow platform Prometheus to scrape UWM Prometheus's own /metrics
+                // endpoint.
+                port: 9091,
+                protocol: 'TCP',
+              },
+              {
+                // Allow access to the /federate endpoint for cross-Prometheus federation.
+                port: 9092,
+                protocol: 'TCP',
+              },
+              {
+                // Allow Thanos Querier to reach the Thanos sidecar gRPC endpoint
+                // for StoreAPI queries.
+                port: 10901,
+                protocol: 'TCP',
+              },
+              {
+                // Allow Prometheus to scrape the Thanos sidecar's own metrics.
+                port: 10903,
                 protocol: 'TCP',
               },
             ],

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -636,8 +636,25 @@ function(params)
           {
             ports: [
               {
-                // allow prometheus to update endpoints(port number: 10901, port name: grpc)
-                port: 'grpc',
+                // Allow to query the Prometheus API and UI.
+                port: 9091,
+                protocol: 'TCP',
+              },
+              {
+                // Allow platform Prometheus to scrape this Prometheus instance's own
+                // /metrics endpoint.
+                port: 9092,
+                protocol: 'TCP',
+              },
+              {
+                // Allow Thanos Querier to reach the Thanos sidecar gRPC endpoint
+                // for StoreAPI queries.
+                port: 10901,
+                protocol: 'TCP',
+              },
+              {
+                // Allow Prometheus to scrape the Thanos sidecar's own metrics.
+                port: 10903,
                 protocol: 'TCP',
               },
             ],

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -626,6 +626,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'prometheus',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/telemeter-client.libsonnet
+++ b/jsonnet/components/telemeter-client.libsonnet
@@ -130,6 +130,7 @@ function(params) {
       podSelector: {
         matchLabels: {
           'app.kubernetes.io/name': 'telemeter-client',
+          'app.kubernetes.io/part-of': 'openshift-monitoring',
         },
       },
       policyTypes: [

--- a/jsonnet/components/telemeter-client.libsonnet
+++ b/jsonnet/components/telemeter-client.libsonnet
@@ -140,9 +140,8 @@ function(params) {
         {
           ports: [
             {
-              // allow prometheus to scrape telemeter-client endpoint,
-              // 8443(port name: https) port
-              port: 'https',
+              // Allow Prometheus to scrape telemeter-client's /metrics endpoint.
+              port: 8443,
               protocol: 'TCP',
             },
           ],

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -670,11 +670,24 @@ function(params)
         ingress: [
           {
             ports: [
-              // allow for thanos-querier tenancy endpoint, 9092 port(port name: tenancy),
-              // for example, expose tenancy-aware /api/v1/labels for thanos query,
-              // load metrics result on admin web UI
               {
-                port: 'tenancy',
+                // Allow to query the Thanos Querier API.
+                port: 9091,
+                protocol: 'TCP',
+              },
+              {
+                // Allow to access tenancy-aware query endpoints.
+                port: 9092,
+                protocol: 'TCP',
+              },
+              {
+                // Allow to access tenancy-aware rules and alerts endpoints.
+                port: 9093,
+                protocol: 'TCP',
+              },
+              {
+                // Allow Prometheus to scrape Thanos Querier's own /metrics endpoint.
+                port: 9094,
                 protocol: 'TCP',
               },
             ],

--- a/jsonnet/components/thanos-querier.libsonnet
+++ b/jsonnet/components/thanos-querier.libsonnet
@@ -661,6 +661,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'thanos-query',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -585,6 +585,7 @@ function(params)
         podSelector: {
           matchLabels: {
             'app.kubernetes.io/name': 'thanos-ruler',
+            'app.kubernetes.io/part-of': 'openshift-monitoring',
           },
         },
         policyTypes: [

--- a/jsonnet/components/thanos-ruler.libsonnet
+++ b/jsonnet/components/thanos-ruler.libsonnet
@@ -594,9 +594,20 @@ function(params)
         ingress: [
           {
             ports: [
-              // allow prometheus to scrape thanos-ruler endpoint, 9092(port name: metrics) port
               {
-                port: 'metrics',
+                // Allow to access the Thanos Ruler API.
+                port: 9091,
+                protocol: 'TCP',
+              },
+              {
+                // Allow Prometheus to scrape Thanos Ruler's own /metrics endpoint.
+                port: 9092,
+                protocol: 'TCP',
+              },
+              {
+                // Allow Thanos Querier to reach Thanos Ruler's gRPC store API
+                // endpoint for rule evaluation results.
+                port: 10901,
                 protocol: 'TCP',
               },
             ],

--- a/manifests/0000_50_cluster-monitoring-operator_04-networkpolicy.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_04-networkpolicy.yaml
@@ -16,9 +16,9 @@ spec:
   - {}
   ingress:
   - ports:
-    # allow cluster-monitoring-operator to deploy individual component and allow prometheus
-    # to scrape cluster-monitoring-operator endpoint, 8443(port name: https) port
-    - port: https
+    # Allow Prometheus to scrape CMO's /metrics endpoint and allow CMO to serve
+    # its HTTPS API.
+    - port: 8443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/test/e2e/alertmanager_user_workload_test.go
+++ b/test/e2e/alertmanager_user_workload_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,7 +22,6 @@ import (
 	"time"
 
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestUserWorkloadWithAlertmanager(t *testing.T) {
@@ -40,52 +38,7 @@ func TestUserWorkloadWithAlertmanager(t *testing.T) {
 	f.AssertStatefulSetExistsAndRolloutFunc("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
 	f.AssertServiceExistsFunc("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
 
-	// since this func enabled User Workload Alertmanager, check all NetworkPolicies are deployed
-	// under UWM project and the total deployed NetworkPolicies count matches with the required
-	// NetworkPolicies count, this also can avoid extra setup/teardown of UWM cycle
-	ctx := context.Background()
-	networkPolicyNames := []string{
-		"alertmanager-user-workload",
-		"default-deny-user-workload-operands",
-		"prometheus-operator-user-workload",
-		"prometheus-user-workload",
-		"thanos-ruler",
-	}
-
-	for _, scenario := range []struct {
-		name string
-		f    func(*testing.T)
-	}{
-		{
-			name: "assert UWM alert access",
-			f:    assertUWMAlertsAccess,
-		},
-		{
-			name: "check user workload monitoring NetworkPolicies",
-			f: func(t *testing.T) {
-				for _, netpol := range networkPolicyNames {
-					t.Run(fmt.Sprintf("assert %s networkpolicy exists", netpol), func(t *testing.T) {
-						f.AssertNetworkPolicyExistsFunc(netpol, f.UserWorkloadMonitoringNs)(t)
-					})
-				}
-			},
-		},
-		{
-			name: "assert total deployed NetworkPolicies count matches",
-			f: func(t *testing.T) {
-				npList, err := f.KubeClient.NetworkingV1().NetworkPolicies(f.UserWorkloadMonitoringNs).List(ctx, metav1.ListOptions{})
-				if err != nil {
-					t.Fatalf("failed to list NetworkPolicies: %v", err)
-				}
-
-				if len(npList.Items) != len(networkPolicyNames) {
-					t.Errorf("NetworkPolicies count = %d, want %d", len(npList.Items), len(networkPolicyNames))
-				}
-			},
-		},
-	} {
-		t.Run(scenario.name, scenario.f)
-	}
+	t.Run("assert UWM alert access", assertUWMAlertsAccess)
 }
 
 // assertUWMAlertsAccess ensures that a user can't access all alerts from the UWM alertmanager via the api.

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -21,14 +21,19 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 
 	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -38,6 +43,11 @@ var f *framework.Framework
 // clusterMonitoringCRDAvailable is set once in testMain(); tests that require the
 // ClusterMonitoring CRD (TechPreview / ClusterMonitoringConfig feature gate) should Skip when false.
 var clusterMonitoringCRDAvailable bool
+
+const (
+	clusterMonitoringDenyAllTrafficNPName      = "deny-cluster-monitoring-operator-and-operands"
+	userWorkloadMonitoringDenyAllTrafficNPName = "default-deny-user-workload-operands"
+)
 
 func TestMain(m *testing.M) {
 	if err := testMain(m); err != nil {
@@ -204,12 +214,61 @@ func TestMemoryUsageRecordingRule(t *testing.T) {
 	)
 }
 
-// TestNetworkPolicy ensures that the NetworkPolicies
-// are deployed under openshift-monitoring namespace
+// assertNetworkPolicyPortsAreNumeric verifies that all NetworkPolicy ports
+// use numeric values, not named ports.
+func assertNetworkPolicyPortsAreNumeric(t *testing.T, nps []networkingv1.NetworkPolicy) {
+	t.Helper()
+
+	for _, np := range nps {
+		for _, rule := range np.Spec.Ingress {
+			for _, p := range rule.Ports {
+				require.Equalf(t, intstr.Int, p.Port.Type, "NetworkPolicy %s/%s has named port %q", np.Namespace, np.Name, p.Port.StrVal)
+			}
+		}
+		for _, rule := range np.Spec.Egress {
+			for _, p := range rule.Ports {
+				require.Equalf(t, intstr.Int, p.Port.Type, "NetworkPolicy %s/%s has named port %q", np.Namespace, np.Name, p.Port.StrVal)
+			}
+		}
+	}
+}
+
+// expectLabel returns a PodAssertion that checks a pod has the given label with the expected value.
+func expectLabel(labelKey, expectedValue string) framework.PodAssertion {
+	return func(pod v1.Pod) error {
+		if value, ok := pod.Labels[labelKey]; ok {
+			if value == expectedValue {
+				return nil
+			}
+			return fmt.Errorf("pod %s has label %s with value %q, expected %q", pod.Name, labelKey, value, expectedValue)
+		}
+		return fmt.Errorf("pod %s is missing required label %s", pod.Name, labelKey)
+	}
+}
+
+const npProbeNamespace = "e2e-test-np-connectivity"
+
+// TestNetworkPolicy validates NetworkPolicy configuration and enforcement
+// across all monitoring namespaces.
 func TestNetworkPolicy(t *testing.T) {
 	ctx := context.Background()
-	networkPolicyNames := []string{
-		"deny-cluster-monitoring-operator-and-operands",
+
+	setupUserWorkloadAssetsWithTeardownHook(t, f)
+
+	// Enable the UWM Alertmanager so its NetworkPolicy is also tested.
+	uwmCM := f.BuildUserWorkloadConfigMap(t, `alertmanager:
+  enabled: true
+`)
+	f.MustCreateOrUpdateConfigMap(t, uwmCM)
+	t.Cleanup(func() { f.MustDeleteConfigMap(t, uwmCM) })
+	f.AssertStatefulSetExistsAndRolloutFunc("alertmanager-user-workload", f.UserWorkloadMonitoringNs)(t)
+
+	cleanupNS, err := f.CreateNamespace(npProbeNamespace)
+	require.NoError(t, err, "failed to create probe namespace")
+	t.Cleanup(func() { require.NoError(t, cleanupNS(), "failed to cleanup probe namespace") })
+
+	clusterMonitoringNPNames := []string{
+		clusterMonitoringDenyAllTrafficNPName,
 		"cluster-monitoring-operator",
 		"alertmanager",
 		"prometheus",
@@ -222,48 +281,170 @@ func TestNetworkPolicy(t *testing.T) {
 		"telemeter-client",
 		"thanos-querier",
 	}
+	uwmNPNames := []string{
+		userWorkloadMonitoringDenyAllTrafficNPName,
+		"alertmanager-user-workload",
+		"prometheus-operator-user-workload",
+		"prometheus-user-workload",
+		"thanos-ruler",
+	}
 
-	t.Run("check in-cluster monitoring NetworkPolicies", func(t *testing.T) {
-		for _, name := range networkPolicyNames {
-			t.Run(fmt.Sprintf("assert %s networkpolicy exists", name), func(t *testing.T) {
-				f.AssertNetworkPolicyExistsFunc(name, f.Ns)(t)
+	expectedNPs := map[string][]string{
+		f.Ns:                       clusterMonitoringNPNames,
+		f.UserWorkloadMonitoringNs: uwmNPNames,
+	}
+
+	for _, ns := range []string{f.Ns, f.UserWorkloadMonitoringNs} {
+		t.Run(fmt.Sprintf("%s/pod-labels", ns), func(t *testing.T) {
+			f.AssertPodConfigurationFunc(ns, "", []framework.PodAssertion{
+				expectLabel("app.kubernetes.io/part-of", "openshift-monitoring"),
+			})(t)
+		})
+
+		expectedNPNames := expectedNPs[ns]
+
+		t.Run(fmt.Sprintf("%s/existence", ns), func(t *testing.T) {
+			for _, name := range expectedNPNames {
+				t.Run(name, func(t *testing.T) {
+					f.AssertNetworkPolicyExistsFunc(name, ns)(t)
+				})
+			}
+		})
+
+		nps, err := f.KubeClient.NetworkingV1().NetworkPolicies(ns).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err, "failed to list NetworkPolicies in %s", ns)
+
+		t.Run(fmt.Sprintf("%s/count", ns), func(t *testing.T) {
+			require.Equal(t, len(expectedNPNames), len(nps.Items), "unexpected number of NetworkPolicies in %s", ns)
+		})
+
+		t.Run(fmt.Sprintf("%s/numeric-ports", ns), func(t *testing.T) {
+			assertNetworkPolicyPortsAreNumeric(t, nps.Items)
+		})
+
+		for _, np := range nps.Items {
+			if np.Name == clusterMonitoringDenyAllTrafficNPName || np.Name == userWorkloadMonitoringDenyAllTrafficNPName {
+				continue
+			}
+
+			t.Run(fmt.Sprintf("connectivity/%s/%s", np.Namespace, np.Name), func(t *testing.T) {
+				t.Parallel()
+
+				sel, err := metav1.LabelSelectorAsSelector(&np.Spec.PodSelector)
+				require.NoError(t, err, "failed to parse pod selector for NP %s", np.Name)
+
+				pods, err := f.KubeClient.CoreV1().Pods(np.Namespace).List(ctx, metav1.ListOptions{
+					LabelSelector: sel.String(),
+				})
+				require.NoError(t, err, "failed to list pods for NP %s", np.Name)
+				require.NotEmpty(t, pods.Items, "no pods matched NP %s selector %q", np.Name, sel.String())
+
+				// All pods behind the same NP selector should be similar, pick any.
+				pod := pods.Items[0]
+				podIP := pod.Status.PodIP
+				require.NotEmpty(t, podIP, "pod %s has no IP", pod.Name)
+
+				var allowed []int32
+				for _, rule := range np.Spec.Ingress {
+					for _, p := range rule.Ports {
+						allowed = append(allowed, p.Port.IntVal)
+					}
+				}
+
+				var podPorts []int32
+				for _, c := range pod.Spec.Containers {
+					for _, cp := range c.Ports {
+						port := cp.ContainerPort
+						podPorts = append(podPorts, port)
+						if slices.Contains(allowed, port) {
+							t.Run(fmt.Sprintf("allow-%d", port), func(t *testing.T) {
+								assertReachable(t, ctx, podIP, port)
+							})
+						} else {
+							t.Run(fmt.Sprintf("deny-%d", port), func(t *testing.T) {
+								assertBlocked(t, ctx, podIP, port)
+							})
+						}
+					}
+				}
+
+				// Ensure NP ingress ports are a subset of the pod's container ports
+				// to catch stale NP rules referencing ports the pod no longer exposes.
+				require.Subset(t, podPorts, allowed, "NP %s allows ports not exposed by the pod", np.Name)
 			})
 		}
-	})
-
-	// check the total count of deployed NetworkPolicies is equal to len(networkPolicyNames)
-	t.Run("assert total deployed NetworkPolicies count matches", func(t *testing.T) {
-		npList, err := f.KubeClient.NetworkingV1().NetworkPolicies(f.Ns).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			t.Fatalf("failed to list NetworkPolicies: %v", err)
-		}
-		if len(npList.Items) != len(networkPolicyNames) {
-			t.Errorf("NetworkPolicies count = %d, want %d", len(npList.Items), len(networkPolicyNames))
-		}
-	})
+	}
 }
 
-func TestPodsLabels(t *testing.T) {
-	// Verify that all pods in the openshift-monitoring namespace have the
-	// app.kubernetes.io/part-of: openshift-monitoring label.
-	// This label is used among other things to limit the deny-all NP to CMO and its operands only.
-	f.AssertPodConfigurationFunc(
-		f.Ns,
-		"",
-		[]framework.PodAssertion{
-			expectLabel("app.kubernetes.io/part-of", "openshift-monitoring"),
+// assertReachable verifies that a TCP connection to ip:port succeeds.
+// Only TCP is supported.
+func assertReachable(t *testing.T, ctx context.Context, ip string, port int32) {
+	t.Helper()
+	script := fmt.Sprintf("timeout 5 bash -c 'echo > /dev/tcp/%s/%d'", ip, port)
+	runProbePod(t, ctx, script)
+}
+
+// assertBlocked verifies that a TCP connection to ip:port times out
+// (exit code 124), indicating the packet was dropped by a NetworkPolicy.
+// Only TCP is supported.
+func assertBlocked(t *testing.T, ctx context.Context, ip string, port int32) {
+	t.Helper()
+	script := fmt.Sprintf("rc=0; timeout 5 bash -c 'echo > /dev/tcp/%s/%d' || rc=$?; [ \"$rc\" -eq 124 ]", ip, port)
+	runProbePod(t, ctx, script)
+}
+
+// runProbePod creates an ephemeral pod that runs the given shell script and
+// asserts it exits successfully.
+func runProbePod(t *testing.T, ctx context.Context, script string) {
+	t.Helper()
+
+	probe := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "np-probe-",
+			Namespace:    npProbeNamespace,
 		},
-	)(t)
-}
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+			Containers: []v1.Container{{
+				Name:            "probe",
+				Image:           "registry.redhat.io/openshift4/ose-cli:latest",
+				ImagePullPolicy: v1.PullIfNotPresent,
+				Command:         []string{"bash", "-c", script},
+				SecurityContext: &v1.SecurityContext{
+					Capabilities: &v1.Capabilities{
+						Drop: []v1.Capability{"ALL"},
+					},
+					SeccompProfile: &v1.SeccompProfile{
+						Type: v1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+			}},
+		},
+	}
 
-func expectLabel(labelKey, expectedValue string) framework.PodAssertion {
-	return func(pod v1.Pod) error {
-		if value, ok := pod.Labels[labelKey]; ok {
-			if value == expectedValue {
-				return nil
-			}
-			return fmt.Errorf("pod %s has label %s with value %q, expected %q", pod.Name, labelKey, value, expectedValue)
+	pod, err := f.KubeClient.CoreV1().Pods(npProbeNamespace).Create(ctx, probe, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create probe pod")
+	podName := pod.Name
+	t.Cleanup(func() {
+		_ = f.KubeClient.CoreV1().Pods(npProbeNamespace).Delete(context.Background(), podName, metav1.DeleteOptions{})
+	})
+
+	var phase v1.PodPhase
+	err = framework.Poll(time.Second, 2*time.Minute, func() error {
+		p, err := f.KubeClient.CoreV1().Pods(npProbeNamespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return err
 		}
-		return fmt.Errorf("pod %s is missing required label %s", pod.Name, labelKey)
+		phase = p.Status.Phase
+		if phase != v1.PodSucceeded && phase != v1.PodFailed {
+			return fmt.Errorf("waiting for pod %s", podName)
+		}
+		return nil
+	})
+	require.NoError(t, err, "probe pod %s did not complete in time", podName)
+
+	if phase != v1.PodSucceeded {
+		logs, _ := f.GetLogs(npProbeNamespace, podName, "probe")
+		require.Failf(t, "probe pod failed", "pod %s: %s", podName, logs)
 	}
 }

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -1727,17 +1727,3 @@ func TestPrometheusUserWorkloadEndpointSliceDiscovery(t *testing.T) {
 
 	t.Logf("Successfully verified endpoint slice discovery for prometheus-user-workload")
 }
-
-func TestUserWorkloadPodsLabels(t *testing.T) {
-	// Verify that all pods in the openshift-user-workload-monitoring namespace have the
-	// app.kubernetes.io/part-of: openshift-monitoring label.
-	// This label is used among other things to limit the deny-all NP to User Workload Pods only.
-	setupUserWorkloadAssetsWithTeardownHook(t, f)
-	f.AssertPodConfigurationFunc(
-		f.UserWorkloadMonitoringNs,
-		"",
-		[]framework.PodAssertion{
-			expectLabel("app.kubernetes.io/part-of", "openshift-monitoring"),
-		},
-	)(t)
-}


### PR DESCRIPTION
OVN-Kubernetes silently ignores named ports in NetworkPolicy rules, making them effectively unenforced. Migrate all NP port definitions from named to numeric and add missing ingress rules that were previously undetected due to the same OVN-K behavior.

Consolidate NP validation into a single TestNetworkPolicy that checks existence, count, numeric ports, port-to-pod consistency, and active connectivity enforcement across both monitoring namespaces.