### PR TITLE
MON-4525: manifests: merge TelemeterClientConfig from ClusterMonitoring CRD

### DIFF
--- a/pkg/manifests/config_merge.go
+++ b/pkg/manifests/config_merge.go
@@ -41,6 +41,7 @@ func (c *Config) mergeClusterMonitoringCRD(clusterMonitoring *configv1alpha1.Clu
 	c.mergePrometheusOperatorAdmissionWebhookConfiguration(clusterMonitoring.Spec.PrometheusOperatorAdmissionWebhookConfig)
 	c.mergeAlertmanagerConfiguration(clusterMonitoring.Spec.AlertmanagerConfig)
 	c.mergeMonitoringPluginConfiguration(clusterMonitoring.Spec.MonitoringPluginConfig)
+	c.mergeTelemeterClientConfiguration(clusterMonitoring.Spec.TelemeterClientConfig)
 }
 
 // clusterMonitoringMetricsServerSpecEmpty reports whether the CR's
@@ -120,6 +121,24 @@ func clusterMonitoringMonitoringPluginSpecEmpty(mpc configv1alpha1.MonitoringPlu
 		return false
 	}
 	if len(mpc.TopologySpreadConstraints) > 0 {
+		return false
+	}
+	return true
+}
+
+// clusterMonitoringTelemeterClientSpecEmpty reports whether the CR's
+// telemeterClientConfig stanza contains no user-set field.
+func clusterMonitoringTelemeterClientSpecEmpty(tcc configv1alpha1.TelemeterClientConfig) bool {
+	if len(tcc.NodeSelector) > 0 {
+		return false
+	}
+	if len(tcc.Tolerations) > 0 {
+		return false
+	}
+	if len(tcc.Resources) > 0 {
+		return false
+	}
+	if len(tcc.TopologySpreadConstraints) > 0 {
 		return false
 	}
 	return true
@@ -261,6 +280,25 @@ func (c *Config) mergeMonitoringPluginConfiguration(mpc configv1alpha1.Monitorin
 	cfg.TopologySpreadConstraints = mpc.TopologySpreadConstraints
 
 	c.ClusterMonitoringConfiguration.MonitoringPluginConfig = cfg
+}
+
+func (c *Config) mergeTelemeterClientConfiguration(tcc configv1alpha1.TelemeterClientConfig) {
+	if c.ClusterMonitoringConfiguration.TelemeterClientConfig != nil {
+		return
+	}
+	if clusterMonitoringTelemeterClientSpecEmpty(tcc) {
+		return
+	}
+
+	cfg := &TelemeterClientConfig{}
+	cfg.NodeSelector = tcc.NodeSelector
+	cfg.Tolerations = tcc.Tolerations
+	if res := containerResourcesFromCRD(tcc.Resources); res != nil {
+		cfg.Resources = res
+	}
+	cfg.TopologySpreadConstraints = tcc.TopologySpreadConstraints
+
+	c.ClusterMonitoringConfiguration.TelemeterClientConfig = cfg
 }
 
 func (c *Config) mergeAlertmanagerConfiguration(ac configv1alpha1.AlertmanagerConfig) {

--- a/pkg/manifests/config_merge_test.go
+++ b/pkg/manifests/config_merge_test.go
@@ -139,6 +139,23 @@ func TestClusterMonitoringPrometheusOperatorAdmissionWebhookSpecEmpty(t *testing
 	}))
 }
 
+func TestClusterMonitoringTelemeterClientSpecEmpty(t *testing.T) {
+	require.True(t, clusterMonitoringTelemeterClientSpecEmpty(configv1alpha1.TelemeterClientConfig{}))
+	require.False(t, clusterMonitoringTelemeterClientSpecEmpty(configv1alpha1.TelemeterClientConfig{
+		NodeSelector: map[string]string{"k": "v"},
+	}))
+	require.False(t, clusterMonitoringTelemeterClientSpecEmpty(configv1alpha1.TelemeterClientConfig{
+		Resources: []configv1alpha1.ContainerResource{
+			{Name: "cpu", Request: resource.MustParse("10m")},
+		},
+	}))
+	require.False(t, clusterMonitoringTelemeterClientSpecEmpty(configv1alpha1.TelemeterClientConfig{
+		Tolerations: []v1.Toleration{
+			{Key: "key", Operator: v1.TolerationOpEqual, Value: "val"},
+		},
+	}))
+}
+
 func TestLogLevelCRDToManifest(t *testing.T) {
 	require.Equal(t, "debug", logLevelCRDToManifest(configv1alpha1.LogLevelDebug))
 	require.Equal(t, "", logLevelCRDToManifest(configv1alpha1.LogLevel("Unknown")))
@@ -338,6 +355,54 @@ func TestConfig_MergeClusterMonitoringCRD_PrometheusOperatorAdmissionWebhookConf
 		require.NotNil(t, c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources)
 		require.Equal(t, resource.MustParse("100m"), c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources.Requests[v1.ResourceCPU])
 		require.Equal(t, resource.MustParse("200m"), c.ClusterMonitoringConfiguration.PrometheusOperatorAdmissionWebhookConfig.Resources.Limits[v1.ResourceCPU])
+	})
+}
+
+func TestConfig_MergeClusterMonitoringCRD_TelemeterClientConfigPhase1(t *testing.T) {
+	t.Run("CR applies when ConfigMap left TelemeterClientConfig nil", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				TelemeterClientConfig: configv1alpha1.TelemeterClientConfig{
+					NodeSelector: map[string]string{"role": "infra"},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{}", cm)
+		require.NoError(t, err)
+		require.NotNil(t, c.ClusterMonitoringConfiguration.TelemeterClientConfig)
+		require.Equal(t, map[string]string{"role": "infra"}, c.ClusterMonitoringConfiguration.TelemeterClientConfig.NodeSelector)
+	})
+	t.Run("CR ignored when ConfigMap already set TelemeterClientConfig", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				TelemeterClientConfig: configv1alpha1.TelemeterClientConfig{
+					NodeSelector: map[string]string{"from": "crd"},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{telemeterClient: {nodeSelector: {from: configmap}}}", cm)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"from": "configmap"}, c.ClusterMonitoringConfiguration.TelemeterClientConfig.NodeSelector)
+	})
+	t.Run("CR maps ContainerResource to Resources", func(t *testing.T) {
+		cm := &configv1alpha1.ClusterMonitoring{
+			Spec: configv1alpha1.ClusterMonitoringSpec{
+				TelemeterClientConfig: configv1alpha1.TelemeterClientConfig{
+					Resources: []configv1alpha1.ContainerResource{
+						{
+							Name:    "cpu",
+							Request: resource.MustParse("100m"),
+							Limit:   resource.MustParse("200m"),
+						},
+					},
+				},
+			},
+		}
+		c, err := NewConfigFromStringAndClusterMonitoringResource("{}", cm)
+		require.NoError(t, err)
+		require.NotNil(t, c.ClusterMonitoringConfiguration.TelemeterClientConfig.Resources)
+		require.Equal(t, resource.MustParse("100m"), c.ClusterMonitoringConfiguration.TelemeterClientConfig.Resources.Requests[v1.ResourceCPU])
+		require.Equal(t, resource.MustParse("200m"), c.ClusterMonitoringConfiguration.TelemeterClientConfig.Resources.Limits[v1.ResourceCPU])
 	})
 }
 


### PR DESCRIPTION
Apply Phase 1 CR merge when cluster-monitoring-config omits
telemeterClient. Map NodeSelector, Tolerations, Resources and
TopologySpreadConstraints from the CRD.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>