### PR TITLE
OCPBUGS-86352: jsonnet: exclude ReplicationController from catch-all …

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -781,7 +781,7 @@ spec:
             OR
             label_replace(
               group by (cluster, namespace, pod, owner_name, owner_kind) (
-                kube_pod_owner{job="kube-state-metrics", owner_kind!="ReplicaSet", owner_kind!="DaemonSet", owner_kind!="StatefulSet", owner_kind!="Job", owner_kind!="Node", owner_kind!=""}
+                kube_pod_owner{job="kube-state-metrics", owner_kind!~"ReplicaSet|ReplicationController|DaemonSet|StatefulSet|Job|Node|"}
               )
               , "workload", "$1", "owner_name", "(.+)"
             )

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -482,6 +482,24 @@ local patchedRules = [
       },
     ],
   },
+  {
+    // OCPBUGS-86352: exclude ReplicationController from the catch-all pod_owner rule
+    // to prevent duplicate namespace_workload_pod:kube_pod_owner:relabel series when
+    // a DeploymentConfig (which creates a ReplicationController) is used. Our custom
+    // deploymentconfig rule already handles this owner_kind.
+    name: 'k8s.rules.pod_owner',
+    rules: [
+      {
+        record: 'namespace_workload_pod:kube_pod_owner:relabel',
+        expr: function(expr)
+          std.strReplace(
+            expr,
+            'owner_kind!="ReplicaSet", owner_kind!="DaemonSet", owner_kind!="StatefulSet", owner_kind!="Job", owner_kind!="Node", owner_kind!=""',
+            'owner_kind!~"ReplicaSet|ReplicationController|DaemonSet|StatefulSet|Job|Node|"',
+          ),
+      },
+    ],
+  },
 ];
 
 local openShiftRunbook(runbook) =

--- a/test/rules/OCPBUGS-86352.yaml
+++ b/test/rules/OCPBUGS-86352.yaml
@@ -1,0 +1,39 @@
+# Tests for https://issues.redhat.com/browse/OCPBUGS-86352
+# A DeploymentConfig creates a ReplicationController which owns pods.
+# Both the custom deploymentconfig rule and the upstream catch-all rule
+# produce namespace_workload_pod:kube_pod_owner:relabel for the same pod,
+# causing "many-to-many matching not allowed" errors in dashboard queries.
+
+rule_files:
+  - rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+  - interval: 1m
+    input_series:
+      # Pod owned by a ReplicationController (created by a DeploymentConfig)
+      - series: 'kube_pod_owner{job="kube-state-metrics", namespace="test-httpd", pod="hello-openshift-dc-1-2hx8v", owner_kind="ReplicationController", owner_name="hello-openshift-dc-1", owner_is_controller="true"}'
+        values: '1+0x5'
+      # The ReplicationController is owned by a DeploymentConfig
+      - series: 'kube_replicationcontroller_owner{job="kube-state-metrics", namespace="test-httpd", replicationcontroller="hello-openshift-dc-1", owner_kind="DeploymentConfig", owner_name="hello-openshift-dc", owner_is_controller="true"}'
+        values: '1+0x5'
+    promql_expr_test:
+      # There must be exactly ONE series per (namespace, pod), not two.
+      # The deploymentconfig rule should produce the result, and the
+      # catch-all should NOT also produce a ReplicationController result.
+      - expr: count(namespace_workload_pod:kube_pod_owner:relabel{namespace="test-httpd", pod="hello-openshift-dc-1-2hx8v"})
+        eval_time: 5m
+        exp_samples:
+          - labels: '{}'
+            value: 1
+      # Verify the single result has workload_type=deploymentconfig
+      - expr: namespace_workload_pod:kube_pod_owner:relabel{namespace="test-httpd", pod="hello-openshift-dc-1-2hx8v", workload_type="deploymentconfig"}
+        eval_time: 5m
+        exp_samples:
+          - labels: 'namespace_workload_pod:kube_pod_owner:relabel{namespace="test-httpd", pod="hello-openshift-dc-1-2hx8v", workload="hello-openshift-dc", workload_type="deploymentconfig"}'
+            value: 1
+      # Verify no ReplicationController result exists
+      - expr: namespace_workload_pod:kube_pod_owner:relabel{namespace="test-httpd", pod="hello-openshift-dc-1-2hx8v", workload_type="ReplicationController"}
+        eval_time: 5m
+        exp_samples: []


### PR DESCRIPTION
When a `DeploymentConfig` is used, the pod ownership chain is `DeploymentConfig → ReplicationController → Pod`. Two recording rules both produce a `namespace_workload_pod:kube_pod_owner:relabel` series for the same `(namespace, pod)`:
1. Our custom DeploymentConfig rule walks from `ReplicationController` to `DeploymentConfig` via `kube_replicationcontroller_owner` and emits `workload_type=deploymentconfig`.
2. The upstream catch-all rule (from kubernetes-mixin) matches any `owner_kind` not explicitly excluded. It excludes `ReplicaSet`, `DaemonSet`, `StatefulSet`, `Job`, and `Node` — but not `ReplicationController`. So it also fires and emits `workload_type=ReplicationController`.
Dashboard queries that join on `(namespace, pod)` with `group_left` then fail with: `many-to-many matching not allowed: matching labels must be unique on one side`.
Reproduced on 4.21.0-0.nightly-2026-05-24-163444.

## Fix
Exclude `owner_kind=ReplicationController` from the upstream catch-all rule via the existing `patchedRules` mechanism in `sanitize-rules.libsonnet`, so that only our custom DeploymentConfig rule produces the recording rule result for these pods.

## Testing
- Added `test/rules/OCPBUGS-86352.yaml` — promtool unit test simulating a DeploymentConfig pod, asserting exactly one series per `(namespace, pod)` with `workload_type=deploymentconfig`.
- Full `make test-rules` passes with no regressions.
- Verified fix on a live 4.21 cluster: before the fix, 2 series per pod; after, only 1.

