### PR TITLE
OCPBUGS-86782: fix: wait for SCC use before creating Alertmanager operands

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1642,8 +1642,10 @@ func (c *Client) WaitForClusterRoleBindingSCCUse(ctx context.Context, cr *rbacv1
 		namespace string
 		name      string
 		sccName   string
+		ok        bool
 	}
 
+	// Generate bucket of SCC objects to check, skip all non ServiceAccountKind
 	var checks []sccUseCheck
 	for _, subject := range crb.Subjects {
 		if subject.Kind != rbacv1.ServiceAccountKind {
@@ -1662,64 +1664,62 @@ func (c *Client) WaitForClusterRoleBindingSCCUse(ctx context.Context, cr *rbacv1
 		return nil
 	}
 
+	// Helper function to execute check, currently only needed by WaitForClusterRoleBindingSCCUse
+	subjectAccessReviewSCCAllowed := func(ctx context.Context, user, sccName string) (bool, string, error) {
+		sar, err := c.kclient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authzv1.SubjectAccessReview{
+			Spec: authzv1.SubjectAccessReviewSpec{
+				User: user,
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Group:    secv1.GroupName,
+					Resource: "securitycontextconstraints",
+					Name:     sccName,
+					Verb:     "use",
+				},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return false, "", err
+		}
+
+		return sar.Status.Allowed, sar.Status.Reason, nil
+	}
+
 	pending := append([]sccUseCheck(nil), checks...)
 	var lastErr error
 	if err := Poll(ctx, func(ctx context.Context) (bool, error) {
-		// avoid creating access reviews on already successful runs
-		var stillPending []sccUseCheck
-		for _, check := range pending {
-			allowed, reason, err := c.subjectAccessReviewSCCAllowed(ctx, check.namespace, check.name, check.sccName)
-			if err != nil {
-				lastErr = err
-				klog.V(4).ErrorS(err, "WaitForClusterRoleBindingSCCUse: failed to create SubjectAccessReview")
-				stillPending = append(stillPending, check)
-				continue
-			}
-			if allowed {
+		successfullyCheckedAll := true
+		for i, check := range pending {
+			// skip successful runs
+			if pending[i].ok {
 				continue
 			}
 
 			user := fmt.Sprintf("system:serviceaccount:%s:%s", check.namespace, check.name)
-			if reason != "" {
-				lastErr = fmt.Errorf("%s cannot use SCC %q: %s", user, check.sccName, reason)
-			} else {
-				lastErr = fmt.Errorf("%s cannot use SCC %q", user, check.sccName)
+			allowed, reason, err := subjectAccessReviewSCCAllowed(ctx, user, check.sccName)
+			if err != nil {
+				lastErr = fmt.Errorf("failed to check access for service account %s/%s and SCC %s: %w", check.namespace, check.name, check.sccName, err)
+				klog.V(4).ErrorS(err, "WaitForClusterRoleBindingSCCUse: failed to create SubjectAccessReview")
+				successfullyCheckedAll = false
+				continue
 			}
-			stillPending = append(stillPending, check)
+			if allowed {
+				pending[i].ok = true
+				continue
+			}
+
+			successfullyCheckedAll = false
+			if reason == "" {
+				reason = "no reason"
+			}
+			lastErr = fmt.Errorf("%s cannot use SCC %q: %s", user, check.sccName, reason)
 		}
 
-		pending = stillPending
-		if len(pending) == 0 {
-			return true, nil
-		}
-
-		return false, nil
+		return successfullyCheckedAll, nil
 	}, WithPollInterval(time.Second), WithPollTimeout(30*time.Second), WithLastError(&lastErr)); err != nil {
 		return fmt.Errorf("waiting for ClusterRoleBinding %q SCC permissions: %w", crb.Name, err)
 	}
 
 	return nil
-}
-
-func (c *Client) subjectAccessReviewSCCAllowed(ctx context.Context, namespace, name, sccName string) (bool, string, error) {
-	user := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, name)
-
-	sar, err := c.kclient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authzv1.SubjectAccessReview{
-		Spec: authzv1.SubjectAccessReviewSpec{
-			User: user,
-			ResourceAttributes: &authzv1.ResourceAttributes{
-				Group:    secv1.GroupName,
-				Resource: "securitycontextconstraints",
-				Name:     sccName,
-				Verb:     "use",
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return false, "", err
-	}
-
-	return sar.Status.Allowed, sar.Status.Reason, nil
 }
 
 func (c *Client) CreateOrUpdateServiceAccount(ctx context.Context, sa *v1.ServiceAccount) error {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1607,25 +1607,28 @@ func (c *Client) CreateOrUpdateClusterRoleBinding(ctx context.Context, crb *rbac
 	return err
 }
 
-func (c *Client) WaitForClusterRoleBindingSCCUse(ctx context.Context, crb *rbacv1.ClusterRoleBinding) error {
-	if crb.RoleRef.Kind != "ClusterRole" {
+func (c *Client) WaitForClusterRoleBindingSCCUse(ctx context.Context, cr *rbacv1.ClusterRole, crb *rbacv1.ClusterRoleBinding) error {
+	if cr == nil || crb == nil {
+		return nil
+	}
+	if crb.RoleRef.Kind != "ClusterRole" || crb.RoleRef.Name != cr.Name {
 		return nil
 	}
 
-	cr, err := c.kclient.RbacV1().ClusterRoles().Get(ctx, crb.RoleRef.Name, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("getting ClusterRole %q for SCC propagation wait: %w", crb.RoleRef.Name, err)
+	// account for wildcard rules
+	matches := func(values []string, target string) bool {
+		return slices.Contains(values, target) || slices.Contains(values, "*")
 	}
 
 	var sccNames []string
 	for _, rule := range cr.Rules {
-		if !slices.Contains(rule.Verbs, "use") {
+		if !matches(rule.Verbs, "use") {
 			continue
 		}
-		if !slices.Contains(rule.APIGroups, "security.openshift.io") {
+		if !matches(rule.APIGroups, secv1.GroupName) {
 			continue
 		}
-		if !slices.Contains(rule.Resources, "securitycontextconstraints") {
+		if !matches(rule.Resources, "securitycontextconstraints") {
 			continue
 		}
 
@@ -1635,56 +1638,88 @@ func (c *Client) WaitForClusterRoleBindingSCCUse(ctx context.Context, crb *rbacv
 		return nil
 	}
 
+	type sccUseCheck struct {
+		namespace string
+		name      string
+		sccName   string
+	}
+
+	var checks []sccUseCheck
 	for _, subject := range crb.Subjects {
 		if subject.Kind != rbacv1.ServiceAccountKind {
 			continue
 		}
 
 		for _, sccName := range sccNames {
-			if err := c.waitForServiceAccountSCCUse(ctx, subject.Namespace, subject.Name, sccName); err != nil {
-				return err
-			}
+			checks = append(checks, sccUseCheck{
+				namespace: subject.Namespace,
+				name:      subject.Name,
+				sccName:   sccName,
+			})
 		}
+	}
+	if len(checks) == 0 {
+		return nil
+	}
+
+	pending := append([]sccUseCheck(nil), checks...)
+	var lastErr error
+	if err := Poll(ctx, func(ctx context.Context) (bool, error) {
+		// avoid creating access reviews on already successful runs
+		var stillPending []sccUseCheck
+		for _, check := range pending {
+			allowed, reason, err := c.subjectAccessReviewSCCAllowed(ctx, check.namespace, check.name, check.sccName)
+			if err != nil {
+				lastErr = err
+				klog.V(4).ErrorS(err, "WaitForClusterRoleBindingSCCUse: failed to create SubjectAccessReview")
+				stillPending = append(stillPending, check)
+				continue
+			}
+			if allowed {
+				continue
+			}
+
+			user := fmt.Sprintf("system:serviceaccount:%s:%s", check.namespace, check.name)
+			if reason != "" {
+				lastErr = fmt.Errorf("%s cannot use SCC %q: %s", user, check.sccName, reason)
+			} else {
+				lastErr = fmt.Errorf("%s cannot use SCC %q", user, check.sccName)
+			}
+			stillPending = append(stillPending, check)
+		}
+
+		pending = stillPending
+		if len(pending) == 0 {
+			return true, nil
+		}
+
+		return false, nil
+	}, WithPollInterval(time.Second), WithPollTimeout(30*time.Second), WithLastError(&lastErr)); err != nil {
+		return fmt.Errorf("waiting for ClusterRoleBinding %q SCC permissions: %w", crb.Name, err)
 	}
 
 	return nil
 }
 
-func (c *Client) waitForServiceAccountSCCUse(ctx context.Context, namespace, name, sccName string) error {
+func (c *Client) subjectAccessReviewSCCAllowed(ctx context.Context, namespace, name, sccName string) (bool, string, error) {
 	user := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, name)
-	var lastReason string
 
-	err := Poll(ctx, func(ctx context.Context) (bool, error) {
-		sar, err := c.kclient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authzv1.SubjectAccessReview{
-			Spec: authzv1.SubjectAccessReviewSpec{
-				User: user,
-				ResourceAttributes: &authzv1.ResourceAttributes{
-					Group:    "security.openshift.io",
-					Resource: "securitycontextconstraints",
-					Name:     sccName,
-					Verb:     "use",
-				},
+	sar, err := c.kclient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: user,
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Group:    secv1.GroupName,
+				Resource: "securitycontextconstraints",
+				Name:     sccName,
+				Verb:     "use",
 			},
-		}, metav1.CreateOptions{})
-		if err != nil {
-			return false, err
-		}
-		if sar.Status.Allowed {
-			return true, nil
-		}
-
-		lastReason = sar.Status.Reason
-		return false, nil
-	}, WithPollInterval(time.Second), WithPollTimeout(30*time.Second))
-
+		},
+	}, metav1.CreateOptions{})
 	if err != nil {
-		if lastReason != "" {
-			return fmt.Errorf("waiting for %s to use SCC %q: %w: %s", user, sccName, err, lastReason)
-		}
-		return fmt.Errorf("waiting for %s to use SCC %q: %w", user, sccName, err)
+		return false, "", err
 	}
 
-	return nil
+	return sar.Status.Allowed, sar.Status.Reason, nil
 }
 
 func (c *Client) CreateOrUpdateServiceAccount(ctx context.Context, sa *v1.ServiceAccount) error {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -44,6 +44,7 @@ import (
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	authzv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -1604,6 +1605,86 @@ func (c *Client) CreateOrUpdateClusterRole(ctx context.Context, cr *rbacv1.Clust
 func (c *Client) CreateOrUpdateClusterRoleBinding(ctx context.Context, crb *rbacv1.ClusterRoleBinding) error {
 	_, _, err := resourceapply.ApplyClusterRoleBinding(ctx, c.kclient.RbacV1(), c.eventRecorder, crb)
 	return err
+}
+
+func (c *Client) WaitForClusterRoleBindingSCCUse(ctx context.Context, crb *rbacv1.ClusterRoleBinding) error {
+	if crb.RoleRef.Kind != "ClusterRole" {
+		return nil
+	}
+
+	cr, err := c.kclient.RbacV1().ClusterRoles().Get(ctx, crb.RoleRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting ClusterRole %q for SCC propagation wait: %w", crb.RoleRef.Name, err)
+	}
+
+	var sccNames []string
+	for _, rule := range cr.Rules {
+		if !slices.Contains(rule.Verbs, "use") {
+			continue
+		}
+		if !slices.Contains(rule.APIGroups, "security.openshift.io") {
+			continue
+		}
+		if !slices.Contains(rule.Resources, "securitycontextconstraints") {
+			continue
+		}
+
+		sccNames = append(sccNames, rule.ResourceNames...)
+	}
+	if len(sccNames) == 0 {
+		return nil
+	}
+
+	for _, subject := range crb.Subjects {
+		if subject.Kind != rbacv1.ServiceAccountKind {
+			continue
+		}
+
+		for _, sccName := range sccNames {
+			if err := c.waitForServiceAccountSCCUse(ctx, subject.Namespace, subject.Name, sccName); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) waitForServiceAccountSCCUse(ctx context.Context, namespace, name, sccName string) error {
+	user := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, name)
+	var lastReason string
+
+	err := Poll(ctx, func(ctx context.Context) (bool, error) {
+		sar, err := c.kclient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authzv1.SubjectAccessReview{
+			Spec: authzv1.SubjectAccessReviewSpec{
+				User: user,
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Group:    "security.openshift.io",
+					Resource: "securitycontextconstraints",
+					Name:     sccName,
+					Verb:     "use",
+				},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return false, err
+		}
+		if sar.Status.Allowed {
+			return true, nil
+		}
+
+		lastReason = sar.Status.Reason
+		return false, nil
+	}, WithPollInterval(time.Second), WithPollTimeout(30*time.Second))
+
+	if err != nil {
+		if lastReason != "" {
+			return fmt.Errorf("waiting for %s to use SCC %q: %w: %s", user, sccName, err, lastReason)
+		}
+		return fmt.Errorf("waiting for %s to use SCC %q: %w", user, sccName, err)
+	}
+
+	return nil
 }
 
 func (c *Client) CreateOrUpdateServiceAccount(ctx context.Context, sa *v1.ServiceAccount) error {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -33,14 +33,17 @@ import (
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	authzv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 )
@@ -2331,4 +2334,83 @@ func TestPollUntil(t *testing.T) {
 	cancelParentCtx3()
 	wg.Wait()
 	require.ErrorContains(t, pollErr, "context deadline exceeded")
+}
+
+func TestWaitForClusterRoleBindingSCCUse(t *testing.T) {
+	ctx := context.Background()
+
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-main"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{"security.openshift.io"},
+			Resources:     []string{"securitycontextconstraints"},
+			ResourceNames: []string{"nonroot"},
+			Verbs:         []string{"use"},
+		}},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-main"},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     cr.Name,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      "alertmanager-main",
+			Namespace: ns,
+		}},
+	}
+
+	t.Run("allowed", func(t *testing.T) {
+		kclient := fake.NewClientset(cr)
+		kclient.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &authzv1.SubjectAccessReview{
+				Status: authzv1.SubjectAccessReviewStatus{Allowed: true},
+			}, nil
+		})
+
+		c := Client{kclient: kclient}
+		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, crb))
+	})
+
+	t.Run("denied then allowed", func(t *testing.T) {
+		kclient := fake.NewClientset(cr)
+		var calls int
+		kclient.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			calls++
+			allowed := calls > 1
+			return true, &authzv1.SubjectAccessReview{
+				Status: authzv1.SubjectAccessReviewStatus{
+					Allowed: allowed,
+					Reason:  "waiting for RBAC",
+				},
+			}, nil
+		})
+
+		c := Client{kclient: kclient}
+		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, crb))
+		require.Greater(t, calls, 1)
+	})
+
+	t.Run("no scc rules", func(t *testing.T) {
+		kclient := fake.NewClientset(&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-scc"},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get"},
+			}},
+		})
+
+		c := Client{kclient: kclient}
+		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-scc"},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "no-scc",
+			},
+		}))
+	})
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2371,7 +2371,7 @@ func TestWaitForClusterRoleBindingSCCUse(t *testing.T) {
 		})
 
 		c := Client{kclient: kclient}
-		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, crb))
+		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, cr, crb))
 	})
 
 	t.Run("denied then allowed", func(t *testing.T) {
@@ -2389,28 +2389,29 @@ func TestWaitForClusterRoleBindingSCCUse(t *testing.T) {
 		})
 
 		c := Client{kclient: kclient}
-		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, crb))
+		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, cr, crb))
 		require.Greater(t, calls, 1)
 	})
 
 	t.Run("no scc rules", func(t *testing.T) {
-		kclient := fake.NewClientset(&rbacv1.ClusterRole{
+		noSCCRole := &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{Name: "no-scc"},
 			Rules: []rbacv1.PolicyRule{{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
 				Verbs:     []string{"get"},
 			}},
-		})
-
-		c := Client{kclient: kclient}
-		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, &rbacv1.ClusterRoleBinding{
+		}
+		noSCCBinding := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{Name: "no-scc"},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
 				Name:     "no-scc",
 			},
-		}))
+		}
+
+		c := Client{kclient: fake.NewClientset()}
+		require.NoError(t, c.WaitForClusterRoleBindingSCCUse(ctx, noSCCRole, noSCCBinding))
 	})
 }

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -168,6 +168,11 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return fmt.Errorf("reconciling Alertmanager ServiceAccount failed: %w", err)
 	}
 
+	err = t.client.WaitForClusterRoleBindingSCCUse(ctx, crb)
+	if err != nil {
+		return fmt.Errorf("waiting for role binding permissions failed: %w", err)
+	}
+
 	ps, err := t.factory.AlertmanagerRBACProxyWebSecret()
 	if err != nil {
 		return fmt.Errorf("initializing Alertmanager proxy web Secret failed: %w", err)

--- a/pkg/tasks/alertmanager.go
+++ b/pkg/tasks/alertmanager.go
@@ -168,7 +168,7 @@ func (t *AlertmanagerTask) create(ctx context.Context) error {
 		return fmt.Errorf("reconciling Alertmanager ServiceAccount failed: %w", err)
 	}
 
-	err = t.client.WaitForClusterRoleBindingSCCUse(ctx, crb)
+	err = t.client.WaitForClusterRoleBindingSCCUse(ctx, cr, crb)
 	if err != nil {
 		return fmt.Errorf("waiting for role binding permissions failed: %w", err)
 	}

--- a/pkg/tasks/alertmanager_user_workload.go
+++ b/pkg/tasks/alertmanager_user_workload.go
@@ -157,6 +157,11 @@ func (t *AlertmanagerUserWorkloadTask) create(ctx context.Context) error {
 		return fmt.Errorf("reconciling Alertmanager User Workload ServiceAccount failed: %w", err)
 	}
 
+	err = t.client.WaitForClusterRoleBindingSCCUse(ctx, crb)
+	if err != nil {
+		return fmt.Errorf("waiting for role binding permissions failed: %w", err)
+	}
+
 	svc, err := t.factory.AlertmanagerUserWorkloadService()
 	if err != nil {
 		return fmt.Errorf("initializing Alertmanager User Workload Service failed: %w", err)

--- a/pkg/tasks/alertmanager_user_workload.go
+++ b/pkg/tasks/alertmanager_user_workload.go
@@ -157,7 +157,7 @@ func (t *AlertmanagerUserWorkloadTask) create(ctx context.Context) error {
 		return fmt.Errorf("reconciling Alertmanager User Workload ServiceAccount failed: %w", err)
 	}
 
-	err = t.client.WaitForClusterRoleBindingSCCUse(ctx, crb)
+	err = t.client.WaitForClusterRoleBindingSCCUse(ctx, cr, crb)
 	if err != nil {
 		return fmt.Errorf("waiting for role binding permissions failed: %w", err)
 	}


### PR DESCRIPTION
Alertmanager pods could be denied at install when ClusterRoleBinding SCC permissions had not yet propagated to admission, causing the openshift Early SCC test to fail on slow installs (e.g. two-node fencing metal jobs).

Add WaitForClusterRoleBindingSCCUse to poll SubjectAccessReview until each bound service account can use the SCCs granted by its ClusterRole. Call it from platform and user-workload Alertmanager tasks after RBAC is applied and before the Alertmanager CR is created.


Model: Composer

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
