### PR TITLE
MON-4583: adding NVIDIA H200 GPU device to accelerators configmap

### DIFF
--- a/assets/node-exporter/accelerators-collector-configmap.yaml
+++ b/assets/node-exporter/accelerators-collector-configmap.yaml
@@ -70,6 +70,8 @@ data:
         "pciID": "0x2bb5"
       - "modelName": "Blackwell GB100"
         "pciID": "0x2941"
+      - "modelName": "NVIDIA H200"
+        "pciID": "0x2335"
       "vendorID": "0x10de"
       "vendorName": "NVIDIA"
     - "models":

--- a/jsonnet/components/node-exporter.libsonnet
+++ b/jsonnet/components/node-exporter.libsonnet
@@ -46,6 +46,7 @@ local acceleratorsConfigData = [
       { pciID: '0x25b0', modelName: 'NVIDIA RTX A1000' },
       { pciID: '0x2bb5', modelName: 'Blackwell RTX PRO 6000' },
       { pciID: '0x2941', modelName: 'Blackwell GB100' },
+      { pciID: '0x2335', modelName: 'NVIDIA H200' },
     ],
   },
   {


### PR DESCRIPTION
## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
