### PR TITLE
NO-ISSUE: Fix typo in KubeDeploymentReplicasMismatch alert description

### DIFF
--- a/assets/cluster-monitoring-operator/prometheus-rule.yaml
+++ b/assets/cluster-monitoring-operator/prometheus-rule.yaml
@@ -287,7 +287,7 @@ spec:
         severity: warning
     - alert: KubeDeploymentReplicasMismatch
       annotations:
-        description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes. This indicates that cluster infrastructure is unable to start or restart the necessary components. This most often occurs when one or more nodes are down or partioned from the cluster, or a fault occurs on the node that prevents the workload from starting. In rare cases this may indicate a new version of a cluster component cannot start due to a bug or configuration error. Assess the pods for this deployment to verify they are running on healthy nodes and then contact support.
+        description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes. This indicates that cluster infrastructure is unable to start or restart the necessary components. This most often occurs when one or more nodes are down or partitioned from the cluster, or a fault occurs on the node that prevents the workload from starting. In rare cases this may indicate a new version of a cluster component cannot start due to a bug or configuration error. Assess the pods for this deployment to verify they are running on healthy nodes and then contact support.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeDeploymentReplicasMismatch.md
         summary: Deployment has not matched the expected number of replicas
       expr: |

--- a/jsonnet/rules.libsonnet
+++ b/jsonnet/rules.libsonnet
@@ -447,7 +447,7 @@ function(params) {
           alert: 'KubeDeploymentReplicasMismatch',
           'for': '15m',
           annotations: {
-            description: 'Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes. This indicates that cluster infrastructure is unable to start or restart the necessary components. This most often occurs when one or more nodes are down or partioned from the cluster, or a fault occurs on the node that prevents the workload from starting. In rare cases this may indicate a new version of a cluster component cannot start due to a bug or configuration error. Assess the pods for this deployment to verify they are running on healthy nodes and then contact support.',
+            description: 'Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes. This indicates that cluster infrastructure is unable to start or restart the necessary components. This most often occurs when one or more nodes are down or partitioned from the cluster, or a fault occurs on the node that prevents the workload from starting. In rare cases this may indicate a new version of a cluster component cannot start due to a bug or configuration error. Assess the pods for this deployment to verify they are running on healthy nodes and then contact support.',
             summary: 'Deployment has not matched the expected number of replicas',
           },
           labels: {

--- a/test/rules/bz1974830.yaml
+++ b/test/rules/bz1974830.yaml
@@ -56,7 +56,7 @@ tests:
             exp_annotations:
               summary: 'Deployment has not matched the expected number of replicas'
               description: >-
-                Deployment openshift-apiserver/apiserver has not matched the expected number of replicas for longer than 15 minutes. This indicates that cluster infrastructure is unable to start or restart the necessary components. This most often occurs when one or more nodes are down or partioned from the cluster, or a fault occurs on the node that prevents the workload from starting. In rare cases this may indicate a new version of a cluster component cannot start due to a bug or configuration error. Assess the pods for this deployment to verify they are running on healthy nodes and then contact support.
+                Deployment openshift-apiserver/apiserver has not matched the expected number of replicas for longer than 15 minutes. This indicates that cluster infrastructure is unable to start or restart the necessary components. This most often occurs when one or more nodes are down or partitioned from the cluster, or a fault occurs on the node that prevents the workload from starting. In rare cases this may indicate a new version of a cluster component cannot start due to a bug or configuration error. Assess the pods for this deployment to verify they are running on healthy nodes and then contact support.
               runbook_url: 'https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubeDeploymentReplicasMismatch.md'
     # Test the 'KubeDeploymentReplicasMismatch' will not fire if all replicas are available
   - interval: 5m


### PR DESCRIPTION
## Summary
- Correct spelling in the `KubeDeploymentReplicasMismatch` alert description: `partioned` → `partitioned`
- Update generated PrometheusRule manifest and promtool unit test fixture
- Cosmetic change only; alert expression and firing behavior are unchanged

## Test plan
- [x] `hack/test-rules.sh` passes (including `test/rules/bz1974830.yaml`)
- [ ] Verify on cluster after merge:
  ```bash
  oc -n openshift-monitoring get prometheusrule cluster-monitoring-operator-prometheus-rules -o yaml | grep partitioned
  ```

Fixes [MON-4586](https://redhat.atlassian.net/browse/MON-4586)

Made with [Cursor](https://cursor.com)