### PR TITLE
RFE-7224: Add maximum CPU usage visualization to Kubernetes/Compute Resources/Pod dashboard

### DIFF
--- a/manifests/0000_90_cluster-monitoring-operator_02-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_02-dashboards.yaml
@@ -8459,6 +8459,12 @@ data:
                                 "format": "time_series",
                                 "legendFormat": "limits",
                                 "legendLink": null
+                            },
+                            {
+                                "expr": "max_over_time(sum by (container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=\"$pod\", container!=\"\"})[5m:])",
+                                "format": "time_series",
+                                "legendFormat": "{{container}} (max)",
+                                "legendLink": null
                             }
                         ],
                         "thresholds": [


### PR DESCRIPTION
## Summary

* Adds a `max_over_time()` target to the "CPU Usage" panel in the **Kubernetes / Compute Resources / Pod** Observe Dashboard, showing per-container peak CPU consumption alongside the existing current usage, requests, and limits lines.
* Enables users to see CPU spikes that are otherwise hidden when viewing longer timeframes (e.g., 2 weeks), directly addressing the need to accurately rightsize CPU limits.

## Details

### Problem

The current "CPU Usage" panel in the Observe Dashboard (Kubernetes / Compute Resources / Pod) only shows instantaneous CPU usage rate. Over longer timeframes (e.g., 2 weeks), Grafana downsamples data points, effectively erasing peaks. Users cannot see maximum CPU consumption, leading to:

- **Incorrect CPU limit sizing** — limits set too low cause throttling and outages
- **Resource waste** — limits set too high waste cluster resources
- **No visibility into spikes** — transient CPU bursts are invisible in the dashboard

Ref: [RFE-7224](https://redhat.atlassian.net/browse/RFE-7224)

### Solution

**1 file changed (6 lines added, 0 deleted):**

| File | Change |
| --- | --- |
| `manifests/0000_90_cluster-monitoring-operator_02-dashboards.yaml` | Added 4th target to the CPU Usage panel in the `dashboard-k8s-resources-pod` ConfigMap |

The new target:
```json
{
    "expr": "max_over_time(sum by (container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=\"$pod\", container!=\"\"})[5m:])",
    "format": "time_series",
    "legendFormat": "{{container}} (max)",
    "legendLink": null
}
```

This uses `max_over_time()` with a 5-minute subquery window to capture per-container peak CPU usage, displayed as `<container> (max)` in the panel legend.

### Backward Compatibility

This change is **fully backward compatible**:

* The 3 existing targets (current usage, requests, limits) are completely untouched
* No Go code, operator logic, or reconciliation behavior is modified
* The dashboard file is a static manifest (not jsonnet-generated); the file header states "Any future change to these dashboards should be made here directly"
* No other dashboards or panels are affected — only Row 0, Panel 0 ("CPU Usage") of `k8s-resources-pod.json`
* The `max_over_time()` subquery adds minimal Prometheus evaluation cost at pod-level granularity
* No repos outside cluster-monitoring-operator need changes — `openshift/console` and `openshift/monitoring-plugin` already support multi-target panels

### Customer Benefit

* **Accurate CPU limit sizing** — Users can see peak CPU consumption alongside requests/limits, enabling informed decisions about resource allocation
* **Spike visibility over long timeframes** — The max line preserves peaks that the current-usage line hides when viewing 1-week or 2-week windows
* **Prevents throttling and outages** — Users can detect when peak CPU approaches or exceeds limits before problems occur
* **Zero risk to existing users** — Adds a read-only query to an existing panel with no behavioral changes

## Test Plan

### Structural Validation (PASSED)

* YAML parsing: 9 documents parsed successfully
* JSON parsing: `k8s-resources-pod.json` valid
* Panel structure: CPU Usage panel has 4 targets (was 3)
* All 9 dashboards in the manifest file validated

### New Target Validation (8/8 PASSED)

| Check | Result |
| --- | --- |
| Has `max_over_time` | PASS |
| Scoped to `$namespace` | PASS |
| Scoped to `$pod` | PASS |
| Excludes empty container (`container!=""`) | PASS |
| Uses 5m subquery window (`[5m:]`) | PASS |
| Uses correct recording rule | PASS |
| Legend has `(max)` suffix | PASS |
| Format is `time_series` | PASS |

### PromQL Query Validation (PASSED)

Both existing and new queries return `status: "success"` from Thanos, confirming valid PromQL syntax.

### Live Data Evidence (max_over_time comparison)

Tested with working metrics on a live OCP 4.22 cluster (`apps.logitechloki.india.aws.cee.support`):

**Instant query — current vs max (etcd pods):**

| Pod | Current (cores) | Max 5m (cores) | Difference |
| --- | --- | --- | --- |
| etcd-...-1-137 | 0.061407 | 0.062333 | **+1.5%** |
| etcd-...-42-205 | 0.053185 | 0.055111 | **+3.6%** |
| etcd-...-79-179 | 0.051756 | 0.053852 | **+4.0%** |

**Range query — 1-hour window (simulates dashboard view):**

| Pod | Data Points | Min | Max | Spread |
| --- | --- | --- | --- | --- |
| etcd-...-1-137 | 13 | 0.058 | 0.068 | **17.6%** |
| etcd-...-42-205 | 13 | 0.054 | 0.060 | **10.4%** |
| etcd-...-79-179 | 13 | 0.053 | 0.066 | **23.6%** |

### No Regression Check (PASSED)

* All 9 dashboards in the manifest validated successfully
* 12 other panels in the pod dashboard are completely unaffected
* No existing tests reference this dashboard (confirmed by codebase search)

### UI Verification

Navigate: **Administrator → Observe → Dashboards → "Kubernetes / Compute Resources / Pod"**

Expected after patch:
- 4 series visible in CPU Usage panel (current, requests, limits, max)
- Legend shows `<container> (max)` entries
- Max line ≥ current usage line at all times

Made with [Cursor](https://cursor.com)