### PR TITLE
OCPBUGS-87800: fix(TestDocExamples) flake: use internal registry for test pods

### DIFF
--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -109,7 +109,7 @@ func TestDocExamples(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            containerName,
-									Image:           "registry.redhat.io/openshift4/ose-cli:latest",
+									Image:           "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest",
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									Command:         []string{"bash", "-c", test.Script},
 									SecurityContext: &corev1.SecurityContext{

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -407,7 +407,7 @@ func runProbePod(t *testing.T, ctx context.Context, script string) {
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{{
 				Name:            "probe",
-				Image:           "registry.redhat.io/openshift4/ose-cli:latest",
+				Image:           "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest",
 				ImagePullPolicy: v1.PullIfNotPresent,
 				Command:         []string{"bash", "-c", script},
 				SecurityContext: &v1.SecurityContext{


### PR DESCRIPTION
   The ose-cli image (~584MB!!) pulled from registry.redhat.io can take over
    60s, causing TestDocExamples to flake when the pod stays
    in Pending past the poll timeout. Switch to the cli image from the
    cluster's internal registry (openshift/cli) to avoid external pulls.


ALSO

    fix(TestNetworkPolicy): use internal registry for test pods
    
    Same as the TestDocExamples fix: switch runProbePod from
    registry.redhat.io/openshift4/ose-cli:latest to the internal registry
    path to avoid slow external image pulls in CI.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
