### PR TITLE
OCPBUGS-87799: fix TestTelemetryReport flake by waiting for rate() on  raw metrics

### DIFF
--- a/test/e2e/telemetry_report_test.go
+++ b/test/e2e/telemetry_report_test.go
@@ -55,11 +55,11 @@ func TestTelemetryReport(t *testing.T) {
 	t.Cleanup(cleanup)
 	promURL := fmt.Sprintf("http://%s", host)
 
-	// Wait for recording rules to produce data: a trivial one and a
-	// rate()-based one that needs multiple scrape cycles. The extra sleep
-	// gives the remaining rules time to evaluate through their chains.
-	waitForQuery(t, promURL, "e2etelemetry:const_one:gauge", 5*time.Minute)
-	waitForQuery(t, promURL, "e2etelemetry:etcd_wal_fsync:deep_rate", 5*time.Minute)
+	// rate() on a raw metric (etcd metrics here) requires >=2 scrapes (~30s apart) to return
+	// data; this implicitly confirms the PrometheusRule is loaded and targets
+	// are being scraped. The extra sleep gives the remaining rule chains
+	// time to fully evaluate.
+	waitForQuery(t, promURL, "e2etelemetry:suffix_ok:rate", 5*time.Minute)
 	time.Sleep(30 * time.Second)
 
 	tests := map[string]string{


### PR DESCRIPTION
The test previously waited for recording rules that apply rate() on other recording rules (3s evaluation interval), which need far fewer samples than rate() on raw scraped metrics (30s scrape interval).

When Prometheus restarts and because emptyDir is used the TSDB, the old waitForQuery calls could return before a second raw scrape occurred, causing rate-based recording rules to report 0 timeseries and fail the golden file comparison.

In the linked job run, Prometheus restarted right before TestTelemetryReport. The fresh pod had an empty TSDB with only one scrape worth of data.

Wait for e2etelemetry:suffix_ok:rate instead, which applies rate() directly on a raw counter. This won't return data until at least two scrapes have landed, which also implicitly confirms that the PrometheusRule is loaded and targets are being scraped.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
