### PR TITLE
wip: speed up e2e tests

### DIFF
--- a/test/e2e/alert_relabel_config_test.go
+++ b/test/e2e/alert_relabel_config_test.go
@@ -40,6 +40,8 @@ const (
 )
 
 func TestAlertRelabelConfig(t *testing.T) {
+	// Not safe to run in parallel: creates/deletes AlertRelabelConfig in the shared openshift-monitoring namespace and validates the Prometheus config secret.
+	// t.Parallel()
 	initialRelabelConfig := prometheusRelabelConfig(t)
 
 	// By default, we drop prometheus_replica label + add openshift_io_alert_source = 2

--- a/test/e2e/alerting_rule_test.go
+++ b/test/e2e/alerting_rule_test.go
@@ -39,6 +39,8 @@ const (
 )
 
 func TestAlertingRule(t *testing.T) {
+	// Not safe to run in parallel: creates/deletes AlertingRules and PrometheusRules in the shared openshift-monitoring namespace and asserts on PrometheusRule count.
+	// t.Parallel()
 	ctx := context.Background()
 	alertingRules := f.OpenShiftMonitoringClient.MonitoringV1().AlertingRules(f.Ns)
 
@@ -142,6 +144,8 @@ func TestAlertingRule(t *testing.T) {
 // scheme, before the hash was changed to SHA-224 in
 // https://github.com/openshift/cluster-monitoring-operator/pull/2086.
 func TestAlertingRuleLegacyPrometheusRuleCleanup(t *testing.T) {
+	// Not safe to run in parallel: creates/deletes AlertingRules and PrometheusRules in the shared namespace.
+	// t.Parallel()
 	const arName = "legacy-rule-test"
 
 	createAlertingRule(t, &osmv1.AlertingRule{
@@ -226,6 +230,7 @@ func prometheusRuleCount(t *testing.T) int {
 }
 
 func assertPrometheusRuleCount(t *testing.T, count int) {
+	t.Helper()
 	currentCount := prometheusRuleCount(t)
 	if currentCount != count {
 		t.Fatalf("Different generated PrometheusRule count (%d != %d)", currentCount, count)

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -47,6 +47,8 @@ import (
 // TestAlertmanagerTenancyAPI ensures that the Alertmanager API exposed on the
 // tenancy port enforces the namespace value.
 func TestAlertmanagerTenancyAPI(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	for _, tc := range []struct {
 		name               string
 		config             string
@@ -368,6 +370,8 @@ func testAlertmanagerTenancyAPI(t *testing.T, host string) {
 // Even when no persistent storage is configured, silences (and notifications)
 // shouldn't be lost when new Alertmanager pods are rolled out.
 func TestAlertmanagerDataReplication(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		silenceLabelName  = "test"
 		silenceLabelValue = "AlertmanagerReplication"
@@ -465,6 +469,8 @@ func TestAlertmanagerDataReplication(t *testing.T) {
 
 // The Alertmanager API should be protected by authentication/authorization.
 func TestAlertmanagerAPI(t *testing.T) {
+	// The test uses its own isolated namespace, safe to run in parallel.
+	t.Parallel()
 	err := framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		body, err := f.AlertmanagerClient.GetAlertmanagerAlerts(
 			"filter", `alertname="Watchdog"`,
@@ -679,6 +685,8 @@ func checkAlertmanagerAPIVerbs(_ *testing.T, client *framework.PrometheusClient,
 
 // Users should be able to disable Alertmanager through the cluster-monitoring-config
 func TestAlertmanagerDisabling(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, "alertmanagerMain: { enabled: false }"))
 
 	assertions := []struct {
@@ -755,6 +763,8 @@ func TestAlertmanagerDisabling(t *testing.T) {
 // correct Alertmanager (depending on whether user-defined Alertmanager is
 // enabled or not).
 func TestAlertmanagerConfigPipeline(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap.
+	// t.Parallel()
 	for _, tc := range []struct {
 		name               string
 		config             string
@@ -964,8 +974,10 @@ func assertLabelSelectorRequirement(reqs []metav1.LabelSelectorRequirement, must
 }
 
 // TestAlertmanagerPlatformSecrets ensures secrets
-// are mounted correctly in Platform AlertManager container
+// are mounted correctly in Platform AlertManager container.
 func TestAlertmanagerPlatformSecrets(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	amSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
@@ -1043,8 +1055,10 @@ func TestAlertmanagerPlatformSecrets(t *testing.T) {
 }
 
 // TestAlertmanagerUWMSecrets ensures secrets
-// are mounted correctly in UWM AlertManager container
+// are mounted correctly in UWM AlertManager container.
 func TestAlertmanagerUWMSecrets(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap.
+	// t.Parallel()
 	amSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
@@ -1132,6 +1146,7 @@ func TestAlertmanagerUWMSecrets(t *testing.T) {
 // via pod port-forwarding to port 9093. Even though it is not exposed through
 // the service, it is useful to catch broken UI embeds after a version bump.
 func TestAlertmanagerWebUI(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
 	t.Parallel()
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
 		host, cleanUp, err := f.ForwardPodPort(t, f.Ns, "alertmanager-main-0", 9093)

--- a/test/e2e/alertmanager_user_workload_test.go
+++ b/test/e2e/alertmanager_user_workload_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 func TestUserWorkloadWithAlertmanager(t *testing.T) {
-
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap.
+	// t.Parallel()
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
 	uwmCM := f.BuildUserWorkloadConfigMap(t, `alertmanager:

--- a/test/e2e/cluster_monitoring_test.go
+++ b/test/e2e/cluster_monitoring_test.go
@@ -34,6 +34,8 @@ const clusterMonitoringName = "cluster"
 
 // TestClusterMonitoringUserDefined tests UserDefinedMonitoring (enable/disable user workload monitoring via CRD).
 func TestClusterMonitoringUserDefined(t *testing.T) {
+	// Not safe to run in parallel: modifies the ClusterMonitoring CRD.
+	// t.Parallel()
 	if !clusterMonitoringCRDAvailable {
 		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
 		return
@@ -157,6 +159,8 @@ func TestClusterMonitoringUserDefined(t *testing.T) {
 // TestConfigMapEnableUserWorkloadOverridesCRD verifies that when enableUserWorkload is set in the
 // cluster-monitoring-config ConfigMap, that value is used and the ClusterMonitoring CRD is ignored.
 func TestConfigMapEnableUserWorkloadOverridesCRD(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap and ClusterMonitoring CRD.
+	// t.Parallel()
 	if !clusterMonitoringCRDAvailable {
 		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
 		return
@@ -217,6 +221,8 @@ func TestConfigMapEnableUserWorkloadOverridesCRD(t *testing.T) {
 
 // TestClusterMonitoringMetricsServer tests MetricsServerConfig via ClusterMonitoring CRD.
 func TestClusterMonitoringMetricsServer(t *testing.T) {
+	// Not safe to run in parallel: modifies the ClusterMonitoring CRD.
+	// t.Parallel()
 	if !clusterMonitoringCRDAvailable {
 		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
 		return
@@ -285,6 +291,8 @@ func TestClusterMonitoringMetricsServer(t *testing.T) {
 // TestClusterMonitorMetricsServerConfigMapAndCRD verifies Phase 1 merge: when both ConfigMap and CR
 // specify metricsServer, the ConfigMap wins at the top level and CR values are ignored.
 func TestClusterMonitorMetricsServerConfigMapAndCRD(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap and ClusterMonitoring CRD.
+	// t.Parallel()
 	if !clusterMonitoringCRDAvailable {
 		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
 		return
@@ -365,6 +373,8 @@ func TestClusterMonitorMetricsServerConfigMapAndCRD(t *testing.T) {
 
 // TestClusterMonitoringPrometheusOperator tests PrometheusOperatorConfig via ClusterMonitoring CRD.
 func TestClusterMonitoringPrometheusOperator(t *testing.T) {
+	// Not safe to run in parallel: modifies the ClusterMonitoring CRD.
+	// t.Parallel()
 	if !clusterMonitoringCRDAvailable {
 		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
 		return
@@ -437,6 +447,8 @@ func TestClusterMonitoringPrometheusOperator(t *testing.T) {
 // TestClusterMonitorPrometheusOperatorConfigMapAndCRD verifies Phase 1 merge: when both ConfigMap and CR
 // specify prometheusOperator / prometheusOperatorConfig, the ConfigMap wins at the top level and CR values are ignored.
 func TestClusterMonitorPrometheusOperatorConfigMapAndCRD(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap and ClusterMonitoring CRD.
+	// t.Parallel()
 	if !clusterMonitoringCRDAvailable {
 		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
 		return
@@ -515,6 +527,8 @@ func TestClusterMonitorPrometheusOperatorConfigMapAndCRD(t *testing.T) {
 
 // TestClusterMonitoringAlertmanager tests alertmanagerConfig via ClusterMonitoring CRD (CustomConfig).
 func TestClusterMonitoringAlertmanager(t *testing.T) {
+	// Not safe to run in parallel: modifies the ClusterMonitoring CRD.
+	// t.Parallel()
 	if !clusterMonitoringCRDAvailable {
 		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
 		return
@@ -585,6 +599,8 @@ func TestClusterMonitoringAlertmanager(t *testing.T) {
 // TestClusterMonitorAlertmanagerConfigMapAndCRD verifies Phase 1 merge: when both ConfigMap and CR
 // specify alertmanagerMain / alertmanagerConfig, the ConfigMap wins at the top level and CR values are ignored.
 func TestClusterMonitorAlertmanagerConfigMapAndCRD(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap and ClusterMonitoring CRD.
+	// t.Parallel()
 	if !clusterMonitoringCRDAvailable {
 		t.Skip("ClusterMonitoring CRD not available (TechPreview / ClusterMonitoringConfig feature gate may be disabled)")
 		return

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -37,6 +37,8 @@ import (
 )
 
 func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	// Enable user workload monitoring to assess that an invalid configuration
 	// doesn't rollback the last known and valid configuration.
 	setupUserWorkloadAssets(t, f)
@@ -90,6 +92,8 @@ func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
 }
 
 func TestClusterMonitoringStatus(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config and user-workload-monitoring-config ConfigMaps.
+	// t.Parallel()
 	const (
 		storage = "2Gi"
 	)
@@ -205,6 +209,8 @@ prometheusK8s:
 }
 
 func TestClusterMonitorPrometheusOperatorConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		containerName = "prometheus-operator"
 	)
@@ -235,6 +241,8 @@ func TestClusterMonitorPrometheusOperatorConfig(t *testing.T) {
 }
 
 func TestClusterMonitorPrometheusK8Config(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		pvcClaimName    = "prometheus-k8s-db-prometheus-k8s-0"
 		statefulsetName = "prometheus-k8s"
@@ -320,6 +328,8 @@ func TestClusterMonitorPrometheusK8Config(t *testing.T) {
 }
 
 func TestClusterMonitorAlertManagerConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		pvcClaimName    = "alertmanager-main-db-alertmanager-main-0"
 		statefulsetName = "alertmanager-main"
@@ -372,6 +382,8 @@ func TestClusterMonitorAlertManagerConfig(t *testing.T) {
 }
 
 func TestClusterMonitorKSMConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		deploymentName = "kube-state-metrics"
 	)
@@ -403,6 +415,8 @@ func TestClusterMonitorKSMConfig(t *testing.T) {
 }
 
 func TestClusterMonitorOSMConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		deploymentName = "openshift-state-metrics"
 	)
@@ -434,6 +448,8 @@ func TestClusterMonitorOSMConfig(t *testing.T) {
 }
 
 func TestClusterMonitorTelemeterClientConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		deploymentName = "telemeter-client"
 	)
@@ -467,6 +483,8 @@ func TestClusterMonitorTelemeterClientConfig(t *testing.T) {
 }
 
 func TestTelemeterClientSecret(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	for _, tc := range []struct {
 		name         string
 		oldC         string
@@ -511,6 +529,8 @@ func TestTelemeterClientSecret(t *testing.T) {
 }
 
 func TestClusterMonitorThanosQuerierConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		deploymentName = "thanos-querier"
 		containerName  = "thanos-query"
@@ -552,6 +572,8 @@ func TestClusterMonitorThanosQuerierConfig(t *testing.T) {
 }
 
 func TestUserWorkloadMonitorPromOperatorConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		containerName = "prometheus-operator"
 	)
@@ -585,6 +607,8 @@ func TestUserWorkloadMonitorPromOperatorConfig(t *testing.T) {
 }
 
 func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap.
+	// t.Parallel()
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 	const (
 		pvcClaimName    = "prometheus-user-workload-db-prometheus-user-workload-0"
@@ -702,6 +726,8 @@ func TestUserWorkloadMonitorPrometheusK8Config(t *testing.T) {
 }
 
 func TestUserWorkloadMonitorThanosRulerConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		containerName   = "thanos-ruler"
 		pvcClaimName    = "thanos-ruler-user-workload-data-thanos-ruler-user-workload-0"
@@ -830,6 +856,8 @@ func checkMonitorConsolePluginReachable(t *testing.T, pluginName string) {
 }
 
 func TestClusterMonitorConsolePlugin(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		deploymentName = "monitoring-plugin"
 		cpu            = "10m"
@@ -881,6 +909,8 @@ monitoringPlugin:
 }
 
 func TestClusterMonitoringDeprecatedConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	metricName := "cluster_monitoring_operator_deprecated_config_in_use"
 	checkMetricValue := func(value float64) {
 		t.Helper()

--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -65,6 +65,8 @@ func setupEnv(t *testing.T) {
 }
 
 func TestDocExamples(t *testing.T) {
+	// The test creates its own isolated namespace, safe to run in parallel.
+	t.Parallel()
 	filesDir := "test_command/scripts/"
 	tempDir := t.TempDir()
 	kubeConfigPath := f.KubeConfigPath

--- a/test/e2e/kube_state_metrics_test.go
+++ b/test/e2e/kube_state_metrics_test.go
@@ -32,7 +32,8 @@ import (
 )
 
 func TestKSMMetricsSuppression(t *testing.T) {
-
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	suppressedPattern, _ := regexp.Compile("kube_.*_annotations")
 
 	err := framework.Poll(5*time.Second, time.Minute, func() error {
@@ -74,6 +75,8 @@ func TestKSMMetricsSuppression(t *testing.T) {
 }
 
 func TestKSMCRSMetrics(t *testing.T) {
+	// Not safe to run in parallel: creates/deletes a VPA CRD (cluster-wide) and a VPA CR in the shared openshift-monitoring namespace.
+	// t.Parallel()
 	const timeout = 5 * time.Minute
 	assetsDir := "./assets"
 	ksmCRSMetricPrefix := "kube_customresource"

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -151,6 +151,8 @@ func testMain(m *testing.M) error {
 }
 
 func TestTargetsUp(t *testing.T) {
+	// Not safe to run in parallel: deletes and waits for secret recreation, other tests may trigger scrape failures.
+	// t.Parallel()
 	ctx := context.Background()
 
 	// Check that all targets are up initially.
@@ -207,6 +209,8 @@ func testTargetsUp(t *testing.T) {
 // Once we have the need to test multiple recording rules, we can unite them in
 // a single test function.
 func TestMemoryUsageRecordingRule(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	f.ThanosQuerierClient.WaitForQueryReturnGreaterEqualOne(
 		t,
 		time.Minute,
@@ -251,6 +255,8 @@ const npProbeNamespace = "e2e-test-np-connectivity"
 // TestNetworkPolicy validates NetworkPolicy configuration and enforcement
 // across all monitoring namespaces.
 func TestNetworkPolicy(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap and creates probe pods.
+	// t.Parallel()
 	ctx := context.Background()
 
 	setupUserWorkloadAssetsWithTeardownHook(t, f)

--- a/test/e2e/metrics_adapter_test.go
+++ b/test/e2e/metrics_adapter_test.go
@@ -58,6 +58,8 @@ func isAPIServiceAvailable(conditions []apiservicesv1.APIServiceCondition) bool 
 }
 
 func TestMetricsAPIAvailability(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	ctx := context.Background()
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -85,6 +87,8 @@ func TestMetricsAPIAvailability(t *testing.T) {
 }
 
 func TestNodeMetricsPresence(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	ctx := context.Background()
 	var lastErr error
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -123,6 +127,8 @@ func TestNodeMetricsPresence(t *testing.T) {
 }
 
 func TestPodMetricsPresence(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	var lastErr error
 	ctx := context.Background()
 	err := wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -164,6 +170,8 @@ func TestPodMetricsPresence(t *testing.T) {
 }
 
 func TestAggregatedMetricPermissions(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	ctx := context.Background()
 	present := func(where []string, what string) bool {
 		sort.Strings(where)
@@ -230,6 +238,8 @@ func TestAggregatedMetricPermissions(t *testing.T) {
 }
 
 func TestMetricsServerRollout(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	for _, test := range []scenario{
 		{
 			name:      "assert metrics-server deployment is rolled out",

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 func TestMultinamespacePrometheusRule(t *testing.T) {
-	// The test shouldn't be disruptive, safe to run in parallel with others.
-	t.Parallel()
+	// Not safe to run in parallel: creates a namespace with openshift.io/cluster-monitoring label, adds PrometheusRules, and triggers operator reconciliation.
+	// t.Parallel()
 	nsName := "openshift-test-prometheus-rules"
 	firingAlertName := "FiringAlertInNamespace"
 

--- a/test/e2e/node_exporter_test.go
+++ b/test/e2e/node_exporter_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestNodeExporterCollectorEnablement(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	t.Cleanup(func() {
 		f.MustDeleteConfigMap(t, f.BuildCMOConfigMap(t, ""))
 	})
@@ -132,6 +134,8 @@ nodeExporter:
 }
 
 func TestNodeExporterCollectorDisablement(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	t.Cleanup(func() {
 		f.MustDeleteConfigMap(t, f.BuildCMOConfigMap(t, ""))
 	})
@@ -236,6 +240,8 @@ nodeExporter:
 
 // This test ensures necessary collectors stay operational after changing generic options in Node Exporter.
 func TestNodeExporterGenericOptions(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	t.Cleanup(func() {
 		f.MustDeleteConfigMap(t, f.BuildCMOConfigMap(t, ""))
 	})
@@ -296,6 +302,8 @@ nodeExporter:
 }
 
 func TestNodeExporterNetworkDevicesExclusion(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	t.Cleanup(func() {
 		f.MustDeleteConfigMap(t, f.BuildCMOConfigMap(t, ""))
 	})
@@ -362,6 +370,8 @@ nodeExporter:
 }
 
 func TestNodeExporterSystemdUnits(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	t.Cleanup(func() {
 		f.MustDeleteConfigMap(t, f.BuildCMOConfigMap(t, ""))
 	})

--- a/test/e2e/priority_class_test.go
+++ b/test/e2e/priority_class_test.go
@@ -27,6 +27,8 @@ import (
 // system-cluster-critical   2000000000   false            114m
 // system-node-critical      2000001000   false            114m
 func TestToEnsureUserPriorityClassIsPresentAndLower(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	ctx := context.Background()
 
 	// Get system priority class values.

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -35,6 +35,8 @@ import (
 )
 
 func TestPrometheusMetrics(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	expectedHealthyTargetsByJob := map[string]int{
 		"prometheus-operator":           1,
 		"prometheus-k8s":                2,
@@ -49,6 +51,7 @@ func TestPrometheusMetrics(t *testing.T) {
 
 	for jobName, expectedTargets := range expectedHealthyTargetsByJob {
 		t.Run(jobName, func(t *testing.T) {
+			t.Parallel()
 			f.PrometheusK8sClient.WaitForTargetsReturn(t, time.Minute, func(body []byte) error {
 				j, err := gabs.ParseJSON(body)
 				if err != nil {
@@ -81,6 +84,8 @@ func TestPrometheusMetrics(t *testing.T) {
 // consider whether the new default value is still suitable.
 // Refer to this link for some points that may need to be examined https://github.com/openshift/prometheus/pull/206#issuecomment-2182168575.
 func TestPrometheusGOGC(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	gogc := 75
 	f.ThanosQuerierClient.WaitForQueryReturn(
 		t, 5*time.Minute, `min(go_gc_gogc_percent{namespace="openshift-monitoring", service="prometheus-k8s", container="kube-rbac-proxy"})`, // kube-rbac-proxy exposes prometheus container's metrics.
@@ -95,6 +100,8 @@ func TestPrometheusGOGC(t *testing.T) {
 }
 
 func TestAntiAffinity(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	for _, tc := range []struct {
 		name     string
 		instance string
@@ -137,6 +144,8 @@ type remoteWriteTest struct {
 }
 
 func TestPrometheusRemoteWrite(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	ctx := context.Background()
 
 	// Use the same image than k8s' for the remote write target.
@@ -389,6 +398,8 @@ func remoteWriteCheckMetrics(ctx context.Context, t *testing.T, promClient *fram
 }
 
 func TestBodySizeLimit(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap.
+	// t.Parallel()
 	const (
 		bodySizeLimitSmall         = "1MB"
 		bodySizeLimitSmallNumber   = 1 * 1024 * 1024
@@ -441,6 +452,7 @@ func TestBodySizeLimit(t *testing.T) {
 // via pod port-forwarding to port 9090. Even though it is not exposed through
 // the service, it is useful in some situations.
 func TestPrometheusWebUI(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
 	t.Parallel()
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
 		host, cleanUp, err := f.ForwardPodPort(t, f.Ns, "prometheus-k8s-0", 9090)

--- a/test/e2e/security_headers_test.go
+++ b/test/e2e/security_headers_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestAlertmanagerPolicyHeaders(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	// The tenancy port (9092) is only exposed in-cluster, so we need to use
 	// port forwarding to access kube-rbac-proxy.
 	host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "alertmanager-main", 9092)
@@ -36,6 +38,8 @@ func TestAlertmanagerPolicyHeaders(t *testing.T) {
 }
 
 func TestPrometheusPolicyHeaders(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "prometheus-k8s", 9091)
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -32,6 +32,8 @@ import (
 // TestTelemeterRemoteWrite verifies that the monitoring stack can send data to
 // the telemeter server using the native Prometheus remote write endpoint.
 func TestTelemeterRemoteWrite(t *testing.T) {
+	// Not safe to run in parallel: modifies the CMO deployment and cluster version overrides.
+	// t.Parallel()
 	cm := f.BuildCMOConfigMap(t, "{}")
 	f.MustCreateOrUpdateConfigMap(t, cm)
 
@@ -110,6 +112,8 @@ func TestTelemeterRemoteWrite(t *testing.T) {
 
 // TestTelemeterClient verifies that the telemeter client can collect metrics from the monitoring stack and forward them to the telemeter server.
 func TestTelemeterClient(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	{
 		f.PrometheusK8sClient.WaitForQueryReturn(
 			t,
@@ -139,6 +143,8 @@ func TestTelemeterClient(t *testing.T) {
 
 // TestTelemeterClusterMetrics verifies that key Telemetry metrics are present.
 func TestTelemeterClusterMetrics(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	for _, q := range []string{
 		`count(cluster:usage:resources:sum) > 0`,
 		`count(cluster:usage:resources:sum{resource="pods"}) > 0`,

--- a/test/e2e/telemetry_report_test.go
+++ b/test/e2e/telemetry_report_test.go
@@ -36,6 +36,8 @@ import (
 var testdataDir = filepath.Join("..", "..", "hack", "telemetry_report", "testdata")
 
 func TestTelemetryReport(t *testing.T) {
+	// Not safe to run in parallel: creates PrometheusRules in the shared namespace.
+	// t.Parallel()
 	ctx := context.Background()
 
 	data, err := os.ReadFile(filepath.Join(testdataDir, "prometheusrule.yaml"))

--- a/test/e2e/thanos_querier_test.go
+++ b/test/e2e/thanos_querier_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestThanosQueryCanQueryWatchdogAlert(t *testing.T) {
+	// The test is read-only, safe to run in parallel.
+	t.Parallel()
 	// The 2-minute timeout is what console CI tests set.
 	// If this test is flaky, we should increase until
 	// we can fix the possible DNS resolve issues.
@@ -43,7 +45,8 @@ const (
 )
 
 func TestMonitoringApiRoles(t *testing.T) {
-
+	// The test uses its own isolated namespace, safe to run in parallel.
+	t.Parallel()
 	cf, err := f.CreateNamespace(testNamespaceTQ)
 	if err != nil {
 		t.Fatal("Failed to create test namespace", err)

--- a/test/e2e/thanos_ruler_test.go
+++ b/test/e2e/thanos_ruler_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestUserWorkloadThanosRulerWithAdditionalAlertmanagers(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap.
+	// t.Parallel()
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
 	// Ensure there is no existing alertmanager in f.UserWorkloadMonitoringNs as we're using

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -38,6 +38,8 @@ func atLeastVersionTLS12(v string) string {
 }
 
 func TestDefaultTLSSecurityProfileConfiguration(t *testing.T) {
+	// Not safe to run in parallel: modifies the global API server TLS security profile.
+	// t.Parallel()
 	// The admission webhook supports only TLS versions >= 1.2.
 	assertCorrectTLSConfiguration(t, "prometheus-operator-admission-webhook", "deployment",
 		manifests.PrometheusOperatorWebTLSCipherSuitesFlag,

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -50,6 +50,8 @@ type scenario struct {
 }
 
 func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config and cluster-monitoring-config ConfigMaps.
+	// t.Parallel()
 	uwmCM := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      framework.UserWorkloadMonitorConfigMapName,
@@ -97,6 +99,8 @@ func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
 }
 
 func TestUserWorkloadMonitoring(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config and cluster-monitoring-config ConfigMaps.
+	// t.Parallel()
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
 	uwmCM := f.BuildUserWorkloadConfigMap(t,
@@ -121,20 +125,37 @@ namespacesWithoutLabelEnforcement:
 		t.Fatalf("failed to deploy global rules: %s", err)
 	}
 
+	// Read-only subtests run in parallel. The parent subtest acts as a barrier
+	// so all parallel checks complete before the sequential ones start.
+	t.Run("read-only", func(t *testing.T) {
+		for _, check := range []struct {
+			name string
+			f    func(*testing.T)
+		}{
+			{"assert metrics for user workload components", assertMetricsForMonitoringComponents},
+			{"assert user workload metrics", assertUserWorkloadMetrics},
+			{"assert prometheus is not deployed in user namespace", f.AssertStatefulsetDoesNotExistFunc("prometheus-not-to-be-reconciled", userWorkloadTestNs)},
+			{"assert alertmanager is not deployed in user namespace", f.AssertStatefulsetDoesNotExistFunc("alertmanager-not-to-be-reconciled", userWorkloadTestNs)},
+			{"assert user workload rules", assertUserWorkloadRules},
+			{"assert rules without namespace enforcement", assertGlobalRulesWithoutNamespaceEnforcement},
+		} {
+			t.Run(check.name, func(t *testing.T) {
+				t.Parallel()
+				check.f(t)
+			})
+		}
+	})
+
+	// Sequential subtests: these create RBAC resources (ServiceAccounts,
+	// RoleBindings) in shared namespaces or mutate cluster state.
 	for _, check := range []struct {
 		name string
 		f    func(*testing.T)
 	}{
-		{"assert metrics for user workload components", assertMetricsForMonitoringComponents},
-		{"assert user workload metrics", assertUserWorkloadMetrics},
 		{"assert tenancy model is enforced for metrics", assertTenancyForMetrics},
 		{"assert tenancy model is enforced for series metadata", assertTenancyForSeriesMetadata},
-		{"assert prometheus is not deployed in user namespace", f.AssertStatefulsetDoesNotExistFunc("prometheus-not-to-be-reconciled", userWorkloadTestNs)},
-		{"assert alertmanager is not deployed in user namespace", f.AssertStatefulsetDoesNotExistFunc("alertmanager-not-to-be-reconciled", userWorkloadTestNs)},
 		{"assert UWM federate endpoint is exposed", assertUWMFederateEndpoint},
-		{"assert user workload rules", assertUserWorkloadRules},
 		{"assert tenancy model is enforced for rules and alerts", assertTenancyForRulesAndAlerts},
-		{"assert rules without namespace enforcement", assertGlobalRulesWithoutNamespaceEnforcement},
 		{"assert namespace opt out removes appropriate targets", assertNamespaceOptOut},
 		{"assert grpc tls rotation", assertGRPCTLSRotation},
 		{"assert service monitor opt out removes appropriate targets", assertServiceMonitorOptOut},
@@ -151,6 +172,8 @@ userWorkload:
 }
 
 func TestUserWorkloadMonitoringWithAdditionalAlertmanagerConfigs(t *testing.T) {
+	// Not safe to run in parallel: modifies the user-workload-monitoring-config ConfigMap.
+	// t.Parallel()
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
 	if err := createSelfSignedCertificateSecret("alertmanager-tls"); err != nil {
@@ -1415,6 +1438,8 @@ func assertServiceMonitorOptOut(t *testing.T) {
 }
 
 func TestPrometheusUserWorkloadEndpointSliceDiscovery(t *testing.T) {
+	// Not safe to run in parallel: modifies the cluster-monitoring-config ConfigMap and sets up UWM assets.
+	// t.Parallel()
 	ctx := context.Background()
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 

--- a/test/e2e/validatingwebhook_test.go
+++ b/test/e2e/validatingwebhook_test.go
@@ -128,6 +128,8 @@ spec:
 )
 
 func TestPrometheusRuleValidatingWebhook(t *testing.T) {
+	// Not safe to run in parallel: creates PrometheusRules in the shared namespace without cleanup.
+	// t.Parallel()
 	ctx := context.Background()
 
 	_, err := f.AdmissionClient.ValidatingWebhookConfigurations().Get(ctx, prometheusRuleWebhookName, metav1.GetOptions{})
@@ -158,6 +160,8 @@ func TestPrometheusRuleValidatingWebhook(t *testing.T) {
 }
 
 func TestPrometheusRuleValidatingWebhookUTF8Names(t *testing.T) {
+	// Not safe to run in parallel: creates PrometheusRules in the shared namespace.
+	// t.Parallel()
 	ctx := context.Background()
 
 	// Test PrometheusRule with UTF-8 names.
@@ -176,6 +180,8 @@ func TestPrometheusRuleValidatingWebhookUTF8Names(t *testing.T) {
 }
 
 func TestAlertManagerConfigValidatingWebhook(t *testing.T) {
+	// Not safe to run in parallel: creates AlertmanagerConfigs in the shared namespace without cleanup.
+	// t.Parallel()
 	ctx := context.Background()
 
 	_, err := f.AdmissionClient.ValidatingWebhookConfigurations().Get(ctx, alertmanagerConfigWebhookName, metav1.GetOptions{})


### PR DESCRIPTION
## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
