### PR TITLE
OCPBUGS-90090: chore(test): wait for full config restore in TestTelemeterRemoteWrite cleanup

### DIFF
--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -21,8 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 )
 
 // TestTelemeterRemoteWrite verifies that the monitoring stack can send data to
@@ -30,10 +34,6 @@ import (
 func TestTelemeterRemoteWrite(t *testing.T) {
 	cm := f.BuildCMOConfigMap(t, "{}")
 	f.MustCreateOrUpdateConfigMap(t, cm)
-
-	t.Cleanup(func() {
-		f.MustDeleteConfigMap(t, cm)
-	})
 
 	// Put CMO deployment into unmanaged state and enable telemetry via remote-write manually.
 	ctx := context.Background()
@@ -54,8 +54,28 @@ func TestTelemeterRemoteWrite(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		f.MustDeleteConfigMap(t, cm)
+
 		patch := []byte(`{"spec": {"overrides": []}}`)
 		_, _ = f.OpenShiftConfigClient.ConfigV1().ClusterVersions().Patch(ctx, "version", types.MergePatchType, patch, metav1.PatchOptions{})
+
+		// Wait for CVO -> CMO -> Prometheus Operator to fully restore
+		// the config, then force-delete the Prometheus pods so the
+		// next test gets fresh pods with the updated config.
+		require.NoError(t, framework.Poll(5*time.Second, 5*time.Minute, func() error {
+			cfg := f.PrometheusConfigFromSecret(t, f.Ns, "prometheus-k8s")
+			if len(cfg.RemoteWriteConfigs) > 0 {
+				return fmt.Errorf("prometheus config still has %d remote write configs", len(cfg.RemoteWriteConfigs))
+			}
+			return nil
+		}))
+
+		require.NoError(t, f.KubeClient.CoreV1().Pods(f.Ns).DeleteCollection(ctx,
+			metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))},
+			metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s"},
+		))
+
+		f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns)(t)
 	})
 
 	dep, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(ctx, "cluster-monitoring-operator", metav1.GetOptions{})


### PR DESCRIPTION
    chore(test): wait for full config restore in TestTelemeterRemoteWrite cleanup
    
    TestTelemeterRemoteWrite patches the CVO overrides to put the CMO
    deployment in unmanaged state and enables remote write. Its cleanup
    removes the overrides but did not wait for the restore to complete.
    
    This triggered a cascade: CVO re-deployed CMO, CMO reconciled and
    updated the Prometheus CR, Prometheus Operator rolled the StatefulSet,
    all while TestTelemetryReport was already running and port-forwarding
    to a Prometheus pod that got recreated underneath it.
    
    Poll the Prometheus config secret until the remote write config is
    removed, then wait for the StatefulSet rollout. This proves the full
    CVO -> CMO -> Prometheus Operator chain completed before the next
    test starts.
    
    Failing run (if link still works):
    https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-monitoring-operator/2959/pull-ci-openshift-cluster-monitoring-operator-main-e2e-agnostic-operator/2066417110673788928

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
