### PR TITLE
OCPBUGS-90089: chore(test): clean up remote write config in TestPrometheusRemoteWrite

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 func TestPrometheusMetrics(t *testing.T) {
@@ -186,6 +187,39 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Clean up after all subtests: reset the ConfigMap, wait for
+	// Prometheus Operator to remove the remote write config from the
+	// Prometheus config secret, then force-delete the Prometheus pods to
+	// skip the ~2m shutdown delay.
+	//
+	// The last subtest deletes the receiver but leaves the ConfigMap with
+	// remoteWrite. When the ConfigMap is reset, Prometheus Operator
+	// removes the TLS certs from its TLS assets secret simultaneously
+	// with the config update. Because Prometheus re-reads cert files on
+	// every send attempt, the queue_manager drain fails with "no such file"
+	// and retries until
+	// the flush-deadline expires (2x1m for samples + metadata = ~2m).
+	// Force-deleting the pods avoids this.
+	// See https://github.com/prometheus/prometheus/issues/6747
+	t.Cleanup(func() {
+		f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, "{}"))
+
+		require.NoError(t, framework.Poll(5*time.Second, 5*time.Minute, func() error {
+			cfg := f.PrometheusConfigFromSecret(t, f.Ns, "prometheus-k8s")
+			if len(cfg.RemoteWriteConfigs) > 0 {
+				return fmt.Errorf("prometheus config still has %d remote write configs", len(cfg.RemoteWriteConfigs))
+			}
+			return nil
+		}))
+
+		require.NoError(t, f.KubeClient.CoreV1().Pods(f.Ns).DeleteCollection(ctx,
+			metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))},
+			metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s"},
+		))
+
+		f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns)(t)
+	})
 	for _, tc := range []struct {
 		name     string
 		rwSpec   string


### PR DESCRIPTION
TestPrometheusRemoteWrite was not cleaning up the cluster-monitoring-config ConfigMap after its subtests. The last subtest deleted the rwe2e Prometheus receiver but left the remoteWrite section in the ConfigMap, causing Prometheus to accumulate failed remote write samples in its queue_manager.

When a later test (e.g. TestTelemeterRemoteWrite) reset the ConfigMap, Prometheus Operator removed the TLS certs from its TLS assets secret simultaneously with the config update. Because Prometheus re-reads cert files on every send attempt (prometheus/common/config.tlsRoundTripper), the queue_manager drain failed with "no such file or directory" and retried until the flush-deadline expired (2x1m for samples + metadata = ~2m), blocking pod shutdown and causing downstream test timeouts.

Add a t.Cleanup that resets the ConfigMap, waits for the remote write config to be removed from the Prometheus config secret, then force-deletes the Prometheus pods to skip the stalled drain.

In practice, TestTelemeterRemoteWrite ran next and had to absorb this ~2m penalty. Increasing its timeout is not a robust fix: test ordering can change and a different test would inherit the same problem.

Failing run (if link still works):
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-monitoring-operator/2959/pull-ci-openshift-cluster-monitoring-operator-main-e2e-agnostic-operator/2065784368860762112



## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
