### PR TITLE
OCPBUGS-90100: chore(TestPrometheusMetrics): use targets API instead of promQL

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -54,17 +54,20 @@ func TestPrometheusMetrics(t *testing.T) {
 					return err
 				}
 
-				healthyTargets := 0
+				totalTargets, healthyTargets := 0, 0
 				for _, target := range j.Path("data.activeTargets").Children() {
 					job, _ := target.Path("labels.job").Data().(string)
 					health, _ := target.Path("health").Data().(string)
-					if job == jobName && health == "up" {
-						healthyTargets++
+					if job == jobName {
+						totalTargets++
+						if health == "up" {
+							healthyTargets++
+						}
 					}
 				}
 
 				if healthyTargets != expectedTargets {
-					return fmt.Errorf("expected %d healthy targets, got %d", expectedTargets, healthyTargets)
+					return fmt.Errorf("expected %d healthy targets, got %d (total targets: %d)", expectedTargets, healthyTargets, totalTargets)
 				}
 				return nil
 			})

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Jeffail/gabs/v2"
 	osConfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	_ "github.com/prometheus/prometheus/discovery/kubernetes" // required for promConfig.Load to parse kubernetes_sd_configs
@@ -33,7 +34,7 @@ import (
 )
 
 func TestPrometheusMetrics(t *testing.T) {
-	expected := map[string]int{
+	expectedHealthyTargetsByJob := map[string]int{
 		"prometheus-operator":           1,
 		"prometheus-k8s":                2,
 		"prometheus-k8s-thanos-sidecar": 2,
@@ -45,22 +46,28 @@ func TestPrometheusMetrics(t *testing.T) {
 		"telemeter-client":              1,
 	}
 
-	for service, metric := range expected {
-		t.Run(service, func(t *testing.T) {
-			f.ThanosQuerierClient.WaitForQueryReturn(
-				// To avoid making the test wait for more than lookback-delta
-				// in case Prometheus wasn't able to write stale markers
-				// (because it was down), reduce the lookup period but not
-				// lower than the highest scrape interval (which is 2m).
-				t, time.Minute, fmt.Sprintf(`count(last_over_time(up{service="%s",namespace="openshift-monitoring"}[2m30s]) == 1)`, service),
-				func(v float64) error {
-					if v != float64(metric) {
-						return fmt.Errorf("expected %d targets to be up but got %v", metric, v)
-					}
+	for jobName, expectedTargets := range expectedHealthyTargetsByJob {
+		t.Run(jobName, func(t *testing.T) {
+			f.PrometheusK8sClient.WaitForTargetsReturn(t, time.Minute, func(body []byte) error {
+				j, err := gabs.ParseJSON(body)
+				if err != nil {
+					return err
+				}
 
-					return nil
-				},
-			)
+				healthyTargets := 0
+				for _, target := range j.Path("data.activeTargets").Children() {
+					job, _ := target.Path("labels.job").Data().(string)
+					health, _ := target.Path("health").Data().(string)
+					if job == jobName && health == "up" {
+						healthyTargets++
+					}
+				}
+
+				if healthyTargets != expectedTargets {
+					return fmt.Errorf("expected %d healthy targets, got %d", expectedTargets, healthyTargets)
+				}
+				return nil
+			})
 		})
 	}
 }


### PR DESCRIPTION
The PromQL query last_over_time(up{...}[2m30s]) can return stale series when Prometheus fails to write stale markers (e.g. because it was down during a pod rollout). In that case, both old and new series coexist in the lookback window, inflating the count. The targets API returns the current active scrape targets regardless of stale markers.

History of TestPrometheusMetrics query changes:

1. 8dd7f6531 count(up{...}), 10m timeout
2. 1546f3406 count(up{...} == 1), filter to only up targets
3. c9359c604 count(last_over_time(up{...}[1m]) == 1), 1m timeout Avoid waiting lookback-delta when stale markers are missing.
4. f247d5ff5 (OCPBUGS-86989, PR #2943) [1m] -> [2m30s] Window was shorter than the highest scrape interval (2m). Still flaky: widening the window without increasing the timeout makes it more likely to catch stale series from recent rollouts within the 1m polling deadline.
5. This commit: switch to Targets API Instant snapshot of active targets, no reliance on PromQL time windows or stale marker semantics.

Failing run (if link still works):
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-monitoring-operator/2959/pull-ci-openshift-cluster-monitoring-operator-main-e2e-agnostic-operator/2065784368860762112

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
