### PR TITLE
NO-JIRA: test: merge UWM tests and improve resilience

### DIFF
--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -474,6 +474,27 @@ func assertUserWorkloadRules(t *testing.T) {
 	)
 }
 
+func withTenantThanosQuerierClient(t *testing.T, token string, port int, fn func(*framework.PrometheusClient) error) error {
+	t.Helper()
+
+	host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", port)
+	if err != nil {
+		return err
+	}
+	defer cleanUp()
+
+	client := framework.NewPrometheusClient(
+		host,
+		token,
+		&framework.QueryParameterInjector{
+			Name:  "namespace",
+			Value: userWorkloadTestNs,
+		},
+	)
+
+	return fn(client)
+}
+
 // assertTenancyForMetrics ensures that a tenant can access metrics from her namespace (and only from this one).
 func assertTenancyForMetrics(t *testing.T) {
 	const testAccount = "test-metrics"
@@ -553,64 +574,49 @@ func assertTenancyForMetrics(t *testing.T) {
 			}()
 
 			err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-				// The tenancy port (9092) is only exposed in-cluster, so we need to use
-				// port forwarding to access kube-rbac-proxy.
-				host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
-				if err != nil {
-					return err
-				}
-				defer cleanUp()
+				return withTenantThanosQuerierClient(t, token, 9092, func(client *framework.PrometheusClient) error {
+					b, err := client.PrometheusQueryWithStatus(tc.query, tc.expStatus)
+					if err != nil {
+						return err
+					}
 
-				client := framework.NewPrometheusClient(
-					host,
-					token,
-					&framework.QueryParameterInjector{
-						Name:  "namespace",
-						Value: userWorkloadTestNs,
-					},
-				)
+					if tc.expStatus != http.StatusOK {
+						// short circuit if we don't expect HTTP 200, as we
+						// don't need to parse the response
+						return nil
+					}
 
-				b, err := client.PrometheusQueryWithStatus(tc.query, tc.expStatus)
-				if err != nil {
-					return err
-				}
+					res, err := gabs.ParseJSON(b)
+					if err != nil {
+						return err
+					}
 
-				if tc.expStatus != http.StatusOK {
-					// short circuit if we don't expect HTTP 200, as we
-					// don't need to parse the response
+					timeseries, err := res.ArrayElementP(0, "data.result")
+					if err != nil {
+						return err
+					}
+
+					labels := timeseries.Path("metric").ChildrenMap()
+					if len(labels) == 0 {
+						return errors.New("empty metric")
+					}
+
+					ns := labels["namespace"].Data().(string)
+					if ns != userWorkloadTestNs {
+						return fmt.Errorf("expecting 'namespace' label to be %q, got %q", userWorkloadTestNs, ns)
+					}
+
+					value, err := timeseries.ArrayElementP(1, "value")
+					if err != nil {
+						return err
+					}
+
+					if value.Data().(string) != "1" {
+						return fmt.Errorf("expecting value '1', got %q", value.Data().(string))
+					}
+
 					return nil
-				}
-
-				res, err := gabs.ParseJSON(b)
-				if err != nil {
-					return err
-				}
-
-				timeseries, err := res.ArrayElementP(0, "data.result")
-				if err != nil {
-					return err
-				}
-
-				labels := timeseries.Path("metric").ChildrenMap()
-				if len(labels) == 0 {
-					return errors.New("empty metric")
-				}
-
-				ns := labels["namespace"].Data().(string)
-				if ns != userWorkloadTestNs {
-					return fmt.Errorf("expecting 'namespace' label to be %q, got %q", userWorkloadTestNs, ns)
-				}
-
-				value, err := timeseries.ArrayElementP(1, "value")
-				if err != nil {
-					return err
-				}
-
-				if value.Data().(string) != "1" {
-					return fmt.Errorf("expecting value '1', got %q", value.Data().(string))
-				}
-
-				return nil
+				})
 			})
 			if err != nil {
 				t.Errorf("failed to query Thanos querier: %v", err)
@@ -621,39 +627,24 @@ func assertTenancyForMetrics(t *testing.T) {
 	// Check that the account doesn't have to access the rules and alerts endpoints.
 	for _, path := range []string{"/api/v1/rules", "/api/v1/alerts"} {
 		err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-			// The tenancy port (9092) is only exposed in-cluster, so we need to use
-			// port forwarding to access kube-rbac-proxy.
-			host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
-			if err != nil {
-				return err
-			}
-			defer cleanUp()
+			return withTenantThanosQuerierClient(t, token, 9092, func(client *framework.PrometheusClient) error {
+				resp, err := client.Do("GET", path, nil)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
 
-			client := framework.NewPrometheusClient(
-				host,
-				token,
-				&framework.QueryParameterInjector{
-					Name:  "namespace",
-					Value: userWorkloadTestNs,
-				},
-			)
+				b, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
 
-			resp, err := client.Do("GET", path, nil)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
+				if resp.StatusCode/100 == 2 {
+					return fmt.Errorf("expected request to be rejected, but got status code %d (%s)", resp.StatusCode, framework.ClampMax(b))
+				}
 
-			b, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return err
-			}
-
-			if resp.StatusCode/100 == 2 {
-				return fmt.Errorf("expected request to be rejected, but got status code %d (%s)", resp.StatusCode, framework.ClampMax(b))
-			}
-
-			return nil
+				return nil
+			})
 		})
 		if err != nil {
 			t.Fatalf("the account has access to the %q endpoint of Thanos querier: %v", path, err)
@@ -738,45 +729,30 @@ func assertTenancyForMetrics(t *testing.T) {
 
 			// It might take some time for kube-rbac-proxy to catch up the updated permission.
 			err = framework.Poll(time.Second, 5*time.Minute, func() error {
-				// Forward the tenancy port.
-				host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
-				if err != nil {
-					return err
-				}
-				defer cleanUp()
-
-				// Create a Prometheus client with the test SA token.
-				client := framework.NewPrometheusClient(
-					host,
-					token,
-					&framework.QueryParameterInjector{
-						Name:  "namespace",
-						Value: userWorkloadTestNs,
-					},
-				)
-
-				resp, err := client.Do(tc.method, "/api/v1/query?namespace="+userWorkloadTestNs+"&query=up", nil)
-				if err != nil {
-					return err
-				}
-				defer resp.Body.Close()
-				// Body: {"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up",...},"value":[1695582946.784,"1"]}]}}
-				respBodyBytes, err := io.ReadAll(resp.Body)
-				if err != nil {
-					return err
-				}
-
-				if tc.expectNotOKOnQuery {
-					if resp.StatusCode == http.StatusOK {
-						return fmt.Errorf("expected request to be rejected, but succeeded")
+				return withTenantThanosQuerierClient(t, token, 9092, func(client *framework.PrometheusClient) error {
+					resp, err := client.Do(tc.method, "/api/v1/query?namespace="+userWorkloadTestNs+"&query=up", nil)
+					if err != nil {
+						return err
 					}
-				} else {
-					if resp.StatusCode != http.StatusOK {
-						return fmt.Errorf("expected request to be accepted, but got status code %d (%s)", resp.StatusCode, respBodyBytes)
+					defer resp.Body.Close()
+					// Body: {"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up",...},"value":[1695582946.784,"1"]}]}}
+					respBodyBytes, err := io.ReadAll(resp.Body)
+					if err != nil {
+						return err
 					}
-				}
 
-				return nil
+					if tc.expectNotOKOnQuery {
+						if resp.StatusCode == http.StatusOK {
+							return fmt.Errorf("expected request to be rejected, but succeeded")
+						}
+					} else {
+						if resp.StatusCode != http.StatusOK {
+							return fmt.Errorf("expected request to be accepted, but got status code %d (%s)", resp.StatusCode, respBodyBytes)
+						}
+					}
+
+					return nil
+				})
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -812,135 +788,9 @@ func assertTenancyForRulesAndAlerts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var client *framework.PrometheusClient
 	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		// The tenancy port (9093) is only exposed in-cluster, so we need to use
-		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9093)
-		if err != nil {
-			return err
-		}
-		defer cleanUp()
-
-		client = framework.NewPrometheusClient(
-			host,
-			token,
-			&framework.QueryParameterInjector{
-				Name:  "namespace",
-				Value: userWorkloadTestNs,
-			},
-		)
-
-		resp, err := client.Do("GET", "/api/v1/rules", nil)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
-		}
-
-		res, err := gabs.ParseJSON(b)
-		if err != nil {
-			return err
-		}
-
-		groups := res.Path("data.groups").Children()
-		if groups == nil {
-			return errors.New("data.groups not found")
-		}
-
-		if len(groups) != 2 {
-			return fmt.Errorf("expecting 2 rules group, got %d", len(groups))
-		}
-
-		type testData struct {
-			ruleType  string
-			name      string
-			namespace string
-		}
-
-		expected := []testData{
-			{
-				ruleType:  "recording",
-				name:      "version:blah:leaf:count",
-				namespace: "user-workload-test",
-			},
-			{
-				ruleType:  "alerting",
-				name:      "VersionAlert",
-				namespace: "user-workload-test",
-			},
-			{
-				ruleType:  "recording",
-				name:      "version:blah:count",
-				namespace: "user-workload-test",
-			},
-		}
-
-		var got []testData
-
-		for _, group := range groups {
-			rules := group.Path("rules").Children()
-			if rules == nil {
-				return errors.New("rules not found")
-			}
-
-			for _, rule := range rules {
-				labels := rule.Path("labels").ChildrenMap()
-				if labels == nil {
-					return errors.New("labels not found")
-				}
-
-				got = append(got, testData{
-					ruleType:  rule.Path("type").Data().(string),
-					name:      rule.Path("name").Data().(string),
-					namespace: labels["namespace"].Data().(string),
-				})
-			}
-		}
-
-		if !reflect.DeepEqual(expected, got) {
-			return fmt.Errorf("expected rules %v, got %v", expected, got)
-		}
-
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("failed to query rules from Thanos querier: %v", err)
-	}
-
-	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		resp, err := client.Do("GET", "/api/v1/alerts", nil)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("failed to query alerts from Thanos querier: %v", err)
-	}
-
-	// Check that the account doesn't have to access the query endpoints.
-	for _, path := range []string{"/api/v1/range?query=up", "/api/v1/query_range?query=up&start=0&end=0&step=1s"} {
-		err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-			resp, err := client.Do("GET", path, nil)
+		return withTenantThanosQuerierClient(t, token, 9093, func(client *framework.PrometheusClient) error {
+			resp, err := client.Do("GET", "/api/v1/rules", nil)
 			if err != nil {
 				return err
 			}
@@ -951,11 +801,125 @@ func assertTenancyForRulesAndAlerts(t *testing.T) {
 				return err
 			}
 
-			if resp.StatusCode/100 == 2 {
-				return fmt.Errorf("unexpected status code response, got %d (%s)", resp.StatusCode, framework.ClampMax(b))
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
+			}
+
+			res, err := gabs.ParseJSON(b)
+			if err != nil {
+				return err
+			}
+
+			groups := res.Path("data.groups").Children()
+			if groups == nil {
+				return errors.New("data.groups not found")
+			}
+
+			if len(groups) != 2 {
+				return fmt.Errorf("expecting 2 rules group, got %d", len(groups))
+			}
+
+			type testData struct {
+				ruleType  string
+				name      string
+				namespace string
+			}
+
+			expected := []testData{
+				{
+					ruleType:  "recording",
+					name:      "version:blah:leaf:count",
+					namespace: "user-workload-test",
+				},
+				{
+					ruleType:  "alerting",
+					name:      "VersionAlert",
+					namespace: "user-workload-test",
+				},
+				{
+					ruleType:  "recording",
+					name:      "version:blah:count",
+					namespace: "user-workload-test",
+				},
+			}
+
+			var got []testData
+
+			for _, group := range groups {
+				rules := group.Path("rules").Children()
+				if rules == nil {
+					return errors.New("rules not found")
+				}
+
+				for _, rule := range rules {
+					labels := rule.Path("labels").ChildrenMap()
+					if labels == nil {
+						return errors.New("labels not found")
+					}
+
+					got = append(got, testData{
+						ruleType:  rule.Path("type").Data().(string),
+						name:      rule.Path("name").Data().(string),
+						namespace: labels["namespace"].Data().(string),
+					})
+				}
+			}
+
+			if !reflect.DeepEqual(expected, got) {
+				return fmt.Errorf("expected rules %v, got %v", expected, got)
 			}
 
 			return nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("failed to query rules from Thanos querier: %v", err)
+	}
+
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
+		return withTenantThanosQuerierClient(t, token, 9093, func(client *framework.PrometheusClient) error {
+			resp, err := client.Do("GET", "/api/v1/alerts", nil)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("failed to query alerts from Thanos querier: %v", err)
+	}
+
+	// Check that the account doesn't have to access the query endpoints.
+	for _, path := range []string{"/api/v1/range?query=up", "/api/v1/query_range?query=up&start=0&end=0&step=1s"} {
+		err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
+			return withTenantThanosQuerierClient(t, token, 9093, func(client *framework.PrometheusClient) error {
+				resp, err := client.Do("GET", path, nil)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+
+				b, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
+
+				if resp.StatusCode/100 == 2 {
+					return fmt.Errorf("unexpected status code response, got %d (%s)", resp.StatusCode, framework.ClampMax(b))
+				}
+
+				return nil
+			})
 		})
 		if err != nil {
 			t.Fatalf("the account has access to the %q endpoint of Thanos querier: %v", path, err)
@@ -1148,53 +1112,38 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 
 	// check /api/v1/labels endpoint
 	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		// The tenancy port (9092) is only exposed in-cluster, so we need to use
-		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
-		if err != nil {
-			return err
-		}
-		defer cleanUp()
+		return withTenantThanosQuerierClient(t, token, 9092, func(client *framework.PrometheusClient) error {
+			resp, err := client.Do("GET", "/api/v1/labels", nil)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
 
-		client := framework.NewPrometheusClient(
-			host,
-			token,
-			&framework.QueryParameterInjector{
-				Name:  "namespace",
-				Value: userWorkloadTestNs,
-			},
-		)
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
 
-		resp, err := client.Do("GET", "/api/v1/labels", nil)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
+			}
 
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
+			res, err := gabs.ParseJSON(b)
+			if err != nil {
+				return err
+			}
 
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
-		}
+			labels := res.Path("data").Children()
+			if labels == nil {
+				return errors.New("data not found")
+			}
 
-		res, err := gabs.ParseJSON(b)
-		if err != nil {
-			return err
-		}
+			if len(labels) == 0 {
+				return fmt.Errorf("expecting a label list with at least one item, got zero")
+			}
 
-		labels := res.Path("data").Children()
-		if labels == nil {
-			return errors.New("data not found")
-		}
-
-		if len(labels) == 0 {
-			return fmt.Errorf("expecting a label list with at least one item, got zero")
-		}
-
-		return nil
+			return nil
+		})
 	})
 	if err != nil {
 		t.Fatalf("failed to query labels from Thanos querier: %v", err)
@@ -1202,53 +1151,38 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 
 	// Check the /api/v1/series endpoint.
 	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		// The tenancy port (9092) is only exposed in-cluster, so we need to use
-		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
-		if err != nil {
-			return err
-		}
-		defer cleanUp()
+		return withTenantThanosQuerierClient(t, token, 9092, func(client *framework.PrometheusClient) error {
+			resp, err := client.Do("GET", "/api/v1/series?match[]=up", nil)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
 
-		client := framework.NewPrometheusClient(
-			host,
-			token,
-			&framework.QueryParameterInjector{
-				Name:  "namespace",
-				Value: userWorkloadTestNs,
-			},
-		)
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
 
-		resp, err := client.Do("GET", "/api/v1/series?match[]=up", nil)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
+			}
 
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
+			res, err := gabs.ParseJSON(b)
+			if err != nil {
+				return err
+			}
 
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code response, want %d, got %d (%s)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
-		}
+			series := res.Path("data").Children()
+			if series == nil {
+				return errors.New("data not found")
+			}
 
-		res, err := gabs.ParseJSON(b)
-		if err != nil {
-			return err
-		}
+			if len(series) != 1 {
+				return fmt.Errorf("expecting a series list with one item, got %d (%s)", len(series), framework.ClampMax(b))
+			}
 
-		series := res.Path("data").Children()
-		if series == nil {
-			return errors.New("data not found")
-		}
-
-		if len(series) != 1 {
-			return fmt.Errorf("expecting a series list with one item, got %d (%s)", len(series), framework.ClampMax(b))
-		}
-
-		return nil
+			return nil
+		})
 	})
 	if err != nil {
 		t.Fatalf("failed to query series from Thanos querier: %v", err)
@@ -1256,47 +1190,32 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 
 	// Check that /api/v1/label/{namespace}/values returns a single value.
 	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
-		// The tenancy port (9092) is only exposed in-cluster, so we need to use
-		// port forwarding to access kube-rbac-proxy.
-		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
-		if err != nil {
-			return err
-		}
-		defer cleanUp()
+		return withTenantThanosQuerierClient(t, token, 9092, func(client *framework.PrometheusClient) error {
+			b, err := client.PrometheusLabel("namespace")
+			if err != nil {
+				return err
+			}
 
-		client := framework.NewPrometheusClient(
-			host,
-			token,
-			&framework.QueryParameterInjector{
-				Name:  "namespace",
-				Value: userWorkloadTestNs,
-			},
-		)
+			res, err := gabs.ParseJSON(b)
+			if err != nil {
+				return err
+			}
 
-		b, err := client.PrometheusLabel("namespace")
-		if err != nil {
-			return err
-		}
+			values := res.Path("data").Children()
+			if values == nil {
+				return errors.New("data not found")
+			}
 
-		res, err := gabs.ParseJSON(b)
-		if err != nil {
-			return err
-		}
+			if len(values) != 1 {
+				return fmt.Errorf("expecting only 1 value for the 'namespace' label but got %d", len(values))
+			}
 
-		values := res.Path("data").Children()
-		if values == nil {
-			return errors.New("data not found")
-		}
+			if values[0].Data().(string) != userWorkloadTestNs {
+				return fmt.Errorf("expecting 'namespace' label value to be %q but got %q .", userWorkloadTestNs, values[0].Data().(string))
+			}
 
-		if len(values) != 1 {
-			return fmt.Errorf("expecting only 1 value for the 'namespace' label but got %d", len(values))
-		}
-
-		if values[0].Data().(string) != userWorkloadTestNs {
-			return fmt.Errorf("expecting 'namespace' label value to be %q but got %q .", userWorkloadTestNs, values[0].Data().(string))
-		}
-
-		return nil
+			return nil
+		})
 	})
 	if err != nil {
 		t.Fatalf("failed to query namespace label from Thanos querier: %v", err)

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -96,53 +96,7 @@ func TestUserWorkloadMonitoringInvalidConfig(t *testing.T) {
 	f.AssertOperatorConditionMessageFunc(configv1.OperatorUpgradeable, "")(t)
 }
 
-func TestUserWorkloadMonitoringMetrics(t *testing.T) {
-	setupUserWorkloadAssetsWithTeardownHook(t, f)
-
-	f.AssertStatefulSetExistsAndRolloutFunc("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
-	if err := deployUserApplication(f); err != nil {
-		t.Fatal(err)
-	}
-
-	for _, scenario := range []struct {
-		name string
-		f    func(*testing.T)
-	}{
-		{
-			name: "assert metrics for user workload components",
-			f:    assertMetricsForMonitoringComponents,
-		},
-		{
-			name: "assert user workload metrics",
-			f:    assertUserWorkloadMetrics,
-		},
-		{
-			name: "assert tenancy model is enforced for metrics",
-			f:    assertTenancyForMetrics,
-		},
-		{
-			name: "assert tenancy model is enforced for series metadata",
-			f:    assertTenancyForSeriesMetadata,
-		},
-		{
-			name: "assert prometheus is not deployed in user namespace",
-			f:    f.AssertStatefulsetDoesNotExistFunc("prometheus-not-to-be-reconciled", userWorkloadTestNs),
-		},
-		{
-			name: "assert alertmanager is not deployed in user namespace",
-			f:    f.AssertStatefulsetDoesNotExistFunc("alertmanager-not-to-be-reconciled", userWorkloadTestNs),
-		},
-
-		{
-			name: "assert UWM federate endpoint is exposed",
-			f:    assertUWMFederateEndpoint,
-		},
-	} {
-		t.Run(scenario.name, scenario.f)
-	}
-}
-
-func TestUserWorkloadMonitoringAlerting(t *testing.T) {
+func TestUserWorkloadMonitoring(t *testing.T) {
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
 
 	uwmCM := f.BuildUserWorkloadConfigMap(t,
@@ -152,48 +106,40 @@ namespacesWithoutLabelEnforcement:
 `, notEnforcedNs),
 	)
 	f.MustCreateOrUpdateConfigMap(t, uwmCM)
-	defer f.MustDeleteConfigMap(t, uwmCM)
+	t.Cleanup(func() {
+		f.MustDeleteConfigMap(t, uwmCM)
+	})
 
 	f.AssertStatefulSetExistsAndRolloutFunc("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
 
-	if err := deployUserApplication(f); err != nil {
-		t.Fatal(err)
-	}
+	setupUserApplications(t, f)
+	t.Cleanup(func() {
+		tearDownUserApplications(t, f)
+	})
 
 	if err := deployGlobalRules(f); err != nil {
 		t.Fatalf("failed to deploy global rules: %s", err)
 	}
 
-	if err := createPrometheusAlertmanagerInUserNamespace(f); err != nil {
-		t.Fatalf("failed to create Alertmanager object in user namespace: %s", err)
-	}
-
-	for _, scenario := range []struct {
+	for _, check := range []struct {
 		name string
 		f    func(*testing.T)
 	}{
-		{
-			name: "assert user workload rules",
-			f:    assertUserWorkloadRules,
-		},
-		{
-			name: "assert tenancy model is enforced for rules and alerts",
-			f:    assertTenancyForRulesAndAlerts,
-		},
-		{
-			name: "assert rules without namespace enforcement",
-			f:    assertGlobalRulesWithoutNamespaceEnforcement,
-		},
-		{
-			name: "assert prometheus is not deployed in user namespace",
-			f:    f.AssertStatefulsetDoesNotExistFunc("prometheus-not-to-be-reconciled", userWorkloadTestNs),
-		},
-		{
-			name: "assert alertmanager is not deployed in user namespace",
-			f:    f.AssertStatefulsetDoesNotExistFunc("alertmanager-not-to-be-reconciled", userWorkloadTestNs),
-		},
+		{"assert metrics for user workload components", assertMetricsForMonitoringComponents},
+		{"assert user workload metrics", assertUserWorkloadMetrics},
+		{"assert tenancy model is enforced for metrics", assertTenancyForMetrics},
+		{"assert tenancy model is enforced for series metadata", assertTenancyForSeriesMetadata},
+		{"assert prometheus is not deployed in user namespace", f.AssertStatefulsetDoesNotExistFunc("prometheus-not-to-be-reconciled", userWorkloadTestNs)},
+		{"assert alertmanager is not deployed in user namespace", f.AssertStatefulsetDoesNotExistFunc("alertmanager-not-to-be-reconciled", userWorkloadTestNs)},
+		{"assert UWM federate endpoint is exposed", assertUWMFederateEndpoint},
+		{"assert user workload rules", assertUserWorkloadRules},
+		{"assert tenancy model is enforced for rules and alerts", assertTenancyForRulesAndAlerts},
+		{"assert rules without namespace enforcement", assertGlobalRulesWithoutNamespaceEnforcement},
+		{"assert namespace opt out removes appropriate targets", assertNamespaceOptOut},
+		{"assert grpc tls rotation", assertGRPCTLSRotation},
+		{"assert service monitor opt out removes appropriate targets", assertServiceMonitorOptOut},
 	} {
-		t.Run(scenario.name, scenario.f)
+		t.Run(check.name, check.f)
 	}
 
 	// Disable cross-namespace rules via the CMO config.
@@ -202,38 +148,6 @@ userWorkload:
   rulesWithoutLabelEnforcementAllowed: false
 `))
 	t.Run("assert cross-namespace rules are not allowed from CMO config", assertGlobalRulesWithNamespaceEnforcement)
-}
-
-func TestUserWorkloadMonitoringOptOut(t *testing.T) {
-	setupUserWorkloadAssetsWithTeardownHook(t, f)
-
-	f.AssertStatefulSetExistsAndRolloutFunc("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
-	if err := deployUserApplication(f); err != nil {
-		t.Fatal(err)
-	}
-
-	for _, scenario := range []struct {
-		name string
-		f    func(*testing.T)
-	}{
-		{"assert namespace opt out removes appropriate targets", assertNamespaceOptOut},
-		{"assert service monitor opt out removes appropriate targets", assertServiceMonitorOptOut},
-	} {
-		t.Run(scenario.name, scenario.f)
-	}
-}
-
-func TestUserWorkloadMonitoringGrpcSecrets(t *testing.T) {
-	setupUserWorkloadAssetsWithTeardownHook(t, f)
-
-	for _, scenario := range []struct {
-		name string
-		f    func(*testing.T)
-	}{
-		{"assert grpc tls rotation", assertGRPCTLSRotation},
-	} {
-		t.Run(scenario.name, scenario.f)
-	}
 }
 
 func TestUserWorkloadMonitoringWithAdditionalAlertmanagerConfigs(t *testing.T) {
@@ -473,6 +387,7 @@ func assertUserWorkloadMetrics(t *testing.T) {
 	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		body, err := f.AlertmanagerClient.GetAlertmanagerAlerts(
 			"filter", `alertname="VersionAlert"`,
+			"filter", fmt.Sprintf(`namespace="%s"`, userWorkloadTestNs),
 			"active", "true",
 		)
 		if err != nil {
@@ -502,7 +417,7 @@ func assertUserWorkloadMetrics(t *testing.T) {
 	// Assert that recording rule is in thanos querier and we get it
 	// via thanos ruler replica.
 	f.ThanosQuerierClient.WaitForQueryReturn(
-		t, 10*time.Minute, `version:blah:count{thanos_ruler_replica="thanos-ruler-user-workload-0"}`,
+		t, 10*time.Minute, fmt.Sprintf(`version:blah:count{thanos_ruler_replica="thanos-ruler-user-workload-0",namespace="%s"}`, userWorkloadTestNs),
 		func(v float64) error {
 			if v == 1 {
 				return nil
@@ -514,7 +429,7 @@ func assertUserWorkloadMetrics(t *testing.T) {
 	// Assert that recording rule is in thanos querier and we get it
 	// via user workload prometheus.
 	f.ThanosQuerierClient.WaitForQueryReturn(
-		t, 10*time.Minute, `version:blah:leaf:count{prometheus_replica="prometheus-user-workload-0"}`,
+		t, 10*time.Minute, fmt.Sprintf(`version:blah:leaf:count{prometheus_replica="prometheus-user-workload-0",namespace="%s"}`, userWorkloadTestNs),
 		func(v float64) error {
 			if v == 1 {
 				return nil
@@ -637,12 +552,12 @@ func assertTenancyForMetrics(t *testing.T) {
 				}
 			}()
 
-			err = framework.Poll(5*time.Second, time.Minute, func() error {
+			err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 				// The tenancy port (9092) is only exposed in-cluster, so we need to use
 				// port forwarding to access kube-rbac-proxy.
 				host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
 				if err != nil {
-					t.Fatal(err)
+					return err
 				}
 				defer cleanUp()
 
@@ -705,12 +620,12 @@ func assertTenancyForMetrics(t *testing.T) {
 
 	// Check that the account doesn't have to access the rules and alerts endpoints.
 	for _, path := range []string{"/api/v1/rules", "/api/v1/alerts"} {
-		err = framework.Poll(5*time.Second, time.Minute, func() error {
+		err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 			// The tenancy port (9092) is only exposed in-cluster, so we need to use
 			// port forwarding to access kube-rbac-proxy.
 			host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
 			defer cleanUp()
 
@@ -821,25 +736,25 @@ func assertTenancyForMetrics(t *testing.T) {
 				}
 			}()
 
-			// Forward the tenancy port.
-			host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer cleanUp()
-
-			// Create a Prometheus client with the test SA token.
-			client := framework.NewPrometheusClient(
-				host,
-				token,
-				&framework.QueryParameterInjector{
-					Name:  "namespace",
-					Value: userWorkloadTestNs,
-				},
-			)
-
 			// It might take some time for kube-rbac-proxy to catch up the updated permission.
-			err = framework.Poll(time.Second, time.Minute, func() error {
+			err = framework.Poll(time.Second, 5*time.Minute, func() error {
+				// Forward the tenancy port.
+				host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
+				if err != nil {
+					return err
+				}
+				defer cleanUp()
+
+				// Create a Prometheus client with the test SA token.
+				client := framework.NewPrometheusClient(
+					host,
+					token,
+					&framework.QueryParameterInjector{
+						Name:  "namespace",
+						Value: userWorkloadTestNs,
+					},
+				)
+
 				resp, err := client.Do(tc.method, "/api/v1/query?namespace="+userWorkloadTestNs+"&query=up", nil)
 				if err != nil {
 					return err
@@ -897,24 +812,25 @@ func assertTenancyForRulesAndAlerts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The tenancy port (9093) is only exposed in-cluster, so we need to use
-	// port forwarding to access kube-rbac-proxy.
-	host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9093)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanUp()
+	var client *framework.PrometheusClient
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
+		// The tenancy port (9093) is only exposed in-cluster, so we need to use
+		// port forwarding to access kube-rbac-proxy.
+		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9093)
+		if err != nil {
+			return err
+		}
+		t.Cleanup(cleanUp)
 
-	client := framework.NewPrometheusClient(
-		host,
-		token,
-		&framework.QueryParameterInjector{
-			Name:  "namespace",
-			Value: userWorkloadTestNs,
-		},
-	)
+		client = framework.NewPrometheusClient(
+			host,
+			token,
+			&framework.QueryParameterInjector{
+				Name:  "namespace",
+				Value: userWorkloadTestNs,
+			},
+		)
 
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
 		resp, err := client.Do("GET", "/api/v1/rules", nil)
 		if err != nil {
 			return err
@@ -1000,7 +916,7 @@ func assertTenancyForRulesAndAlerts(t *testing.T) {
 		t.Fatalf("failed to query rules from Thanos querier: %v", err)
 	}
 
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		resp, err := client.Do("GET", "/api/v1/alerts", nil)
 		if err != nil {
 			return err
@@ -1023,7 +939,7 @@ func assertTenancyForRulesAndAlerts(t *testing.T) {
 
 	// Check that the account doesn't have to access the query endpoints.
 	for _, path := range []string{"/api/v1/range?query=up", "/api/v1/query_range?query=up&start=0&end=0&step=1s"} {
-		err = framework.Poll(5*time.Second, time.Minute, func() error {
+		err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 			resp, err := client.Do("GET", path, nil)
 			if err != nil {
 				return err
@@ -1110,7 +1026,7 @@ func assertUWMFederateEndpoint(t *testing.T) {
 	defer func() { require.NoError(t, rbCleanup()) }()
 
 	var token string
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		var err error
 		token, err = f.GetServiceAccountToken(userWorkloadTestNs, testAccount)
 		return err
@@ -1118,7 +1034,7 @@ func assertUWMFederateEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	// check /federate endpoint for service
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		host, cleanUp, err := f.ForwardServicePort(t, f.UserWorkloadMonitoringNs, "prometheus-user-workload", 9092)
 		if err != nil {
 			return err
@@ -1156,7 +1072,7 @@ func assertUWMFederateEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	// check /federate endpoint for route
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		r, err := f.OpenShiftRouteClient.Routes(f.UserWorkloadMonitoringNs).Get(ctx, "federate", metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -1222,7 +1138,7 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 	}
 
 	var token string
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		token, err = f.GetServiceAccountToken(userWorkloadTestNs, testAccount)
 		return err
 	})
@@ -1231,7 +1147,7 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 	}
 
 	// check /api/v1/labels endpoint
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		// The tenancy port (9092) is only exposed in-cluster, so we need to use
 		// port forwarding to access kube-rbac-proxy.
 		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
@@ -1285,7 +1201,7 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 	}
 
 	// Check the /api/v1/series endpoint.
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		// The tenancy port (9092) is only exposed in-cluster, so we need to use
 		// port forwarding to access kube-rbac-proxy.
 		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
@@ -1339,7 +1255,7 @@ func assertTenancyForSeriesMetadata(t *testing.T) {
 	}
 
 	// Check that /api/v1/label/{namespace}/values returns a single value.
-	err = framework.Poll(5*time.Second, time.Minute, func() error {
+	err = framework.Poll(5*time.Second, 5*time.Minute, func() error {
 		// The tenancy port (9092) is only exposed in-cluster, so we need to use
 		// port forwarding to access kube-rbac-proxy.
 		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, "thanos-querier", 9092)
@@ -1392,7 +1308,7 @@ func assertGRPCTLSRotation(t *testing.T) {
 	countGRPCSecrets := func(ns string) int {
 		t.Helper()
 		var result int
-		err := framework.Poll(5*time.Second, time.Minute, func() error {
+		err := framework.Poll(5*time.Second, 5*time.Minute, func() error {
 			s, err := f.KubeClient.CoreV1().Secrets(ns).List(ctx, metav1.ListOptions{LabelSelector: "monitoring.openshift.io/hash"})
 			if err != nil {
 				return err
@@ -1472,7 +1388,7 @@ func assertGRPCTLSRotation(t *testing.T) {
 func assertNamespaceOptOut(t *testing.T) {
 	ctx := context.Background()
 
-	serviceMonitorJobName := fmt.Sprintf("serviceMonitor/%s/%s/0", userWorkloadTestNs, serviceMonitorTestName)
+	serviceMonitorJobName := fmt.Sprintf("serviceMonitor/%s/%s/0", userWorkloadOptOutTestNs, serviceMonitorTestName)
 
 	// Ensure the target for the example ServiceMonitor exists.
 	f.ThanosQuerierClient.WaitForTargetsReturn(t, 5*time.Minute, func(body []byte) error {
@@ -1480,7 +1396,7 @@ func assertNamespaceOptOut(t *testing.T) {
 	})
 
 	// Add opt-out label to namespace.
-	ns, err := f.KubeClient.CoreV1().Namespaces().Get(ctx, userWorkloadTestNs, metav1.GetOptions{})
+	ns, err := f.KubeClient.CoreV1().Namespaces().Get(ctx, userWorkloadOptOutTestNs, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to fetch user-workload namespace: %v", err)
 	}
@@ -1504,7 +1420,7 @@ func assertNamespaceOptOut(t *testing.T) {
 	})
 
 	// Remove opt-out label from namespace.
-	ns, err = f.KubeClient.CoreV1().Namespaces().Get(ctx, userWorkloadTestNs, metav1.GetOptions{})
+	ns, err = f.KubeClient.CoreV1().Namespaces().Get(ctx, userWorkloadOptOutTestNs, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to fetch user-workload namespace: %v", err)
 	}
@@ -1579,8 +1495,6 @@ func assertServiceMonitorOptOut(t *testing.T) {
 	})
 }
 
-// TestPrometheusUserWorkloadEndpointSliceDiscovery verifies that
-// prometheus-user-workload can discover and scrape targets using endpoint slices.
 func TestPrometheusUserWorkloadEndpointSliceDiscovery(t *testing.T) {
 	ctx := context.Background()
 	setupUserWorkloadAssetsWithTeardownHook(t, f)
@@ -1631,7 +1545,7 @@ func TestPrometheusUserWorkloadEndpointSliceDiscovery(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:            appName,
-							Image:           "ghcr.io/rhobs/prometheus-example-app:0.3.0",
+							Image:           "ghcr.io/rhobs/prometheus-example-app:0.5.1",
 							SecurityContext: getSecurityContextRestrictedProfile(),
 						},
 					},

--- a/test/e2e/user_workload_monitoring_test.go
+++ b/test/e2e/user_workload_monitoring_test.go
@@ -820,7 +820,7 @@ func assertTenancyForRulesAndAlerts(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		t.Cleanup(cleanUp)
+		defer cleanUp()
 
 		client = framework.NewPrometheusClient(
 			host,

--- a/test/e2e/uwm_helpers.go
+++ b/test/e2e/uwm_helpers.go
@@ -2,14 +2,19 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -17,9 +22,10 @@ import (
 )
 
 const (
-	userWorkloadTestNs     = "user-workload-test"
-	serviceMonitorTestName = "prometheus-example-monitor"
-	notEnforcedNs          = "namespace-not-enforced"
+	userWorkloadTestNs       = "user-workload-test"
+	userWorkloadOptOutTestNs = "user-workload-opt-out-test"
+	serviceMonitorTestName   = "prometheus-example-monitor"
+	notEnforcedNs            = "namespace-not-enforced"
 )
 
 var (
@@ -67,6 +73,45 @@ func tearDownUserWorkloadAssets(t *testing.T, f *framework.Framework) {
 	f.AssertStatefulsetDoesNotExistFunc("prometheus-user-workload", f.UserWorkloadMonitoringNs)(t)
 }
 
+// setupUserApplications deploys the sample apps in both userWorkloadTestNs and userWorkloadOptOutTestNs.
+func setupUserApplications(t *testing.T, f *framework.Framework) {
+	t.Helper()
+	var g errgroup.Group
+
+	g.Go(func() error {
+		if err := deployUserApplication(f, userWorkloadTestNs); err != nil {
+			return fmt.Errorf("deploying to %s: %w", userWorkloadTestNs, err)
+		}
+		if err := createPrometheusAlertmanagerInUserNamespace(f); err != nil {
+			return fmt.Errorf("creating prometheus/alertmanager in user namespace: %w", err)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		if err := deployUserApplication(f, userWorkloadOptOutTestNs); err != nil {
+			return fmt.Errorf("deploying to %s: %w", userWorkloadOptOutTestNs, err)
+		}
+		return nil
+	})
+	require.NoError(t, g.Wait())
+}
+
+// tearDownUserApplications deletes the test namespaces and waits for deletion.
+func tearDownUserApplications(t *testing.T, f *framework.Framework) {
+	t.Helper()
+	err := framework.Poll(time.Second, 5*time.Minute, func() error {
+		err1 := f.DeleteNamespace(t, userWorkloadTestNs)
+		err2 := f.DeleteNamespace(t, userWorkloadOptOutTestNs)
+		return errors.Join(err1, err2)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.AssertNamespaceDoesNotExistFunc(userWorkloadTestNs)(t)
+	f.AssertNamespaceDoesNotExistFunc(userWorkloadOptOutTestNs)(t)
+}
+
 func createNamespaceIfNotExist(f *framework.Framework, ns string) error {
 	_, err := f.KubeClient.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -76,20 +121,20 @@ func createNamespaceIfNotExist(f *framework.Framework, ns string) error {
 			},
 		},
 	}, metav1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
 	return nil
 }
 
-// deployUserApplication is idempotent and deploys the sample app and resources in UserWorkloadTestNs
-func deployUserApplication(f *framework.Framework) error {
-	if err := createNamespaceIfNotExist(f, userWorkloadTestNs); err != nil {
-		return fmt.Errorf("namespace %s: %w", userWorkloadTestNs, err)
+// deployUserApplication is idempotent and deploys the sample app and resources in the given namespace.
+func deployUserApplication(f *framework.Framework, namespace string) error {
+	if err := createNamespaceIfNotExist(f, namespace); err != nil {
+		return fmt.Errorf("namespace %s: %w", namespace, err)
 	}
 
-	app, err := f.KubeClient.AppsV1().Deployments(userWorkloadTestNs).Create(ctx, &appsv1.Deployment{
+	app, err := f.KubeClient.AppsV1().Deployments(namespace).Create(ctx, &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-app",
 			Labels: map[string]string{
@@ -132,7 +177,7 @@ func deployUserApplication(f *framework.Framework) error {
 		}
 	}
 
-	_, err = f.KubeClient.CoreV1().Services(userWorkloadTestNs).Create(ctx, &v1.Service{
+	_, err = f.KubeClient.CoreV1().Services(namespace).Create(ctx, &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-app",
 			Labels: map[string]string{
@@ -155,8 +200,11 @@ func deployUserApplication(f *framework.Framework) error {
 			Type: v1.ServiceTypeClusterIP,
 		},
 	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
 
-	_, err = f.MonitoringClient.ServiceMonitors(userWorkloadTestNs).Create(ctx, &monitoringv1.ServiceMonitor{
+	_, err = f.MonitoringClient.ServiceMonitors(namespace).Create(ctx, &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: serviceMonitorTestName,
 			Labels: map[string]string{
@@ -182,7 +230,7 @@ func deployUserApplication(f *framework.Framework) error {
 		return err
 	}
 
-	_, err = f.MonitoringClient.PrometheusRules(userWorkloadTestNs).Create(ctx, &monitoringv1.PrometheusRule{
+	_, err = f.MonitoringClient.PrometheusRules(namespace).Create(ctx, &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-rule",
 			Labels: map[string]string{
@@ -201,7 +249,7 @@ func deployUserApplication(f *framework.Framework) error {
 						},
 						{
 							Alert: "VersionAlert",
-							Expr:  intstr.FromString(fmt.Sprintf(`version{namespace="%s",job="prometheus-example-app"} == 1`, userWorkloadTestNs)),
+							Expr:  intstr.FromString(fmt.Sprintf(`version{namespace="%s",job="prometheus-example-app"} == 1`, namespace)),
 							For:   func(d monitoringv1.Duration) *monitoringv1.Duration { return &d }("1s"),
 						},
 					},
@@ -213,7 +261,7 @@ func deployUserApplication(f *framework.Framework) error {
 		return err
 	}
 
-	_, err = f.MonitoringClient.PrometheusRules(userWorkloadTestNs).Create(ctx, &monitoringv1.PrometheusRule{
+	_, err = f.MonitoringClient.PrometheusRules(namespace).Create(ctx, &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus-example-rule-leaf",
 			Labels: map[string]string{


### PR DESCRIPTION
from https://github.com/openshift/cluster-monitoring-operator/pull/2397

```

> **Note:** These numbers are based on a single run each, so individual test
> deltas should be taken with a grain of salt.

### Merged tests: 4 → 1

The 4 separate UWM tests that each ran their own setup/teardown cycle are now a single `TestUserWorkloadMonitoring`:

| Before | Duration |
|---|---:|
| `TestUserWorkloadMonitoringMetrics` | 159.83s |
| `TestUserWorkloadMonitoringAlerting` | 205.59s |
| `TestUserWorkloadMonitoringOptOut` | 293.01s |
| `TestUserWorkloadMonitoringGrpcSecrets` | 132.32s |
| **Sum** | **790.75s** |

| After (PR #2964) | Duration |
|---|---:|
| `TestUserWorkloadMonitoring` | **524.85s** |

**Saved: ~266s (33.6%)** mostly from eliminating redundant setup/teardown cycles.

### Suite totals

| | Before | After | Delta |
|---|---:|---:|---:|
| All tests combined | 5250s | 4893s | **-357s (-6.8%)** |
| Suite wall-clock | 89.7m | 83.3m | **-6.4 min** |
```


## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
