### PR TITLE
manifests: add Kubernetes/Compute Resources/Nodes dashboard (RFE-5023)

### DIFF
--- a/manifests/0000_90_cluster-monitoring-operator_02-dashboards.yaml
+++ b/manifests/0000_90_cluster-monitoring-operator_02-dashboards.yaml
@@ -16789,3 +16789,1282 @@ metadata:
     console.openshift.io/dashboard: "true"
   name: dashboard-pod-total
   namespace: openshift-config-managed
+---
+apiVersion: v1
+data:
+  k8s-resources-nodes.json: |-
+    {
+        "annotations": {
+            "list": []
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "hideControls": false,
+        "links": [],
+        "refresh": "10s",
+        "rows": [
+            {
+                "collapse": false,
+                "height": "100px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "fill": 1,
+                        "format": "percentunit",
+                        "id": 1,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 2,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{node=~\"$node\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\", resource=\"cpu\", node=~\"$node\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": "70,80",
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Utilisation",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "singlestat",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "fill": 1,
+                        "format": "percentunit",
+                        "id": 2,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 2,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{node=~\"$node\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\", resource=\"cpu\", node=~\"$node\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": "70,80",
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Requests Commitment",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "singlestat",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "fill": 1,
+                        "format": "percentunit",
+                        "id": 3,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 2,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{node=~\"$node\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\", resource=\"cpu\", node=~\"$node\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": "70,80",
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Limits Commitment",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "singlestat",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "fill": 1,
+                        "format": "percentunit",
+                        "id": 4,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 2,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{node=~\"$node\", container!=\"\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\", resource=\"memory\", node=~\"$node\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": "70,80",
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory Utilisation",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "singlestat",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "fill": 1,
+                        "format": "percentunit",
+                        "id": 5,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 2,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{node=~\"$node\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\", resource=\"memory\", node=~\"$node\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": "70,80",
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory Requests Commitment",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "singlestat",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    },
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "fill": 1,
+                        "format": "percentunit",
+                        "id": 6,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 2,
+                        "stack": false,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{node=~\"$node\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\", resource=\"memory\", node=~\"$node\"})",
+                                "format": "time_series",
+                                "instant": true,
+                                "refId": "A"
+                            }
+                        ],
+                        "thresholds": "70,80",
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory Limits Commitment",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "singlestat",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Headlines",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "fill": 10,
+                        "id": 7,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 0,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "requests",
+                                "color": "#F2495C",
+                                "fill": 0,
+                                "hideTooltip": true,
+                                "legend": true,
+                                "linewidth": 2,
+                                "stack": false
+                            },
+                            {
+                                "alias": "limits",
+                                "color": "#FF9830",
+                                "fill": 0,
+                                "hideTooltip": true,
+                                "legend": true,
+                                "linewidth": 2,
+                                "stack": false
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{node=~\"$node\"}) by (namespace)",
+                                "format": "time_series",
+                                "legendFormat": "{{namespace}}",
+                                "legendLink": null
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Usage",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "CPU",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "$datasource",
+                        "fill": 1,
+                        "id": 8,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "styles": [
+                            {
+                                "alias": "Time",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Time",
+                                "thresholds": [],
+                                "type": "hidden",
+                                "unit": "short"
+                            },
+                            {
+                                "alias": "CPU Usage",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #A",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            },
+                            {
+                                "alias": "CPU Requests",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #B",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            },
+                            {
+                                "alias": "CPU Requests %",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #C",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "percentunit"
+                            },
+                            {
+                                "alias": "CPU Limits",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #D",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "short"
+                            },
+                            {
+                                "alias": "CPU Limits %",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #E",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "percentunit"
+                            },
+                            {
+                                "alias": "Namespace",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": true,
+                                "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?var-datasource=$datasource&var-namespace=$__cell",
+                                "pattern": "namespace",
+                                "thresholds": [],
+                                "type": "string",
+                                "unit": "short"
+                            }
+                        ],
+                        "targets": [
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "A"
+                            },
+                            {
+                                "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "B"
+                            },
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{node=~\"$node\"}) by (namespace) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "C"
+                            },
+                            {
+                                "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "D"
+                            },
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{node=~\"$node\"}) by (namespace) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "E"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "CPU Quota",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "transform": "table",
+                        "type": "table",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "CPU Quota",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "dashLength": 10,
+                        "dashes": false,
+                        "datasource": "$datasource",
+                        "fill": 10,
+                        "id": 9,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 0,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [
+                            {
+                                "alias": "requests",
+                                "color": "#F2495C",
+                                "fill": 0,
+                                "hideTooltip": true,
+                                "legend": true,
+                                "linewidth": 2,
+                                "stack": false
+                            },
+                            {
+                                "alias": "limits",
+                                "color": "#FF9830",
+                                "fill": 0,
+                                "hideTooltip": true,
+                                "legend": true,
+                                "linewidth": 2,
+                                "stack": false
+                            }
+                        ],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": true,
+                        "steppedLine": false,
+                        "targets": [
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{node=~\"$node\", container!=\"\"}) by (namespace)",
+                                "format": "time_series",
+                                "legendFormat": "{{namespace}}",
+                                "legendLink": null
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory Usage (w/o cache)",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "type": "graph",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Memory",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                        "aliasColors": {},
+                        "bars": false,
+                        "datasource": "$datasource",
+                        "fill": 1,
+                        "id": 10,
+                        "legend": {
+                            "avg": false,
+                            "current": false,
+                            "max": false,
+                            "min": false,
+                            "show": true,
+                            "total": false,
+                            "values": false
+                        },
+                        "lines": true,
+                        "linewidth": 1,
+                        "links": [],
+                        "nullPointMode": "null as zero",
+                        "percentage": false,
+                        "pointradius": 5,
+                        "points": false,
+                        "renderer": "flot",
+                        "seriesOverrides": [],
+                        "spaceLength": 10,
+                        "span": 12,
+                        "stack": false,
+                        "steppedLine": false,
+                        "styles": [
+                            {
+                                "alias": "Time",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Time",
+                                "thresholds": [],
+                                "type": "hidden",
+                                "unit": "short"
+                            },
+                            {
+                                "alias": "Memory Usage",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #A",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "bytes"
+                            },
+                            {
+                                "alias": "Memory Requests",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #B",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "bytes"
+                            },
+                            {
+                                "alias": "Memory Requests %",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #C",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "percentunit"
+                            },
+                            {
+                                "alias": "Memory Limits",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #D",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "bytes"
+                            },
+                            {
+                                "alias": "Memory Limits %",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #E",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "percentunit"
+                            },
+                            {
+                                "alias": "Memory RSS",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #F",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "bytes"
+                            },
+                            {
+                                "alias": "Memory Cache",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #G",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "bytes"
+                            },
+                            {
+                                "alias": "Memory Swap",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": false,
+                                "linkUrl": "",
+                                "pattern": "Value #H",
+                                "thresholds": [],
+                                "type": "number",
+                                "unit": "bytes"
+                            },
+                            {
+                                "alias": "Namespace",
+                                "colorMode": null,
+                                "colors": [],
+                                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                                "decimals": 2,
+                                "link": true,
+                                "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?var-datasource=$datasource&var-namespace=$__cell",
+                                "pattern": "namespace",
+                                "thresholds": [],
+                                "type": "string",
+                                "unit": "short"
+                            }
+                        ],
+                        "targets": [
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{node=~\"$node\",container!=\"\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "A"
+                            },
+                            {
+                                "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "B"
+                            },
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{node=~\"$node\",container!=\"\"}) by (namespace) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "C"
+                            },
+                            {
+                                "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "D"
+                            },
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{node=~\"$node\",container!=\"\"}) by (namespace) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{node=~\"$node\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "E"
+                            },
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_memory_rss{node=~\"$node\",container!=\"\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "F"
+                            },
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_memory_cache{node=~\"$node\",container!=\"\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "G"
+                            },
+                            {
+                                "expr": "sum(node_namespace_pod_container:container_memory_swap{node=~\"$node\",container!=\"\"}) by (namespace)",
+                                "format": "table",
+                                "instant": true,
+                                "legendFormat": "",
+                                "refId": "H"
+                            }
+                        ],
+                        "thresholds": [],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Memory Quota",
+                        "tooltip": {
+                            "shared": true,
+                            "sort": 2,
+                            "value_type": "individual"
+                        },
+                        "transform": "table",
+                        "type": "table",
+                        "xaxis": {
+                            "buckets": null,
+                            "mode": "time",
+                            "name": null,
+                            "show": true,
+                            "values": []
+                        },
+                        "yaxes": [
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                            },
+                            {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": false
+                            }
+                        ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Memory Quota",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [
+            "kubernetes-mixin"
+        ],
+        "templating": {
+            "list": [
+                {
+                    "current": {
+                        "text": "default",
+                        "value": "default"
+                    },
+                    "hide": 0,
+                    "label": "Data source",
+                    "name": "datasource",
+                    "options": [],
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "regex": "",
+                    "type": "datasource"
+                },
+                {
+                    "allValue": ".+",
+                    "current": {
+                        "text": "all",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": false,
+                    "name": "role",
+                    "options": [],
+                    "query": "label_values(kube_node_role{}, role)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 1,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": ".+",
+                    "current": {
+                        "selected": true,
+                        "text": "All",
+                        "value": "$__all"
+                    },
+                    "datasource": "$datasource",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": true,
+                    "name": "node",
+                    "options": [],
+                    "query": "label_values(kube_node_info{} * on (node) group_right kube_node_role{role=~\"$role\"}, node)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 1,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-1h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "UTC",
+        "title": "Kubernetes / Compute Resources / Nodes",
+        "uid": "9ace010e5b1c8e7c9c739b24c87a3d9f",
+        "version": 0
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    capability.openshift.io/name: Console
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  labels:
+    app.kubernetes.io/part-of: openshift-monitoring
+    console.openshift.io/dashboard: "true"
+  name: dashboard-k8s-resources-nodes
+  namespace: openshift-config-managed


### PR DESCRIPTION
### What

Adds a new **"Kubernetes / Compute Resources / Nodes"** dashboard (`dashboard-k8s-resources-nodes`) to `openshift-config-managed`.

### Why

Operators running workloads on dedicated node groups (infra, GPU, compute) have no way to see aggregate CPU/memory request vs. actual usage for their node group as a whole. The existing options are:

- `oc describe node` — single node, no trend data, no aggregation
- "Kubernetes / Compute Resources / Cluster" — whole cluster, no node filtering
- "Kubernetes / Compute Resources / Node (Pods)" — pod-level breakdown per node, no namespace aggregation or headline commitment %

This dashboard fills the gap: users select nodes by role and individual name, and see the same commitment overview the cluster dashboard provides — scoped to their selected nodes.

Fixes: [RFE-5023](https://redhat.atlassian.net/browse/RFE-5023)

### How

Pure ConfigMap addition. No Go code changes. No new recording rules — all queries use pre-existing CMO rules that preserve the `node` label via kube-state-metrics. Applied by CVO as part of the release payload.

### Dashboard features

- **Template variables**: `role` (node role filter, include-all) + `node` (multi-select, filtered by role, defaults to All)
- **Headlines row** (6 stat panels): CPU Utilisation, CPU Requests Commitment, CPU Limits Commitment, Memory Utilisation, Memory Requests Commitment, Memory Limits Commitment — all scoped to `node=~"$node"` and normalized against `kube_node_status_allocatable`
- **CPU row**: Time-series of CPU usage by namespace on selected nodes
- **CPU Quota row**: Table — namespace, CPU usage, requests, requests %, limits, limits %
- **Memory row**: Time-series of memory usage (working set) by namespace on selected nodes
- **Memory Quota row**: Table — namespace, memory usage, requests, requests %, limits, limits %, RSS, cache, swap

### Recording rules used (all pre-existing)

| Metric | Node label source |
|--------|-------------------|
| `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate` | explicit `group_left(node)` |
| `node_namespace_pod_container:container_memory_working_set_bytes` | explicit `group_left(node)` |
| `cluster:namespace:pod_cpu/memory:active:kube_pod_container_resource_requests` | kube-state-metrics `node` label preserved via `group_left()` |
| `cluster:namespace:pod_cpu/memory:active:kube_pod_container_resource_limits` | same |
| `kube_node_status_allocatable` | direct node metric |

### Before / After

**Before**: No way to see aggregate CPU/memory commitment for selected nodes.

**After**: Console → Observe → Dashboards → "Kubernetes / Compute Resources / Nodes"
Select `role=infra`, `node=infra-1,infra-2` → combined utilisation + namespace breakdown instantly.

Cluster verification (2026-06-23):
```
CPU Utilisation:          1.52%
CPU Requests Commitment:  6.84%
CPU Limits Commitment:    0.28%
Memory Utilisation:       12.17%
Memory Requests Commitment: 14.07%
Memory Limits Commitment:   5.64%
```
All 6 headline panels populated on first load with Role=All, Node=All.

### Test plan

1. `oc apply -f manifests/0000_90_cluster-monitoring-operator_02-dashboards.yaml`
2. Console → Observe → Dashboards → confirm "Kubernetes / Compute Resources / Nodes" appears
3. Select `role=master` → verify `node` variable shows only master nodes
4. Select individual nodes → headline panels update, CPU/Memory graphs show namespace breakdown
5. Set `node=All` → aggregate values match "Kubernetes / Compute Resources / Cluster"
6. Confirm existing dashboards (Cluster, Node (Pods), Namespace, Pod, Workload) unaffected

Made with [Cursor](https://cursor.com)