### PR TITLE
OCPBUGS-92085: set Prometheus shards value explicitly

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -222,6 +222,7 @@ spec:
     matchLabels:
       openshift.io/cluster-monitoring: "true"
   serviceMonitorSelector: {}
+  shards: 1
   thanos:
     grpcServerTlsConfig:
       caFile: /etc/tls/grpc/ca.crt

--- a/assets/prometheus-user-workload/prometheus.yaml
+++ b/assets/prometheus-user-workload/prometheus.yaml
@@ -284,6 +284,7 @@ spec:
       operator: NotIn
       values:
       - "false"
+  shards: 1
   thanos:
     grpcServerTlsConfig:
       caFile: /etc/tls/grpc/ca.crt

--- a/jsonnet/components/prometheus-user-workload.libsonnet
+++ b/jsonnet/components/prometheus-user-workload.libsonnet
@@ -379,6 +379,8 @@ function(params)
             value: '15ms',
           },
         ],
+        // Explicitly set the shards value to 1 to support VPA use cases.
+        shards: 1,
         containers: [
           {
             name: 'kube-rbac-proxy-federate',

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -419,6 +419,8 @@ function(params)
         // failures when the WAL replay takes a long time.
         // See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
         maximumStartupDurationSeconds: 3600,
+        // Explicitly set the shards value to 1 to support VPA use cases.
+        shards: 1,
         containers: [
           {
             name: 'kube-rbac-proxy-web',


### PR DESCRIPTION
As explained in
https://github.com/prometheus-operator/prometheus-operator/issues/6291, the VPA expects the `.spec.shards` field to be set to an explicit value to scale the resource.