### PR TITLE
OCPBUGS-88323:[release-4.21] fix(TestDocExamples) flake: use internal registry for test pods

### DIFF
--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -109,7 +109,7 @@ func TestDocExamples(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            containerName,
-									Image:           "registry.redhat.io/openshift4/ose-cli:latest",
+									Image:           "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest",
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									Command:         []string{"bash", "-c", test.Script},
 									SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-monitoring-operator/pull/2957 to release-4.21.

The ose-cli image (~584MB!!) pulled from registry.redhat.io can take over
60s, causing TestDocExamples to flake when the pod stays
in Pending past the poll timeout. Switch to the cli image from the
cluster's internal registry (openshift/cli) to avoid external pulls.

Note: The second commit from #2957 (fix for `runProbePod` in `TestNetworkPolicy`) is
not included because the `runProbePod` function does not exist on `release-4.21`.