### PR TITLE
OU-1389: config path to point to correct directory

### DIFF
--- a/assets/monitoring-plugin/deployment.yaml
+++ b/assets/monitoring-plugin/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - args:
-        - --config-path=/opt/app-root/web/dist
+        - --config-path=/opt/app-root/config
         - --static-path=/opt/app-root/web/dist
         - --cert=/var/cert/tls.crt
         - --key=/var/cert/tls.key

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -197,7 +197,7 @@ function(params)
                   $.volumeMount(tlsVolumeName, tlsMountPath),
                 ],
                 args: [
-                  '--config-path=/opt/app-root/web/dist',
+                  '--config-path=/opt/app-root/config',
                   '--static-path=/opt/app-root/web/dist',
                   '--cert=' + tlsCertPath,
                   '--key=' + tlsKeyPath,


### PR DESCRIPTION
This PR is part of a set that looks to update the monitoring-plugin to be feature driven, allowing for each feature to be toggled on or off individually. This conversion will happen over the course of the following PRs:

1. This PR, which fixes CMO to pass the correct config directory to the monitoring-plugin so that the `*.patch.json` feature files are able to be loaded correctly 
2. Change the monitoring-plugin backend to be feature driven and handle no feature flags so that the current monitoring-plugin features are enabled (openshift/monitoring-plugin#1034) for backwards compatability
3. Change CMO to directly pass in the `alerting`, `targets`, `metrics` and `legacy-dashboards` feature flags to the monitoring-plugin. Ensure the `TestClusterMonitorConsolePlugin` test still passes
4. Adjust the monitoring-plugin to serve no features is no feature flags are passed in