### PR TITLE
NO-JIRA: Revert "MON-3697: use maximumStartupDurationSeconds instead of container patch"

### DIFF
--- a/assets/prometheus-k8s/prometheus.yaml
+++ b/assets/prometheus-k8s/prometheus.yaml
@@ -163,7 +163,6 @@ spec:
   externalURL: https://prometheus-k8s.openshift-monitoring.svc:9091
   image: ""
   listenLocal: true
-  maximumStartupDurationSeconds: 3600
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:

--- a/jsonnet/components/prometheus.libsonnet
+++ b/jsonnet/components/prometheus.libsonnet
@@ -415,10 +415,6 @@ function(params)
             value: '15ms',
           },
         ],
-        // Increase the startup probe timeout to 1h from 15m to avoid restart
-        // failures when the WAL replay takes a long time.
-        // See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
-        maximumStartupDurationSeconds: 3600,
         // Explicitly set the shards value to 1 to support VPA use cases.
         shards: 1,
         containers: [

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1519,6 +1519,12 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, telemetrySecret *v1.Secret) 
 	for i, container := range p.Spec.Containers {
 		switch container.Name {
 		case "prometheus":
+			// Increase the startup probe timeout to 1h from 15m to avoid restart failures when the WAL replay
+			// takes a long time. See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
+			p.Spec.Containers[i].StartupProbe = &v1.Probe{
+				PeriodSeconds:    15,
+				FailureThreshold: 240,
+			}
 			// Inject the proxy env vars into the Prometheus container
 			// Mainly intended for all configs that support proxyConfig.proxyFromEnvironment
 			f.injectProxyVariables(&p.Spec.Containers[i])
@@ -1856,9 +1862,6 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		case "prometheus":
 			// Increase the startup probe timeout to 1h from 15m to avoid restart failures when the WAL replay
 			// takes a long time. See https://issues.redhat.com/browse/OCPBUGS-4168 for details.
-			// TODO (JoaoBraveCoding): Once prometheus-operator adds CRD support to configure startupProbe directly
-			// we should use that instead of using strategic merge patch
-			// See https://github.com/prometheus-operator/prometheus-operator/issues/4730
 			p.Spec.Containers[i].StartupProbe = &v1.Probe{
 				PeriodSeconds:    15,
 				FailureThreshold: 240,


### PR DESCRIPTION
This reverts the changes from PR #2251.

With maximumStartupDurationSeconds=3600, prometheus-operator sets PeriodSeconds=60s (instead of the previous 15s), which significantly slows down Prometheus pod restarts, especially in e2e tests where restarts are numerous.

Additionally, UWM Prometheus still uses the container patch approach, so reverting makes the two consistent.

---

## e2e-agnostic-operator runs, revert #2982 vs last 5 PRs merged to `main` 

| PR | Title | Merged | Total | vs Revert |
|------|---------------------------------------|---------|---------|-----------|
| #2981 | [OU-1389](https://redhat.atlassian.net/browse/OU-1389): config path fix | Jul 08 | 82m55s | -5m02s |
| #2979 | OCPBUGS-93756: update prometheus | Jul 02 | 82m11s | -4m18s |
| #2972 | OCPBUGS-92085: set Prom shards | Jun 26 | 83m07s | -5m14s |
| #2919 | [MON-4527](https://redhat.atlassian.net/browse/MON-4527): NodeExporter config | Jun 25 | 78m42s | -0m49s |
| #2971 | NO-JIRA: sync component versions | Jun 25 | 86m26s | -8m33s |
| | **AVG BASELINE (5 runs)** | | **82m40s** | |
| | **REVERT #2982** | | **77m53s** | **-4m47s (5.8%)** |

Revert is faster than every single baseline run.

### Per-test breakdown

| Test | #2981 | #2979 | #2972 | #2919 | #2971 | AVG | REVERT | Δ avg |
|------|-------|-------|-------|-------|-------|-----|--------|-------|
| TestAlertmanagerUWMSecrets | 349s | 201s | 350s | 211s | 201s | 262s | 191s | -71s |
| TestClusterMonitoringStatus | 164s | 163s | 161s | 151s | 164s | 161s | 111s | -50s |
| TestClusterMonitorAlertMgrCfg | 84s | 101s | 99s | 30s | 98s | 83s | 31s | -52s |
| TestAlertingRule | 46s | 38s | 21s | 51s | 62s | 44s | 7s | -37s |
| TestUserWorkloadPromOperCfg | 149s | 139s | 141s | 110s | 140s | 136s | 108s | -28s |
| TestAlertmanagerDisabling | 160s | 145s | 136s | 140s | 155s | 147s | 129s | -18s |


## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
