### PR TITLE
OU-1389: manually pass features to monitoring plugin

### DIFF
--- a/assets/monitoring-plugin/deployment.yaml
+++ b/assets/monitoring-plugin/deployment.yaml
@@ -51,6 +51,7 @@ spec:
         - --cert=/var/cert/tls.crt
         - --key=/var/cert/tls.key
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --features=alerting,legacy-dashboards,targets,metrics
         command:
         - /opt/app-root/plugin-backend
         image: ""

--- a/jsonnet/components/monitoring-plugin.libsonnet
+++ b/jsonnet/components/monitoring-plugin.libsonnet
@@ -202,6 +202,7 @@ function(params)
                   '--cert=' + tlsCertPath,
                   '--key=' + tlsKeyPath,
                   '--tls-cipher-suites=' + cfg.tlsCipherSuites,
+                  '--features=alerting,legacy-dashboards,targets,metrics',
                 ],
                 command: [
                   '/opt/app-root/plugin-backend',

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -790,19 +790,27 @@ func assertThanosRulerEvaluationInterval(evaluationInterval string) func(*testin
 
 // checkMonitorConsolePluginReachable makes sure that one of the pods at least can serve /plugin-manifest.json
 func checkMonitorConsolePluginReachable(t *testing.T, pluginName string) {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
 		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, pluginName, 9443)
 		if err != nil {
-			t.Fatal(err)
+			return fmt.Errorf("port-forward failed: %w", err)
 		}
 		defer cleanUp()
 
-		client := &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/plugin-manifest.json", host), nil)
+		if err != nil {
+			return fmt.Errorf("fail to create request: %w", err)
 		}
-		resp, err := client.Get(fmt.Sprintf("https://%s/plugin-manifest.json", host))
+
+		resp, err := client.Do(req)
 		if err != nil {
 			return err
 		}
@@ -832,19 +840,27 @@ func checkMonitorConsolePluginReachable(t *testing.T, pluginName string) {
 
 // checkMonitorConsolePluginFeatures makes sure that the monitoring related features are enabled
 func checkMonitorConsolePluginFeatures(t *testing.T, pluginName string) {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	err := framework.Poll(time.Second, 5*time.Minute, func() error {
 		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, pluginName, 9443)
 		if err != nil {
-			t.Fatal(err)
+			return fmt.Errorf("port-forward failed: %w", err)
 		}
 		defer cleanUp()
 
-		client := &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/features", host), nil)
+		if err != nil {
+			return fmt.Errorf("fail to create request: %w", err)
 		}
-		resp, err := client.Get(fmt.Sprintf("https://%s/features", host))
+
+		resp, err := client.Do(req)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -829,6 +830,50 @@ func checkMonitorConsolePluginReachable(t *testing.T, pluginName string) {
 	require.NoError(t, err)
 }
 
+// checkMonitorConsolePluginFeatures makes sure that the monitoring related features are enabled
+func checkMonitorConsolePluginFeatures(t *testing.T, pluginName string) {
+	err := framework.Poll(time.Second, 5*time.Minute, func() error {
+		host, cleanUp, err := f.ForwardServicePort(t, f.Ns, pluginName, 9443)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanUp()
+
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+		resp, err := client.Get(fmt.Sprintf("https://%s/features", host))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("fail to read response body: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("expected status %d, got %d (%q)", http.StatusOK, resp.StatusCode, framework.ClampMax(b))
+		}
+
+		var features map[string]bool
+		if err := json.Unmarshal(b, &features); err != nil {
+			return fmt.Errorf("fail to parse features response: %w", err)
+		}
+
+		for _, feature := range []string{"alerting", "legacy-dashboards", "targets", "metrics"} {
+			if !features[feature] {
+				return fmt.Errorf("expected feature %q to be enabled, got features: %v", feature, features)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestClusterMonitorConsolePlugin(t *testing.T) {
 	const (
 		deploymentName = "monitoring-plugin"
@@ -841,6 +886,7 @@ func TestClusterMonitorConsolePlugin(t *testing.T) {
 	// ensure console-plugin is running and reachable before the change
 	f.AssertDeploymentExistsAndRolloutFunc(deploymentName, f.Ns)(t)
 	checkMonitorConsolePluginReachable(t, deploymentName)
+	checkMonitorConsolePluginFeatures(t, deploymentName)
 
 	data := fmt.Sprintf(`
 monitoringPlugin:
@@ -874,6 +920,10 @@ monitoringPlugin:
 		{
 			name:      "assert one of the pods can serve /plugin-manifest.json",
 			assertion: func(t *testing.T) { checkMonitorConsolePluginReachable(t, deploymentName) },
+		},
+		{
+			name:      "assert monitoring related features are enabled",
+			assertion: func(t *testing.T) { checkMonitorConsolePluginFeatures(t, deploymentName) },
 		},
 	} {
 		t.Run(tc.name, tc.assertion)


### PR DESCRIPTION
This PR is part of a set that looks to update the monitoring-plugin to be feature driven, allowing for each feature to be toggled on or off individually (#2981, openshift/monitoring-plugin#1034).

This PR looks to change CMO to directly pass in the `alerting`, `targets`, `metrics` and `legacy-dashboards` feature flags to the monitoring-plugin. 

It also adds another test to ensure the correct features are returned from the monitoring-plugin after passing in the features