### PR TITLE
OCPBUGS-99019: jsonnet: exclude AlertmanagerClusterFailedPeers from shipped rules

### DIFF
--- a/assets/alertmanager/prometheus-rule.yaml
+++ b/assets/alertmanager/prometheus-rule.yaml
@@ -101,14 +101,3 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: AlertmanagerClusterFailedPeers
-      annotations:
-        description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has {{ $value }} failed peers in the {{$labels.job}} cluster.
-        summary: An Alertmanager instance has failed peers in the cluster.
-      expr: |
-        # Without max_over_time, failed scrapes could create false negatives, see
-        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        max_over_time(alertmanager_cluster_failed_peers{job=~"alertmanager-main|alertmanager-user-workload"}[5m]) > 0
-      for: 15m
-      labels:
-        severity: warning

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -29,6 +29,12 @@ local excludedRules = [
       { alert: 'AlertmanagerClusterCrashlooping' },
       //
       { alert: 'AlertmanagerClusterFailedToSendAlerts', severity: 'warning' },
+      // New upstream mixin alert (prometheus/alertmanager). It fires when a peer
+      // is temporarily unreachable during Alertmanager StatefulSet rollouts
+      // (DNS/no-such-host / stale peer IP), which is common in CI and creates
+      // Origin "No new alerts should be firing" failures. Sustained HA issues
+      // remain covered by AlertmanagerMembersInconsistent / AlertmanagerClusterDown.
+      { alert: 'AlertmanagerClusterFailedPeers' },
     ],
   },
   {


### PR DESCRIPTION
The upstream alertmanager mixin added a new AlertmanagerClusterFailedPeers
alert (prometheus/alertmanager@34fb323) which was pulled in via a jsonnet
dependency bump in PR #2953. The alert fires when
alertmanager_cluster_failed_peers > 0 for 15 minutes.

In CI (and any environment where Alertmanager pods are recreated), the
alert fires on transient peer failures during StatefulSet rollouts:
DNS resolution briefly fails for the old pod, or the stale peer IP
times out, causing the metric to stay above zero long enough to trigger
the alert. This is expected operational behavior, not a real HA problem.

Origin e2e tests reject any new alert without historical test data
("[sig-trt][invariant] No new alerts should be firing"), which caused
techpreview serial jobs to fail after the merge.

Exclude the alert from the shipped PrometheusRule, consistent with how
we already exclude AlertmanagerClusterCrashlooping. Sustained HA issues
remain covered by AlertmanagerMembersInconsistent and
AlertmanagerClusterDown.

Reference: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-e2e-gcp-ovn-techpreview-serial-1of2/2077851826295672832
