### PR TITLE
Fix Prometheus rule expression for KubeJobNotCompleted

### DIFF
--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -181,7 +181,7 @@ spec:
       expr: |
         time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
           and
-        kube_job_status_active{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0) > 43200
+        ( kube_job_status_active{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0 ) > 0) > 43200
       labels:
         severity: warning
     - alert: KubeJobFailed

--- a/assets/control-plane/prometheus-rule.yaml
+++ b/assets/control-plane/prometheus-rule.yaml
@@ -181,7 +181,7 @@ spec:
       expr: |
         time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
           and
-        ( kube_job_status_active{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0 ) > 0) > 43200
+        (kube_job_status_active{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0) > 0) > 43200
       labels:
         severity: warning
     - alert: KubeJobFailed


### PR DESCRIPTION
kube_job_status_active is 0 when completed, but it exists.
So the metric is still included and the time() - max still grows leading to an alert.
AI discovered this.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
