### PR TITLE
OCPBUGS-99988: fix: convert OpenShift TLS version to Prometheus format for additional alertmanager configs

### DIFF
--- a/pkg/manifests/amcfg.go
+++ b/pkg/manifests/amcfg.go
@@ -43,9 +43,15 @@ func (a PrometheusAdditionalAlertmanagerConfigs) MarshalYAMLWithTLSConfig(cipher
 func (f *Factory) MarshalPrometheusAdditionalAlertmanagerConfigs(amConfigs []AdditionalAlertmanagerConfig) ([]byte, error) {
 	prometheusAmConfigs := PrometheusAdditionalAlertmanagerConfigs(amConfigs)
 	cipherSuites := f.APIServerConfig.TLSCiphers()
-	minTLSVersion := f.APIServerConfig.MinTLSVersion()
 
-	result, err := prometheusAmConfigs.MarshalYAMLWithTLSConfig(cipherSuites, minTLSVersion)
+	// Convert the OpenShift TLS version format (e.g. "VersionTLS12") to the
+	// Prometheus-compatible format (e.g. "TLS12").
+	promTLSVersion, err := convertTLSVersionToMonitoringV1(f.APIServerConfig.MinTLSVersion())
+	if err != nil {
+		return nil, fmt.Errorf("converting TLS version for additional alertmanager config: %w", err)
+	}
+
+	result, err := prometheusAmConfigs.MarshalYAMLWithTLSConfig(cipherSuites, string(*promTLSVersion))
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +189,13 @@ func (f *Factory) ConvertToThanosAlertmanagerConfiguration(ta []AdditionalAlertm
 	result := make([]thanosAlertmanagerConfiguration, len(ta))
 
 	cipherSuites := f.APIServerConfig.TLSCiphers()
-	minTLSVersion := f.APIServerConfig.MinTLSVersion()
+
+	// Convert the OpenShift TLS version format (e.g. "VersionTLS12") to the
+	// Prometheus-compatible format (e.g. "TLS12").
+	promTLSVersion, err := convertTLSVersionToMonitoringV1(f.APIServerConfig.MinTLSVersion())
+	if err != nil {
+		return nil, fmt.Errorf("converting TLS version for Thanos alertmanager config: %w", err)
+	}
 
 	for i, a := range ta {
 		cfg := thanosAlertmanagerConfiguration{
@@ -213,7 +225,7 @@ func (f *Factory) ConvertToThanosAlertmanagerConfiguration(ta []AdditionalAlertm
 
 		// Apply TLS security settings only for HTTPS connections without explicit TLS config
 		if needsTLSSecuritySettings {
-			cfg.HTTPConfig.TLSConfig.MinVersion = minTLSVersion
+			cfg.HTTPConfig.TLSConfig.MinVersion = string(*promTLSVersion)
 			cfg.HTTPConfig.TLSConfig.CipherSuites = cipherSuites
 		}
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -2094,7 +2094,7 @@ func TestPrometheusK8sAdditionalAlertManagerConfigsSecret(t *testing.T) {
   authorization:
     credentials_file: /etc/prometheus/secrets/alertmanager1-bearer-token/token
   tls_config:
-    min_version: VersionTLS12
+    min_version: TLS12
     cipher_suites:
     - TLS_AES_128_GCM_SHA256
     - TLS_AES_256_GCM_SHA384
@@ -2402,7 +2402,7 @@ func TestThanosRulerAdditionalAlertManagerConfigsSecret(t *testing.T) {
   api_version: v2
   http_config:
     tls_config:
-      min_version: VersionTLS12
+      min_version: TLS12
       cipher_suites:
       - TLS_AES_128_GCM_SHA256
       - TLS_AES_256_GCM_SHA384


### PR DESCRIPTION


The APIServerConfig.MinTLSVersion() returns the OpenShift constant format (e.g. "VersionTLS12") which Prometheus cannot parse, causing prometheus-k8s pods to crash with "unknown TLS version: VersionTLS12" when additionalAlertmanagerConfigs use scheme: https.

Use the existing convertTLSVersionToMonitoringV1() function to convert to the Prometheus-compatible format (e.g. "TLS12") in both the Prometheus and Thanos Ruler additional alertmanager config paths.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
