### PR TITLE
NO-JIRA: test: make TestDocExamples and TestNetworkPolicy more stable

### DIFF
--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -63,6 +63,7 @@ func setupEnv(t *testing.T) {
 		require.NoError(t, cleanupBinding())
 	})
 
+	require.NoError(t, f.WaitForNamespaceSCCAnnotation(testNamespace))
 	require.NoError(t, f.WaitForServiceAccountImagePullSecrets(testNamespace, serviceAccount))
 }
 

--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -62,6 +62,8 @@ func setupEnv(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, cleanupBinding())
 	})
+
+	require.NoError(t, f.WaitForServiceAccountImagePullSecrets(testNamespace, serviceAccount))
 }
 
 func TestDocExamples(t *testing.T) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -797,6 +797,27 @@ func (f *Framework) WaitForServiceAccountImagePullSecrets(namespace, name string
 	})
 }
 
+// WaitForNamespaceSCCAnnotation polls until the namespace has the
+// "openshift.io/sa.scc.uid-range" annotation set by the
+// namespace-security-allocation-controller.
+// Without this, pods created immediately after namespace creation may be
+// rejected by the SCC admission plugin.
+func (f *Framework) WaitForNamespaceSCCAnnotation(namespace string) error {
+	return Poll(time.Second, 3*time.Minute, func() error {
+		ns, err := f.KubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("namespace %s not found yet", namespace)
+			}
+			return err
+		}
+		if _, ok := ns.Annotations["openshift.io/sa.scc.uid-range"]; !ok {
+			return fmt.Errorf("namespace %s missing openshift.io/sa.scc.uid-range annotation", namespace)
+		}
+		return nil
+	})
+}
+
 func (f *Framework) DeleteNamespace(t *testing.T, nsName string) error {
 	t.Helper()
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -774,6 +774,29 @@ func (f *Framework) CreateNamespace(namespace string) (CleanUpFunc, error) {
 	}, nil
 }
 
+// WaitForServiceAccountImagePullSecrets polls until the named ServiceAccount
+// in the given namespace has at least one imagePullSecret containing
+// "dockercfg".
+// Without this, pods created immediately after the SA may lack imagePullSecrets
+// in their spec and fail to pull images.
+func (f *Framework) WaitForServiceAccountImagePullSecrets(namespace, name string) error {
+	return Poll(time.Second, 3*time.Minute, func() error {
+		sa, err := f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("service account %s/%s not found yet", namespace, name)
+			}
+			return err
+		}
+		for _, s := range sa.ImagePullSecrets {
+			if strings.Contains(s.Name, "dockercfg") {
+				return nil
+			}
+		}
+		return fmt.Errorf("service account %s/%s has no dockercfg imagePullSecret yet", namespace, name)
+	})
+}
+
 func (f *Framework) DeleteNamespace(t *testing.T, nsName string) error {
 	t.Helper()
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -267,6 +267,7 @@ func TestNetworkPolicy(t *testing.T) {
 	require.NoError(t, err, "failed to create probe namespace")
 	t.Cleanup(func() { require.NoError(t, cleanupNS(), "failed to cleanup probe namespace") })
 
+	require.NoError(t, f.WaitForNamespaceSCCAnnotation(npProbeNamespace))
 	require.NoError(t, f.WaitForServiceAccountImagePullSecrets(npProbeNamespace, "default"))
 
 	clusterMonitoringNPNames := []string{

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -267,6 +267,8 @@ func TestNetworkPolicy(t *testing.T) {
 	require.NoError(t, err, "failed to create probe namespace")
 	t.Cleanup(func() { require.NoError(t, cleanupNS(), "failed to cleanup probe namespace") })
 
+	require.NoError(t, f.WaitForServiceAccountImagePullSecrets(npProbeNamespace, "default"))
+
 	clusterMonitoringNPNames := []string{
 		clusterMonitoringDenyAllTrafficNPName,
 		"cluster-monitoring-operator",


### PR DESCRIPTION
test: wait for SA imagePullSecrets before creating pods - #3013#3013

Pods created immediately after a ServiceAccount or namespace creation may permanently fail with ErrImagePull if the openshift-controller-manager has not yet provisioned the dockercfg secret for the SA. Since pod.spec.imagePullSecrets is immutable after creation, the pod never recovers even after the secret is eventually linked.

Example failure from CI:

  ErrImagePull: unable to pull image or OCI artifact:
    pull image err: initializing source
    docker://image-registry.openshift-image-registry.svc:5000/openshift/cli:latest:
    reading manifest latest in
    image-registry.openshift-image-registry.svc:5000/openshift/cli:
    authentication required

Add WaitForServiceAccountImagePullSecrets() to the e2e framework and call it in TestDocExamples and
TestNetworkPolicy to ensure the
dockercfg secret is present before any pod is created.

AND

[test: wait for namespace SCC annotation before creating pods](https://github.com/openshift/cluster-monitoring-operator/pull/3013/changes/4a33a4f4326d6cc213613ba6538ebd056e92ea10)
Pods created immediately after namespace creation may be rejected by
the SCC admission plugin if the namespace-security-allocation-controller
has not yet populated the openshift.io/sa.scc.uid-range annotation.
Unlike scheduling failures, SCC admission errors are fatal and the pod
is never retried.

Example failure from CI:

  pods "test-2mhqn32b70ue4" is forbidden: error fetching namespace
    "test-doc-examples-in-cluster": unable to find annotation
    openshift.io/sa.scc.uid-range

Add WaitForNamespaceSCCAnnotation() to the e2e framework and call it
in TestDocExamples and TestNetworkPolicy to ensure the annotation is
present before any pod is created.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
