### PR TITLE
MON-4548,MON-4549,MON-4550,MON-4551: Enforce Thanos grpc tls parameters

### DIFF
--- a/pkg/manifests/apiserver_config.go
+++ b/pkg/manifests/apiserver_config.go
@@ -32,13 +32,13 @@ var (
 	// tlsGroupToGoCurveName maps OpenShift TLSGroup IETF names to Go crypto/tls CurveID string names
 	// as accepted by Thanos's --grpc-server-tls-curves flag.
 	tlsGroupToGoCurveName = map[configv1.TLSGroup]string{
-		configv1.TLSGroupX25519:              "X25519",
-		configv1.TLSGroupSecP256r1:           "CurveP256",
-		configv1.TLSGroupSecP384r1:           "CurveP384",
-		configv1.TLSGroupSecP521r1:           "CurveP521",
-		configv1.TLSGroupX25519MLKEM768:      "X25519MLKEM768",
-		configv1.TLSGroupSecP256r1MLKEM768:   "SecP256r1MLKEM768",
-		configv1.TLSGroupSecP384r1MLKEM1024:  "SecP384r1MLKEM1024",
+		configv1.TLSGroupX25519:             "X25519",
+		configv1.TLSGroupSecP256r1:          "CurveP256",
+		configv1.TLSGroupSecP384r1:          "CurveP384",
+		configv1.TLSGroupSecP521r1:          "CurveP521",
+		configv1.TLSGroupX25519MLKEM768:     "X25519MLKEM768",
+		configv1.TLSGroupSecP256r1MLKEM768:  "SecP256r1MLKEM768",
+		configv1.TLSGroupSecP384r1MLKEM1024: "SecP384r1MLKEM1024",
 	}
 )
 

--- a/pkg/manifests/apiserver_config.go
+++ b/pkg/manifests/apiserver_config.go
@@ -28,6 +28,18 @@ var (
 	APIServerDefaultTLSCiphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers
 	// APIServerDefaultMinTLSVersion is the default minimum TLS version for API servers
 	APIServerDefaultMinTLSVersion = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion
+
+	// tlsGroupToGoCurveName maps OpenShift TLSGroup IETF names to Go crypto/tls CurveID string names
+	// as accepted by Thanos's --grpc-server-tls-curves flag.
+	tlsGroupToGoCurveName = map[configv1.TLSGroup]string{
+		configv1.TLSGroupX25519:              "X25519",
+		configv1.TLSGroupSecP256r1:           "CurveP256",
+		configv1.TLSGroupSecP384r1:           "CurveP384",
+		configv1.TLSGroupSecP521r1:           "CurveP521",
+		configv1.TLSGroupX25519MLKEM768:      "X25519MLKEM768",
+		configv1.TLSGroupSecP256r1MLKEM768:   "SecP256r1MLKEM768",
+		configv1.TLSGroupSecP384r1MLKEM1024:  "SecP384r1MLKEM1024",
+	}
 )
 
 // APIServerConfig is the cluster-wide configuration for all API servers.
@@ -46,7 +58,8 @@ func NewAPIServerConfig(config *configv1.APIServer) *APIServerConfig {
 // current configuration.
 func (c *APIServerConfig) Equal(other *APIServerConfig) bool {
 	return c.MinTLSVersion() == other.MinTLSVersion() &&
-		slices.Equal(c.TLSCiphers(), other.TLSCiphers())
+		slices.Equal(c.TLSCiphers(), other.TLSCiphers()) &&
+		slices.Equal(c.TLSCurves(), other.TLSCurves())
 }
 
 // TLSCiphers returns the TLS ciphers for the
@@ -67,6 +80,23 @@ func (c *APIServerConfig) MinTLSVersion() string {
 		return string(APIServerDefaultMinTLSVersion)
 	}
 	return string(profile.MinTLSVersion)
+}
+
+// TLSCurves returns the TLS curve preferences for the TLS security profile
+// defined in the APIServerConfig, converted to Go crypto/tls CurveID names.
+// Returns nil when no groups are configured (caller should use Go defaults).
+func (c *APIServerConfig) TLSCurves() []string {
+	profile := c.getTLSProfile()
+	if len(profile.Groups) == 0 {
+		return nil
+	}
+	curves := make([]string, 0, len(profile.Groups))
+	for _, group := range profile.Groups {
+		if name, ok := tlsGroupToGoCurveName[group]; ok {
+			curves = append(curves, name)
+		}
+	}
+	return curves
 }
 
 func convertTLSVersionToMonitoringV1(v string) (*monv1.TLSVersion, error) {

--- a/pkg/manifests/apiserver_config_test.go
+++ b/pkg/manifests/apiserver_config_test.go
@@ -152,6 +152,109 @@ func TestGetTLSCiphers(t *testing.T) {
 	}
 }
 
+func TestTLSCurves(t *testing.T) {
+	defaultCurves := []string{"X25519MLKEM768", "X25519", "CurveP256", "CurveP384"}
+
+	testCases := []struct {
+		name           string
+		config         *APIServerConfig
+		expectedCurves []string
+	}{
+		{
+			name:           "nil config",
+			config:         nil,
+			expectedCurves: defaultCurves,
+		},
+		{
+			name:           "nil APIServer",
+			config:         NewAPIServerConfig(nil),
+			expectedCurves: defaultCurves,
+		},
+		{
+			name:           "nil profile",
+			config:         newApiserverConfig(nil),
+			expectedCurves: defaultCurves,
+		},
+		{
+			name: "intermediate profile",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			}),
+			expectedCurves: defaultCurves,
+		},
+		{
+			name: "old profile",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			}),
+			expectedCurves: defaultCurves,
+		},
+		{
+			name: "modern profile",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			}),
+			expectedCurves: defaultCurves,
+		},
+		{
+			name: "custom profile without groups",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"cipher-1"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			}),
+			expectedCurves: nil,
+		},
+		{
+			name: "custom profile with known groups",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"cipher-1"},
+						MinTLSVersion: configv1.VersionTLS12,
+						Groups: []configv1.TLSGroup{
+							configv1.TLSGroupX25519,
+							configv1.TLSGroupSecP256r1,
+						},
+					},
+				},
+			}),
+			expectedCurves: []string{"X25519", "CurveP256"},
+		},
+		{
+			name: "custom profile with all supported groups",
+			config: newApiserverConfig(&configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"cipher-1"},
+						MinTLSVersion: configv1.VersionTLS12,
+						Groups: []configv1.TLSGroup{
+							configv1.TLSGroupX25519,
+							configv1.TLSGroupSecP256r1MLKEM768,
+						},
+					},
+				},
+			}),
+			expectedCurves: []string{"X25519", "SecP256r1MLKEM768"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			actualCurves := tt.config.TLSCurves()
+			if !reflect.DeepEqual(tt.expectedCurves, actualCurves) {
+				t.Fatalf("invalid curves, got %v, want %v", actualCurves, tt.expectedCurves)
+			}
+		})
+	}
+}
+
 func newApiserverConfig(profile *configv1.TLSSecurityProfile) *APIServerConfig {
 	config := NewAPIServerConfig(&configv1.APIServer{
 		Spec: configv1.APIServerSpec{

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1559,6 +1559,9 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, telemetrySecret *v1.Secret) 
 	}
 	p.Spec.Thanos.GRPCServerTLSConfig.SafeTLSConfig.MinVersion = grpcTLSVersion
 	p.Spec.Thanos.GRPCServerTLSConfig.CipherSuites = crypto.OpenSSLToIANACipherSuites(f.APIServerConfig.TLSCiphers())
+	if curves := f.APIServerConfig.TLSCurves(); len(curves) > 0 {
+		p.Spec.Thanos.GRPCServerTLSConfig.Curves = curves
+	}
 
 	p.Spec.Volumes = append(p.Spec.Volumes, v1.Volume{
 		Name: "secret-grpc-tls",
@@ -1868,6 +1871,9 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 	}
 	p.Spec.Thanos.GRPCServerTLSConfig.SafeTLSConfig.MinVersion = grpcTLSVersion
 	p.Spec.Thanos.GRPCServerTLSConfig.CipherSuites = crypto.OpenSSLToIANACipherSuites(f.APIServerConfig.TLSCiphers())
+	if curves := f.APIServerConfig.TLSCurves(); len(curves) > 0 {
+		p.Spec.Thanos.GRPCServerTLSConfig.Curves = curves
+	}
 	p.Spec.Volumes = append(p.Spec.Volumes, v1.Volume{
 		Name: "secret-grpc-tls",
 		VolumeSource: v1.VolumeSource{

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3329,6 +3329,9 @@ func (f *Factory) ThanosRulerCustomResource(
 	}
 	t.Spec.GRPCServerTLSConfig.SafeTLSConfig.MinVersion = grpcTLSVersion
 	t.Spec.GRPCServerTLSConfig.CipherSuites = crypto.OpenSSLToIANACipherSuites(f.APIServerConfig.TLSCiphers())
+	if curves := f.APIServerConfig.TLSCurves(); len(curves) > 0 {
+		t.Spec.GRPCServerTLSConfig.Curves = curves
+	}
 
 	// Mounting TLS secret to thanos-ruler
 	if grpcTLS == nil {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -3322,6 +3322,7 @@ func (f *Factory) ThanosRulerCustomResource(
 		return nil, err
 	}
 	t.Spec.GRPCServerTLSConfig.SafeTLSConfig.MinVersion = grpcTLSVersion
+	t.Spec.GRPCServerTLSConfig.CipherSuites = crypto.OpenSSLToIANACipherSuites(f.APIServerConfig.TLSCiphers())
 
 	// Mounting TLS secret to thanos-ruler
 	if grpcTLS == nil {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1558,6 +1558,7 @@ func (f *Factory) PrometheusK8s(grpcTLS *v1.Secret, telemetrySecret *v1.Secret) 
 		return nil, err
 	}
 	p.Spec.Thanos.GRPCServerTLSConfig.SafeTLSConfig.MinVersion = grpcTLSVersion
+	p.Spec.Thanos.GRPCServerTLSConfig.CipherSuites = crypto.OpenSSLToIANACipherSuites(f.APIServerConfig.TLSCiphers())
 
 	p.Spec.Volumes = append(p.Spec.Volumes, v1.Volume{
 		Name: "secret-grpc-tls",
@@ -1866,6 +1867,7 @@ func (f *Factory) PrometheusUserWorkload(grpcTLS *v1.Secret) (*monv1.Prometheus,
 		return nil, err
 	}
 	p.Spec.Thanos.GRPCServerTLSConfig.SafeTLSConfig.MinVersion = grpcTLSVersion
+	p.Spec.Thanos.GRPCServerTLSConfig.CipherSuites = crypto.OpenSSLToIANACipherSuites(f.APIServerConfig.TLSCiphers())
 	p.Spec.Volumes = append(p.Spec.Volumes, v1.Volume{
 		Name: "secret-grpc-tls",
 		VolumeSource: v1.VolumeSource{

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1719,6 +1719,7 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
 	}
 
 	require.Equal(t, "TLS12", string(*p.Spec.Thanos.GRPCServerTLSConfig.SafeTLSConfig.MinVersion))
+	require.Equal(t, crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), p.Spec.Thanos.GRPCServerTLSConfig.CipherSuites)
 }
 
 func TestPrometheusUserWorkloadConfiguration(t *testing.T) {
@@ -1806,6 +1807,7 @@ func TestPrometheusUserWorkloadConfiguration(t *testing.T) {
 	require.Equal(t, p.Spec.ExternalLabels, map[string]string{"foo": "bar", "oof": "rab"})
 
 	require.Equal(t, "TLS12", string(*p.Spec.Thanos.GRPCServerTLSConfig.SafeTLSConfig.MinVersion))
+	require.Equal(t, crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), p.Spec.Thanos.GRPCServerTLSConfig.CipherSuites)
 }
 
 func TestPrometheusQueryLogFileConfig(t *testing.T) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -4523,6 +4523,7 @@ func TestThanosRulerConfiguration(t *testing.T) {
 
 	require.Equal(t, "TLS12", string(*tr.Spec.GRPCServerTLSConfig.SafeTLSConfig.MinVersion))
 	require.Equal(t, crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), tr.Spec.GRPCServerTLSConfig.CipherSuites)
+	require.Equal(t, []string{"X25519MLKEM768", "X25519", "CurveP256", "CurveP384"}, tr.Spec.GRPCServerTLSConfig.Curves)
 
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -4520,6 +4520,7 @@ func TestThanosRulerConfiguration(t *testing.T) {
 	}
 
 	require.Equal(t, "TLS12", string(*tr.Spec.GRPCServerTLSConfig.SafeTLSConfig.MinVersion))
+	require.Equal(t, crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), tr.Spec.GRPCServerTLSConfig.CipherSuites)
 
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1720,6 +1720,7 @@ func TestPrometheusK8sConfiguration(t *testing.T) {
 
 	require.Equal(t, "TLS12", string(*p.Spec.Thanos.GRPCServerTLSConfig.SafeTLSConfig.MinVersion))
 	require.Equal(t, crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), p.Spec.Thanos.GRPCServerTLSConfig.CipherSuites)
+	require.Equal(t, []string{"X25519MLKEM768", "X25519", "CurveP256", "CurveP384"}, p.Spec.Thanos.GRPCServerTLSConfig.Curves)
 }
 
 func TestPrometheusUserWorkloadConfiguration(t *testing.T) {
@@ -1808,6 +1809,7 @@ func TestPrometheusUserWorkloadConfiguration(t *testing.T) {
 
 	require.Equal(t, "TLS12", string(*p.Spec.Thanos.GRPCServerTLSConfig.SafeTLSConfig.MinVersion))
 	require.Equal(t, crypto.OpenSSLToIANACipherSuites(APIServerDefaultTLSCiphers), p.Spec.Thanos.GRPCServerTLSConfig.CipherSuites)
+	require.Equal(t, []string{"X25519MLKEM768", "X25519", "CurveP256", "CurveP384"}, p.Spec.Thanos.GRPCServerTLSConfig.Curves)
 }
 
 func TestPrometheusQueryLogFileConfig(t *testing.T) {


### PR DESCRIPTION
This add the remaining TLS parameter enforcement to thanos grpc endpoints. I link only [MON-4548](https://redhat.atlassian.net/browse/MON-4548) in the title, but the PR has a commit for each of the following:
https://redhat.atlassian.net/browse/MON-4548
https://redhat.atlassian.net/browse/MON-4549
https://redhat.atlassian.net/browse/MON-4550
https://redhat.atlassian.net/browse/MON-4551

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
