### PR TITLE
OCPBUGS-100367: [release-4.22] fix: watch cluster wide proxy changes and apply changes accordingly

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -229,7 +229,7 @@ function(params) {
       {
         apiGroups: ['config.openshift.io'],
         resources: ['proxies'],
-        verbs: ['get'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['config.openshift.io'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -108,6 +108,8 @@ rules:
   - proxies
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -360,6 +360,16 @@ func (c *Client) ConsoleListWatch() *cache.ListWatch {
 	)
 }
 
+// ProxyListWatch watches for the cluster's proxy configuration resource.
+func (c *Client) ProxyListWatch() *cache.ListWatch {
+	return cache.NewListWatchFromClient(
+		c.oscclient.ConfigV1().RESTClient(),
+		"proxies",
+		"",
+		fields.OneTermEqualSelector("metadata.name", ClusterResourceName),
+	)
+}
+
 // ClusterVersionListWatch watches for the cluster version resource.
 func (c *Client) ClusterVersionListWatch() *cache.ListWatch {
 	return cache.NewListWatchFromClient(

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -374,6 +374,19 @@ func New(
 	}
 	o.informers = append(o.informers, informer)
 
+	// Watch the cluster Proxy resource to reconcile when proxy settings change.
+	informer = cache.NewSharedIndexInformer(
+		o.client.ProxyListWatch(),
+		&configv1.Proxy{}, resyncPeriod, cache.Indexers{},
+	)
+	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, newObj interface{}) { o.handleEvent(newObj) },
+	})
+	if err != nil {
+		return nil, err
+	}
+	o.informers = append(o.informers, informer)
+
 	informer = cache.NewSharedIndexInformer(
 		o.client.ClusterOperatorListWatch("ingress"),
 		&configv1.ClusterOperator{}, resyncPeriod, cache.Indexers{},
@@ -654,6 +667,7 @@ func (o *Operator) handleEvent(obj interface{}) {
 		*configv1.Console,
 		*configv1.ClusterOperator,
 		*configv1.ClusterVersion,
+		*configv1.Proxy,
 		*configv1alpha1.ClusterMonitoring:
 		// Log GroupKind and Name of the obj
 		rtObj := obj.(k8sruntime.Object)

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
@@ -1248,4 +1250,53 @@ func assertQueryLogValueEquals(namespace, crName, value string) func(t *testing.
 			t.Fatal(err)
 		}
 	}
+}
+
+// TestProxyConfigWatch verifies that CMO watches the cluster Proxy
+// resource and triggers a reconciliation when it changes.
+// Exact injection correctness is covered by unit tests; here we only
+// check that a Proxy spec change propagates to the Prometheus CR env
+// vars. A Proxy change triggers a full CMO sync so all components are
+// reconciled, we only assert on Prometheus for simplicity.
+//
+// It is still possible that an unrelated event triggers the sync.
+func TestProxyConfigWatch(t *testing.T) {
+	ctx := context.Background()
+	proxies := f.OpenShiftConfigClient.ConfigV1().Proxies()
+
+	proxy, err := proxies.Get(ctx, "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+	originalHTTPProxy := proxy.Spec.HTTPProxy
+
+	httpProxyMarker := fmt.Sprintf("http://cmo-e2e-proxy-%d.invalid:3128", time.Now().UnixNano())
+
+	t.Cleanup(func() {
+		patch := []byte(fmt.Sprintf(`{"spec":{"httpProxy":%q}}`, originalHTTPProxy))
+		_, err := proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{})
+		require.NoError(t, err)
+	})
+
+	patch := []byte(fmt.Sprintf(`{"spec":{"httpProxy":%q}}`, httpProxyMarker))
+	_, err = proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, framework.Poll(5*time.Second, 5*time.Minute, func() error {
+		prom, err := f.MonitoringClient.Prometheuses(f.Ns).Get(ctx, "k8s", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, c := range prom.Spec.Containers {
+			if c.Name == "prometheus" {
+				for _, e := range c.Env {
+					if e.Name == "HTTP_PROXY" {
+						if strings.Contains(e.Value, httpProxyMarker) {
+							return nil
+						}
+						return fmt.Errorf("HTTP_PROXY=%q, want it to contain %q", e.Value, httpProxyMarker)
+					}
+				}
+			}
+		}
+		return fmt.Errorf("HTTP_PROXY not set for prometheus container")
+	}))
 }


### PR DESCRIPTION
This change watches the cluster Proxy resource and triggers a
reconciliation when it changes. This ensures that proxy settings
are propagated to managed components like Prometheus.

Backport of https://github.com/openshift/cluster-monitoring-operator/pull/3004 to release-4.22.