### PR TITLE
OCPBUGS-100371: [release-4.20] fix: watch cluster wide proxy changes and apply changes accordingly

### DIFF
--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -229,7 +229,7 @@ function(params) {
       {
         apiGroups: ['config.openshift.io'],
         resources: ['proxies'],
-        verbs: ['get'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['config.openshift.io'],

--- a/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_02-role.yaml
@@ -108,6 +108,8 @@ rules:
   - proxies
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -379,6 +379,16 @@ func (c *Client) ConsoleListWatch(ctx context.Context) *cache.ListWatch {
 	}
 }
 
+// ProxyListWatch watches for the cluster's proxy configuration resource.
+func (c *Client) ProxyListWatch() *cache.ListWatch {
+	return cache.NewListWatchFromClient(
+		c.oscclient.ConfigV1().RESTClient(),
+		"proxies",
+		"",
+		fields.OneTermEqualSelector("metadata.name", "cluster"),
+	)
+}
+
 func (c *Client) ClusterVersionListWatch(ctx context.Context, name string) *cache.ListWatch {
 	clusterVersionInterface := c.oscclient.ConfigV1().ClusterVersions()
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -389,6 +389,19 @@ func New(
 	}
 	o.informers = append(o.informers, informer)
 
+	// Watch the cluster Proxy resource to reconcile when proxy settings change.
+	informer = cache.NewSharedIndexInformer(
+		o.client.ProxyListWatch(),
+		&configv1.Proxy{}, resyncPeriod, cache.Indexers{},
+	)
+	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, newObj interface{}) { o.handleEvent(newObj) },
+	})
+	if err != nil {
+		return nil, err
+	}
+	o.informers = append(o.informers, informer)
+
 	informer = cache.NewSharedIndexInformer(
 		o.client.ClusterOperatorListWatch(ctx, "ingress"),
 		&configv1.ClusterOperator{}, resyncPeriod, cache.Indexers{},
@@ -630,7 +643,8 @@ func (o *Operator) handleEvent(obj interface{}) {
 		*configv1.APIServer,
 		*configv1.Console,
 		*configv1.ClusterOperator,
-		*configv1.ClusterVersion:
+		*configv1.ClusterVersion,
+		*configv1.Proxy:
 		// Log GroupKind and Name of the obj
 		rtObj := obj.(k8sruntime.Object)
 		gk := rtObj.GetObjectKind().GroupVersionKind().GroupKind()

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestClusterMonitoringOperatorConfiguration(t *testing.T) {
@@ -1240,4 +1242,53 @@ func assertQueryLogValueEquals(namespace, crName, value string) func(t *testing.
 			t.Fatal(err)
 		}
 	}
+}
+
+// TestProxyConfigWatch verifies that CMO watches the cluster Proxy
+// resource and triggers a reconciliation when it changes.
+// Exact injection correctness is covered by unit tests; here we only
+// check that a Proxy spec change propagates to the Prometheus CR env
+// vars. A Proxy change triggers a full CMO sync so all components are
+// reconciled, we only assert on Prometheus for simplicity.
+//
+// It is still possible that an unrelated event triggers the sync.
+func TestProxyConfigWatch(t *testing.T) {
+	ctx := context.Background()
+	proxies := f.OpenShiftConfigClient.ConfigV1().Proxies()
+
+	proxy, err := proxies.Get(ctx, "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+	originalHTTPProxy := proxy.Spec.HTTPProxy
+
+	httpProxyMarker := fmt.Sprintf("http://cmo-e2e-proxy-%d.invalid:3128", time.Now().UnixNano())
+
+	t.Cleanup(func() {
+		patch := []byte(fmt.Sprintf(`{"spec":{"httpProxy":%q}}`, originalHTTPProxy))
+		_, err := proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{})
+		require.NoError(t, err)
+	})
+
+	patch := []byte(fmt.Sprintf(`{"spec":{"httpProxy":%q}}`, httpProxyMarker))
+	_, err = proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, framework.Poll(5*time.Second, 5*time.Minute, func() error {
+		prom, err := f.MonitoringClient.Prometheuses(f.Ns).Get(ctx, "k8s", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, c := range prom.Spec.Containers {
+			if c.Name == "prometheus" {
+				for _, e := range c.Env {
+					if e.Name == "HTTP_PROXY" {
+						if strings.Contains(e.Value, httpProxyMarker) {
+							return nil
+						}
+						return fmt.Errorf("HTTP_PROXY=%q, want it to contain %q", e.Value, httpProxyMarker)
+					}
+				}
+			}
+		}
+		return fmt.Errorf("HTTP_PROXY not set for prometheus container")
+	}))
 }

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -1254,8 +1254,25 @@ func assertQueryLogValueEquals(namespace, crName, value string) func(t *testing.
 // It is still possible that an unrelated event triggers the sync.
 func TestProxyConfigWatch(t *testing.T) {
 	ctx := context.Background()
-	proxies := f.OpenShiftConfigClient.ConfigV1().Proxies()
 
+	// Scale CVO and MCO to 0 replicas to prevent proxy changes from triggering node reboots.
+	require.NoError(t, framework.Poll(5*time.Second, 3*time.Minute, func() error {
+		for _, d := range []struct{ ns, name string }{
+			{"openshift-cluster-version", "cluster-version-operator"},
+			{"openshift-machine-config-operator", "machine-config-operator"},
+		} {
+			dep, err := f.KubeClient.AppsV1().Deployments(d.ns).Patch(ctx, d.name, types.MergePatchType, []byte(`{"spec":{"replicas":0}}`), metav1.PatchOptions{})
+			if err != nil {
+				return err
+			}
+			if dep.Status.AvailableReplicas != 0 {
+				return fmt.Errorf("waiting for %s/%s scale-down: available=%d", d.ns, d.name, dep.Status.AvailableReplicas)
+			}
+		}
+		return nil
+	}))
+
+	proxies := f.OpenShiftConfigClient.ConfigV1().Proxies()
 	proxy, err := proxies.Get(ctx, "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
 	originalHTTPProxy := proxy.Spec.HTTPProxy
@@ -1264,8 +1281,22 @@ func TestProxyConfigWatch(t *testing.T) {
 
 	t.Cleanup(func() {
 		patch := []byte(fmt.Sprintf(`{"spec":{"httpProxy":%q}}`, originalHTTPProxy))
-		_, err := proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{})
-		require.NoError(t, err)
+		if _, err := proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+			t.Logf("restoring proxy: %v", err)
+		}
+
+		prom, err := f.MonitoringClient.Prometheuses(f.Ns).Get(ctx, "k8s", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("getting Prometheus for rollout wait: %v", err)
+		} else {
+			if err := f.WaitForPrometheusUpdate(ctx, prom); err != nil {
+				t.Logf("waiting for Prometheus update after proxy cleanup: %v", err)
+			}
+		}
+
+		if _, err := f.KubeClient.AppsV1().Deployments("openshift-cluster-version").Patch(ctx, "cluster-version-operator", types.MergePatchType, []byte(`{"spec":{"replicas":1}}`), metav1.PatchOptions{}); err != nil {
+			t.Logf("restoring CVO: %v", err)
+		}
 	})
 
 	patch := []byte(fmt.Sprintf(`{"spec":{"httpProxy":%q}}`, httpProxyMarker))

--- a/test/e2e/framework/prometheus.go
+++ b/test/e2e/framework/prometheus.go
@@ -17,10 +17,12 @@ package framework
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	routev1 "github.com/openshift/api/route/v1"
@@ -32,6 +34,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
+
+// WaitForPrometheusUpdate reads the current generation from the given
+// Prometheus resource and polls the Kubernetes API until the resource's
+// generation is incremented and it matches with the status observedGeneration.
+func (f Framework) WaitForPrometheusUpdate(ctx context.Context, p *monitoringv1.Prometheus) error {
+	initialGeneration := p.Generation
+	return Poll(time.Second, 5*time.Minute, func() error {
+		current, err := f.MonitoringClient.Prometheuses(p.Namespace).Get(ctx, p.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if current.Generation <= initialGeneration {
+			return fmt.Errorf("generation not yet incremented (current: %d, initial: %d)", current.Generation, initialGeneration)
+		}
+		for _, c := range current.Status.Conditions {
+			if c.ObservedGeneration != current.Generation {
+				return fmt.Errorf("condition %q observedGeneration (%d) not yet caught up to generation (%d)", c.Type, c.ObservedGeneration, current.Generation)
+			}
+		}
+		return nil
+	})
+}
 
 func (f Framework) MakePrometheusWithWebTLSRemoteReceive(name, tlsSecretName string, image *string) *monitoringv1.Prometheus {
 	// This is not required in the Prometheus spec, but we inspect that value in


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-monitoring-operator/pull/3004 to release-4.20.