### PR TITLE
NO-JIRA: tasks: pass context to MetricsServerTask methods instead of storing it

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -852,7 +852,7 @@ func (o *Operator) sync(ctx context.Context) error {
 				newTaskSpec("NodeExporter", tasks.NewNodeExporterTask(o.client, factory)),
 				newTaskSpec("KubeStateMetrics", tasks.NewKubeStateMetricsTask(o.client, factory)),
 				newTaskSpec("OpenshiftStateMetrics", tasks.NewOpenShiftStateMetricsTask(o.client, factory)),
-				newTaskSpec("MetricsServer", tasks.NewMetricsServerTask(ctx, o.namespace, o.client, factory, config)),
+				newTaskSpec("MetricsServer", tasks.NewMetricsServerTask(o.namespace, o.client, factory, config)),
 				newTaskSpec("TelemeterClient", tasks.NewTelemeterClientTask(o.client, factory, config)),
 				newTaskSpec("ThanosQuerier", tasks.NewThanosQuerierTask(o.client, factory, config)),
 				newTaskSpec("ControlPlaneComponents", tasks.NewControlPlaneTask(o.client, factory, config)),

--- a/pkg/tasks/metricsserver.go
+++ b/pkg/tasks/metricsserver.go
@@ -13,19 +13,17 @@ import (
 
 type MetricsServerTask struct {
 	client    *client.Client
-	ctx       context.Context
 	factory   *manifests.Factory
 	config    *manifests.Config
 	namespace string
 }
 
-func NewMetricsServerTask(ctx context.Context, namespace string, client *client.Client, factory *manifests.Factory, config *manifests.Config) *MetricsServerTask {
+func NewMetricsServerTask(namespace string, client *client.Client, factory *manifests.Factory, config *manifests.Config) *MetricsServerTask {
 	return &MetricsServerTask{
 		client:    client,
 		factory:   factory,
 		config:    config,
 		namespace: namespace,
-		ctx:       ctx,
 	}
 }
 
@@ -192,7 +190,7 @@ func (t *MetricsServerTask) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to create metrics-server client-ca secret: %w", err)
 		}
 
-		err = t.deleteOldMetricsServerSecrets(secret.Labels["monitoring.openshift.io/hash"])
+		err = t.deleteOldMetricsServerSecrets(ctx, secret.Labels["monitoring.openshift.io/hash"])
 		if err != nil {
 			return fmt.Errorf("deleting old metrics-server secrets failed: %w", err)
 		}
@@ -251,8 +249,8 @@ func (t *MetricsServerTask) Run(ctx context.Context) error {
 	return nil
 }
 
-func (t *MetricsServerTask) deleteOldMetricsServerSecrets(newHash string) error {
-	secrets, err := t.client.KubernetesInterface().CoreV1().Secrets(t.namespace).List(t.ctx, metav1.ListOptions{
+func (t *MetricsServerTask) deleteOldMetricsServerSecrets(ctx context.Context, newHash string) error {
+	secrets, err := t.client.KubernetesInterface().CoreV1().Secrets(t.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "monitoring.openshift.io/name=metrics-server,monitoring.openshift.io/hash!=" + newHash,
 	})
 
@@ -261,7 +259,7 @@ func (t *MetricsServerTask) deleteOldMetricsServerSecrets(newHash string) error 
 	}
 
 	for i := range secrets.Items {
-		err := t.client.KubernetesInterface().CoreV1().Secrets(t.namespace).Delete(t.ctx, secrets.Items[i].Name, metav1.DeleteOptions{})
+		err := t.client.KubernetesInterface().CoreV1().Secrets(t.namespace).Delete(ctx, secrets.Items[i].Name, metav1.DeleteOptions{})
 		if err != nil {
 			return fmt.Errorf("error deleting secret: %s: %w", secrets.Items[i].Name, err)
 		}


### PR DESCRIPTION
MetricsServerTask stored context.Context as a struct field, captured at construction time. Currently both contexts are the same, but storing context in a struct is a Go anti-pattern, it decouples the work's lifetime from the caller's intent and breaks if the caller ever passes a different context (e.g. a per-sync cancellable context).

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
