### PR TITLE
OCPBUGS-104536: Backport e2e stabilization 4.22

### DIFF
--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -132,13 +132,13 @@ func TestDocExamples(t *testing.T) {
 						require.NoError(t, err)
 					})
 
-					err = framework.Poll(time.Second, time.Minute, func() error {
+					err = framework.Poll(5*time.Second, time.Minute, func() error {
 						pod, err = f.KubeClient.CoreV1().Pods(testNamespace).Get(ctx, podName, metav1.GetOptions{})
 						if err != nil {
 							return err
 						}
 						if pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
-							return fmt.Errorf("waiting for pod")
+							return fmt.Errorf("waiting for pod %s/%s: phase %q", testNamespace, podName, pod.Status.Phase)
 						}
 						return nil
 					})

--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -63,6 +63,7 @@ func setupEnv(t *testing.T) {
 		require.NoError(t, cleanupBinding())
 	})
 
+	require.NoError(t, f.WaitForNamespaceSCCAnnotation(testNamespace))
 	require.NoError(t, f.WaitForServiceAccountImagePullSecrets(testNamespace, serviceAccount))
 }
 

--- a/test/e2e/doc_examples_test.go
+++ b/test/e2e/doc_examples_test.go
@@ -62,6 +62,8 @@ func setupEnv(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, cleanupBinding())
 	})
+
+	require.NoError(t, f.WaitForServiceAccountImagePullSecrets(testNamespace, serviceAccount))
 }
 
 func TestDocExamples(t *testing.T) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -781,6 +781,27 @@ func (f *Framework) WaitForServiceAccountImagePullSecrets(namespace, name string
 	})
 }
 
+// WaitForNamespaceSCCAnnotation polls until the namespace has the
+// "openshift.io/sa.scc.uid-range" annotation set by the
+// namespace-security-allocation-controller.
+// Without this, pods created immediately after namespace creation may be
+// rejected by the SCC admission plugin.
+func (f *Framework) WaitForNamespaceSCCAnnotation(namespace string) error {
+	return Poll(time.Second, 3*time.Minute, func() error {
+		ns, err := f.KubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("namespace %s not found yet", namespace)
+			}
+			return err
+		}
+		if _, ok := ns.Annotations["openshift.io/sa.scc.uid-range"]; !ok {
+			return fmt.Errorf("namespace %s missing openshift.io/sa.scc.uid-range annotation", namespace)
+		}
+		return nil
+	})
+}
+
 func (f *Framework) DeleteNamespace(t *testing.T, nsName string) error {
 	t.Helper()
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -758,6 +758,29 @@ func (f *Framework) CreateNamespace(namespace string) (CleanUpFunc, error) {
 	}, nil
 }
 
+// WaitForServiceAccountImagePullSecrets polls until the named ServiceAccount
+// in the given namespace has at least one imagePullSecret containing
+// "dockercfg".
+// Without this, pods created immediately after the SA may lack imagePullSecrets
+// in their spec and fail to pull images.
+func (f *Framework) WaitForServiceAccountImagePullSecrets(namespace, name string) error {
+	return Poll(time.Second, 3*time.Minute, func() error {
+		sa, err := f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("service account %s/%s not found yet", namespace, name)
+			}
+			return err
+		}
+		for _, s := range sa.ImagePullSecrets {
+			if strings.Contains(s.Name, "dockercfg") {
+				return nil
+			}
+		}
+		return fmt.Errorf("service account %s/%s has no dockercfg imagePullSecret yet", namespace, name)
+	})
+}
+
 func (f *Framework) DeleteNamespace(t *testing.T, nsName string) error {
 	t.Helper()
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -258,6 +258,8 @@ func TestNetworkPolicy(t *testing.T) {
 	require.NoError(t, err, "failed to create probe namespace")
 	t.Cleanup(func() { require.NoError(t, cleanupNS(), "failed to cleanup probe namespace") })
 
+	require.NoError(t, f.WaitForServiceAccountImagePullSecrets(npProbeNamespace, "default"))
+
 	clusterMonitoringNPNames := []string{
 		clusterMonitoringDenyAllTrafficNPName,
 		"cluster-monitoring-operator",

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -258,6 +258,7 @@ func TestNetworkPolicy(t *testing.T) {
 	require.NoError(t, err, "failed to create probe namespace")
 	t.Cleanup(func() { require.NoError(t, cleanupNS(), "failed to cleanup probe namespace") })
 
+	require.NoError(t, f.WaitForNamespaceSCCAnnotation(npProbeNamespace))
 	require.NoError(t, f.WaitForServiceAccountImagePullSecrets(npProbeNamespace, "default"))
 
 	clusterMonitoringNPNames := []string{

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -24,6 +24,7 @@ import (
 	osConfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	_ "github.com/prometheus/prometheus/discovery/kubernetes" // required for promConfig.Load to parse kubernetes_sd_configs
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -20,17 +20,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Jeffail/gabs/v2"
+	osConfigv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	_ "github.com/prometheus/prometheus/discovery/kubernetes" // required for promConfig.Load to parse kubernetes_sd_configs
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	osConfigv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 )
 
 func TestPrometheusMetrics(t *testing.T) {
-	expected := map[string]int{
+	expectedHealthyTargetsByJob := map[string]int{
 		"prometheus-operator":           1,
 		"prometheus-k8s":                2,
 		"prometheus-k8s-thanos-sidecar": 2,
@@ -42,22 +42,28 @@ func TestPrometheusMetrics(t *testing.T) {
 		"telemeter-client":              1,
 	}
 
-	for service, metric := range expected {
-		t.Run(service, func(t *testing.T) {
-			f.ThanosQuerierClient.WaitForQueryReturn(
-				// To avoid making the test wait for more than lookback-delta
-				// in case Prometheus wasn't able to write stale markers
-				// (because it was down), reduce the lookup period but not
-				// lower than the highest scrape interval (which is 2m).
-				t, time.Minute, fmt.Sprintf(`count(last_over_time(up{service="%s",namespace="openshift-monitoring"}[2m30s]) == 1)`, service),
-				func(v float64) error {
-					if v != float64(metric) {
-						return fmt.Errorf("expected %d targets to be up but got %v", metric, v)
-					}
+	for jobName, expectedTargets := range expectedHealthyTargetsByJob {
+		t.Run(jobName, func(t *testing.T) {
+			f.PrometheusK8sClient.WaitForTargetsReturn(t, time.Minute, func(body []byte) error {
+				j, err := gabs.ParseJSON(body)
+				if err != nil {
+					return err
+				}
 
-					return nil
-				},
-			)
+				healthyTargets := 0
+				for _, target := range j.Path("data.activeTargets").Children() {
+					job, _ := target.Path("labels.job").Data().(string)
+					health, _ := target.Path("health").Data().(string)
+					if job == jobName && health == "up" {
+						healthyTargets++
+					}
+				}
+
+				if healthyTargets != expectedTargets {
+					return fmt.Errorf("expected %d healthy targets, got %d", expectedTargets, healthyTargets)
+				}
+				return nil
+			})
 		})
 	}
 }

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -50,17 +50,20 @@ func TestPrometheusMetrics(t *testing.T) {
 					return err
 				}
 
-				healthyTargets := 0
+				totalTargets, healthyTargets := 0, 0
 				for _, target := range j.Path("data.activeTargets").Children() {
 					job, _ := target.Path("labels.job").Data().(string)
 					health, _ := target.Path("health").Data().(string)
-					if job == jobName && health == "up" {
-						healthyTargets++
+					if job == jobName {
+						totalTargets++
+						if health == "up" {
+							healthyTargets++
+						}
 					}
 				}
 
 				if healthyTargets != expectedTargets {
-					return fmt.Errorf("expected %d healthy targets, got %d", expectedTargets, healthyTargets)
+					return fmt.Errorf("expected %d healthy targets, got %d (total targets: %d)", expectedTargets, healthyTargets, totalTargets)
 				}
 				return nil
 			})

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 func TestPrometheusMetrics(t *testing.T) {
@@ -192,6 +193,39 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Clean up after all subtests: reset the ConfigMap, wait for
+	// Prometheus Operator to remove the remote write config from the
+	// Prometheus config secret, then force-delete the Prometheus pods to
+	// skip the ~2m shutdown delay.
+	//
+	// The last subtest deletes the receiver but leaves the ConfigMap with
+	// remoteWrite. When the ConfigMap is reset, Prometheus Operator
+	// removes the TLS certs from its TLS assets secret simultaneously
+	// with the config update. Because Prometheus re-reads cert files on
+	// every send attempt, the queue_manager drain fails with "no such file"
+	// and retries until
+	// the flush-deadline expires (2x1m for samples + metadata = ~2m).
+	// Force-deleting the pods avoids this.
+	// See https://github.com/prometheus/prometheus/issues/6747
+	t.Cleanup(func() {
+		f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, "{}"))
+
+		require.NoError(t, framework.Poll(5*time.Second, 5*time.Minute, func() error {
+			cfg := f.PrometheusConfigFromSecret(t, f.Ns, "prometheus-k8s")
+			if len(cfg.RemoteWriteConfigs) > 0 {
+				return fmt.Errorf("prometheus config still has %d remote write configs", len(cfg.RemoteWriteConfigs))
+			}
+			return nil
+		}))
+
+		require.NoError(t, f.KubeClient.CoreV1().Pods(f.Ns).DeleteCollection(ctx,
+			metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))},
+			metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s"},
+		))
+
+		f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns)(t)
+	})
 	for _, tc := range []struct {
 		name     string
 		rwSpec   string

--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -21,8 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 )
 
 // TestTelemeterRemoteWrite verifies that the monitoring stack can send data to
@@ -30,10 +34,6 @@ import (
 func TestTelemeterRemoteWrite(t *testing.T) {
 	cm := f.BuildCMOConfigMap(t, "{}")
 	f.MustCreateOrUpdateConfigMap(t, cm)
-
-	t.Cleanup(func() {
-		f.MustDeleteConfigMap(t, cm)
-	})
 
 	// Put CMO deployment into unmanaged state and enable telemetry via remote-write manually.
 	ctx := context.Background()
@@ -54,8 +54,28 @@ func TestTelemeterRemoteWrite(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		f.MustDeleteConfigMap(t, cm)
+
 		patch := []byte(`{"spec": {"overrides": []}}`)
 		_, _ = f.OpenShiftConfigClient.ConfigV1().ClusterVersions().Patch(ctx, "version", types.MergePatchType, patch, metav1.PatchOptions{})
+
+		// Wait for CVO -> CMO -> Prometheus Operator to fully restore
+		// the config, then force-delete the Prometheus pods so the
+		// next test gets fresh pods with the updated config.
+		require.NoError(t, framework.Poll(5*time.Second, 5*time.Minute, func() error {
+			cfg := f.PrometheusConfigFromSecret(t, f.Ns, "prometheus-k8s")
+			if len(cfg.RemoteWriteConfigs) > 0 {
+				return fmt.Errorf("prometheus config still has %d remote write configs", len(cfg.RemoteWriteConfigs))
+			}
+			return nil
+		}))
+
+		require.NoError(t, f.KubeClient.CoreV1().Pods(f.Ns).DeleteCollection(ctx,
+			metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))},
+			metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s"},
+		))
+
+		f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns)(t)
 	})
 
 	dep, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(ctx, "cluster-monitoring-operator", metav1.GetOptions{})

--- a/test/e2e/test_command/scripts/openshift-monitoring_alertmanager-main_service_port_9092.yaml
+++ b/test/e2e/test_command/scripts/openshift-monitoring_alertmanager-main_service_port_9092.yaml
@@ -31,7 +31,7 @@ tests:
           "comment": "Silence test"
         }'
     tearDown: |
-      oc delete namespace test-alertmanager-tenancy-monitoring-rules-edit --wait=false
+      oc delete namespace test-alertmanager-tenancy-monitoring-rules-edit --ignore-not-found=true --wait=false
   - script: |
       ## The following example exercises permissions granted by the `monitoring-edit` cluster role.
       ## The binding commands must be run by a user with the necessary privileges.
@@ -64,4 +64,4 @@ tests:
           "comment": "Silence test"
         }'
     tearDown: |
-      oc delete namespace test-alertmanager-tenancy-monitoring-edit --wait=false
+      oc delete namespace test-alertmanager-tenancy-monitoring-edit --ignore-not-found=true --wait=false

--- a/test/e2e/test_command/scripts/openshift-monitoring_alertmanager-main_service_port_9094.yaml
+++ b/test/e2e/test_command/scripts/openshift-monitoring_alertmanager-main_service_port_9094.yaml
@@ -19,8 +19,8 @@ tests:
       # Access Alertmanager endpoints from within the cluster.
       curl -k -H "Authorization: Bearer $TOKEN" "https://alertmanager-main.openshift-monitoring:9094/api/v2/alerts?filter=alertname=Watchdog"
     tearDown: |
-      oc delete rolebinding test-alertmanager-web-monitoring-alertmanager-view --namespace=openshift-monitoring
-      oc delete namespace test-alertmanager-web-monitoring-alertmanager-view --wait=false
+      oc delete rolebinding test-alertmanager-web-monitoring-alertmanager-view --ignore-not-found=true --namespace=openshift-monitoring
+      oc delete namespace test-alertmanager-web-monitoring-alertmanager-view --ignore-not-found=true --wait=false
   - script: |
       ## The following example exercises permissions granted by the `monitoring-alertmanager-edit` role.
       ## The binding commands must be run by a user with the necessary privileges.
@@ -69,5 +69,5 @@ tests:
           "comment": "Silence test"
         }'
     tearDown: |
-      oc delete rolebinding test-alertmanager-web-monitoring-alertmanager-edit --namespace=openshift-monitoring
-      oc delete namespace test-alertmanager-web-monitoring-alertmanager-edit --wait=false
+      oc delete rolebinding test-alertmanager-web-monitoring-alertmanager-edit --ignore-not-found=true --namespace=openshift-monitoring
+      oc delete namespace test-alertmanager-web-monitoring-alertmanager-edit --ignore-not-found=true --wait=false

--- a/test/e2e/test_command/scripts/openshift-monitoring_prometheus-k8s_service_port_9091.yaml
+++ b/test/e2e/test_command/scripts/openshift-monitoring_prometheus-k8s_service_port_9091.yaml
@@ -19,8 +19,8 @@ tests:
       # Access Prometheus endpoints from within the cluster.
       curl -k -H "Authorization: Bearer $TOKEN" "https://prometheus-k8s.openshift-monitoring:9091/api/v1/query?query=up"
     tearDown: |
-      oc delete rolebinding test-prometheus-web-cluster-monitoring-view --namespace=openshift-monitoring
-      oc delete namespace test-prometheus-web-cluster-monitoring-view --wait=false
+      oc delete rolebinding test-prometheus-web-cluster-monitoring-view --ignore-not-found=true --namespace=openshift-monitoring
+      oc delete namespace test-prometheus-web-cluster-monitoring-view --ignore-not-found=true --wait=false
   - script: |
       ## The following example exercises permissions granted by the `cluster-monitoring-metrics-api` role.
       ## The binding commands must be run by a user with the necessary privileges.
@@ -41,5 +41,5 @@ tests:
       # Access Prometheus endpoints from within the cluster.
       curl -k -H "Authorization: Bearer $TOKEN" "https://prometheus-k8s.openshift-monitoring:9091/api/v1/query?query=up"
     tearDown: |
-      oc delete rolebinding test-prometheus-web-cluster-monitoring-metrics-api --namespace=openshift-monitoring
-      oc delete namespace test-prometheus-web-cluster-monitoring-metrics-api --wait=false
+      oc delete rolebinding test-prometheus-web-cluster-monitoring-metrics-api --ignore-not-found=true --namespace=openshift-monitoring
+      oc delete namespace test-prometheus-web-cluster-monitoring-metrics-api --ignore-not-found=true --wait=false

--- a/test/e2e/test_command/scripts/openshift-monitoring_thanos-querier_service_port_9091.yaml
+++ b/test/e2e/test_command/scripts/openshift-monitoring_thanos-querier_service_port_9091.yaml
@@ -19,8 +19,8 @@ tests:
       # Access Thanos Querier endpoints from within the cluster.
       curl -k -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9091/api/v1/query?query=up"
     tearDown: |
-      oc delete rolebinding test-thanos-querier-web-cluster-monitoring-view --namespace=openshift-monitoring
-      oc delete namespace test-thanos-querier-web-cluster-monitoring-view --wait=false
+      oc delete rolebinding test-thanos-querier-web-cluster-monitoring-view --ignore-not-found=true --namespace=openshift-monitoring
+      oc delete namespace test-thanos-querier-web-cluster-monitoring-view --ignore-not-found=true --wait=false
   - script: |
       ## The following example exercises permissions granted by the `cluster-monitoring-metrics-api` role.
       ## The binding commands must be run by a user with the necessary privileges.
@@ -41,5 +41,5 @@ tests:
       # Access Thanos Querier endpoints from within the cluster.
       curl -k -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9091/api/v1/query?query=up"
     tearDown: |
-      oc delete rolebinding test-thanos-querier-web-cluster-monitoring-metrics-api --namespace=openshift-monitoring
-      oc delete namespace test-thanos-querier-web-cluster-monitoring-metrics-api --wait=false
+      oc delete rolebinding test-thanos-querier-web-cluster-monitoring-metrics-api --ignore-not-found=true --namespace=openshift-monitoring
+      oc delete namespace test-thanos-querier-web-cluster-monitoring-metrics-api --ignore-not-found=true --wait=false

--- a/test/e2e/test_command/scripts/openshift-monitoring_thanos-querier_service_port_9092.yaml
+++ b/test/e2e/test_command/scripts/openshift-monitoring_thanos-querier_service_port_9092.yaml
@@ -16,4 +16,4 @@ tests:
       # Access Thanos Querier endpoints from within the cluster. The port is not exposed externally by default.
       curl -k -f -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9092/api/v1/query?query=up&namespace=test-thanos-querier-tenancy-view"
     tearDown: |
-      oc delete namespace test-thanos-querier-tenancy-view --wait=false
+      oc delete namespace test-thanos-querier-tenancy-view --ignore-not-found=true --wait=false

--- a/test/e2e/test_command/scripts/openshift-monitoring_thanos-querier_service_port_9093.yaml
+++ b/test/e2e/test_command/scripts/openshift-monitoring_thanos-querier_service_port_9093.yaml
@@ -17,7 +17,7 @@ tests:
       curl -k -f -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9093/api/v1/rules?namespace=test-thanos-querier-tenancy-rules-monitoring-rules-edit"
       curl -k -f -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9093/api/v1/alerts?namespace=test-thanos-querier-tenancy-rules-monitoring-rules-edit"
     tearDown: |
-      oc delete namespace test-thanos-querier-tenancy-rules-monitoring-rules-edit --wait=false
+      oc delete namespace test-thanos-querier-tenancy-rules-monitoring-rules-edit --ignore-not-found=true --wait=false
   - script: |
       ## The following example exercises permissions granted by the `monitoring-edit` cluster role.
       ## The binding commands must be run by a user with the necessary privileges.
@@ -36,7 +36,7 @@ tests:
       curl -k -f -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9093/api/v1/rules?namespace=test-thanos-querier-tenancy-rules-monitoring-edit"
       curl -k -f -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9093/api/v1/alerts?namespace=test-thanos-querier-tenancy-rules-monitoring-edit"
     tearDown: |
-      oc delete namespace test-thanos-querier-tenancy-rules-monitoring-edit --wait=false
+      oc delete namespace test-thanos-querier-tenancy-rules-monitoring-edit --ignore-not-found=true --wait=false
   - script: |
       ## The following example exercises permissions granted by the `monitoring-rules-view` cluster role.
       ## The binding commands must be run by a user with the necessary privileges.
@@ -55,4 +55,4 @@ tests:
       curl -k -f -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9093/api/v1/rules?namespace=test-thanos-querier-tenancy-rules-monitoring-rules-view"
       curl -k -f -H "Authorization: Bearer $TOKEN" "https://thanos-querier.openshift-monitoring:9093/api/v1/alerts?namespace=test-thanos-querier-tenancy-rules-monitoring-rules-view"
     tearDown: |
-      oc delete namespace test-thanos-querier-tenancy-rules-monitoring-rules-view --wait=false
+      oc delete namespace test-thanos-querier-tenancy-rules-monitoring-rules-view --ignore-not-found=true --wait=false


### PR DESCRIPTION
## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
