### PR TITLE
OCPBUGS-104538: Backport e2e stabilization 4.20

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -20,18 +20,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Jeffail/gabs/v2"
+	osConfigv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	_ "github.com/prometheus/prometheus/discovery/kubernetes" // required for promConfig.Load to parse kubernetes_sd_configs
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-
-	osConfigv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 )
 
 func TestPrometheusMetrics(t *testing.T) {
-	expected := map[string]int{
+	expectedHealthyTargetsByJob := map[string]int{
 		"prometheus-operator":           1,
 		"prometheus-k8s":                2,
 		"prometheus-k8s-thanos-sidecar": 2,
@@ -43,22 +43,28 @@ func TestPrometheusMetrics(t *testing.T) {
 		"telemeter-client":              1,
 	}
 
-	for service, metric := range expected {
-		t.Run(service, func(t *testing.T) {
-			f.ThanosQuerierClient.WaitForQueryReturn(
-				// To avoid making the test wait for more than lookback-delta
-				// in case Prometheus wasn't able to write stale markers
-				// (because it was down), reduce the lookup period but not
-				// lower than the highest scrape interval (which is 2m).
-				t, time.Minute, fmt.Sprintf(`count(last_over_time(up{service="%s",namespace="openshift-monitoring"}[2m30s]) == 1)`, service),
-				func(v float64) error {
-					if v != float64(metric) {
-						return fmt.Errorf("expected %d targets to be up but got %f", metric, v)
-					}
+	for jobName, expectedTargets := range expectedHealthyTargetsByJob {
+		t.Run(jobName, func(t *testing.T) {
+			f.PrometheusK8sClient.WaitForTargetsReturn(t, time.Minute, func(body []byte) error {
+				j, err := gabs.ParseJSON(body)
+				if err != nil {
+					return err
+				}
 
-					return nil
-				},
-			)
+				healthyTargets := 0
+				for _, target := range j.Path("data.activeTargets").Children() {
+					job, _ := target.Path("labels.job").Data().(string)
+					health, _ := target.Path("health").Data().(string)
+					if job == jobName && health == "up" {
+						healthyTargets++
+					}
+				}
+
+				if healthyTargets != expectedTargets {
+					return fmt.Errorf("expected %d healthy targets, got %d", expectedTargets, healthyTargets)
+				}
+				return nil
+			})
 		})
 	}
 }

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -24,6 +24,7 @@ import (
 	osConfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 	_ "github.com/prometheus/prometheus/discovery/kubernetes" // required for promConfig.Load to parse kubernetes_sd_configs
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -224,7 +225,7 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 			metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s"},
 		))
 
-		f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns)(t)
+		f.AssertStatefulSetExistsAndRollout("prometheus-k8s", f.Ns)(t)
 	})
 	for _, tc := range []struct {
 		name     string

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	osConfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
@@ -183,6 +184,39 @@ func TestPrometheusRemoteWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Clean up after all subtests: reset the ConfigMap, wait for
+	// Prometheus Operator to remove the remote write config from the
+	// Prometheus config secret, then force-delete the Prometheus pods to
+	// skip the ~2m shutdown delay.
+	//
+	// The last subtest deletes the receiver but leaves the ConfigMap with
+	// remoteWrite. When the ConfigMap is reset, Prometheus Operator
+	// removes the TLS certs from its TLS assets secret simultaneously
+	// with the config update. Because Prometheus re-reads cert files on
+	// every send attempt, the queue_manager drain fails with "no such file"
+	// and retries until
+	// the flush-deadline expires (2x1m for samples + metadata = ~2m).
+	// Force-deleting the pods avoids this.
+	// See https://github.com/prometheus/prometheus/issues/6747
+	t.Cleanup(func() {
+		f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, "{}"))
+
+		require.NoError(t, framework.Poll(5*time.Second, 5*time.Minute, func() error {
+			cfg := f.PrometheusConfigFromSecret(t, f.Ns, "prometheus-k8s")
+			if len(cfg.RemoteWriteConfigs) > 0 {
+				return fmt.Errorf("prometheus config still has %d remote write configs", len(cfg.RemoteWriteConfigs))
+			}
+			return nil
+		}))
+
+		require.NoError(t, f.KubeClient.CoreV1().Pods(f.Ns).DeleteCollection(ctx,
+			metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))},
+			metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s"},
+		))
+
+		f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns)(t)
+	})
 	for _, tc := range []struct {
 		name     string
 		rwSpec   string

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -51,17 +51,20 @@ func TestPrometheusMetrics(t *testing.T) {
 					return err
 				}
 
-				healthyTargets := 0
+				totalTargets, healthyTargets := 0, 0
 				for _, target := range j.Path("data.activeTargets").Children() {
 					job, _ := target.Path("labels.job").Data().(string)
 					health, _ := target.Path("health").Data().(string)
-					if job == jobName && health == "up" {
-						healthyTargets++
+					if job == jobName {
+						totalTargets++
+						if health == "up" {
+							healthyTargets++
+						}
 					}
 				}
 
 				if healthyTargets != expectedTargets {
-					return fmt.Errorf("expected %d healthy targets, got %d", expectedTargets, healthyTargets)
+					return fmt.Errorf("expected %d healthy targets, got %d (total targets: %d)", expectedTargets, healthyTargets, totalTargets)
 				}
 				return nil
 			})

--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -21,8 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/openshift/cluster-monitoring-operator/test/e2e/framework"
 )
 
 // TestTelemeterRemoteWrite verifies that the monitoring stack can send data to
@@ -30,10 +34,6 @@ import (
 func TestTelemeterRemoteWrite(t *testing.T) {
 	cm := f.BuildCMOConfigMap(t, "{}")
 	f.MustCreateOrUpdateConfigMap(t, cm)
-
-	t.Cleanup(func() {
-		f.MustDeleteConfigMap(t, cm)
-	})
 
 	// Put CMO deployment into unmanaged state and enable telemetry via remote-write manually.
 	ctx := context.Background()
@@ -54,8 +54,28 @@ func TestTelemeterRemoteWrite(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		f.MustDeleteConfigMap(t, cm)
+
 		patch := []byte(`{"spec": {"overrides": []}}`)
 		_, _ = f.OpenShiftConfigClient.ConfigV1().ClusterVersions().Patch(ctx, "version", types.MergePatchType, patch, metav1.PatchOptions{})
+
+		// Wait for CVO -> CMO -> Prometheus Operator to fully restore
+		// the config, then force-delete the Prometheus pods so the
+		// next test gets fresh pods with the updated config.
+		require.NoError(t, framework.Poll(5*time.Second, 5*time.Minute, func() error {
+			cfg := f.PrometheusConfigFromSecret(t, f.Ns, "prometheus-k8s")
+			if len(cfg.RemoteWriteConfigs) > 0 {
+				return fmt.Errorf("prometheus config still has %d remote write configs", len(cfg.RemoteWriteConfigs))
+			}
+			return nil
+		}))
+
+		require.NoError(t, f.KubeClient.CoreV1().Pods(f.Ns).DeleteCollection(ctx,
+			metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))},
+			metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s"},
+		))
+
+		f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns)(t)
 	})
 
 	dep, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(ctx, "cluster-monitoring-operator", metav1.GetOptions{})

--- a/test/e2e/telemeter_test.go
+++ b/test/e2e/telemeter_test.go
@@ -75,7 +75,7 @@ func TestTelemeterRemoteWrite(t *testing.T) {
 			metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s"},
 		))
 
-		f.AssertStatefulSetExistsAndRolloutFunc("prometheus-k8s", f.Ns)(t)
+		f.AssertStatefulSetExistsAndRollout("prometheus-k8s", f.Ns)(t)
 	})
 
 	dep, err := f.KubeClient.AppsV1().Deployments(f.Ns).Get(ctx, "cluster-monitoring-operator", metav1.GetOptions{})


### PR DESCRIPTION
## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
