### PR TITLE
MON-4577: restrict alertmanager gossip mesh ports to same-instance pods

### DIFF
--- a/assets/alertmanager-user-workload/network-policy-downstream.yaml
+++ b/assets/alertmanager-user-workload/network-policy-downstream.yaml
@@ -17,6 +17,13 @@ spec:
       protocol: TCP
     - port: 9097
       protocol: TCP
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/instance: user-workload
+          app.kubernetes.io/name: alertmanager
+          app.kubernetes.io/part-of: openshift-monitoring
+    ports:
     - port: 9094
       protocol: TCP
     - port: 9094

--- a/assets/alertmanager/network-policy-downstream.yaml
+++ b/assets/alertmanager/network-policy-downstream.yaml
@@ -17,6 +17,13 @@ spec:
       protocol: TCP
     - port: 9097
       protocol: TCP
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/instance: main
+          app.kubernetes.io/name: alertmanager
+          app.kubernetes.io/part-of: openshift-monitoring
+    ports:
     - port: 9094
       protocol: TCP
     - port: 9094

--- a/jsonnet/components/alertmanager-user-workload.libsonnet
+++ b/jsonnet/components/alertmanager-user-workload.libsonnet
@@ -456,6 +456,19 @@ function(params)
                 port: 9097,
                 protocol: 'TCP',
               },
+            ],
+          },
+          {
+            from: [{
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/name': 'alertmanager',
+                  'app.kubernetes.io/part-of': 'openshift-monitoring',
+                  'app.kubernetes.io/instance': 'user-workload',
+                },
+              },
+            }],
+            ports: [
               {
                 // Allow UWM Alertmanager replicas to communicate via the HA gossip mesh
                 // (injected by Prometheus Operator).

--- a/jsonnet/components/alertmanager.libsonnet
+++ b/jsonnet/components/alertmanager.libsonnet
@@ -502,6 +502,19 @@ function(params)
                 port: 9097,
                 protocol: 'TCP',
               },
+            ],
+          },
+          {
+            from: [{
+              podSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/name': 'alertmanager',
+                  'app.kubernetes.io/part-of': 'openshift-monitoring',
+                  'app.kubernetes.io/instance': 'main',
+                },
+              },
+            }],
+            ports: [
               {
                 // Allow Alertmanager replicas to communicate via the HA gossip mesh
                 // (injected by Prometheus Operator).

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -349,6 +349,11 @@ func TestNetworkPolicy(t *testing.T) {
 
 				var allowed []int32
 				for _, rule := range np.Spec.Ingress {
+					if len(rule.From) > 0 {
+						// Won't go this way; this test is a safeguard,
+						// not a validation of NP enforcement semantics.
+						continue
+					}
 					for _, p := range rule.Ports {
 						allowed = append(allowed, p.Port.IntVal)
 					}


### PR DESCRIPTION
first part of https://github.com/openshift/cluster-monitoring-operator/pull/2926

---

Split the alertmanager NetworkPolicy ingress rules so that ports 9094 TCP/UDP (used for the HA gossip mesh) are only accessible from alertmanager pods of the same instance, while the service ports (9092, 9095, 9097) remain open to all sources.

This applies to both the platform alertmanager (openshift-monitoring) and the user-workload alertmanager (openshift-user-workload-monitoring).

The e2e network policy connectivity test is updated to skip ingress rules that have a 'from' selector since the probe pod won't match the restricted source criteria.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
