### PR TITLE
NO-JIRA: Allow to pass custom arguments to e2e test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ test-unit:
 .PHONY: test-e2e
 test-e2e: KUBECONFIG?=$(HOME)/.kube/config
 test-e2e:
-	go test -v -timeout=150m ./test/e2e/ --kubeconfig $(KUBECONFIG)
+	go test -v -timeout=150m $(E2E_TEST_ARGS) ./test/e2e/ --kubeconfig $(KUBECONFIG)
 
 .PHONY: test-ginkgo
 test-ginkgo: KUBECONFIG?=$(HOME)/.kube/config


### PR DESCRIPTION
Needed by https://github.com/openshift/monitoring-plugin which doesn't need to run all CMO tests but only the ones exercising the monitoring plugin.