### PR TITLE
NO-JIRA: Add test descriptions

### DIFF
--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -904,6 +904,8 @@ func checkMonitorConsolePluginFeatures(t *testing.T, pluginName string) {
 	require.NoError(t, err)
 }
 
+// TestClusterMonitorConsolePlugin exercises the monitoring-plugin configuration.
+// Don't rename the test because the monitoring-plugin CI targets it specifically.
 func TestClusterMonitorConsolePlugin(t *testing.T) {
 	const (
 		deploymentName = "monitoring-plugin"

--- a/test/e2e/tls_security_profile_test.go
+++ b/test/e2e/tls_security_profile_test.go
@@ -37,6 +37,8 @@ func atLeastVersionTLS12(v string) string {
 	return v
 }
 
+// TestDefaultTLSSecurityProfileConfiguration exercises the TLS profile configuration.
+// Don't rename the test because the monitoring-plugin CI targets it specifically.
 func TestDefaultTLSSecurityProfileConfiguration(t *testing.T) {
 	// The admission webhook supports only TLS versions >= 1.2.
 	assertCorrectTLSConfiguration(t, "prometheus-operator-admission-webhook", "deployment",


### PR DESCRIPTION
This commit adds descriptions for tests which the monitoring plugin CI depends on. In particular they advertise not changing the names to avoid side effects.

