### PR TITLE
OCPBUGS-104850: : e2e: scale down CVO and MCO to prevent node reboots during proxy config watch test

### DIFF
--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -1380,13 +1380,12 @@ func TestProxyConfigWatch(t *testing.T) {
 	ctx := context.Background()
 
 	// Scale CVO and MCO to 0 replicas to prevent proxy changes from triggering node reboots.
-	scaleTo0 := []byte(`{"spec":{"replicas":0}}`)
 	require.NoError(t, framework.Poll(5*time.Second, 3*time.Minute, func() error {
 		for _, d := range []struct{ ns, name string }{
 			{"openshift-cluster-version", "cluster-version-operator"},
 			{"openshift-machine-config-operator", "machine-config-operator"},
 		} {
-			dep, err := f.KubeClient.AppsV1().Deployments(d.ns).Patch(ctx, d.name, types.MergePatchType, scaleTo0, metav1.PatchOptions{})
+			dep, err := f.KubeClient.AppsV1().Deployments(d.ns).Patch(ctx, d.name, types.MergePatchType, []byte(`{"spec":{"replicas":0}}`), metav1.PatchOptions{})
 			if err != nil {
 				return err
 			}
@@ -1421,8 +1420,7 @@ func TestProxyConfigWatch(t *testing.T) {
 			}
 		}
 
-		scaleTo1 := []byte(`{"spec":{"replicas":1}}`)
-		if _, err := f.KubeClient.AppsV1().Deployments("openshift-cluster-version").Patch(ctx, "cluster-version-operator", types.MergePatchType, scaleTo1, metav1.PatchOptions{}); err != nil {
+		if _, err := f.KubeClient.AppsV1().Deployments("openshift-cluster-version").Patch(ctx, "cluster-version-operator", types.MergePatchType, []byte(`{"spec":{"replicas":1}}`), metav1.PatchOptions{}); err != nil {
 			t.Logf("restoring CVO: %v", err)
 		}
 	})

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -1378,8 +1378,26 @@ func assertPrometheusRetentionSize(namespace, name, size string) func(*testing.T
 // It is still possible that an unrelated event triggers the sync.
 func TestProxyConfigWatch(t *testing.T) {
 	ctx := context.Background()
-	proxies := f.OpenShiftConfigClient.ConfigV1().Proxies()
 
+	// Scale CVO and MCO to 0 replicas to prevent proxy changes from triggering node reboots.
+	scaleTo0 := []byte(`{"spec":{"replicas":0}}`)
+	require.NoError(t, framework.Poll(5*time.Second, 3*time.Minute, func() error {
+		for _, d := range []struct{ ns, name string }{
+			{"openshift-cluster-version", "cluster-version-operator"},
+			{"openshift-machine-config-operator", "machine-config-operator"},
+		} {
+			dep, err := f.KubeClient.AppsV1().Deployments(d.ns).Patch(ctx, d.name, types.MergePatchType, scaleTo0, metav1.PatchOptions{})
+			if err != nil {
+				return err
+			}
+			if dep.Status.AvailableReplicas != 0 {
+				return fmt.Errorf("waiting for %s/%s scale-down: available=%d", d.ns, d.name, dep.Status.AvailableReplicas)
+			}
+		}
+		return nil
+	}))
+
+	proxies := f.OpenShiftConfigClient.ConfigV1().Proxies()
 	proxy, err := proxies.Get(ctx, "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
 	originalHTTPProxy := proxy.Spec.HTTPProxy
@@ -1387,17 +1405,14 @@ func TestProxyConfigWatch(t *testing.T) {
 	httpProxyMarker := fmt.Sprintf("http://cmo-e2e-proxy-%d.invalid:3128", time.Now().UnixNano())
 
 	t.Cleanup(func() {
-		prom, err := f.MonitoringClient.Prometheuses(f.Ns).Get(ctx, "k8s", metav1.GetOptions{})
-		require.NoError(t, err)
-
 		patch := []byte(fmt.Sprintf(`{"spec":{"httpProxy":%q}}`, originalHTTPProxy))
-		_, err = proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{})
-		require.NoError(t, err)
+		if _, err := proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+			t.Logf("restoring proxy: %v", err)
+		}
 
-		// Best effort: wait for the rollout triggered by the proxy
-		// cleanup so the next test doesn't start mid-rollout.
-		if err := f.WaitForPrometheusUpdate(ctx, prom); err != nil {
-			t.Logf("waiting for Prometheus update after proxy cleanup: %v", err)
+		scaleTo1 := []byte(`{"spec":{"replicas":1}}`)
+		if _, err := f.KubeClient.AppsV1().Deployments("openshift-cluster-version").Patch(ctx, "cluster-version-operator", types.MergePatchType, scaleTo1, metav1.PatchOptions{}); err != nil {
+			t.Logf("restoring CVO: %v", err)
 		}
 	})
 

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -1379,23 +1379,6 @@ func assertPrometheusRetentionSize(namespace, name, size string) func(*testing.T
 func TestProxyConfigWatch(t *testing.T) {
 	ctx := context.Background()
 
-	// Scale CVO and MCO to 0 replicas to prevent proxy changes from triggering node reboots.
-	require.NoError(t, framework.Poll(5*time.Second, 3*time.Minute, func() error {
-		for _, d := range []struct{ ns, name string }{
-			{"openshift-cluster-version", "cluster-version-operator"},
-			{"openshift-machine-config-operator", "machine-config-operator"},
-		} {
-			dep, err := f.KubeClient.AppsV1().Deployments(d.ns).Patch(ctx, d.name, types.MergePatchType, []byte(`{"spec":{"replicas":0}}`), metav1.PatchOptions{})
-			if err != nil {
-				return err
-			}
-			if dep.Status.AvailableReplicas != 0 {
-				return fmt.Errorf("waiting for %s/%s scale-down: available=%d", d.ns, d.name, dep.Status.AvailableReplicas)
-			}
-		}
-		return nil
-	}))
-
 	proxies := f.OpenShiftConfigClient.ConfigV1().Proxies()
 	proxy, err := proxies.Get(ctx, "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -1424,6 +1407,23 @@ func TestProxyConfigWatch(t *testing.T) {
 			t.Logf("restoring CVO: %v", err)
 		}
 	})
+
+	// Scale CVO and MCO to 0 replicas to prevent proxy changes from triggering node reboots.
+	require.NoError(t, framework.Poll(5*time.Second, 3*time.Minute, func() error {
+		for _, d := range []struct{ ns, name string }{
+			{"openshift-cluster-version", "cluster-version-operator"},
+			{"openshift-machine-config-operator", "machine-config-operator"},
+		} {
+			dep, err := f.KubeClient.AppsV1().Deployments(d.ns).Patch(ctx, d.name, types.MergePatchType, []byte(`{"spec":{"replicas":0}}`), metav1.PatchOptions{})
+			if err != nil {
+				return err
+			}
+			if dep.Status.AvailableReplicas != 0 {
+				return fmt.Errorf("waiting for %s/%s scale-down: available=%d", d.ns, d.name, dep.Status.AvailableReplicas)
+			}
+		}
+		return nil
+	}))
 
 	patch := []byte(fmt.Sprintf(`{"spec":{"httpProxy":%q}}`, httpProxyMarker))
 	_, err = proxies.Patch(ctx, "cluster", types.MergePatchType, patch, metav1.PatchOptions{})

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -1403,6 +1403,7 @@ func TestProxyConfigWatch(t *testing.T) {
 			}
 		}
 
+		// CVO manages the MCO deployment; scaling it back up restores MCO automatically.
 		if _, err := f.KubeClient.AppsV1().Deployments("openshift-cluster-version").Patch(ctx, "cluster-version-operator", types.MergePatchType, []byte(`{"spec":{"replicas":1}}`), metav1.PatchOptions{}); err != nil {
 			t.Logf("restoring CVO: %v", err)
 		}

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -1410,6 +1410,17 @@ func TestProxyConfigWatch(t *testing.T) {
 			t.Logf("restoring proxy: %v", err)
 		}
 
+		prom, err := f.MonitoringClient.Prometheuses(f.Ns).Get(ctx, "k8s", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("getting Prometheus for rollout wait: %v", err)
+		} else {
+			// Best effort: wait for the rollout triggered by the proxy
+			// cleanup so the next test doesn't start mid-rollout.
+			if err := f.WaitForPrometheusUpdate(ctx, prom); err != nil {
+				t.Logf("waiting for Prometheus update after proxy cleanup: %v", err)
+			}
+		}
+
 		scaleTo1 := []byte(`{"spec":{"replicas":1}}`)
 		if _, err := f.KubeClient.AppsV1().Deployments("openshift-cluster-version").Patch(ctx, "cluster-version-operator", types.MergePatchType, scaleTo1, metav1.PatchOptions{}); err != nil {
 			t.Logf("restoring CVO: %v", err)


### PR DESCRIPTION


## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
