### PR TITLE
OCPBUGS-105304: [release-4.22] wrap library-go resourceCache with mutex for thread safety

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -53,6 +53,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	apiutilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -95,8 +96,18 @@ type Client struct {
 	aggclient   aggregatorclient.Interface
 
 	eventRecorder events.Recorder
+	// resourceCache is set to a no-op implementation that never caches.
+	// The library-go resourceCache is not thread-safe
+	// and CMO runs tasks concurrently with the same client, which causes data races.
+	// TODO: consider re-enabling caching once we can use a library-go that ships the thread-safe
+	// implementation (see https://github.com/openshift/library-go/pull/2380).
 	resourceCache resourceapply.ResourceCache
 }
+
+type noOpResourceCache struct{}
+
+func (noOpResourceCache) UpdateCachedResourceMetadata(_ runtime.Object, _ runtime.Object) {}
+func (noOpResourceCache) SafeToSkipApply(_ runtime.Object, _ runtime.Object) bool         { return false }
 
 func NewForConfig(cfg *rest.Config, version string, namespace, userWorkloadNamespace string, options ...Option) (*Client, error) {
 	client := New(version, namespace, userWorkloadNamespace, options...)
@@ -264,7 +275,7 @@ func New(version string, namespace, userWorkloadNamespace string, options ...Opt
 		version:               version,
 		namespace:             namespace,
 		userWorkloadNamespace: userWorkloadNamespace,
-		resourceCache:         resourceapply.NewResourceCache(),
+		resourceCache:         noOpResourceCache{},
 	}
 
 	for _, opt := range options {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/imdario/mergo"
@@ -96,18 +97,34 @@ type Client struct {
 	aggclient   aggregatorclient.Interface
 
 	eventRecorder events.Recorder
-	// resourceCache is set to a no-op implementation that never caches.
-	// The library-go resourceCache is not thread-safe
-	// and CMO runs tasks concurrently with the same client, which causes data races.
-	// TODO: consider re-enabling caching once we can use a library-go that ships the thread-safe
-	// implementation (see https://github.com/openshift/library-go/pull/2380).
 	resourceCache resourceapply.ResourceCache
 }
 
-type noOpResourceCache struct{}
+// threadSafeResourceCache wraps library-go's resourceCache with a mutex
+// because the upstream implementation uses a plain map that is not safe
+// for concurrent use.
+// TODO: remove once library-go ships the thread-safe resourceCache
+// from https://github.com/openshift/library-go/pull/2380.
+type threadSafeResourceCache struct {
+	mu    sync.RWMutex
+	inner resourceapply.ResourceCache
+}
 
-func (noOpResourceCache) UpdateCachedResourceMetadata(_ runtime.Object, _ runtime.Object) {}
-func (noOpResourceCache) SafeToSkipApply(_ runtime.Object, _ runtime.Object) bool         { return false }
+func newThreadSafeResourceCache() *threadSafeResourceCache {
+	return &threadSafeResourceCache{inner: resourceapply.NewResourceCache()}
+}
+
+func (c *threadSafeResourceCache) UpdateCachedResourceMetadata(required, actual runtime.Object) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inner.UpdateCachedResourceMetadata(required, actual)
+}
+
+func (c *threadSafeResourceCache) SafeToSkipApply(required, existing runtime.Object) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.inner.SafeToSkipApply(required, existing)
+}
 
 func NewForConfig(cfg *rest.Config, version string, namespace, userWorkloadNamespace string, options ...Option) (*Client, error) {
 	client := New(version, namespace, userWorkloadNamespace, options...)
@@ -275,7 +292,7 @@ func New(version string, namespace, userWorkloadNamespace string, options ...Opt
 		version:               version,
 		namespace:             namespace,
 		userWorkloadNamespace: userWorkloadNamespace,
-		resourceCache:         noOpResourceCache{},
+		resourceCache:         newThreadSafeResourceCache(),
 	}
 
 	for _, opt := range options {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -921,13 +921,13 @@ func TestCreateOrUpdateServiceAccount(t *testing.T) {
 				c = Client{
 					kclient:       fake.NewSimpleClientset(),
 					eventRecorder: eventRecorder,
-					resourceCache: noOpResourceCache{},
+					resourceCache: newThreadSafeResourceCache(),
 				}
 			} else {
 				c = Client{
 					kclient:       fake.NewSimpleClientset(sa.DeepCopy()),
 					eventRecorder: eventRecorder,
-					resourceCache: noOpResourceCache{},
+					resourceCache: newThreadSafeResourceCache(),
 				}
 				_, err := c.kclient.CoreV1().ServiceAccounts(ns).Get(ctx, sa.Name, metav1.GetOptions{})
 				if err != nil {
@@ -1934,7 +1934,7 @@ func TestCreateOrUpdateValidatingWebhookConfiguration(t *testing.T) {
 	c := Client{
 		kclient:       fake.NewSimpleClientset(webhook.DeepCopy()),
 		eventRecorder: events.NewInMemoryRecorder("cluster-monitoring-operator", clocktesting.NewFakePassiveClock(time.Now())),
-		resourceCache: noOpResourceCache{},
+		resourceCache: newThreadSafeResourceCache(),
 	}
 
 	if _, err := c.kclient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, webhook.Name, metav1.GetOptions{}); err != nil {
@@ -2354,7 +2354,7 @@ func TestResourceCacheConcurrentAccess(t *testing.T) {
 	c := Client{
 		kclient:       fake.NewSimpleClientset(existing...),
 		eventRecorder: events.NewInMemoryRecorder("test", clocktesting.NewFakePassiveClock(time.Now())),
-		resourceCache: noOpResourceCache{},
+		resourceCache: newThreadSafeResourceCache(),
 	}
 
 	// Mimics CMO's errgroup tasks reconciling resources concurrently.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -27,7 +27,6 @@ import (
 	osrfake "github.com/openshift/client-go/route/clientset/versioned/fake"
 	ossfake "github.com/openshift/client-go/security/clientset/versioned/fake"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monfake "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
 	"github.com/stretchr/testify/require"
@@ -37,6 +36,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -921,13 +921,13 @@ func TestCreateOrUpdateServiceAccount(t *testing.T) {
 				c = Client{
 					kclient:       fake.NewSimpleClientset(),
 					eventRecorder: eventRecorder,
-					resourceCache: resourceapply.NewResourceCache(),
+					resourceCache: noOpResourceCache{},
 				}
 			} else {
 				c = Client{
 					kclient:       fake.NewSimpleClientset(sa.DeepCopy()),
 					eventRecorder: eventRecorder,
-					resourceCache: resourceapply.NewResourceCache(),
+					resourceCache: noOpResourceCache{},
 				}
 				_, err := c.kclient.CoreV1().ServiceAccounts(ns).Get(ctx, sa.Name, metav1.GetOptions{})
 				if err != nil {
@@ -1934,7 +1934,7 @@ func TestCreateOrUpdateValidatingWebhookConfiguration(t *testing.T) {
 	c := Client{
 		kclient:       fake.NewSimpleClientset(webhook.DeepCopy()),
 		eventRecorder: events.NewInMemoryRecorder("cluster-monitoring-operator", clocktesting.NewFakePassiveClock(time.Now())),
-		resourceCache: resourceapply.NewResourceCache(),
+		resourceCache: noOpResourceCache{},
 	}
 
 	if _, err := c.kclient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, webhook.Name, metav1.GetOptions{}); err != nil {
@@ -2331,4 +2331,49 @@ func TestPollUntil(t *testing.T) {
 	cancelParentCtx3()
 	wg.Wait()
 	require.ErrorContains(t, pollErr, "context deadline exceeded")
+}
+
+// TestResourceCacheConcurrentAccess reproduces OCPBUGS-99769: concurrent map access
+// in the shared resourceCache.
+func TestResourceCacheConcurrentAccess(t *testing.T) {
+	ctx := context.Background()
+
+	// Pre-existing resources force Apply through both SafeToSkipApply (read) and
+	// UpdateCachedResourceMetadata (write).
+	existing := make([]runtime.Object, 10)
+	for i := range 10 {
+		existing[i] = &v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("sa-%d", i),
+				Namespace:       ns,
+				ResourceVersion: "1",
+			},
+		}
+	}
+
+	c := Client{
+		kclient:       fake.NewSimpleClientset(existing...),
+		eventRecorder: events.NewInMemoryRecorder("test", clocktesting.NewFakePassiveClock(time.Now())),
+		resourceCache: noOpResourceCache{},
+	}
+
+	// Mimics CMO's errgroup tasks reconciling resources concurrently.
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 10 {
+				sa := &v1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("sa-%d", i),
+						Namespace: ns,
+						Labels:    map[string]string{"app": "test"},
+					},
+				}
+				_ = c.CreateOrUpdateServiceAccount(ctx, sa)
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

The library-go `resourceCache` is not thread-safe and CMO runs tasks concurrently with the same client, which causes data races.

Replace the cache with a no-op implementation until we can use a library-go that ships a thread-safe version (see https://github.com/openshift/library-go/pull/2380).

Disabling the cache is the simplest fix to backport, especially since we were not heavily relying on it.

## Changes

- Replace `resourceapply.NewResourceCache()` with a `noOpResourceCache{}` that always returns `false` from `SafeToSkipApply`

/jira OCPBUGS-99769
/cherry-pick main