### PR TITLE
NO-JIRA: feat: validate systemd units

### DIFF
--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -387,6 +388,10 @@ func (c *Config) validate() error {
 		return fmt.Errorf("prometheus: %w", err)
 	}
 
+	if err := validateNodeExporterConfig(c.ClusterMonitoringConfiguration.NodeExporterConfig); err != nil {
+		return fmt.Errorf("node-exporter: %w", err)
+	}
+
 	return nil
 }
 
@@ -424,6 +429,21 @@ func validateRemoteWriteConfigs(rwSpecs []RemoteWriteSpec) error {
 		if rw.MessageVersion != "" && !slices.Contains(supportedRemoteWriteMessageVersions, rw.MessageVersion) {
 			return fmt.Errorf("remoteWrite[%d]: messageVersion %q is not supported, supported values are: %v",
 				i, rw.MessageVersion, supportedRemoteWriteMessageVersions)
+		}
+	}
+	return nil
+}
+
+func validateNodeExporterConfig(config *NodeExporterConfig) error {
+	if config == nil {
+		return nil
+	}
+	if config.Collectors.Systemd.Enabled {
+		for _, unit := range config.Collectors.Systemd.Units {
+			_, err := regexp.Compile(unit)
+			if err != nil {
+				return fmt.Errorf("systemd: invalid regexp pattern: %s", unit)
+			}
 		}
 	}
 	return nil

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -996,3 +996,46 @@ func TestDeprecatedConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeExporterSystemdUnits(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config string
+		err    bool
+	}{
+		{
+			name: "valid units",
+			config: `
+nodeExporter:
+  collectors:
+    systemd:
+      enabled: true
+      units:
+      - foo
+      - bar
+`,
+		},
+		{
+			name: "invalid units",
+			config: `
+nodeExporter:
+  collectors:
+    systemd:
+      enabled: true
+      units:
+      - network
+      - /\
+`,
+			err: true,
+		},
+	} {
+		t.Run(tc.name, func(st *testing.T) {
+			_, err := NewConfigFromString(tc.config)
+			if tc.err {
+				require.ErrorIs(t, err, ErrConfigValidation)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1033,14 +1033,9 @@ func (f *Factory) updateNodeExporterArgs(args []string) ([]string, error) {
 	return args, nil
 }
 
-// concatenate all patterns into a single regexp using OR
+// regexListToArg concatenates all regexp patterns into a single regexp using
+// OR and anchored on both sides.
 func regexListToArg(list []string) (string, error) {
-	for _, pattern := range list {
-		_, err := regexp.Compile(pattern)
-		if err != nil {
-			return "", fmt.Errorf("invalid regexp pattern: %s", pattern)
-		}
-	}
 	r := "^(" + strings.Join(list, "|") + ")$"
 	_, err := regexp.Compile(r)
 	return r, err

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -3749,36 +3749,6 @@ nodeExporter:
 
 }
 
-func TestNodeExporterSystemdUnits(t *testing.T) {
-
-	testName := "enable systemd collector with invalid units pattern"
-	config := `
-nodeExporter:
-  collectors:
-    systemd:
-      enabled: true
-      units:
-      - network.+
-      - /\
-`
-	t.Run(testName, func(st *testing.T) {
-		c, err := NewConfigFromString(config)
-		if err != nil {
-			t.Fatal(err)
-		}
-		c.SetImages(map[string]string{
-			"node-exporter":   "docker.io/openshift/origin-prometheus-node-exporter:latest",
-			"kube-rbac-proxy": "docker.io/openshift/origin-kube-rbac-proxy:latest",
-		})
-
-		f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", c, defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
-		_, err = f.NodeExporterDaemonSet()
-		if err == nil || !strings.Contains(err.Error(), "systemd unit pattern validation error:") {
-			t.Fatalf(`expected error "systemd unit pattern validation error:.*", got %v`, err)
-		}
-	})
-}
-
 func TestNodeExporterGeneralSettings(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
This commit moves the validation of the system units from the operator's reconciliation to the configuration loading. It improves the user experience because invalid values will now be flagged by the admission webhook service.
