### PR TITLE
ART-22049: remove references to configmap-reloader image

### DIFF
--- a/examples/cluster-monitoring-configmap.yaml
+++ b/examples/cluster-monitoring-configmap.yaml
@@ -8,7 +8,6 @@ data:
     prometheusOperator:
       baseImage: quay.io/coreos/prometheus-operator
       prometheusConfigReloaderBaseImage: quay.io/coreos/prometheus-config-reloader
-      configReloaderBaseImage: quay.io/coreos/configmap-reload
     prometheusK8s:
       retention: 24h
       baseImage: quay.io/prometheus/prometheus

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment-ibm-cloud-managed.yaml
@@ -38,7 +38,6 @@ spec:
         - -images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest
         - -images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest
         - -images=prometheus-operator-admission-webhook=quay.io/openshift/origin-prometheus-operator-admission-webhook:latest
-        - -images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest
         - -images=prometheus=quay.io/openshift/origin-prometheus:latest
         - -images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest
         - -images=node-exporter=quay.io/openshift/origin-prometheus-node-exporter:latest

--- a/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
+++ b/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml
@@ -64,7 +64,6 @@ spec:
         - "-images=prometheus-operator=quay.io/openshift/origin-prometheus-operator:latest"
         - "-images=prometheus-config-reloader=quay.io/openshift/origin-prometheus-config-reloader:latest"
         - "-images=prometheus-operator-admission-webhook=quay.io/openshift/origin-prometheus-operator-admission-webhook:latest"
-        - "-images=configmap-reloader=quay.io/openshift/origin-configmap-reloader:latest"
         - "-images=prometheus=quay.io/openshift/origin-prometheus:latest"
         - "-images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest"
         - "-images=node-exporter=quay.io/openshift/origin-prometheus-node-exporter:latest"

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -18,10 +18,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-prometheus-operator-admission-webhook:latest
-  - name: configmap-reloader
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-configmap-reloader:latest
   - name: prometheus
     from:
       kind: DockerImage

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -671,7 +671,6 @@ func TestPrometheusOperatorConfiguration(t *testing.T) {
 	c.SetImages(map[string]string{
 		"prometheus-operator":        "docker.io/openshift/origin-prometheus-operator:latest",
 		"prometheus-config-reloader": "docker.io/openshift/origin-prometheus-config-reloader:latest",
-		"configmap-reloader":         "docker.io/openshift/origin-configmap-reloader:latest",
 		"kube-rbac-proxy":            "docker.io/openshift/origin-kube-rbac-proxy:latest",
 	})
 
@@ -4946,7 +4945,6 @@ func TestPrometheusOperatorUserWorkloadConfiguration(t *testing.T) {
 	c.SetImages(map[string]string{
 		"prometheus-operator":        "docker.io/openshift/origin-prometheus-operator:latest",
 		"prometheus-config-reloader": "docker.io/openshift/origin-prometheus-config-reloader:latest",
-		"configmap-reloader":         "docker.io/openshift/origin-configmap-reloader:latest",
 		"kube-rbac-proxy":            "docker.io/openshift/origin-kube-rbac-proxy:latest",
 	})
 


### PR DESCRIPTION
This commit removes the last references to the configmap-reloader image which was used for the telemeter-client deployment but has been replaced by the prometheus-config-reloader a long time ago.

https://github.com/openshift/cluster-monitoring-operator/pull/970