### PR TITLE
OCPBUGS-112569: Makefile: version-stamp golangci-lint binary to prevent stale linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ JB_BIN=$(BIN_DIR)/jb
 GOJSONTOYAML_BIN=$(BIN_DIR)/gojsontoyaml
 JSONNET_BIN=$(BIN_DIR)/jsonnet
 JSONNETFMT_BIN=$(BIN_DIR)/jsonnetfmt
-GOLANGCI_LINT_BIN=$(BIN_DIR)/golangci-lint
 GOLANGCI_LINT_VERSION=v2.12.2
+GOLANGCI_LINT_BIN=$(BIN_DIR)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 PROMTOOL_BIN=$(BIN_DIR)/promtool
 DOCGEN_BIN=$(BIN_DIR)/docgen
 MISSPELL_BIN=$(BIN_DIR)/misspell
@@ -227,8 +227,11 @@ golangci-lint: $(GOLANGCI_LINT_BIN)
 golangci-lint-fix: $(GOLANGCI_LINT_BIN)
 	$(GOLANGCI_LINT_BIN) run --verbose --fix
 
-$(GOLANGCI_LINT_BIN): $(BIN_DIR)
+# Version-stamped target ensures the correct golangci-lint is used across checkouts.
+# (|) avoids timestamp skew caused by the mv.
+$(GOLANGCI_LINT_BIN): | $(BIN_DIR)
 	curl -sfL https://golangci-lint.run/install.sh | sh -s -- -b $(BIN_DIR) $(GOLANGCI_LINT_VERSION)
+	mv $(BIN_DIR)/golangci-lint $(GOLANGCI_LINT_BIN)
 
 .PHONY:
 misspell: $(MISSPELL_BIN)


### PR DESCRIPTION
The golangci-lint install target used a plain file target, so Make would skip the download if the binary already existed, even after bumping GOLANGCI_LINT_VERSION. This could silently use an outdated linter across branch switches or version bumps.

Encode the version in the binary filename (golangci-lint-<version>) so that a version change naturally triggers a re-download.

Note: unlike the previous approach, offline runs will fail if the exact version isn't already cached locally. In that case, one can still invoke an older cached binary directly, bypassing Make. Old versioned binaries are not cleaned up automatically and must be removed manually or via `make clean`.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
