### PR TITLE
NO-JIRA: Fix staticcheck warnings across multiple packages

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,8 +28,6 @@ linters:
         - "-QF*"     # quickfix suggestions (style preference)
         - "-ST1000"  # package comments (style preference)
         - "-ST1003"  # naming conventions like API vs Api (style preference)
-        - "-ST1005"  # error string capitalization (style preference)
-        - "-ST1019"  # duplicate imports (style preference)
         - "-ST1020"  # comment format on functions (style preference)
         - "-ST1021"  # comment format on types (style preference)
     depguard:

--- a/pkg/alert/relabel_controller.go
+++ b/pkg/alert/relabel_controller.go
@@ -182,7 +182,7 @@ func (c *RelabelConfigController) processNextWorkItem(ctx context.Context) bool 
 	defer c.queue.Done(key)
 
 	if err := c.sync(ctx, key); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error syncing AlertRelabelConfig (%s): %w", key, err))
+		utilruntime.HandleError(fmt.Errorf("error syncing AlertRelabelConfig (%s): %w", key, err))
 
 		// Re-queue failed sync.
 		c.queue.AddRateLimited(key)

--- a/pkg/alert/rule_controller.go
+++ b/pkg/alert/rule_controller.go
@@ -230,7 +230,7 @@ func (rc *RuleController) processNextWorkItem(ctx context.Context) bool {
 	defer rc.queue.Done(key)
 
 	if err := rc.sync(ctx, key); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error syncing AlertingRule (%s): %w", key, err))
+		utilruntime.HandleError(fmt.Errorf("error syncing AlertingRule (%s): %w", key, err))
 
 		// Re-queue failed sync.
 		rc.queue.AddRateLimited(key)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1503,12 +1503,12 @@ func (c *Client) WaitForDaemonSetRollout(ctx context.Context, ds *appsv1.DaemonS
 		maxUnavailable, intstrErr := intstr.GetScaledValueFromIntOrPercent(&maxUnavailableIntStr, int(want), true)
 
 		if intstrErr != nil {
-			lastErr = fmt.Errorf("The daemonset has an invalid MaxUnavailable value: %w", intstrErr)
+			lastErr = fmt.Errorf("the daemonset has an invalid MaxUnavailable value: %w", intstrErr)
 			return false, nil
 		}
 
 		if int(numberUnavailable) > maxUnavailable {
-			lastErr = fmt.Errorf("Too many daemonset pods are unavailable (%d > %d max unavailable).", numberUnavailable, maxUnavailable)
+			lastErr = fmt.Errorf("too many daemonset pods are unavailable (%d > %d max unavailable)", numberUnavailable, maxUnavailable)
 			return false, nil
 		}
 		return true, nil

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2245,10 +2245,8 @@ func TestPollUntil(t *testing.T) {
 	defer cancel()
 	err = Poll(parentCtx1, func(ctx context.Context) (bool, error) {
 		// This also ensures that when the parent context is Done, the condition context is cancelled as well.
-		select {
-		case <-ctx.Done():
-			return false, nil
-		}
+		<-ctx.Done()
+		return false, nil
 	}, WithPollInterval(10*time.Millisecond), WithPollTimeout(time.Hour))
 	require.Error(t, parentCtx1.Err())
 	require.ErrorContains(t, err, "context deadline exceeded")
@@ -2316,11 +2314,9 @@ func TestPollUntil(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		pollErr = Poll(parentCtx3, func(ctx context.Context) (bool, error) {
-			select {
-			case <-ctx.Done():
-				close(waitCh3)
-				return false, nil
-			}
+			<-ctx.Done()
+			close(waitCh3)
+			return false, nil
 		}, WithPollInterval(10*time.Millisecond), WithPollTimeout(pollTimeout3))
 	}()
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -40,7 +40,6 @@ import (
 	yaml2 "gopkg.in/yaml.v2"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -3677,8 +3676,8 @@ func doubleServiceMonitorInterval(sm *monv1.ServiceMonitor) error {
 	return nil
 }
 
-func containerNameEquals(name string) func(corev1.Container) bool {
-	return func(c corev1.Container) bool {
+func containerNameEquals(name string) func(v1.Container) bool {
+	return func(c v1.Container) bool {
 		return c.Name == name
 	}
 }

--- a/pkg/manifests/tls_test.go
+++ b/pkg/manifests/tls_test.go
@@ -124,13 +124,13 @@ func TestRotateGrpcTLSSecret(t *testing.T) {
 				time.Sleep(1 * time.Second)
 			},
 			test: func(spre, spost *v1.Secret) error {
-				if bytes.Compare(spre.Data["ca.crt"], spost.Data["ca.crt"]) == 0 {
+				if bytes.Equal(spre.Data["ca.crt"], spost.Data["ca.crt"]) {
 					return fmt.Errorf("expected ca certificate data not to be equal, but it is")
 				}
-				if bytes.Compare(spre.Data["prometheus-server.crt"], spost.Data["prometheus-server.crt"]) == 0 {
+				if bytes.Equal(spre.Data["prometheus-server.crt"], spost.Data["prometheus-server.crt"]) {
 					return fmt.Errorf("expected server certificate data not to be equal, but it is")
 				}
-				if bytes.Compare(spre.Data["thanos-querier-client.crt"], spost.Data["thanos-querier-client.crt"]) == 0 {
+				if bytes.Equal(spre.Data["thanos-querier-client.crt"], spost.Data["thanos-querier-client.crt"]) {
 					return fmt.Errorf("expected client certificate data not to be equal, but it is")
 				}
 
@@ -164,7 +164,7 @@ func TestRotateGrpcTLSSecret(t *testing.T) {
 				s.Annotations["foo/bar"] = "true"
 			},
 			test: func(spre, spost *v1.Secret) error {
-				if bytes.Compare(spre.Data["ca.crt"], spost.Data["ca.crt"]) != 0 {
+				if !bytes.Equal(spre.Data["ca.crt"], spost.Data["ca.crt"]) {
 					return fmt.Errorf("expected certificate data to be equal, but they aren't")
 				}
 				return nil
@@ -180,7 +180,7 @@ func TestRotateGrpcTLSSecret(t *testing.T) {
 					return errors.New("expected certificate data to have rotated, but it wasn't")
 				}
 
-				if bytes.Compare(spre.Data["ca.crt"], spost.Data["ca.crt"]) == 0 {
+				if bytes.Equal(spre.Data["ca.crt"], spost.Data["ca.crt"]) {
 					return errors.New("expected certificate data not to be equal, but they are")
 				}
 

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -225,17 +225,11 @@ func isNilOrAsExpected(s client.StateInfo) bool {
 }
 
 func isDegraded(r runReport) bool {
-	if isNilOrAsExpected(r.degraded) {
-		return false
-	}
-	return true
+	return !isNilOrAsExpected(r.degraded)
 }
 
 func isUnavailable(r runReport) bool {
-	if isNilOrAsExpected(r.available) {
-		return false
-	}
-	return true
+	return !isNilOrAsExpected(r.available)
 }
 
 func TestRunReport(t *testing.T) {

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -410,9 +410,9 @@ func TestAlertmanagerDataReplication(t *testing.T) {
 		containerName   = "alertmanager"
 	)
 
-	data := fmt.Sprintf(`alertmanagerMain:
+	data := `alertmanagerMain:
   logLevel: warn
-`)
+`
 	f.MustCreateOrUpdateConfigMap(t, f.BuildCMOConfigMap(t, data))
 
 	for _, test := range []scenario{

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -463,7 +463,7 @@ func (f *Framework) AssertOperatorConditionMessageContainsFunc(conditionType con
 			}
 			for _, c := range co.Status.Conditions {
 				if c.Type == conditionType {
-					if strings.Index(c.Message, conditionMessage) >= 0 {
+					if strings.Contains(c.Message, conditionMessage) {
 						return nil
 					}
 					return fmt.Errorf("expecting condition %q to have message %q, got %q", conditionType, conditionMessage, c.Message)


### PR DESCRIPTION
## Summary

This PR fixes several staticcheck warnings across multiple packages:

**Source code fixes:**
- **ST1005** (`pkg/alert/relabel_controller.go`, `pkg/alert/rule_controller.go`, `pkg/client/client.go`): Lowercase error strings per Go conventions. Also removes trailing punctuation from one error string.
- **ST1019** (`pkg/manifests/manifests.go`): Consolidate duplicate import of `k8s.io/api/core/v1`.

**Test code fixes:**
- **S1000** (`pkg/client/client_test.go`): Simplify single-case `select` blocks to direct channel receives.
- **S1008** (`pkg/operator/operator_test.go`): Simplify redundant `if-return-false-return-true` to direct boolean return.
- **S1004** (`pkg/manifests/tls_test.go`): Use `bytes.Equal` instead of `bytes.Compare(...) == 0`.
- **S1039** (`test/e2e/alertmanager_test.go`): Remove unnecessary `fmt.Sprintf` for a string literal.
- **S1003** (`test/e2e/framework/assertions.go`): Use `strings.Contains` instead of `strings.Index(...) >= 0`.

All changes are mechanical. `go vet` and `go build` pass cleanly.