### PR TITLE
MON-4638: align ThanosQueryOverload description with for=1h

### DIFF
--- a/assets/thanos-querier/prometheus-rule.yaml
+++ b/assets/thanos-querier/prometheus-rule.yaml
@@ -82,7 +82,7 @@ spec:
         severity: warning
     - alert: ThanosQueryOverload
       annotations:
-        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} has been overloaded for more than 15 minutes. This may be a symptom of excessive simultaneous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connected Prometheus instances, look for potential senders of these requests and then contact support.
+        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} has been overloaded for more than 1 hour. This may be a symptom of excessive simultaneous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connected Prometheus instances, look for potential senders of these requests and then contact support.
         summary: Thanos query reaches its maximum capacity serving concurrent requests.
       expr: |
         (

--- a/jsonnet/utils/sanitize-rules.libsonnet
+++ b/jsonnet/utils/sanitize-rules.libsonnet
@@ -479,6 +479,20 @@ local patchedRules = [
   {
     name: 'thanos-query',
     rules: [
+      // MON-4638: OpenShift sets for=1h for thanos-query alerts, but the upstream
+      // ThanosQueryOverload description still says "15 minutes". Override the
+      // description to match the OpenShift for duration. Named patch must come
+      // before the wildcard (alert: '') patch because matching stops at first hit.
+      {
+        alert: 'ThanosQueryOverload',
+        'for': '1h',
+        labels: {
+          severity: 'warning',
+        },
+        annotations: {
+          description: 'Thanos Query {{$labels.job}} in {{$labels.namespace}} has been overloaded for more than 1 hour. This may be a symptom of excessive simultaneous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connected Prometheus instances, look for potential senders of these requests and then contact support.',
+        },
+      },
       {
         alert: '',
         'for': '1h',


### PR DESCRIPTION
## Summary
- OpenShift sets `for: 1h` for all `thanos-query` alerts (since #1087), but the upstream `ThanosQueryOverload` description still said the query had been overloaded for more than **15 minutes**.
- Add a named sanitize-rules patch for `ThanosQueryOverload` (before the wildcard `alert: ''` entry) so the description says **1 hour**, matching the OpenShift `for` duration.
- Update the generated `assets/thanos-querier/prometheus-rule.yaml` accordingly.
- Cosmetic / docs-in-alert change only: expression and firing behavior are unchanged.

## Test plan
- [x] Diff shows only the description duration wording (`15 minutes` → `1 hour`) plus the sanitize-rules override
- [ ] After merge / on a cluster with the new CMO build, confirm:
  ```bash
  oc -n openshift-monitoring get prometheusrule thanos-querier -o yaml | grep -A2 ThanosQueryOverload
  ```
  Description should say "more than 1 hour" while `for` remains `1h`.
- [ ] Optional: ask OWNERS whether Minor backports to release branches are desired (not assumed).

Fixes [MON-4638](https://redhat.atlassian.net/browse/MON-4638)