### PR TITLE
OCPBUGS-112572: [release-4.22] Makefile: version-stamp golangci-lint binary to prevent stale linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ JB_BIN=$(BIN_DIR)/jb
 GOJSONTOYAML_BIN=$(BIN_DIR)/gojsontoyaml
 JSONNET_BIN=$(BIN_DIR)/jsonnet
 JSONNETFMT_BIN=$(BIN_DIR)/jsonnetfmt
-GOLANGCI_LINT_BIN=$(BIN_DIR)/golangci-lint
 GOLANGCI_LINT_VERSION=v2.11.3
+GOLANGCI_LINT_BIN=$(BIN_DIR)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 PROMTOOL_BIN=$(BIN_DIR)/promtool
 DOCGEN_BIN=$(BIN_DIR)/docgen
 MISSPELL_BIN=$(BIN_DIR)/misspell
@@ -225,8 +225,11 @@ golangci-lint: $(GOLANGCI_LINT_BIN)
 golangci-lint-fix: $(GOLANGCI_LINT_BIN)
 	$(GOLANGCI_LINT_BIN) run --verbose --print-resources-usage --fix
 
-$(GOLANGCI_LINT_BIN): $(BIN_DIR)
+# Version-stamped target ensures the correct golangci-lint is used across checkouts.
+# (|) avoids timestamp skew caused by the mv.
+$(GOLANGCI_LINT_BIN): | $(BIN_DIR)
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(BIN_DIR) $(GOLANGCI_LINT_VERSION)
+	mv $(BIN_DIR)/golangci-lint $(GOLANGCI_LINT_BIN)
 
 .PHONY:
 misspell: $(MISSPELL_BIN)


### PR DESCRIPTION

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
