### PR TITLE
MON-4617: Update kube-prometheus and add resourceMetricsAPI field

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -181,8 +181,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "323aac18b8017ca825a7d759070fab67b17c8700",
-      "sum": "kkEWfJM/9uym7b5tChgcVV2IOTFUy7/q6RCCi4++iJk="
+      "version": "4d719f1dea8853540b3823ab1fbe6be74a9953b3",
+      "sum": "4P4kMSdM9nN+nf03fWRk/hOSM0AW1m4XyZwynDNmSuQ="
     },
     {
       "source": {

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -33,6 +33,10 @@ local telemeterClient = import './components/telemeter-client.libsonnet';
 local commonConfig = {
   namespace: 'openshift-monitoring',
   namespaceUserWorkload: 'openshift-user-workload-monitoring',
+  // Required by the upstream kube-prometheus anti-affinity addon which
+  // conditionally applies anti-affinity based on this field. Set to 'none'
+  // because CMO's metrics-server component manages its own affinity settings.
+  resourceMetricsAPI:: 'none',
   clusterMonitoringNamespaceSelector: {
     matchLabels: {
       'openshift.io/cluster-monitoring': 'true',


### PR DESCRIPTION
To fix syncbot failures https://github.com/rhobs/syncbot/actions/runs/33345424632/job/99348499123

Bump kube-prometheus jsonnet dependency to latest main which includes the metrics-server component (prometheus-operator/kube-prometheus#2851).

Add resourceMetricsAPI hidden field to commonConfig, required by the upstream anti-affinity addon. Set to 'none' because CMO's metrics-server component manages its own affinity settings.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

NA

```telemetry_report
```
