### PR TITLE
ARO-28987: allow disabling monitoring plugin features

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -216,6 +216,7 @@ The `MonitoringPluginConfig` resource defines settings for the Console Plugin co
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
+| disabledFeatures | []string | Defines monitoring plugin features to omit from the default set enabled by the Cluster Monitoring Operator. Features that aren't enabled by default have no effect. At least one default feature must remain enabled. |
 | nodeSelector | map[string]string | Defines the nodes on which the Pods are scheduled. |
 | resources | *[v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#resourcerequirements-v1-core) | Defines resource requests and limits for the console-plugin container. |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#toleration-v1-core) | Defines tolerations for the pods. |

--- a/Documentation/openshiftdocs/modules/monitoringpluginconfig.adoc
+++ b/Documentation/openshiftdocs/modules/monitoringpluginconfig.adoc
@@ -18,6 +18,8 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 [options="header"]
 |===
 | Property | Type | Description 
+|disabledFeatures|[]string|Defines monitoring plugin features to omit from the default set enabled by the Cluster Monitoring Operator. Features that aren't enabled by default have no effect. At least one default feature must remain enabled.
+
 |nodeSelector|map[string]string|Defines the nodes on which the Pods are scheduled.
 
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the console-plugin container.

--- a/pkg/manifests/config_test.go
+++ b/pkg/manifests/config_test.go
@@ -50,6 +50,15 @@ func TestNewConfigFromString(t *testing.T) {
 			},
 		},
 		{
+			name: "monitoring plugin disabled features",
+			configString: func() string {
+				return `{"monitoringPlugin": {"disabledFeatures": ["alerting"]}}`
+			},
+			configCheck: func(c *Config) {
+				require.Equal(t, []string{"alerting"}, c.ClusterMonitoringConfiguration.MonitoringPluginConfig.DisabledFeatures)
+			},
+		},
+		{
 			name: "json string with unknown root field",
 			configString: func() string {
 				return `{"prometheusK8ss": {}}`

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -337,6 +337,7 @@ var (
 	KubeRbacProxyMinTLSVersionFlag                       = "--tls-min-version="
 	MonitoringPluginTLSCipherSuitesFlag                  = "--tls-cipher-suites="
 	MonitoringPluginTLSMinTLSVersionFlag                 = "--tls-min-version="
+	MonitoringPluginFeaturesFlag                         = "--features="
 
 	AuthProxyExternalURLFlag  = "-external-url="
 	AuthProxyCookieDomainFlag = "-cookie-domain="
@@ -2918,6 +2919,13 @@ func (f *Factory) MonitoringPluginDeployment() (*appsv1.Deployment, error) {
 		return d, nil
 	}
 
+	if len(cfg.DisabledFeatures) > 0 {
+		containers[idx].Args, err = disableMonitoringPluginFeatures(containers[idx].Args, cfg.DisabledFeatures)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if cfg.Resources != nil {
 		containers[idx].Resources = *cfg.Resources
 	}
@@ -2935,6 +2943,27 @@ func (f *Factory) MonitoringPluginDeployment() (*appsv1.Deployment, error) {
 	}
 
 	return d, nil
+}
+
+func disableMonitoringPluginFeatures(args, disabledFeatures []string) ([]string, error) {
+	for i, arg := range args {
+		if !strings.HasPrefix(arg, MonitoringPluginFeaturesFlag) {
+			continue
+		}
+
+		features := strings.Split(strings.TrimPrefix(arg, MonitoringPluginFeaturesFlag), ",")
+		features = slices.DeleteFunc(features, func(feature string) bool {
+			return slices.Contains(disabledFeatures, feature)
+		})
+		if len(features) == 0 {
+			return nil, errors.New("monitoring plugin must have at least one feature enabled")
+		}
+
+		args[i] = MonitoringPluginFeaturesFlag + strings.Join(features, ",")
+		return args, nil
+	}
+
+	return nil, errors.New("monitoring plugin features argument not found")
 }
 
 func (f *Factory) MonitoringPluginPodDisruptionBudget() (*policyv1.PodDisruptionBudget, error) {

--- a/pkg/manifests/monitoring_plugin_test.go
+++ b/pkg/manifests/monitoring_plugin_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The Cluster Monitoring Operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifests
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitoringPluginDeploymentDisabledFeatures(t *testing.T) {
+	defaultDeployment, err := newMonitoringPluginTestFactory(mustDefaultConfig()).MonitoringPluginDeployment()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name             string
+		disabledFeatures []string
+		expectedArgument string
+		expectedError    string
+	}{
+		{
+			name:             "disable alerting",
+			disabledFeatures: []string{"alerting"},
+			expectedArgument: "--features=legacy-dashboards,targets,metrics",
+		},
+		{
+			name:             "disable multiple features",
+			disabledFeatures: []string{"alerting", "targets"},
+			expectedArgument: "--features=legacy-dashboards,metrics",
+		},
+		{
+			name:             "ignore features that are not enabled by default",
+			disabledFeatures: []string{"alerting-management"},
+			expectedArgument: "--features=alerting,legacy-dashboards,targets,metrics",
+		},
+		{
+			name:             "require at least one feature",
+			disabledFeatures: []string{"alerting", "legacy-dashboards", "targets", "metrics"},
+			expectedError:    "monitoring plugin must have at least one feature enabled",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := mustDefaultConfig()
+			cfg.ClusterMonitoringConfiguration.MonitoringPluginConfig = &MonitoringPluginConfig{
+				DisabledFeatures: tc.disabledFeatures,
+			}
+			deployment, err := newMonitoringPluginTestFactory(cfg).MonitoringPluginDeployment()
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+
+			expectedDeployment := defaultDeployment.DeepCopy()
+			containerIndex := slices.IndexFunc(expectedDeployment.Spec.Template.Spec.Containers, containerNameEquals(MonitoringPluginDeploymentContainer))
+			require.NotEqual(t, -1, containerIndex)
+
+			args := expectedDeployment.Spec.Template.Spec.Containers[containerIndex].Args
+			featuresArgIndex := slices.IndexFunc(args, func(arg string) bool {
+				return strings.HasPrefix(arg, MonitoringPluginFeaturesFlag)
+			})
+			require.NotEqual(t, -1, featuresArgIndex)
+			args[featuresArgIndex] = tc.expectedArgument
+
+			require.Equal(t, expectedDeployment, deployment)
+		})
+	}
+}
+
+func newMonitoringPluginTestFactory(cfg *Config) *Factory {
+	return NewFactory(
+		"openshift-monitoring",
+		"openshift-user-workload-monitoring",
+		cfg,
+		defaultInfrastructureReader(),
+		&fakeProxyReader{},
+		NewAssets(assetsPath),
+		&APIServerConfig{},
+		&configv1.Console{},
+	)
+}

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -868,6 +868,10 @@ type PrometheusOperatorAdmissionWebhookConfig struct {
 // The `MonitoringPluginConfig` resource defines settings for the
 // Console Plugin component in the `openshift-monitoring` namespace.
 type MonitoringPluginConfig struct {
+	// Defines monitoring plugin features to omit from the default set enabled by
+	// the Cluster Monitoring Operator. Features that aren't enabled by default
+	// have no effect. At least one default feature must remain enabled.
+	DisabledFeatures []string `json:"disabledFeatures,omitempty"`
 	// Defines the nodes on which the Pods are scheduled.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Defines resource requests and limits for the console-plugin container.


### PR DESCRIPTION
## Summary

- add `monitoringPlugin.disabledFeatures` to `cluster-monitoring-config`
- remove configured entries from CMO's default monitoring plugin feature set
- reject configurations that would leave the plugin with no enabled features
- document and test the new configuration

## Why

Managed service providers may not support every monitoring plugin feature exposed by the OpenShift payload. An omission list lets CMO retain ownership of the default feature set while providers disable only unsupported features, such as `alerting`.

This draft exposes the setting through `cluster-monitoring-config`, which is the configuration surface needed by the HyperShift provider integration. Exposing the same field through the `ClusterMonitoring` API would require a corresponding `openshift/api` change.

Jira: https://redhat.atlassian.net/browse/ARO-28987

## Testing

- `go test ./pkg/manifests`
- `make verify`
