### PR TITLE
NO-JIRA: Makefile: ensure JUnit test name prefix is applied even on test failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,9 +295,11 @@ endif
 test-e2e:
 ifdef ARTIFACT_DIR
 	mkdir -p $(dir $(E2E_JUNIT))
-	$(GOTESTSUM_BIN) --format=standard-verbose --junitfile=$(E2E_JUNIT) -- -v -timeout=150m $(E2E_TEST_ARGS) ./test/e2e/ --kubeconfig $(KUBECONFIG)
-	# Add some metadata.
-	sed -i 's/ name="Test/ name="$(TEST_NAME_PREFIX) Test/g' $(E2E_JUNIT)
+	# Run tests then add metadata prefix to JUnit test names, even on failure.
+	$(GOTESTSUM_BIN) --format=standard-verbose --junitfile=$(E2E_JUNIT) -- -v -timeout=150m $(E2E_TEST_ARGS) ./test/e2e/ --kubeconfig $(KUBECONFIG); \
+	rc=$$?; \
+	sed -i 's/ name="Test/ name="$(TEST_NAME_PREFIX) Test/g' $(E2E_JUNIT); \
+	exit $$rc
 else
 	go test -v -timeout=150m $(E2E_TEST_ARGS) ./test/e2e/ --kubeconfig $(KUBECONFIG)
 endif


### PR DESCRIPTION
The test-e2e target runs gotestsum to produce JUnit XML, then runs sed to add a [sig-instrumentation]... prefix to test names. Because these were separate Make recipe lines, when gotestsum exited non-zero (test failure), Make stopped the recipe and sed never ran.

This caused test failures to have bare Go test names (e.g. "TestPrometheusIsUp") while passes got the prefixed names (e.g. "[sig-instrumentation]... TestPrometheusIsUp"). Sippy tracked these as separate tests, splitting CI signal.

Fix by chaining gotestsum and sed into a single shell command that captures the exit code, always runs sed, then exits with the original code. This ensures consistent test names in JUnit XML regardless of whether tests pass or fail.

## Telemetry report

<!-- Required when modifying selectors in
     manifests/0000_50_cluster-monitoring-operator_04-config.yaml.

     Run the tool with all added or modified selectors, address the
     failing checks, then paste the final output here for review.

     Use a cluster where the involved metrics are present, representative
     of real-world cardinality, and in a steady state.

     Usage: go run -mod=mod ./hack/telemetry_report/ <prometheus_url> '<selector>'...
-->

```telemetry_report
```
