### PR TITLE
RFE-8850: add app.kubernetes.io/name label to cluster-monitoring-view

### DIFF
--- a/assets/cluster-monitoring-operator/cluster-role-view.yaml
+++ b/assets/cluster-monitoring-operator/cluster-role-view.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/managed-by: cluster-monitoring-operator
+    app.kubernetes.io/name: cluster-monitoring-view
     app.kubernetes.io/part-of: openshift-monitoring
   name: cluster-monitoring-view
 rules:

--- a/jsonnet/components/cluster-monitoring-operator.libsonnet
+++ b/jsonnet/components/cluster-monitoring-operator.libsonnet
@@ -397,6 +397,9 @@ function(params) {
     kind: 'ClusterRole',
     metadata: {
       name: 'cluster-monitoring-view',
+      labels: {
+        'app.kubernetes.io/name': 'cluster-monitoring-view',
+      },
     },
     rules: [
       {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -5560,6 +5560,13 @@ func TestPromConfigurationExternalLabels(t *testing.T) {
 	}
 }
 
+func TestClusterMonitoringClusterRoleViewNameLabel(t *testing.T) {
+	f := NewFactory("openshift-monitoring", "openshift-user-workload-monitoring", mustDefaultConfig(), defaultInfrastructureReader(), &fakeProxyReader{}, NewAssets(assetsPath), &APIServerConfig{}, &configv1.Console{})
+	cr, err := f.ClusterMonitoringClusterRoleView()
+	require.NoError(t, err)
+	require.Equal(t, "cluster-monitoring-view", cr.Labels["app.kubernetes.io/name"])
+}
+
 func mustDefaultConfig() *Config {
 	cfg, err := NewConfigFromString("{}")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `app.kubernetes.io/name: cluster-monitoring-view` to the CMO-owned `cluster-monitoring-view` ClusterRole so it can be selected for RBAC aggregation, matching `cluster-logging-*-view`.
- This covers the monitoring half of [RFE-8850](https://redhat.atlassian.net/browse/RFE-8850). `cluster-reader` remains owned by openshift-apiserver bootstrap policy.

## Test plan
- [ ] Confirm generated `assets/cluster-monitoring-operator/cluster-role-view.yaml` includes `app.kubernetes.io/name: cluster-monitoring-view`
- [ ] `go test ./pkg/manifests -run TestClusterMonitoringClusterRoleViewNameLabel`
- [ ] After install, `oc get clusterrole cluster-monitoring-view -o jsonpath='{.metadata.labels}'` shows the name label